### PR TITLE
nRFMicro: Charger issue. Use correct macro for board

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,4 +1,3 @@
-# Find Zephyr. This also loads Zephyr's build system.
 cmake_minimum_required(VERSION 3.13.1)
 
 set(CONFIG_APPLICATION_DEFINED_SYSCALL true)
@@ -15,6 +14,7 @@ list(APPEND SYSCALL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/drivers/zephyr)
 
 include(cmake/zmk_config.cmake)
 
+# Find Zephyr. This also loads Zephyr's build system.
 find_package(Zephyr REQUIRED HINTS ../zephyr)
 project(zmk)
 

--- a/app/boards/arm/nrfmicro/pinmux.c
+++ b/app/boards/arm/nrfmicro/pinmux.c
@@ -17,7 +17,7 @@ static int pinmux_nrfmicro_init(struct device *port)
 
 	struct device *p1 = device_get_binding("GPIO_1");
 
-#if defined(BOARD_NRFMICRO_13)
+#if CONFIG_BOARD_NRFMICRO_13
 	struct device *p0 = device_get_binding("GPIO_0");
 	// enable EXT_VCC (use 0 for nRFMicro 1.3, use 1 for nRFMicro 1.1)
 	gpio_pin_configure(p1, 9, GPIO_OUTPUT);


### PR DESCRIPTION
The macro defined for board has CONFIG_ prefix which is missing in code and hence skips some initialization code for nrfmicro 1.3
Found this issue while verifying the software charger.

Verified the fix by testing the battery voltage