### PR TITLE
Remove bt_unpair_combo from romac_plus.overlay

### DIFF
--- a/app/boards/shields/romac_plus/romac_plus.overlay
+++ b/app/boards/shields/romac_plus/romac_plus.overlay
@@ -22,12 +22,6 @@
 			, <&pro_micro_a 2 GPIO_ACTIVE_HIGH>
 			, <&pro_micro_a 3 GPIO_ACTIVE_HIGH>
 			;
-
-	};
-
-	bt_unpair_combo: bt_unpair_combo {
-		compatible = "zmk,bt-unpair-combo";
-		key-positions = <0 11>;
 	};
 
 };


### PR DESCRIPTION
I'm not sure but I found the bt_unpair_combo in the overlay file. This PR seeks to clean this up.