### PR TITLE
Blank OLED after one second

### DIFF
--- a/app/src/display.c
+++ b/app/src/display.c
@@ -52,5 +52,11 @@ void zmk_display_task_handler()
 {
     lv_tick_inc(10);
     lv_task_handler();
-    k_sleep(K_MSEC(10));
+    k_sleep(K_MSEC(1000));
+    display = device_get_binding(ZMK_DISPLAY_NAME);
+    if (display == NULL) {
+        LOG_ERR("Failed to find display device");
+        return -EINVAL;
+    }
+    display_blanking_on(display);
 }

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -30,8 +30,8 @@ void main(void)
 #ifdef CONFIG_ZMK_DISPLAY
 	zmk_display_init();
 
-	while (1) {
+	//while (1) {
 		zmk_display_task_handler();
-	}
+	//}
 #endif /* CONFIG_ZMK_DISPLAY */
 }


### PR DESCRIPTION
Quick hack to blank the OLED after it displays the ZMK message for one second