### PR TITLE
QAZ shield keymap update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tools
 /zephyr
 /build
+*.DS_Store

--- a/app/boards/shields/qaz/Kconfig.defconfig
+++ b/app/boards/shields/qaz/Kconfig.defconfig
@@ -1,5 +1,5 @@
- # Copyright (c) 2020 TJ Campie
- # SPDX-License-Identifier: MIT
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
 
 if SHIELD_QAZ
 

--- a/app/boards/shields/qaz/Kconfig.shield
+++ b/app/boards/shields/qaz/Kconfig.shield
@@ -1,5 +1,5 @@
-# Copyright (c) 2020 TJ Campie
+# Copyright (c) 2020 The ZMK Contributors
 # SPDX-License-Identifier: MIT
- 
- config SHIELD_MY_BOARD
-    def_bool $(shields_list_contains,qaz)
+
+config SHIELD_MY_BOARD
+   def_bool $(shields_list_contains,qaz)

--- a/app/boards/shields/qaz/Kconfig.shield
+++ b/app/boards/shields/qaz/Kconfig.shield
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
-config SHIELD_MY_BOARD
+config SHIELD_QAZ
    def_bool $(shields_list_contains,qaz)

--- a/app/boards/shields/qaz/qaz.keymap
+++ b/app/boards/shields/qaz/qaz.keymap
@@ -52,7 +52,7 @@
     &bt BT_CLR &bt BT_NXT &bt BT_PRV &none &none &none &none &kp UARW &none &kp BKSP    
     &trans &trans &trans &trans &none &none &kp LARW &kp DARW &kp RARW &none       
     &none &none &none &none &none &none &none &none &none
-    &bt BT_CLR &bt BT_NXT &none &trans &trans &kp RET &trans &kp FSLH
+    &none &none &none &trans &trans &kp RET &trans &kp FSLH
             >;
         };
     };

--- a/app/boards/shields/qaz/qaz.keymap
+++ b/app/boards/shields/qaz/qaz.keymap
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <dt-bindings/zmk/bt.h>
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
@@ -11,7 +12,20 @@
 #define DEFAULT 0
 #define NUM_SYM 1
 #define NAV     2
- 
+
+/ {
+    behaviors {
+    hm: homerow_mods {
+			compatible = "zmk,behavior-hold-tap";
+			label = "homerow mods";
+			#binding-cells = <2>;
+			tapping_term_ms = <225>;
+            flavor = "tap-preferred";
+			bindings = <&kp>, <&kp>;
+        };
+    };
+};
+
 / {
     keymap {
         compatible = "zmk,keymap";
@@ -19,9 +33,9 @@
         default_layer {
             bindings = <
     &kp Q &kp W &kp E &kp R &kp T &kp Y &kp U &kp I &kp O &kp P    
-    &kp A &kp S &kp D &kp F &kp G &kp H &kp J &kp K &kp L &kp RET
+    &hm LGUI A &hm LALT S &hm LCTL D &hm LSFT F &kp G &kp H &hm RSFT J &hm RCTL K &hm RALT L &hm RGUI RET
     &kp Z &kp X &kp C &kp V &kp B &kp N &kp M &kp CMMA &kp DOT
-    &kp LSFT &kp LGUI &kp LALT &mo NAV &kp SPC &mo NUM_SYM &kp QUOT &kp FSLH
+    &kp LSFT &kp LGUI &kp LALT &lt NAV RET &lt NUM_SYM SPC &kp COLN &kp QUOT &kp FSLH
             >;
         };
         num_sym {
@@ -38,7 +52,7 @@
     &bt BT_CLR &bt BT_NXT &bt BT_PRV &none &none &none &none &kp UARW &none &kp BKSP    
     &trans &trans &trans &trans &none &none &kp LARW &kp DARW &kp RARW &none       
     &none &none &none &none &none &none &none &none &none
-    &none &none &none &none &none &trans &trans &kp RET &trans &kp FSLH
+    &bt BT_CLR &bt BT_NXT &none &trans &trans &kp RET &trans &kp FSLH
             >;
         };
     };

--- a/app/boards/shields/qaz/qaz.keymap
+++ b/app/boards/shields/qaz/qaz.keymap
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020 TJ Campie
- * 
+ * Copyright (c) 2020 The ZMK Contributors
+ *
  * SPDX-License-Identifier: MIT
  */
 
@@ -14,13 +14,13 @@
 
 / {
     behaviors {
-    hm: homerow_mods {
-			compatible = "zmk,behavior-hold-tap";
-			label = "homerow mods";
-			#binding-cells = <2>;
-			tapping_term_ms = <225>;
+        hm: homerow_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "homerow mods";
+            #binding-cells = <2>;
+            tapping_term_ms = <225>;
             flavor = "tap-preferred";
-			bindings = <&kp>, <&kp>;
+            bindings = <&kp>, <&kp>;
         };
     };
 };

--- a/app/boards/shields/qaz/qaz.keymap
+++ b/app/boards/shields/qaz/qaz.keymap
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <dt-bindings/zmk/bt.h>
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>

--- a/app/boards/shields/qaz/qaz.overlay
+++ b/app/boards/shields/qaz/qaz.overlay
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020 TJ Campie
- * 
+ * Copyright (c) 2020 The ZMK Contributors
+ *
  * SPDX-License-Identifier: MIT
  */
 


### PR DESCRIPTION
Wanted to update the default keymap to something more filled out with the available features in the main branch now - homerow modtaps and layer taps for examples. 