### PR TITLE
Fix Sofle build.

### DIFF
--- a/app/boards/shields/sofle/sofle.dtsi
+++ b/app/boards/shields/sofle/sofle.dtsi
@@ -50,6 +50,7 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
         a-gpios = <&pro_micro_a 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro_a 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         resolution = <4>;
+        status = "disabled";
     };
 
     right_encoder: encoder_right {
@@ -58,6 +59,7 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
         a-gpios = <&pro_micro_a 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro_a 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         resolution = <4>;
+        status = "disabled";
     };
 
     sensors {

--- a/docs/docs/feature/keymaps.md
+++ b/docs/docs/feature/keymaps.md
@@ -55,7 +55,7 @@ in the stack _also_ get the event.
 ## Behavior Bindings
 
 Binding a behavior at a certain key position may include up to two extra parameters that are used to
-alter the behavior when that specific key position is activated/deactived. For example, when binding
+alter the behavior when that specific key position is activated/deactivated. For example, when binding
 the "key press" (`kp`) behavior at a certain key position, you must specific _which_ keycode should
 be used for that key position.
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -32,7 +32,7 @@ include:
 - One Shot
 - Complete split support
 - Battery reporting
-- Low power mode
+- Low power sleep states
 - Shell over BLE
 - Macros
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -18,23 +18,21 @@ include:
 
 - HID Over GATT (HOG) - This is the official term for BLE HID devices
 - Keymaps and layers with basic keycodes
-- Mod-Tap
-- Layer Tap
+- Some initial work on one "behavior", Mod-Tap
 - Basic HID over USB
 - Basic consumer (media) keycodes.
 - Basic OLED display logic
 - Basic Split support
-- Basic RGB Underglow
 - Encoders
 
 ## Missing Features
 
 - One Shot
+- Layer Tap
 - Complete split support
 - Battery reporting
-- Low power sleep states
+- Low power mode
 - Shell over BLE
-- Macros
 
 ## Code Of Conduct
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -18,21 +18,23 @@ include:
 
 - HID Over GATT (HOG) - This is the official term for BLE HID devices
 - Keymaps and layers with basic keycodes
-- Some initial work on one "behavior", Mod-Tap
+- Mod-Tap
+- Layer Tap
 - Basic HID over USB
 - Basic consumer (media) keycodes.
 - Basic OLED display logic
 - Basic Split support
+- Basic RGB Underglow
 - Encoders
 
 ## Missing Features
 
 - One Shot
-- Layer Tap
 - Complete split support
 - Battery reporting
 - Low power mode
 - Shell over BLE
+- Macros
 
 ## Code Of Conduct
 


### PR DESCRIPTION
Got this error: https://github.com/CrossR/zmk_config/runs/1068763312 when enabling encoders in my config, and my assumption is that its because they default to `"okay"` and I set them to that in the l/r overlay, it was causing a conflict.

~~Whilst I was fixing this, updated the intro page to move bits around and add macros since I've seen a few people question if ZMK had them yet.~~ Backed out in favour of #159.