### PR TITLE
Shell script tidy up.

### DIFF
--- a/docs/static/setup.ps1
+++ b/docs/static/setup.ps1
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The ZMK Contributors
+#
+# SPDX-License-Identifier: MIT
+
 $ErrorActionPreference = "Stop"
 
 function Get-Choice-From-Options {
@@ -10,7 +14,7 @@ function Get-Choice-From-Options {
         for ($i = 0; $i -lt $Options.length; $i++) {
             Write-Host "$($i + 1)) $($Options[$i])"
         }
-        
+
         Write-Host "$($Options.length + 1)) Quit"
         $selection = Read-Host $Prompt
 
@@ -103,7 +107,7 @@ if ($github_user -ne "") {
     }
 
     $github_repo = Read-Host "GitHub Repo [https://github.com/$github_user/$repo_name.git]"
-    
+
     if ($github_repo -eq "") {
         $github_repo = "https://github.com/$github_user/$repo_name.git"
     }

--- a/docs/static/setup.ps1
+++ b/docs/static/setup.ps1
@@ -1,0 +1,176 @@
+$ErrorActionPreference = "Stop"
+
+function Get-Choice-From-Options {
+    param(
+        [String[]] $Options,
+        [String] $Prompt
+    )
+
+    while ($true) {
+        for ($i = 0; $i -lt $Options.length; $i++) {
+            Write-Host "$($i + 1)) $($Options[$i])"
+        }
+        
+        Write-Host "$($Options.length + 1)) Quit"
+        $selection = Read-Host $Prompt
+
+        if ($selection -eq $Options.length + 1) {
+            Write-Host "Goodbye!"
+            exit
+        }
+        elseif ($selection -le $Options.length) {
+            $choice = $($selection - 1)
+            break
+        }
+        else {
+            Write-Host "Invalid Option. Try another one."
+        }
+    }
+
+    return $choice
+}
+
+function Test-Git-Config {
+    param(
+        [String] $Option,
+        [String] $ErrMsg
+    )
+
+    git config $Option | Out-Null
+
+    if ($lastExitCode -ne 0) {
+        Write-Host $ErrMsg
+        exit
+    }
+}
+
+try {
+    git | Out-Null
+}
+catch [System.Management.Automation.CommandNotFoundException] {
+    Write-Host "Git is not installed, and is required for this script!"
+    exit
+}
+
+Test-Git-Config -Option "user.name" -ErrMsg "Git username not set!`nRun: git config --global user.name 'My Name'"
+Test-Git-Config -Option "user.email" -ErrMsg "Git email not set!`nRun: git config --global user.name 'example@myemail.com'"
+
+$repo_path = "https://github.com/zmkfirmware/zmk-config-split-template.git"
+
+$title = "ZMK Config Setup:"
+$prompt = "Pick an MCU board"
+$options = "nice!nano", "QMK Proton-C", "BlueMicro840 (v1)"
+$boards = "nice_nano", "proton_c", "bluemicro840_v1"
+
+Write-Host "$title"
+Write-Host ""
+Write-Host "MCU Board Selection:"
+
+$choice = Get-Choice-From-Options -Options $options -Prompt $prompt
+$board = $($boards[$choice])
+
+Write-Host ""
+Write-Host "Keyboard Shield Selection:"
+$prompt = "Pick a keyboard"
+
+# TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
+$options = "Kyria", "Lily58", "Corne", "Splitreus62", "Sofle", "Iris", "RoMac"
+$names = "kyria", "lily58", "corne", "splitreus62", "sofle", "iris", "romac"
+$splits = "y", "y", "y", "y", "y", "y", "n"
+
+$choice = Get-Choice-From-Options -Options $options -Prompt $prompt
+$shield_title = $($options[$choice])
+$shield = $($names[$choice])
+$split = $($splits[$choice])
+
+if ($split -eq "n") {
+    $repo_path = "https://github.com/zmkfirmware/zmk-config-template.git"
+}
+
+$copy_keymap = Read-Host "Copy in the stock keymap for customisation? [Yn]"
+
+if ($copy_keymap -eq "" -or $copy_keymap -eq "Y" -or $copy_keymap -eq "y") {
+    $copy_keymap = "yes"
+}
+
+$github_user = Read-Host "GitHub Username (leave empty to skip GitHub repo creation)"
+
+if ($github_user -ne "") {
+    $repo_name = Read-Host "GitHub Repo Name [zmk-config]"
+
+    if ($repo_name -eq "") {
+        $repo_name = "zmk-config"
+    }
+
+    $github_repo = Read-Host "GitHub Repo [https://github.com/$github_user/$repo_name.git]"
+    
+    if ($github_repo -eq "") {
+        $github_repo = "https://github.com/$github_user/$repo_name.git"
+    }
+}
+else {
+    $repo_name = "zmk-config"
+    $github_repo = ""
+}
+
+Write-Host ""
+Write-Host "Preparing a user config for:"
+Write-Host "* MCU Board: ${board}"
+Write-Host "* Shield: ${shield}"
+
+if ($copy_keymap -eq "yes") {
+    Write-Host "* Copy Keymap?: Yes"
+}
+else {
+    Write-Host "* Copy Keymap?: No"
+}
+
+if ($github_repo -ne "") {
+    Write-Host "* GitHub Repo to Push (please create this in GH first!): $github_repo"
+}
+
+Write-Host ""
+$do_it = Read-Host "Continue? [Yn]"
+
+if ($do_it -ne "" -and $do_it -ne "Y" -and $do_it -ne "y") {
+    Write-Host "Aborting..."
+    exit
+}
+
+git clone --single-branch "$repo_path" "$repo_name"
+Set-Location "$repo_name"
+
+Push-Location config
+
+Invoke-RestMethod -Uri "https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/shields/${shield}/${shield}.conf" -OutFile "${shield}.conf"
+
+if ($copy_keymap -eq "yes") {
+    Invoke-RestMethod -Uri "https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/shields/${shield}/${shield}.keymap" -OutFile "${shield}.keymap"
+}
+
+Pop-Location
+
+$build_file = (Get-Content .github/workflows/build.yml).replace("BOARD_NAME", $board)
+$build_file = $build_file.replace("SHIELD_NAME", $shield)
+$build_file = $build_file.replace("KEYBOARD_TITLE", $shield_title)
+
+if ($board -eq "proton_c") {
+    $build_file = $build_file.replace("uf2", "hex")
+}
+
+Set-Content -Path .github/workflows/build.yml -Value $build_file
+
+Remove-Item -Recurse -Force .git
+git init .
+git add .
+git commit -m "Initial User Config."
+
+if ($github_repo -ne "") {
+    git remote add origin "$github_repo"
+    git push --set-upstream origin $(git symbolic-ref --short HEAD)
+
+    if ($github_repo -imatch "https") {
+        $actions = "$($github_repo.substring(0, $github_repo.length - 4))/actions"
+        Write-Host "Your firmware should be availalbe from the GitHub Actions shortly: $actions"
+    }
+}

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -1,14 +1,25 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
+CheckExists() {
+    command_to_run=$1
+    error_message=$2
+        
+    if ! eval "$command_to_run" &> /dev/null; then
+        printf "%s\n" "$error_message"
+        exit
+    fi
+}
+
+CheckExists "command -v git" "git is not installed, and is required for this script!"
+CheckExists "command -v curl" "curl is not installed, and is required for this script!"
+
+CheckExists "git config user.name" "Git username not set!\nRun: git config --global user.name 'My Name'"
+CheckExists "git config user.email" "Git email not set!\nRun: git config --global user.email 'example@myemail.com'"
+
 repo_path="https://github.com/zmkfirmware/zmk-config-split-template.git"
 title="ZMK Config Setup:"
-
-
-# TODO: Check for git being installed
-# TODO: Check for curl being installed
-# TODO: Check for user.name and user.email git configs being set
 
 prompt="Pick an MCU board:"
 options=("nice!nano" "QMK Proton-C" "BlueMicro840 (v1)")
@@ -30,9 +41,6 @@ select opt in "${options[@]}" "Quit"; do
 
     esac
 done
-
-#read -p "Is this board a complete keyboard [yN]: " complete
-#echo "$complete"
 
 echo ""
 echo "Keyboard Shield Selection:"
@@ -67,41 +75,43 @@ if [ "$split" == "n" ]; then
     repo_path="https://github.com/zmkfirmware/zmk-config-template.git"
 fi
 
-read -e -p "Copy in the stock keymap for customization? [Yn]: " copy_keymap
+read -r -e -p "Copy in the stock keymap for customization? [Yn]: " copy_keymap
 
 if [ -z "$copy_keymap" ] || [ "$copy_keymap" == "Y" ] || [ "$copy_keymap" == "y" ]; then copy_keymap="yes"; fi
 
-read -e -p "GitHub Username (leave empty to skip GitHub repo creation): " github_user
+read -r -e -p "GitHub Username (leave empty to skip GitHub repo creation): " github_user
 if [ -n "$github_user" ]; then
-	read -p "GitHub Repo Name [zmk-config]: " repo_name
-	if [ -z "$repo_name" ]; then repo_name="zmk-config"; fi
+    read -r -p "GitHub Repo Name [zmk-config]: " repo_name
+    if [ -z "$repo_name" ]; then repo_name="zmk-config"; fi
 
-	read -p "GitHub Repo [https://github.com/${github_user}/${repo_name}.git]: " github_repo
+    read -r -p "GitHub Repo [https://github.com/${github_user}/${repo_name}.git]: " github_repo
 
-	if [ -z "$github_repo" ]; then github_repo="https://github.com/${github_user}/${repo_name}.git"; fi
+    if [ -z "$github_repo" ]; then github_repo="https://github.com/${github_user}/${repo_name}.git"; fi
 else
-	repo_name="zmk-config"
+    repo_name="zmk-config"
 fi
 
 echo ""
 echo "Preparing a user config for:"
 echo "* MCU Board: ${board}"
 echo "* Shield: ${shield}"
+
 if [ "$copy_keymap" == "yes" ]; then
     echo "* Copy Keymap?: ✓"
 else
     echo "* Copy Keymap?: ❌"
 fi
+
 if [ -n "$github_repo" ]; then
-	echo "* GitHub Repo To Push (please create this in GH first!): ${github_repo}"
+    echo "* GitHub Repo To Push (please create this in GH first!): ${github_repo}"
 fi
 
 echo ""
-read -p "Continue? [Yn]: " do_it
+read -r -p "Continue? [Yn]: " do_it
 
 if [ -n "$do_it" ] && [ "$do_it" != "y" ] && [ "$do_it" != "Y" ]; then
-	echo "Aborting..."
-	exit
+    echo "Aborting..."
+    exit
 fi
 
 git clone --single-branch $repo_path ${repo_name}
@@ -118,10 +128,10 @@ fi
 popd
 
 sed -i'.orig' \
-	-e "s/BOARD_NAME/$board/" \
-	-e "s/SHIELD_NAME/$shield/" \
-	-e "s/KEYBOARD_TITLE/$shield_title/" \
-	.github/workflows/build.yml
+    -e "s/BOARD_NAME/$board/" \
+    -e "s/SHIELD_NAME/$shield/" \
+    -e "s/KEYBOARD_TITLE/$shield_title/" \
+    .github/workflows/build.yml
 
 if [ "$board" == "proton_c" ]; then
     # Proton-C board still fa
@@ -136,11 +146,11 @@ git add .
 git commit -m "Initial User Config."
 
 if [ -n "$github_repo" ]; then
-	git remote add origin "$github_repo"
-	git push --set-upstream origin $(git symbolic-ref --short HEAD)
+    git remote add origin "$github_repo"
+    git push --set-upstream origin "$(git symbolic-ref --short HEAD)"
 
     # TODO: Support determing the actions URL when non-https:// repo URL is used.
     if [ "${github_repo}" != "${github_repo#https://}" ]; then
-        echo "Your firmware should be available from the GitHub Actions shortly: ${github_url%.git}/actions"
+        echo "Your firmware should be available from the GitHub Actions shortly: ${github_repo%.git}/actions"
     fi
 fi

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+# Copyright (c) 2020 The ZMK Contributors
+#
+# SPDX-License-Identifier: MIT
+
 set -e
 
 check_exists() {
     command_to_run=$1
     error_message=$2
-        
+
     if ! eval "$command_to_run" &> /dev/null; then
         printf "%s\n" "$error_message"
         exit 1
@@ -28,7 +32,7 @@ echo "$title"
 echo ""
 echo "MCU Board Selection:"
 PS3="$prompt "
-select opt in "${options[@]}" "Quit"; do 
+select opt in "${options[@]}" "Quit"; do
 
     case "$REPLY" in
 
@@ -50,8 +54,8 @@ options=("Kyria" "Lily58" "Corne" "Splitreus62" "Sofle" "Iris" "RoMac")
 
 PS3="$prompt "
 # TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
-# select opt in "${options[@]}" "Other" "Quit"; do 
-select opt in "${options[@]}" "Quit"; do 
+# select opt in "${options[@]}" "Other" "Quit"; do
+select opt in "${options[@]}" "Quit"; do
 
     case "$REPLY" in
 
@@ -64,7 +68,7 @@ select opt in "${options[@]}" "Quit"; do
     7 ) shield_title="RoMac" shield="romac"; split="n"; break;;
 
     # Add link to docs on adding your own custom shield in your ZMK config!
-    # $(( ${#options[@]}+1 )) ) echo "Other!"; break;; 
+    # $(( ${#options[@]}+1 )) ) echo "Other!"; break;;
     $(( ${#options[@]}+1 )) ) echo "Goodbye!"; exit 1;;
     *) echo "Invalid option. Try another one.";continue;;
 
@@ -148,9 +152,10 @@ git commit -m "Initial User Config."
 if [ -n "$github_repo" ]; then
     git remote add origin "$github_repo"
     git push --set-upstream origin "$(git symbolic-ref --short HEAD)"
+    push_return_code=$?
 
     # If push failed, assume that the origin was incorrect and give instructions on fixing.
-    if [ $? -ne 0 ] {
+    if [ ${push_return_code} -ne 0 ]; then
         echo "Remote repository $github_repo not found..."
         echo "Check GitHub URL, and try adding again."
         echo "Run the following: "
@@ -159,7 +164,7 @@ if [ -n "$github_repo" ]; then
         echo "    git push --set-upstream origin $(git symbolic-ref --short HEAD)"
         echo "Once pushed, your firmware should be availalbe from GitHub Actions at: ${github_repo%.git}/actions"
         exit 1
-    }
+    fi
 
     # TODO: Support determing the actions URL when non-https:// repo URL is used.
     if [ "${github_repo}" != "${github_repo#https://}" ]; then


### PR DESCRIPTION
I've tidied up the existing `setup.sh` script as well as implementing a few of the TODOs.
I also added an equivalent script for PowerShell, since (IMO) asking for WSL just to run a single script seems overkill.

Assuming it looks good, I can add it to the docs as well, should just be a case of running

```
iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/CrossR/zmk/CrossR/ShellScriptTidyUp/docs/static/setup.ps1'))
```

The main question I had, which I expect someone has already thought about, is how to deal with the growing list of boards/shields and multiple sources of truth? Its already a pain when there is the source code and the bash script, and now there is a third source. Having a single location and deriving these two scripts from it seems best, though probably a pain in bash/powershell. That question doesn't need to be answered now though.

Potentially easier in something like Python, but I also like that the setup so far only really needs git so adding a dependency on Python could be a pain for Windows.