### PR TITLE
Integration Tests Should Fail on Build Errors

### DIFF
--- a/app/run-test.sh
+++ b/app/run-test.sh
@@ -22,6 +22,7 @@ echo "Running $testcase:"
 west build -d build/$testcase -b native_posix -- -DZMK_CONFIG=$testcase > /dev/null 2>&1
 if [ $? -gt 0 ]; then
 	echo "FAIL: $testcase did not build" >> ./build/tests/pass-fail.log
+	exit 1
 else
 	./build/$testcase/zephyr/zmk.exe | sed -e "s/.*> //" | tee build/$testcase/keycode_events_full.log | sed -n -f $testcase/events.patterns > build/$testcase/keycode_events.log
 	diff -au $testcase/keycode_events.snapshot build/$testcase/keycode_events.log


### PR DESCRIPTION
The issue was the script would return an exit code of 0 because the echo succeeds. Just added an exit statement and all's well.