### PR TITLE
fix(actions): timeout stuck cache west modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Cache west modules
         timeout-minutes: 2
+        continue-on-error: true
         uses: actions/cache@v2
         env:
           cache-name: cache-zephyr-modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache west modules
+        timeout-minutes: 2
         uses: actions/cache@v2
         env:
           cache-name: cache-zephyr-modules


### PR DESCRIPTION
This will cancel runs that get stuck on the cache west modules step. The issue here is that GitHub Actions doesn't support auto re-runs yet... https://github.community/t/how-to-retry-a-build-that-failed/16297