### PR TITLE
Add missing configuration values for RGB underglow

### DIFF
--- a/app/boards/shields/corne/corne.conf
+++ b/app/boards/shields/corne/corne.conf
@@ -1,4 +1,4 @@
-# Uncomment the following line to enable the Corne RGB Underglow
+# Uncomment the following lines to enable the Corne RGB Underglow
 # ZMK_RGB_UNDERGLOW=y
 # CONFIG_WS2812_STRIP=y
 

--- a/app/boards/shields/corne/corne.conf
+++ b/app/boards/shields/corne/corne.conf
@@ -1,5 +1,6 @@
 # Uncomment the following line to enable the Corne RGB Underglow
 # ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y
 
 # Uncomment the following line to enable the Corne OLED Display
 # CONFIG_ZMK_DISPLAY=y

--- a/app/boards/shields/kyria/kyria.conf
+++ b/app/boards/shields/kyria/kyria.conf
@@ -7,3 +7,4 @@
 
 # Uncomment the following line to enable RGB underglow
 # CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/kyria/kyria.conf
+++ b/app/boards/shields/kyria/kyria.conf
@@ -5,6 +5,6 @@
 # Uncomment the following line to enable the Kyria OLED Display
 # CONFIG_ZMK_DISPLAY=y
 
-# Uncomment the following line to enable RGB underglow
+# Uncomment the following lines to enable RGB underglow
 # CONFIG_ZMK_RGB_UNDERGLOW=y
 # CONFIG_WS2812_STRIP=y

--- a/docs/docs/feature/underglow.md
+++ b/docs/docs/feature/underglow.md
@@ -21,11 +21,11 @@ Here you can see the RGB underglow feature in action using WS2812 LEDs.
 
 ## Enabling RGB Underglow
 
-To enable RGB underglow on your board or shield, simply enable the `ZMK_RGB_UNDERGLOW` and `CONFIG_X_STRIP` configuration values in the `.conf` file of your user config directory as such:
+To enable RGB underglow on your board or shield, simply enable the `ZMK_RGB_UNDERGLOW` and `X_STRIP` configuration values in the `.conf` file of your user config directory as such:
 
 ```
 CONFIG_ZMK_RGB_UNDERGLOW=y
-# Use the STRIP config specific tot he LEDs you're using
+# Use the STRIP config specific to the LEDs you're using
 CONFIG_WS2812_STRIP=y
 ```
 
@@ -116,10 +116,10 @@ Once you have your `led_strip` properly defined you need to add it to the root d
 };
 ```
 
-Finally you need to enable the `ZMK_RGB_UNDERGLOW` and `CONFIG_X_STRIP` STRIP configuration values in the `.conf` file of your board (or set a default in the `Kconfig.defconfig`):
+Finally you need to enable the `ZMK_RGB_UNDERGLOW` and `X_STRIP` configuration values in the `.conf` file of your board (or set a default in the `Kconfig.defconfig`):
 
 ```
 CONFIG_ZMK_RGB_UNDERGLOW=y
-# Use the STRIP config specific tot he LEDs you're using
+# Use the STRIP config specific to the LEDs you're using
 CONFIG_WS2812_STRIP=y
 ```

--- a/docs/docs/feature/underglow.md
+++ b/docs/docs/feature/underglow.md
@@ -21,10 +21,12 @@ Here you can see the RGB underglow feature in action using WS2812 LEDs.
 
 ## Enabling RGB Underglow
 
-To enable RGB underglow on your board or shield, simply enable the `ZMK_RGB_UNDERGLOW` configuration value in the `.conf` file of your user config directory as such:
+To enable RGB underglow on your board or shield, simply enable the `ZMK_RGB_UNDERGLOW` and `CONFIG_X_STRIP` configuration values in the `.conf` file of your user config directory as such:
 
 ```
 CONFIG_ZMK_RGB_UNDERGLOW=y
+# Use the STRIP config specific tot he LEDs you're using
+CONFIG_WS2812_STRIP=y
 ```
 
 If your board or shield does not have RGB underglow configured, refer to [Adding RGB Underglow to a Board](#adding-rgb-underglow-to-a-board).
@@ -114,8 +116,10 @@ Once you have your `led_strip` properly defined you need to add it to the root d
 };
 ```
 
-Finally you need to enable the `ZMK_RGB_UNDERGLOW` configuration value in the `.conf` file of your board (or set a default in the `Kconfig.defconfig`):
+Finally you need to enable the `ZMK_RGB_UNDERGLOW` and `CONFIG_X_STRIP` STRIP configuration values in the `.conf` file of your board (or set a default in the `Kconfig.defconfig`):
 
 ```
 CONFIG_ZMK_RGB_UNDERGLOW=y
+# Use the STRIP config specific tot he LEDs you're using
+CONFIG_WS2812_STRIP=y
 ```


### PR DESCRIPTION
This adds all the missing mentions where the shield needs to define the type of LED strip it uses.

This still doesn't address config values not being inherited from `<shield>.conf` by `<shield>_left.conf` and  `<shield>_right.conf`.