### PR TITLE
Add polling (instead of interrupt) based matrix kscan detection, to avoid interrupt limits on stm32

### DIFF
--- a/app/boards/arm/planck/Kconfig.defconfig
+++ b/app/boards/arm/planck/Kconfig.defconfig
@@ -11,4 +11,7 @@ config ZMK_KEYBOARD_NAME
 config ZMK_USB
 	default y
 
+config ZMK_KSCAN_MATRIX_POLLING
+    default y
+
 endif # BOARD_PLANCK_REV6

--- a/app/boards/arm/planck/board.cmake
+++ b/app/boards/arm/planck/board.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
+board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
 board_runner_args(jlink "--device=STM32F303VC" "--speed=4000")
 
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/app/boards/shields/clueboard_california/Kconfig.defconfig
+++ b/app/boards/shields/clueboard_california/Kconfig.defconfig
@@ -8,7 +8,7 @@ config ZMK_KEYBOARD_NAME
 # across A & B controllers, and STM32F303CCT6 can't enable
 # interrutps for multiple controllers for the same "line"
 # for the external interrupts.
-config ZMK_KSCAN_GPIO_POLLING
+config ZMK_KSCAN_DIRECT_POLLING
 	default y
 
 endif

--- a/app/drivers/zephyr/Kconfig
+++ b/app/drivers/zephyr/Kconfig
@@ -5,9 +5,13 @@ config ZMK_KSCAN_GPIO_DRIVER
 
 if ZMK_KSCAN_GPIO_DRIVER
 
-config ZMK_KSCAN_GPIO_POLLING
-	bool "Poll for key event triggers instead of using interrupts"
+config ZMK_KSCAN_MATRIX_POLLING
+	bool "Poll for key event triggers instead of using interrupts on matrix boards."
 	default n
+
+config ZMK_KSCAN_DIRECT_POLLING
+	bool "Poll for key event triggers instead of using interrupts on direct wired boards."
+    default n
 
 endif
 

--- a/app/drivers/zephyr/kscan_gpio_direct.c
+++ b/app/drivers/zephyr/kscan_gpio_direct.c
@@ -33,9 +33,9 @@ struct kscan_gpio_config {
 };
 
 struct kscan_gpio_data {
-#if defined(ZMK_KSCAN_DIRECT_POLLING)
+#if defined(CONFIG_ZMK_KSCAN_DIRECT_POLLING)
     struct k_timer poll_timer;
-#endif /* defined(ZMK_KSCAN_DIRECT_POLLING) */
+#endif /* defined(CONFIG_ZMK_KSCAN_DIRECT_POLLING) */
     kscan_callback_t callback;
     union work_reference work;
     struct device *dev;
@@ -53,7 +53,7 @@ static const struct kscan_gpio_item_config *kscan_gpio_input_configs(struct devi
     return cfg->inputs;
 }
 
-#if !defined(ZMK_KSCAN_DIRECT_POLLING)
+#if !defined(CONFIG_ZMK_KSCAN_DIRECT_POLLING)
 
 struct kscan_gpio_irq_callback {
     union work_reference *work;
@@ -101,7 +101,7 @@ static void kscan_gpio_irq_callback_handler(struct device *dev, struct gpio_call
     }
 }
 
-#else /* !defined(ZMK_KSCAN_DIRECT_POLLING) */
+#else /* !defined(CONFIG_ZMK_KSCAN_DIRECT_POLLING) */
 
 static void kscan_gpio_timer_handler(struct k_timer *timer) {
     struct kscan_gpio_data *data = CONTAINER_OF(timer, struct kscan_gpio_data, poll_timer);
@@ -120,7 +120,7 @@ static int kscan_gpio_direct_disable(struct device *dev) {
     return 0;
 }
 
-#endif /* defined(ZMK_KSCAN_DIRECT_POLLING) */
+#endif /* defined(CONFIG_ZMK_KSCAN_DIRECT_POLLING) */
 
 static int kscan_gpio_direct_configure(struct device *dev, kscan_callback_t callback) {
     struct kscan_gpio_data *data = dev->driver_data;
@@ -173,7 +173,7 @@ static const struct kscan_driver_api gpio_driver_api = {
 #define INST_INPUT_LEN(n) DT_INST_PROP_LEN(n, input_gpios)
 
 #define GPIO_INST_INIT(n)                                                                          \
-    COND_CODE_0(ZMK_KSCAN_DIRECT_POLLING,                                                     \
+    COND_CODE_0(CONFIG_ZMK_KSCAN_DIRECT_POLLING,                                                     \
                 (static struct kscan_gpio_irq_callback irq_callbacks_##n[INST_INPUT_LEN(n)];), ()) \
     static struct kscan_gpio_data kscan_gpio_data_##n = {                                          \
         .inputs = {[INST_INPUT_LEN(n) - 1] = NULL}};                                               \
@@ -195,7 +195,7 @@ static const struct kscan_driver_api gpio_driver_api = {
                 return err;                                                                        \
             }                                                                                      \
             COND_CODE_0(                                                                           \
-                ZMK_KSCAN_DIRECT_POLLING,                                                     \
+                CONFIG_ZMK_KSCAN_DIRECT_POLLING,                                                     \
                 (irq_callbacks_##n[i].work = &data->work;                                          \
                  irq_callbacks_##n[i].debounce_period = cfg->debounce_period;                      \
                  gpio_init_callback(&irq_callbacks_##n[i].callback,                                \
@@ -208,7 +208,7 @@ static const struct kscan_driver_api gpio_driver_api = {
                 ())                                                                                \
         }                                                                                          \
         data->dev = dev;                                                                           \
-        COND_CODE_1(ZMK_KSCAN_DIRECT_POLLING,                                                 \
+        COND_CODE_1(CONFIG_ZMK_KSCAN_DIRECT_POLLING,                                                 \
                     (k_timer_init(&data->poll_timer, kscan_gpio_timer_handler, NULL);), ())        \
         if (cfg->debounce_period > 0) {                                                            \
             k_delayed_work_init(&data->work.delayed, kscan_gpio_work_handler);                     \

--- a/app/drivers/zephyr/kscan_gpio_direct.c
+++ b/app/drivers/zephyr/kscan_gpio_direct.c
@@ -33,9 +33,9 @@ struct kscan_gpio_config {
 };
 
 struct kscan_gpio_data {
-#if defined(CONFIG_ZMK_KSCAN_GPIO_POLLING)
+#if defined(ZMK_KSCAN_DIRECT_POLLING)
     struct k_timer poll_timer;
-#endif /* defined(CONFIG_ZMK_KSCAN_GPIO_POLLING) */
+#endif /* defined(ZMK_KSCAN_DIRECT_POLLING) */
     kscan_callback_t callback;
     union work_reference work;
     struct device *dev;
@@ -53,7 +53,7 @@ static const struct kscan_gpio_item_config *kscan_gpio_input_configs(struct devi
     return cfg->inputs;
 }
 
-#if !defined(CONFIG_ZMK_KSCAN_GPIO_POLLING)
+#if !defined(ZMK_KSCAN_DIRECT_POLLING)
 
 struct kscan_gpio_irq_callback {
     union work_reference *work;
@@ -101,7 +101,7 @@ static void kscan_gpio_irq_callback_handler(struct device *dev, struct gpio_call
     }
 }
 
-#else /* !defined(CONFIG_ZMK_KSCAN_GPIO_POLLING) */
+#else /* !defined(ZMK_KSCAN_DIRECT_POLLING) */
 
 static void kscan_gpio_timer_handler(struct k_timer *timer) {
     struct kscan_gpio_data *data = CONTAINER_OF(timer, struct kscan_gpio_data, poll_timer);
@@ -120,7 +120,7 @@ static int kscan_gpio_direct_disable(struct device *dev) {
     return 0;
 }
 
-#endif /* defined(CONFIG_ZMK_KSCAN_GPIO_POLLING) */
+#endif /* defined(ZMK_KSCAN_DIRECT_POLLING) */
 
 static int kscan_gpio_direct_configure(struct device *dev, kscan_callback_t callback) {
     struct kscan_gpio_data *data = dev->driver_data;
@@ -173,7 +173,7 @@ static const struct kscan_driver_api gpio_driver_api = {
 #define INST_INPUT_LEN(n) DT_INST_PROP_LEN(n, input_gpios)
 
 #define GPIO_INST_INIT(n)                                                                          \
-    COND_CODE_0(CONFIG_ZMK_KSCAN_GPIO_POLLING,                                                     \
+    COND_CODE_0(ZMK_KSCAN_DIRECT_POLLING,                                                     \
                 (static struct kscan_gpio_irq_callback irq_callbacks_##n[INST_INPUT_LEN(n)];), ()) \
     static struct kscan_gpio_data kscan_gpio_data_##n = {                                          \
         .inputs = {[INST_INPUT_LEN(n) - 1] = NULL}};                                               \
@@ -195,7 +195,7 @@ static const struct kscan_driver_api gpio_driver_api = {
                 return err;                                                                        \
             }                                                                                      \
             COND_CODE_0(                                                                           \
-                CONFIG_ZMK_KSCAN_GPIO_POLLING,                                                     \
+                ZMK_KSCAN_DIRECT_POLLING,                                                     \
                 (irq_callbacks_##n[i].work = &data->work;                                          \
                  irq_callbacks_##n[i].debounce_period = cfg->debounce_period;                      \
                  gpio_init_callback(&irq_callbacks_##n[i].callback,                                \
@@ -208,7 +208,7 @@ static const struct kscan_driver_api gpio_driver_api = {
                 ())                                                                                \
         }                                                                                          \
         data->dev = dev;                                                                           \
-        COND_CODE_1(CONFIG_ZMK_KSCAN_GPIO_POLLING,                                                 \
+        COND_CODE_1(ZMK_KSCAN_DIRECT_POLLING,                                                 \
                     (k_timer_init(&data->poll_timer, kscan_gpio_timer_handler, NULL);), ())        \
         if (cfg->debounce_period > 0) {                                                            \
             k_delayed_work_init(&data->work.delayed, kscan_gpio_work_handler);                     \

--- a/app/drivers/zephyr/kscan_gpio_matrix.c
+++ b/app/drivers/zephyr/kscan_gpio_matrix.c
@@ -31,7 +31,8 @@ struct kscan_gpio_item_config {
 #define _KSCAN_GPIO_ROW_CFG_INIT(idx, n) _KSCAN_GPIO_ITEM_CFG_INIT(n, row_gpios, idx)
 #define _KSCAN_GPIO_COL_CFG_INIT(idx, n) _KSCAN_GPIO_ITEM_CFG_INIT(n, col_gpios, idx)
 
-static int kscan_gpio_config_interrupts(struct device **devices,
+COND_CODE_0(ZMK_KSCAN_MATRIX_POLLING,
+(static int kscan_gpio_config_interrupts(struct device **devices,
                                         const struct kscan_gpio_item_config *configs, size_t len,
                                         gpio_flags_t flags) {
     for (int i = 0; i < len; i++) {
@@ -47,7 +48,8 @@ static int kscan_gpio_config_interrupts(struct device **devices,
     }
 
     return 0;
-}
+}), ())
+
 #define INST_MATRIX_ROWS(n) DT_INST_PROP_LEN(n, row_gpios)
 #define INST_MATRIX_COLS(n) DT_INST_PROP_LEN(n, col_gpios)
 #define INST_OUTPUT_LEN(n)                                                                         \
@@ -69,6 +71,7 @@ static int kscan_gpio_config_interrupts(struct device **devices,
     };                                                                                             \
     struct kscan_gpio_data_##n {                                                                   \
         kscan_callback_t callback;                                                                 \
+        COND_CODE_0(ZMK_KSCAN_MATRIX_POLLING, (), (struct k_timer poll_timer;))                    \
         struct COND_CODE_0(DT_INST_PROP(n, debounce_period), (k_work), (k_delayed_work)) work;     \
         bool matrix_state[INST_MATRIX_ROWS(n)][INST_MATRIX_COLS(n)];                               \
         struct device *rows[INST_MATRIX_ROWS(n)];                                                  \
@@ -96,16 +99,17 @@ static int kscan_gpio_config_interrupts(struct device **devices,
         return (                                                                                   \
             COND_CODE_0(DT_ENUM_IDX(DT_DRV_INST(n), diode_direction), (cfg->rows), (cfg->cols)));  \
     }                                                                                              \
-    static int kscan_gpio_enable_interrupts_##n(struct device *dev) {                              \
-        return kscan_gpio_config_interrupts(kscan_gpio_input_devices_##n(dev),                     \
+    COND_CODE_0(ZMK_KSCAN_MATRIX_POLLING,                                                          \
+        (static int kscan_gpio_enable_interrupts_##n(struct device *dev) {                         \
+            return kscan_gpio_config_interrupts(kscan_gpio_input_devices_##n(dev),                 \
                                             kscan_gpio_input_configs_##n(dev), INST_INPUT_LEN(n),  \
                                             GPIO_INT_DEBOUNCE | GPIO_INT_EDGE_BOTH);               \
-    }                                                                                              \
-    static int kscan_gpio_disable_interrupts_##n(struct device *dev) {                             \
-        return kscan_gpio_config_interrupts(kscan_gpio_input_devices_##n(dev),                     \
+         }                                                                                         \
+         static int kscan_gpio_disable_interrupts_##n(struct device *dev) {                        \
+            return kscan_gpio_config_interrupts(kscan_gpio_input_devices_##n(dev),                 \
                                             kscan_gpio_input_configs_##n(dev), INST_INPUT_LEN(n),  \
                                             GPIO_INT_DISABLE);                                     \
-    }                                                                                              \
+         }), ())                                                                                   \
     static void kscan_gpio_set_output_state_##n(struct device *dev, int value) {                   \
         for (int i = 0; i < INST_OUTPUT_LEN(n); i++) {                                             \
             struct device *in_dev = kscan_gpio_output_devices_##n(dev)[i];                         \
@@ -128,7 +132,8 @@ static int kscan_gpio_config_interrupts(struct device **devices,
         /* Disable our interrupts temporarily while we scan, to avoid       */                     \
         /* re-entry while we iterate columns and set them active one by one */                     \
         /* to get pressed state for each matrix cell.                       */                     \
-        kscan_gpio_disable_interrupts_##n(dev);                                                    \
+        COND_CODE_0(ZMK_KSCAN_MATRIX_POLLING,                                                      \
+            (kscan_gpio_disable_interrupts_##n(dev);),())                                          \
         kscan_gpio_set_output_state_##n(dev, 0);                                                   \
         for (int o = 0; o < INST_OUTPUT_LEN(n); o++) {                                             \
             struct device *out_dev = kscan_gpio_output_devices_##n(dev)[o];                        \
@@ -143,10 +148,11 @@ static int kscan_gpio_config_interrupts(struct device **devices,
             }                                                                                      \
             gpio_pin_set(out_dev, out_cfg->pin, 0);                                                \
         }                                                                                          \
-        /* Set all our outputs as active again, then re-enable interrupts, */                      \
-        /* so we can trigger interrupts again for future press/release     */                      \
+        /* Set all our outputs as active again. */                                                 \
         kscan_gpio_set_output_state_##n(dev, 1);                                                   \
-        kscan_gpio_enable_interrupts_##n(dev);                                                     \
+        /*Re-enable interrupts so that they can be triggered again for future press/release*/      \
+        COND_CODE_0(ZMK_KSCAN_MATRIX_POLLING,                                                      \
+            (kscan_gpio_enable_interrupts_##n(dev);), ())                                         \
         for (int r = 0; r < INST_MATRIX_ROWS(n); r++) {                                            \
             for (int c = 0; c < INST_MATRIX_COLS(n); c++) {                                        \
                 bool pressed = read_state[r][c];                                                   \
@@ -193,12 +199,29 @@ static int kscan_gpio_config_interrupts(struct device **devices,
         return 0;                                                                                  \
     };                                                                                             \
     static int kscan_gpio_enable_##n(struct device *dev) {                                         \
-        int err = kscan_gpio_enable_interrupts_##n(dev);                                           \
-        if (err) {                                                                                 \
-            return err;                                                                            \
-        }                                                                                          \
-        return kscan_gpio_read_##n(dev);                                                           \
+        COND_CODE_0(ZMK_KSCAN_MATRIX_POLLING,                                                      \
+        (int err = kscan_gpio_enable_interrupts_##n(dev);                                          \
+         if (err) {                                                                                \
+             return err;                                                                           \
+         }                                                                                         \
+         return kscan_gpio_read_##n(dev);),                                                        \
+        (struct kscan_gpio_data_##n *data = dev->driver_data;                                      \
+         k_timer_start(&data->poll_timer, K_MSEC(10), K_MSEC(10));                                 \
+         return 0;))                                                                               \
     };                                                                                             \
+    static int kscan_gpio_disable_##n(struct device *dev) {                                        \
+        COND_CODE_0(ZMK_KSCAN_MATRIX_POLLING,                                                      \
+            (return kscan_gpio_disable_interrupts_##n(dev);),                                      \
+            (struct kscan_gpio_data_##n *data = dev->driver_data;                                  \
+             k_timer_stop(&data->poll_timer);                                                      \
+             return 0;))                                                                           \
+    };                                                                                             \
+    COND_CODE_0(ZMK_KSCAN_MATRIX_POLLING, (),                                                      \
+        (static void kscan_gpio_timer_handler(struct k_timer *timer) {                             \
+             struct kscan_gpio_data_##n *data =                                                    \
+                         CONTAINER_OF(timer, struct kscan_gpio_data_##n, poll_timer);              \
+             k_work_submit(&data->work.work);                                                      \
+         }))                                                                                       \
     static int kscan_gpio_init_##n(struct device *dev) {                                           \
         struct kscan_gpio_data_##n *data = dev->driver_data;                                       \
         int err;                                                                                   \
@@ -214,6 +237,8 @@ static int kscan_gpio_config_interrupts(struct device **devices,
             if (err) {                                                                             \
                 LOG_ERR("Unable to configure pin %d on %s for input", in_cfg->pin, in_cfg->label); \
                 return err;                                                                        \
+            } else {                                                                               \
+                LOG_DBG("Configured pin %d on %s for input", in_cfg->pin, in_cfg->label);          \
             }                                                                                      \
             irq_callbacks_##n[i].work = &data->work;                                               \
             gpio_init_callback(&irq_callbacks_##n[i].callback,                                     \
@@ -241,6 +266,8 @@ static int kscan_gpio_config_interrupts(struct device **devices,
             }                                                                                      \
         }                                                                                          \
         data->dev = dev;                                                                           \
+        COND_CODE_0(ZMK_KSCAN_MATRIX_POLLING, (),                                                  \
+                    (k_timer_init(&data->poll_timer, kscan_gpio_timer_handler, NULL);))            \
         (COND_CODE_0(DT_INST_PROP(n, debounce_period), (k_work_init), (k_delayed_work_init)))(     \
             &data->work, kscan_gpio_work_handler_##n);                                             \
         return 0;                                                                                  \
@@ -248,7 +275,7 @@ static int kscan_gpio_config_interrupts(struct device **devices,
     static const struct kscan_driver_api gpio_driver_api_##n = {                                   \
         .config = kscan_gpio_configure_##n,                                                        \
         .enable_callback = kscan_gpio_enable_##n,                                                  \
-        .disable_callback = kscan_gpio_disable_interrupts_##n,                                     \
+        .disable_callback = kscan_gpio_disable_##n,                                                \
     };                                                                                             \
     static const struct kscan_gpio_config_##n kscan_gpio_config_##n = {                            \
         .rows = {UTIL_LISTIFY(INST_MATRIX_ROWS(n), _KSCAN_GPIO_ROW_CFG_INIT, n)},                  \

--- a/app/drivers/zephyr/kscan_gpio_matrix.c
+++ b/app/drivers/zephyr/kscan_gpio_matrix.c
@@ -31,7 +31,7 @@ struct kscan_gpio_item_config {
 #define _KSCAN_GPIO_ROW_CFG_INIT(idx, n) _KSCAN_GPIO_ITEM_CFG_INIT(n, row_gpios, idx)
 #define _KSCAN_GPIO_COL_CFG_INIT(idx, n) _KSCAN_GPIO_ITEM_CFG_INIT(n, col_gpios, idx)
 
-#ifdef CONFIG_ZMK_KSCAN_MATRIX_POLLING
+#if !defined(CONFIG_ZMK_KSCAN_MATRIX_POLLING)
 static int kscan_gpio_config_interrupts(struct device **devices,
                                         const struct kscan_gpio_item_config *configs, size_t len,
                                         gpio_flags_t flags) {


### PR DESCRIPTION
This branch is intended to address #202. I added code to do timer-based polling of the matrix instead of the original interrupt-only model.  This will hopefully pave the way for a functional Planck or Preonic board.

Summary of changes:

- A new Kconfig flag was added to enable matrix scanning (ZMK_KSCAN_MATRIX_POLLING). This is defaulted to n overall, but should be set to y for boards like Planck. 
- The polling flag used by the direct wire driver was renamed to better match the new one (ZMK_KSCAN_DIRECT_POLLING).
- Code changes were made to the matrix driver (kscan_gpio_matrix.c) to add the appropriate matrix poll logic when the flag is enabled. 

All changes were modeled after the code written in kscan_gpio_direct.c, which does something similar.