### PR TITLE
Only install `requirements-base.txt`

### DIFF
--- a/docs/docs/dev-setup.md
+++ b/docs/docs/dev-setup.md
@@ -155,7 +155,7 @@ west zephyr-export
 #### Install Zephyr Python Dependencies
 
 ```bash
-pip3 install --user -r zephyr/scripts/requirements.txt
+pip3 install --user -r zephyr/scripts/requirements-base.txt
 ```
 
 ### Environment Variables


### PR DESCRIPTION
For just building, we don't need the full Python dependencies listed in `requirements.txt`, as discovered in #12 and I've verified locally here as well. Switch the docs here slightly with a one liner.