### PR TITLE
Split connection parameter adjustments and 2M PHY added

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -88,6 +88,7 @@ config ZMK_SPLIT_BLE
 	bool "Split keyboard support via BLE transport"
 	depends on ZMK_BLE
 	default y
+	select BT_USER_PHY_UPDATE
 
 if ZMK_SPLIT_BLE
 

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -40,7 +40,7 @@ static void connected(struct bt_conn *conn, u8_t err)
     bt_conn_le_param_update(conn, BT_LE_CONN_PARAM(0x0006, 0x000c, 30, 400));
 
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_ROLE_PERIPHERAL)
-    bt_conn_le_phy_update(default_conn, BT_CONN_LE_PHY_PARAM_2M);
+    bt_conn_le_phy_update(conn, BT_CONN_LE_PHY_PARAM_2M);
 #endif
 
     if (bt_conn_set_security(conn, BT_SECURITY_L2))

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -88,26 +88,12 @@ static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param) {
     return true;
 }
 
-static void le_param_updated(struct bt_conn *conn, u16_t interval,
-				 u16_t latency, u16_t timeout) {
-    static struct bt_conn_info info;
-
-    bt_conn_get_info(conn, &info);
-
-    if (info.role == BT_CONN_ROLE_MASTER && (interval != 6 || latency != 30)) {
-        bt_conn_le_param_update(conn, BT_LE_CONN_PARAM(0x0006, 0x0006, 30, 400));
-    }
-
-    LOG_DBG("Params updated: Interval: %d, Latency: %d", interval, latency);
-};
-
 static struct bt_conn_cb conn_callbacks = {
     .connected = connected,
     .disconnected = disconnected,
     .security_changed = security_changed,
 #if !IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_ROLE_PERIPHERAL)
     .le_param_req = le_param_req,
-    .le_param_updated = le_param_updated,
 #endif
 };
 

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -76,17 +76,21 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
     }
 }
 
+#if !IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_ROLE_PERIPHERAL)
 static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param) {
     static struct bt_conn_info info;
 
     bt_conn_get_info(conn, &info);
 
+    /* This captures a param change from central half of a split board connection
+       to stop default params from getting set over the top of our preferred ones */
     if (info.role == BT_CONN_ROLE_MASTER && (param->interval_min != 6 || param->latency != 30)) {
         return false;
     }
 
     return true;
 }
+#endif
 
 static struct bt_conn_cb conn_callbacks = {
     .connected = connected,

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -37,7 +37,11 @@ static void connected(struct bt_conn *conn, u8_t err)
 
     printk("Connected %s\n", addr);
 
-    bt_conn_le_param_update(conn, BT_LE_CONN_PARAM(0x0006, 0x000c, 5, 400));
+    bt_conn_le_param_update(conn, BT_LE_CONN_PARAM(0x0006, 0x000c, 30, 400));
+
+#if IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_ROLE_PERIPHERAL)
+    bt_conn_le_phy_update(default_conn, BT_CONN_LE_PHY_PARAM_2M);
+#endif
 
     if (bt_conn_set_security(conn, BT_SECURITY_L2))
     {

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -67,13 +67,6 @@ static u8_t split_central_notify_func(struct bt_conn *conn,
 		}
 	}
 
-	bt_conn_le_param_update(conn, BT_LE_CONN_PARAM(0x0006, 0x0006, 30, 400));
-
-	struct bt_conn_info info;
-
-	bt_conn_get_info(conn, &info);
-
-	LOG_DBG("Interval: %d, Latency: %d, PHY: %d", info.le.interval, info.le.latency, info.le.phy->rx_phy);
 
 	return BT_GATT_ITER_CONTINUE;
 }


### PR DESCRIPTION
- Update central split half to only accept 7.5ms
- Update latency from 5 to 30 (maximum officially supported by Apple, good benchmark)
- Add 2M PHY to connection between split halves
- Adds callback function to stop split connection params from resetting to default