### PR TITLE
Create proper fix for split default connection bug

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -124,6 +124,9 @@ config ZMK_USB
 config BT_MAX_CONN
 	default 5
 
+config BT_GAP_AUTO_UPDATE_CONN_PARAMS
+	default n
+
 endif
 
 endchoice

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -76,29 +76,10 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
     }
 }
 
-#if !IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_ROLE_PERIPHERAL)
-static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param) {
-    static struct bt_conn_info info;
-
-    bt_conn_get_info(conn, &info);
-
-    /* This captures a param change from central half of a split board connection
-       to stop default params from getting set over the top of our preferred ones */
-    if (info.role == BT_CONN_ROLE_MASTER && (param->interval_min != 6 || param->latency != 30)) {
-        return false;
-    }
-
-    return true;
-}
-#endif
-
 static struct bt_conn_cb conn_callbacks = {
     .connected = connected,
     .disconnected = disconnected,
     .security_changed = security_changed,
-#if !IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_ROLE_PERIPHERAL)
-    .le_param_req = le_param_req,
-#endif
 };
 
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)


### PR DESCRIPTION
This fixes the odd issue where a few seconds into the connection the central would get a request to reset back to default connection parameters.

The last fix intercepted all requests and denied them unless they were 7.5ms. That was more of a band-aid fix for something that we didn't know why it was happening. 

This is tested working on my Lily58. I don't see any issues with disabling `BT_GAP_AUTO_UPDATE_CONN_PARAMS`.