### PR TITLE
[docs] Add bzip to deps

### DIFF
--- a/docs/docs/dev-setup.md
+++ b/docs/docs/dev-setup.md
@@ -52,6 +52,7 @@ sudo apt install -y \
 	autoconf \
 	automake \
 	build-essential \
+        bzip2 \
 	ccache \
 	device-tree-compiler \
 	dfu-util \
@@ -91,6 +92,7 @@ sudo apt install -y \
 	autoconf \
 	automake \
 	build-essential \
+        bzip2 \
 	ccache \
 	device-tree-compiler \
 	dfu-util \
@@ -130,6 +132,7 @@ sudo dnf install -y \
 	wget \
 	autoconf \
 	automake \
+        bzip2 \
 	ccache \
 	dtc \
 	dfu-util \


### PR DESCRIPTION
closes #120 

This explicitly adds bzip to the dependencies lists in the documentation. 