### PR TITLE
Add timestamps to position and behavior events

### DIFF
--- a/app/include/drivers/behavior.h
+++ b/app/include/drivers/behavior.h
@@ -20,7 +20,7 @@
  */
 
 typedef int (*behavior_keymap_binding_callback_t)(struct device *dev, u32_t position, u32_t param1,
-                                                  u32_t param2);
+                                                  u32_t param2, s64_t timestamp);
 typedef int (*behavior_sensor_keymap_binding_callback_t)(struct device *dev, struct device *sensor,
                                                          u32_t param1, u32_t param2);
 
@@ -43,17 +43,18 @@ __subsystem struct behavior_driver_api {
  * @retval Negative errno code if failure.
  */
 __syscall int behavior_keymap_binding_pressed(struct device *dev, u32_t position, u32_t param1,
-                                              u32_t param2);
+                                              u32_t param2, s64_t timestamp);
 
 static inline int z_impl_behavior_keymap_binding_pressed(struct device *dev, u32_t position,
-                                                         u32_t param1, u32_t param2) {
+                                                         u32_t param1, u32_t param2,
+                                                         s64_t timestamp) {
     const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->driver_api;
 
     if (api->binding_pressed == NULL) {
         return -ENOTSUP;
     }
 
-    return api->binding_pressed(dev, position, param1, param2);
+    return api->binding_pressed(dev, position, param1, param2, timestamp);
 }
 
 /**
@@ -65,17 +66,18 @@ static inline int z_impl_behavior_keymap_binding_pressed(struct device *dev, u32
  * @retval Negative errno code if failure.
  */
 __syscall int behavior_keymap_binding_released(struct device *dev, u32_t position, u32_t param1,
-                                               u32_t param2);
+                                               u32_t param2, s64_t timestamp);
 
 static inline int z_impl_behavior_keymap_binding_released(struct device *dev, u32_t position,
-                                                          u32_t param1, u32_t param2) {
+                                                          u32_t param1, u32_t param2,
+                                                          s64_t timestamp) {
     const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->driver_api;
 
     if (api->binding_released == NULL) {
         return -ENOTSUP;
     }
 
-    return api->binding_released(dev, position, param1, param2);
+    return api->binding_released(dev, position, param1, param2, timestamp);
 }
 
 /**

--- a/app/include/drivers/behavior.h
+++ b/app/include/drivers/behavior.h
@@ -10,6 +10,7 @@
 #include <stddef.h>
 #include <device.h>
 #include <zmk/keys.h>
+#include <zmk/behavior.h>
 
 /**
  * @cond INTERNAL_HIDDEN
@@ -19,10 +20,10 @@
  * (Internal use only.)
  */
 
-typedef int (*behavior_keymap_binding_callback_t)(struct device *dev, u32_t position, u32_t param1,
-                                                  u32_t param2, s64_t timestamp);
-typedef int (*behavior_sensor_keymap_binding_callback_t)(struct device *dev, struct device *sensor,
-                                                         u32_t param1, u32_t param2);
+typedef int (*behavior_keymap_binding_callback_t)(struct zmk_behavior_binding *binding,
+                                                  struct zmk_behavior_binding_event event);
+typedef int (*behavior_sensor_keymap_binding_callback_t)(struct zmk_behavior_binding *binding,
+                                                         struct device *sensor);
 
 __subsystem struct behavior_driver_api {
     behavior_keymap_binding_callback_t binding_pressed;
@@ -42,19 +43,19 @@ __subsystem struct behavior_driver_api {
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-__syscall int behavior_keymap_binding_pressed(struct device *dev, u32_t position, u32_t param1,
-                                              u32_t param2, s64_t timestamp);
+__syscall int behavior_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                              struct zmk_behavior_binding_event event);
 
-static inline int z_impl_behavior_keymap_binding_pressed(struct device *dev, u32_t position,
-                                                         u32_t param1, u32_t param2,
-                                                         s64_t timestamp) {
+static inline int z_impl_behavior_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                                         struct zmk_behavior_binding_event event) {
+    struct device *dev = device_get_binding(binding->behavior_dev);
     const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->driver_api;
 
     if (api->binding_pressed == NULL) {
         return -ENOTSUP;
     }
 
-    return api->binding_pressed(dev, position, param1, param2, timestamp);
+    return api->binding_pressed(binding, event);
 }
 
 /**
@@ -65,19 +66,19 @@ static inline int z_impl_behavior_keymap_binding_pressed(struct device *dev, u32
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-__syscall int behavior_keymap_binding_released(struct device *dev, u32_t position, u32_t param1,
-                                               u32_t param2, s64_t timestamp);
+__syscall int behavior_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                               struct zmk_behavior_binding_event event);
 
-static inline int z_impl_behavior_keymap_binding_released(struct device *dev, u32_t position,
-                                                          u32_t param1, u32_t param2,
-                                                          s64_t timestamp) {
+static inline int z_impl_behavior_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                                          struct zmk_behavior_binding_event event) {
+    struct device *dev = device_get_binding(binding->behavior_dev);
     const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->driver_api;
 
     if (api->binding_released == NULL) {
         return -ENOTSUP;
     }
 
-    return api->binding_released(dev, position, param1, param2, timestamp);
+    return api->binding_released(binding, event);
 }
 
 /**
@@ -90,19 +91,20 @@ static inline int z_impl_behavior_keymap_binding_released(struct device *dev, u3
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-__syscall int behavior_sensor_keymap_binding_triggered(struct device *dev, struct device *sensor,
-                                                       u32_t param1, u32_t param2);
+__syscall int behavior_sensor_keymap_binding_triggered(struct zmk_behavior_binding *binding,
+                                                       struct device *sensor);
 
-static inline int z_impl_behavior_sensor_keymap_binding_triggered(struct device *dev,
-                                                                  struct device *sensor,
-                                                                  u32_t param1, u32_t param2) {
+static inline int
+z_impl_behavior_sensor_keymap_binding_triggered(struct zmk_behavior_binding *binding,
+                                                struct device *sensor) {
+    struct device *dev = device_get_binding(binding->behavior_dev);
     const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->driver_api;
 
     if (api->sensor_binding_triggered == NULL) {
         return -ENOTSUP;
     }
 
-    return api->sensor_binding_triggered(dev, sensor, param1, param2);
+    return api->sensor_binding_triggered(binding, sensor);
 }
 
 /**

--- a/app/include/zmk/behavior.h
+++ b/app/include/zmk/behavior.h
@@ -11,3 +11,9 @@ struct zmk_behavior_binding {
     u32_t param1;
     u32_t param2;
 };
+
+struct zmk_behavior_binding_event {
+    int layer;
+    u32_t position;
+    s64_t timestamp;
+};

--- a/app/include/zmk/events/keycode-state-changed.h
+++ b/app/include/zmk/events/keycode-state-changed.h
@@ -14,16 +14,20 @@ struct keycode_state_changed {
     u8_t usage_page;
     u32_t keycode;
     bool state;
+    u32_t position;
+    s32_t timestamp;
 };
 
 ZMK_EVENT_DECLARE(keycode_state_changed);
 
 inline struct keycode_state_changed *create_keycode_state_changed(u8_t usage_page, u32_t keycode,
-                                                                  bool state) {
+                                                                  bool state, s32_t position,
+                                                                  s32_t timestamp) {
     struct keycode_state_changed *ev = new_keycode_state_changed();
     ev->usage_page = usage_page;
     ev->keycode = keycode;
     ev->state = state;
-
+    ev->position = position;
+    ev->timestamp = timestamp;
     return ev;
 }

--- a/app/include/zmk/events/keycode-state-changed.h
+++ b/app/include/zmk/events/keycode-state-changed.h
@@ -14,20 +14,15 @@ struct keycode_state_changed {
     u8_t usage_page;
     u32_t keycode;
     bool state;
-    u32_t position;
-    s32_t timestamp;
 };
 
 ZMK_EVENT_DECLARE(keycode_state_changed);
 
 inline struct keycode_state_changed *create_keycode_state_changed(u8_t usage_page, u32_t keycode,
-                                                                  bool state, s32_t position,
-                                                                  s32_t timestamp) {
+                                                                  bool state) {
     struct keycode_state_changed *ev = new_keycode_state_changed();
     ev->usage_page = usage_page;
     ev->keycode = keycode;
     ev->state = state;
-    ev->position = position;
-    ev->timestamp = timestamp;
     return ev;
 }

--- a/app/include/zmk/events/position-state-changed.h
+++ b/app/include/zmk/events/position-state-changed.h
@@ -13,6 +13,7 @@ struct position_state_changed {
     struct zmk_event_header header;
     u32_t position;
     bool state;
+    s64_t timestamp;
 };
 
 ZMK_EVENT_DECLARE(position_state_changed);

--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -11,4 +11,4 @@ int zmk_keymap_layer_activate(u8_t layer);
 int zmk_keymap_layer_deactivate(u8_t layer);
 int zmk_keymap_layer_toggle(u8_t layer);
 
-int zmk_keymap_position_state_changed(u32_t position, bool pressed);
+int zmk_keymap_position_state_changed(u32_t position, bool pressed, s64_t timestamp);

--- a/app/src/behaviors/behavior_bt.c
+++ b/app/src/behaviors/behavior_bt.c
@@ -18,7 +18,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include <zmk/ble.h>
 
-static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t command, u32_t arg) {
+static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t command, u32_t arg, s64_t timestamp) {
     switch (command) {
     case BT_CLR_CMD:
         return zmk_ble_clear_bonds();
@@ -38,7 +38,7 @@ static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t c
 static int behavior_bt_init(struct device *dev) { return 0; };
 
 static int on_keymap_binding_released(struct device *dev, u32_t position, u32_t command,
-                                      u32_t arg) {
+                                      u32_t arg, s64_t timestamp) {
     return 0;
 }
 

--- a/app/src/behaviors/behavior_bt.c
+++ b/app/src/behaviors/behavior_bt.c
@@ -8,18 +8,18 @@
 
 #include <device.h>
 #include <drivers/behavior.h>
-
 #include <dt-bindings/zmk/bt.h>
-
 #include <bluetooth/conn.h>
-
 #include <logging/log.h>
+#include <zmk/behavior.h>
+
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include <zmk/ble.h>
 
-static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t command, u32_t arg, s64_t timestamp) {
-    switch (command) {
+static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
+    switch (binding->param1) {
     case BT_CLR_CMD:
         return zmk_ble_clear_bonds();
     case BT_NXT_CMD:
@@ -27,9 +27,9 @@ static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t c
     case BT_PRV_CMD:
         return zmk_ble_prof_prev();
     case BT_SEL_CMD:
-        return zmk_ble_prof_select(arg);
+        return zmk_ble_prof_select(binding->param2);
     default:
-        LOG_ERR("Unknown BT command: %d", command);
+        LOG_ERR("Unknown BT command: %d", binding->param1);
     }
 
     return -ENOTSUP;
@@ -37,8 +37,8 @@ static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t c
 
 static int behavior_bt_init(struct device *dev) { return 0; };
 
-static int on_keymap_binding_released(struct device *dev, u32_t position, u32_t command,
-                                      u32_t arg, s64_t timestamp) {
+static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
     return 0;
 }
 

--- a/app/src/behaviors/behavior_key_press.c
+++ b/app/src/behaviors/behavior_key_press.c
@@ -22,18 +22,22 @@ struct behavior_key_press_data {};
 
 static int behavior_key_press_init(struct device *dev) { return 0; };
 
-static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t keycode, u32_t _) {
+static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t keycode, u32_t _,
+                                     s64_t timestamp) {
     const struct behavior_key_press_config *cfg = dev->config_info;
     LOG_DBG("position %d usage_page 0x%02X keycode 0x%02X", position, cfg->usage_page, keycode);
 
-    return ZMK_EVENT_RAISE(create_keycode_state_changed(cfg->usage_page, keycode, true));
+    return ZMK_EVENT_RAISE(
+        create_keycode_state_changed(cfg->usage_page, keycode, true, position, timestamp));
 }
 
-static int on_keymap_binding_released(struct device *dev, u32_t position, u32_t keycode, u32_t _) {
+static int on_keymap_binding_released(struct device *dev, u32_t position, u32_t keycode, u32_t _,
+                                      s64_t timestamp) {
     const struct behavior_key_press_config *cfg = dev->config_info;
     LOG_DBG("position %d usage_page 0x%02X keycode 0x%02X", position, cfg->usage_page, keycode);
 
-    return ZMK_EVENT_RAISE(create_keycode_state_changed(cfg->usage_page, keycode, false));
+    return ZMK_EVENT_RAISE(
+        create_keycode_state_changed(cfg->usage_page, keycode, false, position, timestamp));
 }
 
 static const struct behavior_driver_api behavior_key_press_driver_api = {

--- a/app/src/behaviors/behavior_key_press.c
+++ b/app/src/behaviors/behavior_key_press.c
@@ -12,6 +12,7 @@
 
 #include <zmk/event-manager.h>
 #include <zmk/events/keycode-state-changed.h>
+#include <zmk/behavior.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
@@ -22,22 +23,24 @@ struct behavior_key_press_data {};
 
 static int behavior_key_press_init(struct device *dev) { return 0; };
 
-static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t keycode, u32_t _,
-                                     s64_t timestamp) {
+static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
+    struct device *dev = device_get_binding(binding->behavior_dev);
     const struct behavior_key_press_config *cfg = dev->config_info;
-    LOG_DBG("position %d usage_page 0x%02X keycode 0x%02X", position, cfg->usage_page, keycode);
+    LOG_DBG("position %d usage_page 0x%02X keycode 0x%02X", event.position, cfg->usage_page,
+            binding->param1);
 
-    return ZMK_EVENT_RAISE(
-        create_keycode_state_changed(cfg->usage_page, keycode, true, position, timestamp));
+    return ZMK_EVENT_RAISE(create_keycode_state_changed(cfg->usage_page, binding->param1, true));
 }
 
-static int on_keymap_binding_released(struct device *dev, u32_t position, u32_t keycode, u32_t _,
-                                      s64_t timestamp) {
+static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
+    struct device *dev = device_get_binding(binding->behavior_dev);
     const struct behavior_key_press_config *cfg = dev->config_info;
-    LOG_DBG("position %d usage_page 0x%02X keycode 0x%02X", position, cfg->usage_page, keycode);
+    LOG_DBG("position %d usage_page 0x%02X keycode 0x%02X", event.position, cfg->usage_page,
+            binding->param1);
 
-    return ZMK_EVENT_RAISE(
-        create_keycode_state_changed(cfg->usage_page, keycode, false, position, timestamp));
+    return ZMK_EVENT_RAISE(create_keycode_state_changed(cfg->usage_page, binding->param1, false));
 }
 
 static const struct behavior_driver_api behavior_key_press_driver_api = {

--- a/app/src/behaviors/behavior_momentary_layer.c
+++ b/app/src/behaviors/behavior_momentary_layer.c
@@ -19,15 +19,15 @@ struct behavior_mo_data {};
 
 static int behavior_mo_init(struct device *dev) { return 0; };
 
-static int mo_keymap_binding_pressed(struct device *dev, u32_t position, u32_t layer, u32_t _) {
+static int mo_keymap_binding_pressed(struct device *dev, u32_t position, u32_t layer, u32_t _,
+                                     s64_t _timestamp) {
     LOG_DBG("position %d layer %d", position, layer);
-
     return zmk_keymap_layer_activate(layer);
 }
 
-static int mo_keymap_binding_released(struct device *dev, u32_t position, u32_t layer, u32_t _) {
+static int mo_keymap_binding_released(struct device *dev, u32_t position, u32_t layer, u32_t _,
+                                      s64_t _timestamp) {
     LOG_DBG("position %d layer %d", position, layer);
-
     return zmk_keymap_layer_deactivate(layer);
 }
 

--- a/app/src/behaviors/behavior_momentary_layer.c
+++ b/app/src/behaviors/behavior_momentary_layer.c
@@ -11,6 +11,7 @@
 #include <logging/log.h>
 
 #include <zmk/keymap.h>
+#include <zmk/behavior.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
@@ -19,16 +20,16 @@ struct behavior_mo_data {};
 
 static int behavior_mo_init(struct device *dev) { return 0; };
 
-static int mo_keymap_binding_pressed(struct device *dev, u32_t position, u32_t layer, u32_t _,
-                                     s64_t _timestamp) {
-    LOG_DBG("position %d layer %d", position, layer);
-    return zmk_keymap_layer_activate(layer);
+static int mo_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
+    LOG_DBG("position %d layer %d", event.position, binding->param1);
+    return zmk_keymap_layer_activate(binding->param1);
 }
 
-static int mo_keymap_binding_released(struct device *dev, u32_t position, u32_t layer, u32_t _,
-                                      s64_t _timestamp) {
-    LOG_DBG("position %d layer %d", position, layer);
-    return zmk_keymap_layer_deactivate(layer);
+static int mo_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
+    LOG_DBG("position %d layer %d", event.position, binding->param1);
+    return zmk_keymap_layer_deactivate(binding->param1);
 }
 
 static const struct behavior_driver_api behavior_mo_driver_api = {

--- a/app/src/behaviors/behavior_none.c
+++ b/app/src/behaviors/behavior_none.c
@@ -19,12 +19,12 @@ struct behavior_none_data {};
 static int behavior_none_init(struct device *dev) { return 0; };
 
 static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t _param1,
-                                     u32_t _param2) {
+                                     u32_t _param2, s64_t _timestamp) {
     return 0;
 }
 
 static int on_keymap_binding_released(struct device *dev, u32_t position, u32_t _param1,
-                                      u32_t _param2) {
+                                      u32_t _param2, s64_t _timestamp) {
     return 0;
 }
 

--- a/app/src/behaviors/behavior_none.c
+++ b/app/src/behaviors/behavior_none.c
@@ -11,6 +11,8 @@
 #include <drivers/behavior.h>
 #include <logging/log.h>
 
+#include <zmk/behavior.h>
+
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 struct behavior_none_config {};
@@ -18,13 +20,13 @@ struct behavior_none_data {};
 
 static int behavior_none_init(struct device *dev) { return 0; };
 
-static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t _param1,
-                                     u32_t _param2, s64_t _timestamp) {
+static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
     return 0;
 }
 
-static int on_keymap_binding_released(struct device *dev, u32_t position, u32_t _param1,
-                                      u32_t _param2, s64_t _timestamp) {
+static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
     return 0;
 }
 

--- a/app/src/behaviors/behavior_reset.c
+++ b/app/src/behaviors/behavior_reset.c
@@ -20,7 +20,7 @@ struct behavior_reset_config {
 static int behavior_reset_init(struct device *dev) { return 0; };
 
 static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t _param1,
-                                     u32_t _param2) {
+                                     u32_t _param2, s64_t _timestamp) {
     const struct behavior_reset_config *cfg = dev->config_info;
 
     // TODO: Correct magic code for going into DFU?

--- a/app/src/behaviors/behavior_reset.c
+++ b/app/src/behaviors/behavior_reset.c
@@ -11,6 +11,8 @@
 #include <drivers/behavior.h>
 #include <logging/log.h>
 
+#include <zmk/behavior.h>
+
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 struct behavior_reset_config {
@@ -19,8 +21,9 @@ struct behavior_reset_config {
 
 static int behavior_reset_init(struct device *dev) { return 0; };
 
-static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t _param1,
-                                     u32_t _param2, s64_t _timestamp) {
+static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
+    struct device *dev = device_get_binding(binding->behavior_dev);
     const struct behavior_reset_config *cfg = dev->config_info;
 
     // TODO: Correct magic code for going into DFU?

--- a/app/src/behaviors/behavior_rgb_underglow.c
+++ b/app/src/behaviors/behavior_rgb_underglow.c
@@ -17,7 +17,8 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 static int behavior_rgb_underglow_init(struct device *dev) { return 0; }
 
-static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t action, u32_t _) {
+static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t action, u32_t _,
+                                     s64_t _timestamp) {
     switch (action) {
     case RGB_TOG:
         return zmk_rgb_underglow_toggle();

--- a/app/src/behaviors/behavior_rgb_underglow.c
+++ b/app/src/behaviors/behavior_rgb_underglow.c
@@ -12,14 +12,15 @@
 
 #include <dt-bindings/zmk/rgb.h>
 #include <zmk/rgb_underglow.h>
+#include <zmk/keymap.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 static int behavior_rgb_underglow_init(struct device *dev) { return 0; }
 
-static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t action, u32_t _,
-                                     s64_t _timestamp) {
-    switch (action) {
+static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
+    switch (binding->param1) {
     case RGB_TOG:
         return zmk_rgb_underglow_toggle();
     case RGB_HUI:

--- a/app/src/behaviors/behavior_sensor_rotate_key_press.c
+++ b/app/src/behaviors/behavior_sensor_rotate_key_press.c
@@ -23,15 +23,16 @@ struct behavior_sensor_rotate_key_press_data {};
 
 static int behavior_sensor_rotate_key_press_init(struct device *dev) { return 0; };
 
-static int on_sensor_binding_triggered(struct device *dev, struct device *sensor,
-                                       u32_t increment_keycode, u32_t decrement_keycode) {
+static int on_sensor_binding_triggered(struct zmk_behavior_binding *binding,
+                                       struct device *sensor) {
+    struct device *dev = device_get_binding(binding->behavior_dev);
     const struct behavior_sensor_rotate_key_press_config *cfg = dev->config_info;
     struct sensor_value value;
     int err;
     u32_t keycode;
     struct keycode_state_changed *ev;
     LOG_DBG("usage_page 0x%02X inc keycode 0x%02X dec keycode 0x%02X", cfg->usage_page,
-            increment_keycode, decrement_keycode);
+            binding->param1, binding->param2);
 
     err = sensor_channel_get(sensor, SENSOR_CHAN_ROTATION, &value);
 
@@ -42,10 +43,10 @@ static int on_sensor_binding_triggered(struct device *dev, struct device *sensor
 
     switch (value.val1) {
     case 1:
-        keycode = increment_keycode;
+        keycode = binding->param1;
         break;
     case -1:
-        keycode = decrement_keycode;
+        keycode = binding->param2;
         break;
     default:
         return -ENOTSUP;

--- a/app/src/behaviors/behavior_toggle_layer.c
+++ b/app/src/behaviors/behavior_toggle_layer.c
@@ -19,15 +19,15 @@ struct behavior_tog_data {};
 
 static int behavior_tog_init(struct device *dev) { return 0; };
 
-static int tog_keymap_binding_pressed(struct device *dev, u32_t position, u32_t layer, u32_t _) {
+static int tog_keymap_binding_pressed(struct device *dev, u32_t position, u32_t layer, u32_t _,
+                                      s64_t _timestamp) {
     LOG_DBG("position %d layer %d", position, layer);
-
     return zmk_keymap_layer_toggle(layer);
 }
 
-static int tog_keymap_binding_released(struct device *dev, u32_t position, u32_t layer, u32_t _) {
+static int tog_keymap_binding_released(struct device *dev, u32_t position, u32_t layer, u32_t _,
+                                       s64_t _timestamp) {
     LOG_DBG("position %d layer %d", position, layer);
-
     return 0;
 }
 

--- a/app/src/behaviors/behavior_toggle_layer.c
+++ b/app/src/behaviors/behavior_toggle_layer.c
@@ -11,6 +11,7 @@
 #include <logging/log.h>
 
 #include <zmk/keymap.h>
+#include <zmk/behavior.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
@@ -19,15 +20,15 @@ struct behavior_tog_data {};
 
 static int behavior_tog_init(struct device *dev) { return 0; };
 
-static int tog_keymap_binding_pressed(struct device *dev, u32_t position, u32_t layer, u32_t _,
-                                      s64_t _timestamp) {
-    LOG_DBG("position %d layer %d", position, layer);
-    return zmk_keymap_layer_toggle(layer);
+static int tog_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
+    LOG_DBG("position %d layer %d", event.position, binding->param1);
+    return zmk_keymap_layer_toggle(binding->param1);
 }
 
-static int tog_keymap_binding_released(struct device *dev, u32_t position, u32_t layer, u32_t _,
-                                       s64_t _timestamp) {
-    LOG_DBG("position %d layer %d", position, layer);
+static int tog_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                       struct zmk_behavior_binding_event event) {
+    LOG_DBG("position %d layer %d", event.position, binding->param1);
     return 0;
 }
 

--- a/app/src/behaviors/behavior_transparent.c
+++ b/app/src/behaviors/behavior_transparent.c
@@ -19,12 +19,12 @@ struct behavior_transparent_data {};
 static int behavior_transparent_init(struct device *dev) { return 0; };
 
 static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t _param1,
-                                     u32_t _param2) {
+                                     u32_t _param2, s64_t _timestamp) {
     return 1;
 }
 
 static int on_keymap_binding_released(struct device *dev, u32_t position, u32_t _param1,
-                                      u32_t _param2) {
+                                      u32_t _param2, s64_t _timestamp) {
     return 1;
 }
 

--- a/app/src/behaviors/behavior_transparent.c
+++ b/app/src/behaviors/behavior_transparent.c
@@ -11,6 +11,8 @@
 #include <drivers/behavior.h>
 #include <logging/log.h>
 
+#include <zmk/behavior.h>
+
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 struct behavior_transparent_config {};
@@ -18,13 +20,13 @@ struct behavior_transparent_data {};
 
 static int behavior_transparent_init(struct device *dev) { return 0; };
 
-static int on_keymap_binding_pressed(struct device *dev, u32_t position, u32_t _param1,
-                                     u32_t _param2, s64_t _timestamp) {
+static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
     return 1;
 }
 
-static int on_keymap_binding_released(struct device *dev, u32_t position, u32_t _param1,
-                                      u32_t _param2, s64_t _timestamp) {
+static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
     return 1;
 }
 

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -107,6 +107,11 @@ bool is_active_layer(u8_t layer, u32_t layer_state) {
 int zmk_keymap_apply_position_state(int layer, u32_t position, bool pressed, s64_t timestamp) {
     struct zmk_behavior_binding *binding = &zmk_keymap[layer][position];
     struct device *behavior;
+    struct zmk_behavior_binding_event event = {
+        .layer = layer,
+        .position = position,
+        .timestamp = timestamp,
+    };
 
     LOG_DBG("layer: %d position: %d, binding name: %s", layer, position,
             log_strdup(binding->behavior_dev));
@@ -119,11 +124,9 @@ int zmk_keymap_apply_position_state(int layer, u32_t position, bool pressed, s64
     }
 
     if (pressed) {
-        return behavior_keymap_binding_pressed(behavior, position, binding->param1, binding->param2,
-                                               timestamp);
+        return behavior_keymap_binding_pressed(binding, event);
     } else {
-        return behavior_keymap_binding_released(behavior, position, binding->param1,
-                                                binding->param2, timestamp);
+        return behavior_keymap_binding_released(binding, event);
     }
 }
 
@@ -171,8 +174,7 @@ int zmk_keymap_sensor_triggered(u8_t sensor_number, struct device *sensor) {
                 continue;
             }
 
-            ret = behavior_sensor_keymap_binding_triggered(behavior, sensor, binding->param1,
-                                                           binding->param2);
+            ret = behavior_sensor_keymap_binding_triggered(binding, sensor);
 
             if (ret > 0) {
                 LOG_DBG("behavior processing to continue to next layer");

--- a/app/src/kscan.c
+++ b/app/src/kscan.c
@@ -52,6 +52,7 @@ void zmk_kscan_process_msgq(struct k_work *item) {
         pos_ev = new_position_state_changed();
         pos_ev->state = pressed;
         pos_ev->position = position;
+        pos_ev->timestamp = k_uptime_get();
         ZMK_EVENT_RAISE(pos_ev);
     }
 }

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -60,6 +60,7 @@ static u8_t split_central_notify_func(struct bt_conn *conn, struct bt_gatt_subsc
                 struct position_state_changed *pos_ev = new_position_state_changed();
                 pos_ev->position = position;
                 pos_ev->state = pressed;
+                pos_ev->timestamp = k_uptime_get();
 
                 LOG_DBG("Trigger key position state change for %d", position);
                 ZMK_EVENT_RAISE(pos_ev);

--- a/app/tests/hold-tap/balanced/many-nested/events.patterns
+++ b/app/tests/hold-tap/balanced/many-nested/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/balanced/many-nested/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced/many-nested/keycode_events.snapshot
@@ -1,0 +1,20 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold (balanced event 3)
+kp_pressed: usage_page 0x07 keycode 0xe1
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided hold (balanced event 3)
+kp_pressed: usage_page 0x07 keycode 0xe0
+ht_binding_pressed: 2 new undecided hold_tap
+ht_binding_released: 0 cleaning up hold-tap
+ht_decide: 2 decided hold (balanced event 3)
+kp_pressed: usage_page 0x07 keycode 0xe3
+ht_binding_pressed: 3 new undecided hold_tap
+ht_binding_released: 1 cleaning up hold-tap
+ht_decide: 3 decided hold (balanced event 3)
+kp_pressed: usage_page 0x07 keycode 0xe2
+kp_released: usage_page 0x07 keycode 0xe1
+kp_released: usage_page 0x07 keycode 0xe0
+kp_released: usage_page 0x07 keycode 0xe3
+ht_binding_released: 2 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0xe2
+ht_binding_released: 3 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced/many-nested/native_posix.keymap
+++ b/app/tests/hold-tap/balanced/many-nested/native_posix.keymap
@@ -1,0 +1,41 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+
+/ {
+	behaviors {
+		ht_bal: behavior_hold_tap_balanced {
+			compatible = "zmk,behavior-hold-tap";
+			label = "HOLD_TAP_BALANCED";
+			#binding-cells = <2>;
+			flavor = "balanced";
+			tapping_term_ms = <300>;
+			bindings = <&kp>, <&kp>;
+		};
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&ht_bal LSFT F &ht_bal LCTL J 
+				&ht_bal LGUI H &ht_bal LALT L
+			>;
+		};
+	};
+};
+
+&kscan {
+	events = <
+	 	ZMK_MOCK_PRESS(0,0,100) 
+		ZMK_MOCK_PRESS(0,1,100) 
+		ZMK_MOCK_PRESS(1,0,100)
+		ZMK_MOCK_PRESS(1,1,100) 
+		ZMK_MOCK_RELEASE(0,0,100) 
+		ZMK_MOCK_RELEASE(0,1,100) 
+		ZMK_MOCK_RELEASE(1,0,100) 
+		ZMK_MOCK_RELEASE(1,1,100) 
+	>;
+};


### PR DESCRIPTION
When events are queued and later replayed, timing information is currently not preserved. This makes timings of things like nested hold-taps difficult. This PR adds timestamp information to position and behavior events, so timings of nested hold-taps can be handled properly. 

![image](https://user-images.githubusercontent.com/486179/91897790-1a16a880-ec9b-11ea-86bf-7eb1d46785f9.png)

previously, this would return hold for the first HT and tap for the other three. Now, all three hold-taps are enabled quickly after one another.

This makes homerow mods much easier to work with. Without this implementation, if you press ctrl+alt+shift TH mods at the same time, you have to wait for 3x the tapping term for all three mods to register. With this PR, you only wait for the tapping_term once!
