### PR TITLE
Exclude some unused Zephyr west submodules.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,4 +53,4 @@ jobs:
         id: west-build
         with:
           command: 'build'
-          command-args: '-s app -b nucleo_wb55rg -- -DSHIELD=petejohanson_handwire'
+          command-args: '-s app -b proton_c -- -DSHIELD=petejohanson_proton_handwire'

--- a/app/west.yml
+++ b/app/west.yml
@@ -11,7 +11,6 @@ manifest:
       import:
         # TODO: Rename once upstream offers option like `exclude` or `denylist`
         name-blacklist:
-          - cmsis
           - ci-tools
           - hal_atmel
           - hal_altera

--- a/app/west.yml
+++ b/app/west.yml
@@ -8,6 +8,17 @@ manifest:
     - name: zephyr
       remote: petejohanson
       revision: kconfig/external-sheilds-shields-as-list-fix
-      import: true
+      import:
+        # TODO: Rename once upstream offers option like `exclude` or `denylist`
+        name-blacklist:
+          - cmsis
+          - ci-tools
+          - hal_atmel
+          - hal_altera
+          - hal_cypress
+          - hal_infineon
+          - hal_microchip
+          - hal_nxp
+          - hal_openisa
   self:
     path: zmk


### PR DESCRIPTION
* Don't waste space/time updating unused modules for architectures
  we aren't targetting (yet).