### PR TITLE
Add better default keymap for Lily58

### DIFF
--- a/app/boards/shields/lily58/keymap/keymap.overlay
+++ b/app/boards/shields/lily58/keymap/keymap.overlay
@@ -10,7 +10,7 @@
 	keymap0: keymap {
 		compatible = "zmk,keymap";
 		label ="Default Lily58 Keymap";
-		layers = <&default>;
+		layers = <&default &lower &raise>;
 	};
 
 	layers {
@@ -18,18 +18,52 @@
 
 		default: layer_0 {
 			label = "DEFAULT";
-// ---------------------------------------------------------------------------------------------------------------------------------
-// |  ESC  |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |  `   |
-// |  TAB  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   |  \   |
-// |  CTRL |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   |   '  |
-// | SHIFT |  Z  |  X  |  C   |  V   |  B   |   "["  |  |  "]"  |  N   |  M    |  ,    |  .   |   /   | CTRL |
-//                     | GUI  | DEL  | RET  |  SPACE |  | SPACE | TAB  | BSPC  | R-ALT |
+// ------------------------------------------------------------------------------------------------------------
+// |  ESC  |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |   `   |
+// |  TAB  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   |   -   |
+// |  CTRL |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   |   '   |
+// | SHIFT |  Z  |  X  |  C   |  V   |  B   |   "["  |  |  "]"  |  N   |  M    |  ,    |  .   |   /   | SHIFT |
+//                     | ALT  | GUI  | LOWER|  SPACE |  | ENTER | RAISE| BSPC  | GUI   |
 			bindings = <
 &kp ESC  &kp NUM_1 &kp NUM_2 &kp NUM_3 &kp NUM_4 &kp NUM_5                    &kp NUM_6 &kp NUM_7 &kp NUM_8 &kp NUM_9 &kp NUM_0 &kp GRAV
-&kp TAB  &kp Q     &kp W     &kp E     &kp R     &kp T                        &kp Y     &kp U     &kp I     &kp O     &kp P     &kp BSLH
+&kp TAB  &kp Q     &kp W     &kp E     &kp R     &kp T                        &kp Y     &kp U     &kp I     &kp O     &kp P     &kp MINUS
 &kp LCTL &kp A     &kp S     &kp D     &kp F     &kp G                        &kp H     &kp J     &kp K     &kp L     &kp SCLN  &kp QUOT
-&kp LSFT &kp Z     &kp X     &kp C     &kp V     &kp B     &kp LBKT  &kp RBKT &kp N     &kp M     &kp CMMA  &kp DOT   &kp FSLH  &kp RCTL
-	                     &kp LGUI &kp DEL  &kp RET &kp SPC                 &kp SPC  &kp TAB  &kp BKSP &kp RALT
+&kp LSFT &kp Z     &kp X     &kp C     &kp V     &kp B   &kp LBKT  &kp RBKT   &kp N     &kp M     &kp CMMA  &kp DOT   &kp FSLH  &kp RSFT
+	                 &kp LALT  &kp LGUI  &mo 1     &kp SPC                      &kp RET   &mo 2     &kp BKSP  &kp RGUI
+			>;
+		};
+
+		lower: layer_1 {
+			label = "LOWER";
+// ------------------------------------------------------------------------------------------------------------
+// |       |     |     |      |      |      |                   |      |       |       |      |       |       |
+// |  F1   |  F2 |  F3 |  F4  |  F5  |  F6  |                   |  F7  |  F8   |  F9   |  F10 |  F11  |  F12  |
+// |   `   |  !  |  @  |  #   |  $   |  %   |                   |  ^   |  &    |  *    |  (   |   )   |   ~   |
+// |       |     |     |      |      |      |        |  |       |      |  _    |  +    |  {   |   }   |  "|"  |
+//                     |      |      |      |        |  |       |      |       |       |
+			bindings = <
+&trans   &trans    &trans    &trans    &trans    &trans                       &trans    &trans    &trans    &trans    &trans    &trans
+&kp F1   &kp F2    &kp F3    &kp F4    &kp F5    &kp F6                       &kp F7    &kp F8    &kp F9    &kp F10   &kp F11   &kp F12
+&kp GRAV &kp BANG  &kp ATSN  &kp HASH  &kp CURU  &kp PRCT                     &kp CRRT  &kp AMPS  &kp KMLT  &kp LPRN  &kp RPRN  &kp TILD
+&trans   &trans    &trans    &trans    &trans    &trans    &trans   &trans    &trans    &kp MINUS &kp KPLS  &kp LCUR  &kp RCUR  &kp PIPE
+	                 &trans    &trans    &trans    &trans                       &trans    &trans    &trans    &trans
+			>;
+		};
+
+		raise: layer_3 {
+			label = "RAISE";
+// ------------------------------------------------------------------------------------------------------------
+// |       |     |     |      |      |      |                   |      |       |       |      |       |       |
+// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |   7   |   8   |  9   |   0   |       |
+// |   F1  |  F2 |  F3 |  F4  |  F5  |  F6  |                   |      |   <-  |   ^   |  v   |  ->   |       |
+// |   F7  |  F8 |  F9 |  F10 |  F11 |  F12 |        |  |       |  +   |   -   |   =   |  [   |   ]   |   \   |
+//                     |      |      |      |        |  |       |      |       |       |
+			bindings = <
+&trans   &trans    &trans    &trans    &trans    &trans                       &trans    &trans    &trans    &trans    &trans    &trans
+&kp GRAV &kp NUM_1 &kp NUM_2 &kp NUM_3 &kp NUM_4 &kp NUM_5                    &kp NUM_6 &kp NUM_7 &kp NUM_8 &kp NUM_9 &kp NUM_0 &trans
+&kp F1   &kp F2    &kp F3    &kp F4    &kp F5    &kp F6                       &trans    &kp LARW  &kp DARW  &kp UARW  &kp RARW  &trans
+&kp F7   &kp F8    &kp F9    &kp F10   &kp F11   &kp F12   &trans   &trans    &kp KPLS  &kp MINUS &kp EQL   &kp LBKT  &kp RBKT  &kp BSLH
+	                 &trans    &trans    &trans    &trans                       &trans    &trans    &trans    &trans
 			>;
 		};
 	};

--- a/app/boards/shields/lily58/keymap/keymap.overlay
+++ b/app/boards/shields/lily58/keymap/keymap.overlay
@@ -29,7 +29,7 @@
 &kp TAB  &kp Q     &kp W     &kp E     &kp R     &kp T                        &kp Y     &kp U     &kp I     &kp O     &kp P     &kp MINUS
 &kp LCTL &kp A     &kp S     &kp D     &kp F     &kp G                        &kp H     &kp J     &kp K     &kp L     &kp SCLN  &kp QUOT
 &kp LSFT &kp Z     &kp X     &kp C     &kp V     &kp B   &kp LBKT  &kp RBKT   &kp N     &kp M     &kp CMMA  &kp DOT   &kp FSLH  &kp RSFT
-	                 &kp LALT  &kp LGUI  &mo 1     &kp SPC                      &kp RET   &mo 2     &kp BKSP  &kp RGUI
+                   &kp LALT  &kp LGUI  &mo 1     &kp SPC                      &kp RET   &mo 2     &kp BKSP  &kp RGUI
 			>;
 		};
 
@@ -46,7 +46,7 @@
 &kp F1   &kp F2    &kp F3    &kp F4    &kp F5    &kp F6                       &kp F7    &kp F8    &kp F9    &kp F10   &kp F11   &kp F12
 &kp GRAV &kp BANG  &kp ATSN  &kp HASH  &kp CURU  &kp PRCT                     &kp CRRT  &kp AMPS  &kp KMLT  &kp LPRN  &kp RPRN  &kp TILD
 &trans   &trans    &trans    &trans    &trans    &trans    &trans   &trans    &trans    &kp MINUS &kp KPLS  &kp LCUR  &kp RCUR  &kp PIPE
-	                 &trans    &trans    &trans    &trans                       &trans    &trans    &trans    &trans
+                   &trans    &trans    &trans    &trans                       &trans    &trans    &trans    &trans
 			>;
 		};
 
@@ -63,7 +63,7 @@
 &kp GRAV &kp NUM_1 &kp NUM_2 &kp NUM_3 &kp NUM_4 &kp NUM_5                    &kp NUM_6 &kp NUM_7 &kp NUM_8 &kp NUM_9 &kp NUM_0 &trans
 &kp F1   &kp F2    &kp F3    &kp F4    &kp F5    &kp F6                       &trans    &kp LARW  &kp DARW  &kp UARW  &kp RARW  &trans
 &kp F7   &kp F8    &kp F9    &kp F10   &kp F11   &kp F12   &trans   &trans    &kp KPLS  &kp MINUS &kp EQL   &kp LBKT  &kp RBKT  &kp BSLH
-	                 &trans    &trans    &trans    &trans                       &trans    &trans    &trans    &trans
+                   &trans    &trans    &trans    &trans                       &trans    &trans    &trans    &trans
 			>;
 		};
 	};

--- a/app/include/dt-bindings/zmk/keys.h
+++ b/app/include/dt-bindings/zmk/keys.h
@@ -50,7 +50,7 @@
 #define LBKT 0x2F
 #define RBKT 0x30
 #define BSLH 0x31
-
+#define TILD 0x32
 #define SCLN 0x33
 #define QUOT 0x34
 #define GRAV 0x35


### PR DESCRIPTION
This keymap follows the one given in the [Lily58 repository as default](https://github.com/kata0510/Lily58/blob/master/Pro/Doc/buildguide_en.md#default-keymap)

Only key that outputs incorrectly is _ (underscore) in the LOWER layer because it doesn't have its own HID code.