### PR TITLE
Add KConfig for board battery charger

### DIFF
--- a/app/boards/arm/nrfmicro/Kconfig
+++ b/app/boards/arm/nrfmicro/Kconfig
@@ -3,3 +3,8 @@ config BOARD_ENABLE_DCDC
 	select SOC_DCDC_NRF52X
 	default y
 	depends on (BOARD_NRFMICRO_11 || BOARD_NRFMICRO_11_FLIPPED || BOARD_NRFMICRO_13)
+
+config BOARD_ENABLE_CHARGER
+	bool "Enable battery charger"
+	default y
+	depends on (BOARD_NRFMICRO_13)

--- a/app/boards/arm/nrfmicro/Kconfig.defconfig
+++ b/app/boards/arm/nrfmicro/Kconfig.defconfig
@@ -29,5 +29,12 @@ config ZMK_USB
 
 config PINMUX
 	default y
-	
+
+if BOARD_NRFMICRO_13
+
+config BOARD_ENABLE_CHARGER
+	default y
+
+endif # BOARD_NRFMICRO_13
+
 endif # BOARD_NRFMICRO_11 || BOARD_NRFMICRO_11_FLIPPED || BOARD_NRFMICRO_13

--- a/app/boards/arm/nrfmicro/pinmux.c
+++ b/app/boards/arm/nrfmicro/pinmux.c
@@ -23,9 +23,13 @@ static int pinmux_nrfmicro_init(struct device *port)
 	gpio_pin_configure(p1, 9, GPIO_OUTPUT);
 	gpio_pin_set(p1, 9, 0);
 
-	// enable charger (nRFMicro 1.3 only)
+#if CONFIG_BOARD_ENABLE_CHARGER
 	gpio_pin_configure(p0, 5, GPIO_OUTPUT);
 	gpio_pin_set(p0, 5, 0);
+#else
+	gpio_pin_configure(p0, 5, GPIO_INPUT);
+#endif
+
 #else
     // enable EXT_VCC (use 0 for nRFMicro 1.3, use 1 for nRFMicro 1.1)
 	gpio_pin_configure(p1, 9, GPIO_OUTPUT);


### PR DESCRIPTION
As in the description. added new Kconfig.
I am not sure whether I have added in all the places required. Please let me know if anything is missing

I have verified the charger enable/disable with nRFMicro 1.3. 
Also verified this config is not visible in nRFMicro 1.1