### PR TITLE
stop on fatal errors

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -56,3 +56,5 @@ target_sources_ifdef(CONFIG_ZMK_RGB_UNDERGLOW app PRIVATE src/rgb_underglow.c)
 target_sources(app PRIVATE src/endpoints.c)
 target_sources(app PRIVATE src/hid_listener.c)
 target_sources(app PRIVATE src/main.c)
+
+zephyr_cc_option(-Wfatal-errors)


### PR DESCRIPTION
This stops the GCC compiler on the first encountered error, so users don't have to wade through pages of macro failures to find their typo.