### PR TITLE
Add RoMac / non-split template support

### DIFF
--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -38,7 +38,7 @@ echo ""
 echo "Keyboard Shield Selection:"
 
 prompt="Pick an keyboard:"
-options=("Kyria" "Lily58" "Corne" "Splitreus62" "Sofle" "Iris")
+options=("Kyria" "Lily58" "Corne" "Splitreus62" "Sofle" "Iris" "RoMac")
 
 PS3="$prompt "
 # TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
@@ -53,6 +53,7 @@ select opt in "${options[@]}" "Quit"; do
     4 ) shield_title="Splitreus62" shield="splitreus62"; split="y"; break;;
     5 ) shield_title="Sofle" shield="sofle"; split="y"; break;;
     6 ) shield_title="Iris" shield="iris"; split="y"; break;;
+    7 ) shield_title="RoMac" shield="romac"; split="n"; break;;
 
     # Add link to docs on adding your own custom shield in your ZMK config!
     # $(( ${#options[@]}+1 )) ) echo "Other!"; break;; 
@@ -61,6 +62,10 @@ select opt in "${options[@]}" "Quit"; do
 
     esac
 done
+
+if [ "$split" == "n" ]; then
+    repo_path="https://github.com/bmcgavin/zmk-config-template.git"
+fi
 
 read -e -p "Copy in the stock keymap for customization? [Yn]: " copy_keymap
 

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -64,7 +64,7 @@ select opt in "${options[@]}" "Quit"; do
 done
 
 if [ "$split" == "n" ]; then
-    repo_path="https://github.com/bmcgavin/zmk-config-template.git"
+    repo_path="https://github.com/zmkfirmware/zmk-config-template.git"
 fi
 
 read -e -p "Copy in the stock keymap for customization? [Yn]: " copy_keymap


### PR DESCRIPTION
You will definitely want to clone this repo : https://github.com/bmcgavin/zmk-config-template and then remove the .git folder and push up to the zmkfirmware account - when this is done I can change this PR to point to the 'official' template repo.