### PR TITLE
feat: HID Usages + Keys Standardisation

### DIFF
--- a/app/dts/behaviors/key_press.dtsi
+++ b/app/dts/behaviors/key_press.dtsi
@@ -1,18 +1,19 @@
-#include <dt-bindings/zmk/keys.h>
+
+#include <dt-bindings/zmk/hid_usage_pages.h>
 
 / {
 	behaviors {
 		kp: behavior_key_press {
 			compatible = "zmk,behavior-key-press";
 			label = "KEY_PRESS";
-			usage_page = <USAGE_KEYPAD>;
+			usage_page = <HID_USAGE_KEY>;
 			#binding-cells = <1>;
 		};
 
 		cp: behavior_consumer_press {
 			compatible = "zmk,behavior-key-press";
 			label = "CONSUMER_PRESS";
-			usage_page = <USAGE_CONSUMER>;
+			usage_page = <HID_USAGE_CONSUMER>;
 			#binding-cells = <1>;
 		};
 	};

--- a/app/dts/behaviors/sensor_rotate_key_press.dtsi
+++ b/app/dts/behaviors/sensor_rotate_key_press.dtsi
@@ -1,18 +1,19 @@
-#include <dt-bindings/zmk/keys.h>
+
+#include <dt-bindings/zmk/hid_usage_pages.h>
 
 / {
 	behaviors {
 		inc_dec_kp: behavior_sensor_rotate_key_press {
 			compatible = "zmk,behavior-sensor-rotate-key-press";
 			label = "ENC_KEY_PRESS";
-			usage_page = <USAGE_KEYPAD>;
+			usage_page = <HID_USAGE_KEY>;
 			#sensor-binding-cells = <2>;
 		};
 
 		inc_dec_cp: behavior_sensor_rotate_consumer_press {
 			compatible = "zmk,behavior-sensor-rotate-key-press";
 			label = "ENC_CONSUMER_PRESS";
-			usage_page = <USAGE_CONSUMER>;
+			usage_page = <HID_USAGE_CONSUMER>;
 			#sensor-binding-cells = <2>;
 		};
 	};

--- a/app/include/dt-bindings/zmk/hid_usage.h
+++ b/app/include/dt-bindings/zmk/hid_usage.h
@@ -1,0 +1,2566 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Based on HID Usage Tables 1.21,
+ * Copyright © 1996-2020, USB Implementers Forum,
+ * https://www.usb.org/sites/default/files/hut1_21.pdf
+ */
+
+#pragma once
+
+/* Page 0x01: Generic Desktop */
+#define HID_USAGE_GD_UNDEFINED (0x00)
+#define HID_USAGE_GD_POINTER (0x01)                                    // CP
+#define HID_USAGE_GD_MOUSE (0x02)                                      // CA
+#define HID_USAGE_GD_JOYSTICK (0x04)                                   // CA
+#define HID_USAGE_GD_GAMEPAD (0x05)                                    // CA
+#define HID_USAGE_GD_KEYBOARD (0x06)                                   // CA
+#define HID_USAGE_GD_KEYPAD (0x07)                                     // CA
+#define HID_USAGE_GD_MULTI_AXIS_CONTROLLER (0x08)                      // CA
+#define HID_USAGE_GD_TABLET_PC_SYSTEM_CONTROLS (0x09)                  // CA
+#define HID_USAGE_GD_WATER_COOLING_DEVICE (0x0A)                       // CA
+#define HID_USAGE_GD_COMPUTER_CHASSIS_DEVICE (0x0B)                    // CA
+#define HID_USAGE_GD_WIRELESS_RADIO_CONTROLS (0x0C)                    // CA
+#define HID_USAGE_GD_PORTABLE_DEVICE_CONTROL (0x0D)                    // CA
+#define HID_USAGE_GD_SYSTEM_MULTI_AXIS_CONTROLLER (0x0E)               // CA
+#define HID_USAGE_GD_SPATIAL_CONTROLLER (0x0F)                         // CA
+#define HID_USAGE_GD_ASSISTIVE_CONTROL (0x10)                          // CA
+#define HID_USAGE_GD_DEVICE_DOCK (0x11)                                // CA
+#define HID_USAGE_GD_DOCKABLE_DEVICE (0x12)                            // CA
+#define HID_USAGE_GD_X (0x30)                                          // DV
+#define HID_USAGE_GD_Y (0x31)                                          // DV
+#define HID_USAGE_GD_Z (0x32)                                          // DV
+#define HID_USAGE_GD_RX (0x33)                                         // DV
+#define HID_USAGE_GD_RY (0x34)                                         // DV
+#define HID_USAGE_GD_RZ (0x35)                                         // DV
+#define HID_USAGE_GD_SLIDER (0x36)                                     // DV
+#define HID_USAGE_GD_DIAL (0x37)                                       // DV
+#define HID_USAGE_GD_WHEEL (0x38)                                      // DV
+#define HID_USAGE_GD_HAT_SWITCH (0x39)                                 // DV
+#define HID_USAGE_GD_COUNTED_BUFFER (0x3A)                             // CL
+#define HID_USAGE_GD_BYTE_COUNT (0x3B)                                 // DV
+#define HID_USAGE_GD_MOTION_WAKEUP (0x3C)                              // OSC, DF
+#define HID_USAGE_GD_START (0x3D)                                      // OOC
+#define HID_USAGE_GD_SELECT (0x3E)                                     // OOC
+#define HID_USAGE_GD_VX (0x40)                                         // DV
+#define HID_USAGE_GD_VY (0x41)                                         // DV
+#define HID_USAGE_GD_VZ (0x42)                                         // DV
+#define HID_USAGE_GD_VBRX (0x43)                                       // DV
+#define HID_USAGE_GD_VBRY (0x44)                                       // DV
+#define HID_USAGE_GD_VBRZ (0x45)                                       // DV
+#define HID_USAGE_GD_VNO (0x46)                                        // DV
+#define HID_USAGE_GD_FEATURE_NOTIFICATION (0x47)                       // DV, DF
+#define HID_USAGE_GD_RESOLUTION_MULTIPLIER (0x48)                      // DV
+#define HID_USAGE_GD_QX (0x49)                                         // DV
+#define HID_USAGE_GD_QY (0x4A)                                         // DV
+#define HID_USAGE_GD_QZ (0x4B)                                         // DV
+#define HID_USAGE_GD_QW (0x4C)                                         // DV
+#define HID_USAGE_GD_SYSTEM_CONTROL (0x80)                             // CA
+#define HID_USAGE_GD_SYSTEM_POWER_DOWN (0x81)                          // OSC
+#define HID_USAGE_GD_SYSTEM_SLEEP (0x82)                               // OSC
+#define HID_USAGE_GD_SYSTEM_WAKE_UP (0x83)                             // OSC
+#define HID_USAGE_GD_SYSTEM_CONTEXT_MENU (0x84)                        // OSC
+#define HID_USAGE_GD_SYSTEM_MAIN_MENU (0x85)                           // OSC
+#define HID_USAGE_GD_SYSTEM_APP_MENU (0x86)                            // OSC
+#define HID_USAGE_GD_SYSTEM_MENU_HELP (0x87)                           // OSC
+#define HID_USAGE_GD_SYSTEM_MENU_EXIT (0x88)                           // OSC
+#define HID_USAGE_GD_SYSTEM_MENU_SELECT (0x89)                         // OSC
+#define HID_USAGE_GD_SYSTEM_MENU_RIGHT (0x8A)                          // RTC
+#define HID_USAGE_GD_SYSTEM_MENU_LEFT (0x8B)                           // RTC
+#define HID_USAGE_GD_SYSTEM_MENU_UP (0x8C)                             // RTC
+#define HID_USAGE_GD_SYSTEM_MENU_DOWN (0x8D)                           // RTC
+#define HID_USAGE_GD_SYSTEM_COLD_RESTART (0x8E)                        // OSC
+#define HID_USAGE_GD_SYSTEM_WARM_RESTART (0x8F)                        // OSC
+#define HID_USAGE_GD_D_PAD_UP (0x90)                                   // OOC
+#define HID_USAGE_GD_D_PAD_DOWN (0x91)                                 // OOC
+#define HID_USAGE_GD_D_PAD_RIGHT (0x92)                                // OOC
+#define HID_USAGE_GD_D_PAD_LEFT (0x93)                                 // OOC
+#define HID_USAGE_GD_INDEX_TRIGGER (0x94)                              // MC, DV
+#define HID_USAGE_GD_PALM_TRIGGER (0x95)                               // MC, DV
+#define HID_USAGE_GD_THUMBSTICK (0x96)                                 // CP
+#define HID_USAGE_GD_SYSTEM_FUNCTION_SHIFT (0x97)                      // MC
+#define HID_USAGE_GD_SYSTEM_FUNCTION_SHIFT_LOCK (0x98)                 // OOC
+#define HID_USAGE_GD_SYSTEM_FUNCTION_SHIFT_LOCK_INDICATOR (0x99)       // DV
+#define HID_USAGE_GD_SYSTEM_DISMISS_NOTIFICATION (0x9A)                // OSC
+#define HID_USAGE_GD_SYSTEM_DO_NOT_DISTURB (0x9B)                      // OOC
+#define HID_USAGE_GD_SYSTEM_DOCK (0xA0)                                // OSC
+#define HID_USAGE_GD_SYSTEM_UNDOCK (0xA1)                              // OSC
+#define HID_USAGE_GD_SYSTEM_SETUP (0xA2)                               // OSC
+#define HID_USAGE_GD_SYSTEM_BREAK (0xA3)                               // OSC
+#define HID_USAGE_GD_SYSTEM_DEBUGGER_BREAK (0xA4)                      // OSC
+#define HID_USAGE_GD_APPLICATION_BREAK (0xA5)                          // OSC
+#define HID_USAGE_GD_APPLICATION_DEBUGGER_BREAK (0xA6)                 // OSC
+#define HID_USAGE_GD_SYSTEM_SPEAKER_MUTE (0xA7)                        // OSC
+#define HID_USAGE_GD_SYSTEM_HIBERNATE (0xA8)                           // OSC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_INVERT (0xB0)                      // OSC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_INTERNAL (0xB1)                    // OSC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_EXTERNAL (0xB2)                    // OSC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_BOTH (0xB3)                        // OSC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_DUAL (0xB4)                        // OSC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_TOGGLE_INT_EXT_MODE (0xB5)         // OSC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_SWAP_PRIMARY_SECONDARY (0xB6)      // OSC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_TOGGLE_LCD_AUTOSCALE (0xB7)        // OSC
+#define HID_USAGE_GD_SENSOR_ZONE (0xC0)                                // CL
+#define HID_USAGE_GD_RPM (0xC1)                                        // DV
+#define HID_USAGE_GD_COOLANT_LEVEL (0xC2)                              // DV
+#define HID_USAGE_GD_COOLANT_CRITICAL_LEVEL (0xC3)                     // SV
+#define HID_USAGE_GD_COOLANT_PUMP (0xC4)                               // US
+#define HID_USAGE_GD_CHASSIS_ENCLOSURE (0xC5)                          // CL
+#define HID_USAGE_GD_WIRELESS_RADIO_BUTTON (0xC6)                      // OOC
+#define HID_USAGE_GD_WIRELESS_RADIO_LED (0xC7)                         // OOC
+#define HID_USAGE_GD_WIRELESS_RADIO_SLIDER_SWITCH (0xC8)               // OOC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_ROTATION_LOCK_BUTTON (0xC9)        // OOC
+#define HID_USAGE_GD_SYSTEM_DISPLAY_ROTATION_LOCK_SLIDER_SWITCH (0xCA) // OOC
+#define HID_USAGE_GD_CONTROL_ENABLE (0xCB)                             // DF
+#define HID_USAGE_GD_DOCKABLE_DEVICE_UNIQUE_ID (0xD0)                  // DV
+#define HID_USAGE_GD_DOCKABLE_DEVICE_VENDOR_ID (0xD1)                  // DV
+#define HID_USAGE_GD_DOCKABLE_DEVICE_PRIMARY_USAGE_PAGE (0xD2)         // DV
+#define HID_USAGE_GD_DOCKABLE_DEVICE_PRIMARY_USAGE_ID (0xD3)           // DV
+#define HID_USAGE_GD_DOCKABLE_DEVICE_DOCKING_STATE (0xD4)              // DF
+#define HID_USAGE_GD_DOCKABLE_DEVICE_DISPLAY_OCCLUSION (0xD5)          // CL
+#define HID_USAGE_GD_DOCKABLE_DEVICE_OBJECT_TYPE (0xD6)                // DV
+
+/* Page 0x02: Simulation Controls */
+#define HID_USAGE_SIM_UNDEFINED (0x00)
+#define HID_USAGE_SIM_FLIGHT_SIMULATION_DEVICE (0x01)       // CA
+#define HID_USAGE_SIM_AUTOMOBILE_SIMULATION_DEVICE (0x02)   // CA
+#define HID_USAGE_SIM_TANK_SIMULATION_DEVICE (0x03)         // CA
+#define HID_USAGE_SIM_SPACESHIP_SIMULATION_DEVICE (0x04)    // CA
+#define HID_USAGE_SIM_SUBMARINE_SIMULATION_DEVICE (0x05)    // CA
+#define HID_USAGE_SIM_SAILING_SIMULATION_DEVICE (0x06)      // CA
+#define HID_USAGE_SIM_MOTORCYCLE_SIMULATION_DEVICE (0x07)   // CA
+#define HID_USAGE_SIM_SPORTS_SIMULATION_DEVICE (0x08)       // CA
+#define HID_USAGE_SIM_AIRPLANE_SIMULATION_DEVICE (0x09)     // CA
+#define HID_USAGE_SIM_HELICOPTER_SIMULATION_DEVICE (0x0A)   // CA
+#define HID_USAGE_SIM_MAGIC_CARPET_SIMULATION_DEVICE (0x0B) // CA
+#define HID_USAGE_SIM_BICYCLE_SIMULATION_DEVICE (0x0C)      // CA
+#define HID_USAGE_SIM_FLIGHT_CONTROL_STICK (0x20)           // CA
+#define HID_USAGE_SIM_FLIGHT_STICK (0x21)                   // CA
+#define HID_USAGE_SIM_CYCLIC_CONTROL (0x22)                 // CP
+#define HID_USAGE_SIM_CYCLIC_TRIM (0x23)                    // CP
+#define HID_USAGE_SIM_FLIGHT_YOKE (0x24)                    // CA
+#define HID_USAGE_SIM_TRACK_CONTROL (0x25)                  // CP
+#define HID_USAGE_SIM_AILERON (0xB0)                        // DV
+#define HID_USAGE_SIM_AILERON_TRIM (0xB1)                   // DV
+#define HID_USAGE_SIM_ANTI_TORQUE_CONTROL (0xB2)            // DV
+#define HID_USAGE_SIM_AUTOPILOT_ENABLE (0xB3)               // OOC
+#define HID_USAGE_SIM_CHAFF_RELEASE (0xB4)                  // OSC
+#define HID_USAGE_SIM_COLLECTIVE_CONTROL (0xB5)             // DV
+#define HID_USAGE_SIM_DIVE_BRAKE (0xB6)                     // DV
+#define HID_USAGE_SIM_ELECTRONIC_COUNTERMEASURES (0xB7)     // OOC
+#define HID_USAGE_SIM_ELEVATOR (0xB8)                       // DV
+#define HID_USAGE_SIM_ELEVATOR_TRIM (0xB9)                  // DV
+#define HID_USAGE_SIM_RUDDER (0xBA)                         // DV
+#define HID_USAGE_SIM_THROTTLE (0xBB)                       // DV
+#define HID_USAGE_SIM_FLIGHT_COMMUNICATIONS (0xBC)          // OOC
+#define HID_USAGE_SIM_FLARE_RELEASE (0xBD)                  // OSC
+#define HID_USAGE_SIM_LANDING_GEAR (0xBE)                   // OOC
+#define HID_USAGE_SIM_TOE_BRAKE (0xBF)                      // DV
+#define HID_USAGE_SIM_TRIGGER (0xC0)                        // MC
+#define HID_USAGE_SIM_WEAPONS_ARM (0xC1)                    // OOC
+#define HID_USAGE_SIM_WEAPONS_SELECT (0xC2)                 // OSC
+#define HID_USAGE_SIM_WING_FLAPS (0xC3)                     // DV
+#define HID_USAGE_SIM_ACCELERATOR (0xC4)                    // DV
+#define HID_USAGE_SIM_BRAKE (0xC5)                          // DV
+#define HID_USAGE_SIM_CLUTCH (0xC6)                         // DV
+#define HID_USAGE_SIM_SHIFTER (0xC7)                        // DV
+#define HID_USAGE_SIM_STEERING (0xC8)                       // DV
+#define HID_USAGE_SIM_TURRET_DIRECTION (0xC9)               // DV
+#define HID_USAGE_SIM_BARREL_ELEVATION (0xCA)               // DV
+#define HID_USAGE_SIM_DIVE_PLANE (0xCB)                     // DV
+#define HID_USAGE_SIM_BALLAST (0xCC)                        // DV
+#define HID_USAGE_SIM_BICYCLE_CRANK (0xCD)                  // DV
+#define HID_USAGE_SIM_HANDLE_BARS (0xCE)                    // DV
+#define HID_USAGE_SIM_FRONT_BRAKE (0xCF)                    // DV
+#define HID_USAGE_SIM_REAR_BRAKE (0xD0)                     // DV
+
+/* Page 0x03: VR Controls */
+#define HID_USAGE_VR_UNDEFINED (0x00)
+#define HID_USAGE_VR_BELT (0x01)                 // CA
+#define HID_USAGE_VR_BODY_SUIT (0x02)            // CA
+#define HID_USAGE_VR_FLEXOR (0x03)               // CP
+#define HID_USAGE_VR_GLOVE (0x04)                // CA
+#define HID_USAGE_VR_HEAD_TRACKER (0x05)         // CP
+#define HID_USAGE_VR_HEAD_MOUNTED_DISPLAY (0x06) // CA
+#define HID_USAGE_VR_HAND_TRACKER (0x07)         // CA
+#define HID_USAGE_VR_OCULOMETER (0x08)           // CA
+#define HID_USAGE_VR_VEST (0x09)                 // CA
+#define HID_USAGE_VR_ANIMATRONIC_DEVICE (0x0A)   // CA
+#define HID_USAGE_VR_STEREO_ENABLE (0x20)        // OOC
+#define HID_USAGE_VR_DISPLAY_ENABLE (0x21)       // OOC
+
+/* Page 0x04: Sport Controls */
+#define HID_USAGE_SPORT_UNDEFINED (0x00)
+#define HID_USAGE_SPORT_BASEBALL_BAT (0x01)         // CA
+#define HID_USAGE_SPORT_GOLF_CLUB (0x02)            // CA
+#define HID_USAGE_SPORT_ROWING_MACHINE (0x03)       // CA
+#define HID_USAGE_SPORT_TREADMILL (0x04)            // CA
+#define HID_USAGE_SPORT_OAR (0x30)                  // DV
+#define HID_USAGE_SPORT_SLOPE (0x31)                // DV
+#define HID_USAGE_SPORT_RATE (0x32)                 // DV
+#define HID_USAGE_SPORT_STICK_SPEED (0x33)          // DV
+#define HID_USAGE_SPORT_STICK_FACE_ANGLE (0x34)     // DV
+#define HID_USAGE_SPORT_STICK_HEEL_TOE (0x35)       // DV
+#define HID_USAGE_SPORT_STICK_FOLLOW_THROUGH (0x36) // DV
+#define HID_USAGE_SPORT_STICK_TEMPO (0x37)          // DV
+#define HID_USAGE_SPORT_STICK_TYPE (0x38)           // NAry
+#define HID_USAGE_SPORT_STICK_HEIGHT (0x39)         // DV
+#define HID_USAGE_SPORT_PUTTER (0x50)               // Sel
+#define HID_USAGE_SPORT_1_IRON (0x51)               // Sel
+#define HID_USAGE_SPORT_2_IRON (0x52)               // Sel
+#define HID_USAGE_SPORT_3_IRON (0x53)               // Sel
+#define HID_USAGE_SPORT_4_IRON (0x54)               // Sel
+#define HID_USAGE_SPORT_5_IRON (0x55)               // Sel
+#define HID_USAGE_SPORT_6_IRON (0x56)               // Sel
+#define HID_USAGE_SPORT_7_IRON (0x57)               // Sel
+#define HID_USAGE_SPORT_8_IRON (0x58)               // Sel
+#define HID_USAGE_SPORT_9_IRON (0x59)               // Sel
+#define HID_USAGE_SPORT_10_IRON (0x5A)              // Sel
+#define HID_USAGE_SPORT_11_IRON (0x5B)              // Sel
+#define HID_USAGE_SPORT_SAND_WEDGE (0x5C)           // Sel
+#define HID_USAGE_SPORT_LOFT_WEDGE (0x5D)           // Sel
+#define HID_USAGE_SPORT_POWER_WEDGE (0x5E)          // Sel
+#define HID_USAGE_SPORT_1_WOOD (0x5F)               // Sel
+#define HID_USAGE_SPORT_3_WOOD (0x60)               // Sel
+#define HID_USAGE_SPORT_5_WOOD (0x61)               // Sel
+#define HID_USAGE_SPORT_7_WOOD (0x62)               // Sel
+#define HID_USAGE_SPORT_9_WOOD (0x63)               // Sel
+
+/* Page 0x05: Game Controls */
+#define HID_USAGE_GAME_UNDEFINED (0x00)
+#define HID_USAGE_GAME_3D_GAME_CONTROLLER (0x01)     // CA
+#define HID_USAGE_GAME_PINBALL_DEVICE (0x02)         // CA
+#define HID_USAGE_GAME_GUN_DEVICE (0x03)             // CA
+#define HID_USAGE_GAME_POINT_OF_VIEW (0x20)          // CP
+#define HID_USAGE_GAME_TURN_RIGHT_LEFT (0x21)        // DV
+#define HID_USAGE_GAME_PITCH_FORWARD_BACKWARD (0x22) // DV
+#define HID_USAGE_GAME_ROLL_RIGHT_LEFT (0x23)        // DV
+#define HID_USAGE_GAME_MOVE_RIGHT_LEFT (0x24)        // DV
+#define HID_USAGE_GAME_MOVE_FORWARD_BACKWARD (0x25)  // DV
+#define HID_USAGE_GAME_MOVE_UP_DOWN (0x26)           // DV
+#define HID_USAGE_GAME_LEAN_RIGHT_LEFT (0x27)        // DV
+#define HID_USAGE_GAME_LEAN_FORWARD_BACKWARD (0x28)  // DV
+#define HID_USAGE_GAME_HEIGHT_OF_POV (0x29)          // DV
+#define HID_USAGE_GAME_FLIPPER (0x2A)                // MC
+#define HID_USAGE_GAME_SECONDARY_FLIPPER (0x2B)      // MC
+#define HID_USAGE_GAME_BUMP (0x2C)                   // MC
+#define HID_USAGE_GAME_NEW_GAME (0x2D)               // OSC
+#define HID_USAGE_GAME_SHOOT_BALL (0x2E)             // OSC
+#define HID_USAGE_GAME_PLAYER (0x2F)                 // OSC
+#define HID_USAGE_GAME_GUN_BOLT (0x30)               // OOC
+#define HID_USAGE_GAME_GUN_CLIP (0x31)               // OOC
+#define HID_USAGE_GAME_GUN_SELECTOR (0x32)           // NAry
+#define HID_USAGE_GAME_GUN_SINGLE_SHOT (0x33)        // Sel
+#define HID_USAGE_GAME_GUN_BURST (0x34)              // Sel
+#define HID_USAGE_GAME_GUN_AUTOMATIC (0x35)          // Sel
+#define HID_USAGE_GAME_GUN_SAFETY (0x36)             // OOC
+#define HID_USAGE_GAME_GAMEPAD_FIRE_JUMP (0x37)      // CL
+#define HID_USAGE_GAME_GAMEPAD_TRIGGER (0x39)        // CL
+#define HID_USAGE_GAME_FORM_FITTING_GAMEPAD (0x3A)   // SF
+
+/* Page 0x06: Generic Device Controls */
+#define HID_USAGE_GDV_UNDEFINED (0x00)
+#define HID_USAGE_GDV_BACKGROUND_NONUSER_CONTROLS (0x01)     // CA
+#define HID_USAGE_GDV_BATTERY_STRENGTH (0x20)                // DV
+#define HID_USAGE_GDV_WIRELESS_CHANNEL (0x21)                // DV
+#define HID_USAGE_GDV_WIRELESS_ID (0x22)                     // DV
+#define HID_USAGE_GDV_DISCOVER_WIRELESS_CONTROL (0x23)       // OSC
+#define HID_USAGE_GDV_SECURITY_CODE_CHARACTER_ENTERED (0x24) // OSC
+#define HID_USAGE_GDV_SECURITY_CODE_CHARACTER_ERASED (0x25)  // OSC
+#define HID_USAGE_GDV_SECURITY_CODE_CLEARED (0x26)           // OSC
+#define HID_USAGE_GDV_SEQUENCE_ID (0x27)                     // DV
+#define HID_USAGE_GDV_SEQUENCE_ID_RESET (0x28)               // DF
+#define HID_USAGE_GDV_RF_SIGNAL_STRENGTH (0x29)              // DV
+#define HID_USAGE_GDV_SOFTWARE_VERSION (0x2A)                // CL
+#define HID_USAGE_GDV_PROTOCOL_VERSION (0x2B)                // CL
+#define HID_USAGE_GDV_HARDWARE_VERSION (0x2C)                // CL
+#define HID_USAGE_GDV_MAJOR (0x2D)                           // SV
+#define HID_USAGE_GDV_MINOR (0x2E)                           // SV
+#define HID_USAGE_GDV_REVISION (0x2F)                        // SV
+#define HID_USAGE_GDV_HANDEDNESS (0x30)                      // NAry
+#define HID_USAGE_GDV_EITHER_HAND (0x31)                     // Sel
+#define HID_USAGE_GDV_LEFT_HAND (0x32)                       // Sel
+#define HID_USAGE_GDV_RIGHT_HAND (0x33)                      // Sel
+#define HID_USAGE_GDV_BOTH_HANDS (0x34)                      // Sel
+#define HID_USAGE_GDV_GRIP_POSE_OFFSET (0x40)                // CP
+#define HID_USAGE_GDV_POINTER_POSE_OFFSET (0x41)             // CP
+
+/* Page 0x07: Keyboard/Keypad */
+#define HID_USAGE_KEY_KEYBOARD_ERRORROLLOVER (0x01)                 // Sel
+#define HID_USAGE_KEY_KEYBOARD_POSTFAIL (0x02)                      // Sel
+#define HID_USAGE_KEY_KEYBOARD_ERRORUNDEFINED (0x03)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_A (0x04)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_B (0x05)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_C (0x06)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_D (0x07)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_E (0x08)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_F (0x09)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_G (0x0A)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_H (0x0B)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_I (0x0C)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_J (0x0D)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_K (0x0E)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_L (0x0F)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_M (0x10)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_N (0x11)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_O (0x12)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_P (0x13)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_Q (0x14)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_R (0x15)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_S (0x16)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_T (0x17)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_U (0x18)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_V (0x19)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_W (0x1A)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_X (0x1B)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_Y (0x1C)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_Z (0x1D)                             // Sel
+#define HID_USAGE_KEY_KEYBOARD_1_AND_EXCLAMATION (0x1E)             // Sel
+#define HID_USAGE_KEY_KEYBOARD_2_AND_AT (0x1F)                      // Sel
+#define HID_USAGE_KEY_KEYBOARD_3_AND_HASH (0x20)                    // Sel
+#define HID_USAGE_KEY_KEYBOARD_4_AND_DOLLAR (0x21)                  // Sel
+#define HID_USAGE_KEY_KEYBOARD_5_AND_PERCENT (0x22)                 // Sel
+#define HID_USAGE_KEY_KEYBOARD_6_AND_CARET (0x23)                   // Sel
+#define HID_USAGE_KEY_KEYBOARD_7_AND_AMPERSAND (0x24)               // Sel
+#define HID_USAGE_KEY_KEYBOARD_8_AND_ASTERISK (0x25)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_9_AND_LEFT_PARENTHESIS (0x26)        // Sel
+#define HID_USAGE_KEY_KEYBOARD_0_AND_RIGHT_PARENTHESIS (0x27)       // Sel
+#define HID_USAGE_KEY_KEYBOARD_RETURN_ENTER (0x28)                  // Sel
+#define HID_USAGE_KEY_KEYBOARD_ESCAPE (0x29)                        // Sel
+#define HID_USAGE_KEY_KEYBOARD_DELETE_BACKSPACE (0x2A)              // Sel
+#define HID_USAGE_KEY_KEYBOARD_TAB (0x2B)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_SPACEBAR (0x2C)                      // Sel
+#define HID_USAGE_KEY_KEYBOARD_MINUS_AND_UNDERSCORE (0x2D)          // Sel
+#define HID_USAGE_KEY_KEYBOARD_EQUAL_AND_PLUS (0x2E)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_LEFT_BRACKET_AND_LEFT_BRACE (0x2F)   // Sel
+#define HID_USAGE_KEY_KEYBOARD_RIGHT_BRACKET_AND_RIGHT_BRACE (0x30) // Sel
+#define HID_USAGE_KEY_KEYBOARD_BACKSLASH_AND_PIPE (0x31)            // Sel
+#define HID_USAGE_KEY_KEYBOARD_NON_US_HASH_AND_TILDE (0x32)         // Sel
+#define HID_USAGE_KEY_KEYBOARD_SEMICOLON_AND_COLON (0x33)           // Sel
+#define HID_USAGE_KEY_KEYBOARD_APOSTROPHE_AND_QUOTE (0x34)          // Sel
+#define HID_USAGE_KEY_KEYBOARD_GRAVE_ACCENT_AND_TILDE (0x35)        // Sel
+#define HID_USAGE_KEY_KEYBOARD_COMMA_AND_LESS_THAN (0x36)           // Sel
+#define HID_USAGE_KEY_KEYBOARD_PERIOD_AND_GREATER_THAN (0x37)       // Sel
+#define HID_USAGE_KEY_KEYBOARD_SLASH_AND_QUESTION_MARK (0x38)       // Sel
+#define HID_USAGE_KEY_KEYBOARD_CAPS_LOCK (0x39)                     // Sel
+#define HID_USAGE_KEY_KEYBOARD_F1 (0x3A)                            // Sel
+#define HID_USAGE_KEY_KEYBOARD_F2 (0x3B)                            // Sel
+#define HID_USAGE_KEY_KEYBOARD_F3 (0x3C)                            // Sel
+#define HID_USAGE_KEY_KEYBOARD_F4 (0x3D)                            // Sel
+#define HID_USAGE_KEY_KEYBOARD_F5 (0x3E)                            // Sel
+#define HID_USAGE_KEY_KEYBOARD_F6 (0x3F)                            // Sel
+#define HID_USAGE_KEY_KEYBOARD_F7 (0x40)                            // Sel
+#define HID_USAGE_KEY_KEYBOARD_F8 (0x41)                            // Sel
+#define HID_USAGE_KEY_KEYBOARD_F9 (0x42)                            // Sel
+#define HID_USAGE_KEY_KEYBOARD_F10 (0x43)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F11 (0x44)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F12 (0x45)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_PRINTSCREEN (0x46)                   // Sel
+#define HID_USAGE_KEY_KEYBOARD_SCROLL_LOCK (0x47)                   // Sel
+#define HID_USAGE_KEY_KEYBOARD_PAUSE (0x48)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_INSERT (0x49)                        // Sel
+#define HID_USAGE_KEY_KEYBOARD_HOME (0x4A)                          // Sel
+#define HID_USAGE_KEY_KEYBOARD_PAGEUP (0x4B)                        // Sel
+#define HID_USAGE_KEY_KEYBOARD_DELETE_FORWARD (0x4C)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_END (0x4D)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_PAGEDOWN (0x4E)                      // Sel
+#define HID_USAGE_KEY_KEYBOARD_RIGHTARROW (0x4F)                    // Sel
+#define HID_USAGE_KEY_KEYBOARD_LEFTARROW (0x50)                     // Sel
+#define HID_USAGE_KEY_KEYBOARD_DOWNARROW (0x51)                     // Sel
+#define HID_USAGE_KEY_KEYBOARD_UPARROW (0x52)                       // Sel
+#define HID_USAGE_KEY_KEYPAD_NUM_LOCK_AND_CLEAR (0x53)              // Sel
+#define HID_USAGE_KEY_KEYPAD_SLASH (0x54)                           // Sel
+#define HID_USAGE_KEY_KEYPAD_ASTERISK (0x55)                        // Sel
+#define HID_USAGE_KEY_KEYPAD_MINUS (0x56)                           // Sel
+#define HID_USAGE_KEY_KEYPAD_PLUS (0x57)                            // Sel
+#define HID_USAGE_KEY_KEYPAD_ENTER (0x58)                           // Sel
+#define HID_USAGE_KEY_KEYPAD_1_AND_END (0x59)                       // Sel
+#define HID_USAGE_KEY_KEYPAD_2_AND_DOWN_ARROW (0x5A)                // Sel
+#define HID_USAGE_KEY_KEYPAD_3_AND_PAGEDN (0x5B)                    // Sel
+#define HID_USAGE_KEY_KEYPAD_4_AND_LEFT_ARROW (0x5C)                // Sel
+#define HID_USAGE_KEY_KEYPAD_5 (0x5D)                               // Sel
+#define HID_USAGE_KEY_KEYPAD_6_AND_RIGHT_ARROW (0x5E)               // Sel
+#define HID_USAGE_KEY_KEYPAD_7_AND_HOME (0x5F)                      // Sel
+#define HID_USAGE_KEY_KEYPAD_8_AND_UP_ARROW (0x60)                  // Sel
+#define HID_USAGE_KEY_KEYPAD_9_AND_PAGEUP (0x61)                    // Sel
+#define HID_USAGE_KEY_KEYPAD_0_AND_INSERT (0x62)                    // Sel
+#define HID_USAGE_KEY_KEYPAD_PERIOD_AND_DELETE (0x63)               // Sel
+#define HID_USAGE_KEY_KEYBOARD_NON_US_BACKSLASH_AND_PIPE (0x64)     // Sel
+#define HID_USAGE_KEY_KEYBOARD_APPLICATION (0x65)                   // Sel
+#define HID_USAGE_KEY_KEYBOARD_POWER (0x66)                         // Sel
+#define HID_USAGE_KEY_KEYPAD_EQUAL (0x67)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F13 (0x68)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F14 (0x69)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F15 (0x6A)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F16 (0x6B)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F17 (0x6C)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F18 (0x6D)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F19 (0x6E)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F20 (0x6F)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F21 (0x70)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F22 (0x71)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F23 (0x72)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_F24 (0x73)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_EXECUTE (0x74)                       // Sel
+#define HID_USAGE_KEY_KEYBOARD_HELP (0x75)                          // Sel
+#define HID_USAGE_KEY_KEYBOARD_MENU (0x76)                          // Sel
+#define HID_USAGE_KEY_KEYBOARD_SELECT (0x77)                        // Sel
+#define HID_USAGE_KEY_KEYBOARD_STOP (0x78)                          // Sel
+#define HID_USAGE_KEY_KEYBOARD_AGAIN (0x79)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_UNDO (0x7A)                          // Sel
+#define HID_USAGE_KEY_KEYBOARD_CUT (0x7B)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_COPY (0x7C)                          // Sel
+#define HID_USAGE_KEY_KEYBOARD_PASTE (0x7D)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_FIND (0x7E)                          // Sel
+#define HID_USAGE_KEY_KEYBOARD_MUTE (0x7F)                          // Sel
+#define HID_USAGE_KEY_KEYBOARD_VOLUME_UP (0x80)                     // Sel
+#define HID_USAGE_KEY_KEYBOARD_VOLUME_DOWN (0x81)                   // Sel
+#define HID_USAGE_KEY_KEYBOARD_LOCKING_CAPS_LOCK (0x82)             // Sel
+#define HID_USAGE_KEY_KEYBOARD_LOCKING_NUM_LOCK (0x83)              // Sel
+#define HID_USAGE_KEY_KEYBOARD_LOCKING_SCROLL_LOCK (0x84)           // Sel
+#define HID_USAGE_KEY_KEYPAD_COMMA (0x85)                           // Sel
+#define HID_USAGE_KEY_KEYPAD_EQUAL_SIGN (0x86)                      // Sel
+#define HID_USAGE_KEY_KEYBOARD_INTERNATIONAL1 (0x87)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_INTERNATIONAL2 (0x88)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_INTERNATIONAL3 (0x89)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_INTERNATIONAL4 (0x8A)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_INTERNATIONAL5 (0x8B)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_INTERNATIONAL6 (0x8C)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_INTERNATIONAL7 (0x8D)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_INTERNATIONAL8 (0x8E)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_INTERNATIONAL9 (0x8F)                // Sel
+#define HID_USAGE_KEY_KEYBOARD_LANG1 (0x90)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_LANG2 (0x91)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_LANG3 (0x92)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_LANG4 (0x93)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_LANG5 (0x94)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_LANG6 (0x95)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_LANG7 (0x96)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_LANG8 (0x97)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_LANG9 (0x98)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_ALTERNATE_ERASE (0x99)               // Sel
+#define HID_USAGE_KEY_KEYBOARD_SYSREQ_ATTENTION (0x9A)              // Sel
+#define HID_USAGE_KEY_KEYBOARD_CANCEL (0x9B)                        // Sel
+#define HID_USAGE_KEY_KEYBOARD_CLEAR (0x9C)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_PRIOR (0x9D)                         // Sel
+#define HID_USAGE_KEY_KEYBOARD_RETURN (0x9E)                        // Sel
+#define HID_USAGE_KEY_KEYBOARD_SEPARATOR (0x9F)                     // Sel
+#define HID_USAGE_KEY_KEYBOARD_OUT (0xA0)                           // Sel
+#define HID_USAGE_KEY_KEYBOARD_OPER (0xA1)                          // Sel
+#define HID_USAGE_KEY_KEYBOARD_CLEAR_AGAIN (0xA2)                   // Sel
+#define HID_USAGE_KEY_KEYBOARD_CRSEL_PROPS (0xA3)                   // Sel
+#define HID_USAGE_KEY_KEYBOARD_EXSEL (0xA4)                         // Sel
+#define HID_USAGE_KEY_KEYPAD_00 (0xB0)                              // Sel
+#define HID_USAGE_KEY_KEYPAD_000 (0xB1)                             // Sel
+#define HID_USAGE_KEY_THOUSANDS_SEPARATOR (0xB2)                    // Sel
+#define HID_USAGE_KEY_DECIMAL_SEPARATOR (0xB3)                      // Sel
+#define HID_USAGE_KEY_CURRENCY_UNIT (0xB4)                          // Sel
+#define HID_USAGE_KEY_CURRENCY_SUB_UNIT (0xB5)                      // Sel
+#define HID_USAGE_KEY_KEYPAD_LEFT_PARENTHESIS (0xB6)                // Sel
+#define HID_USAGE_KEY_KEYPAD_RIGHT_PARENTHESIS (0xB7)               // Sel
+#define HID_USAGE_KEY_KEYPAD_LEFT_BRACE (0xB8)                      // Sel
+#define HID_USAGE_KEY_KEYPAD_RIGHT_BRACE (0xB9)                     // Sel
+#define HID_USAGE_KEY_KEYPAD_TAB (0xBA)                             // Sel
+#define HID_USAGE_KEY_KEYPAD_BACKSPACE (0xBB)                       // Sel
+#define HID_USAGE_KEY_KEYPAD_A (0xBC)                               // Sel
+#define HID_USAGE_KEY_KEYPAD_B (0xBD)                               // Sel
+#define HID_USAGE_KEY_KEYPAD_C (0xBE)                               // Sel
+#define HID_USAGE_KEY_KEYPAD_D (0xBF)                               // Sel
+#define HID_USAGE_KEY_KEYPAD_E (0xC0)                               // Sel
+#define HID_USAGE_KEY_KEYPAD_F (0xC1)                               // Sel
+#define HID_USAGE_KEY_KEYPAD_XOR (0xC2)                             // Sel
+#define HID_USAGE_KEY_KEYPAD_CARET (0xC3)                           // Sel
+#define HID_USAGE_KEY_KEYPAD_PERCENT (0xC4)                         // Sel
+#define HID_USAGE_KEY_KEYPAD_LESS_THAN (0xC5)                       // Sel
+#define HID_USAGE_KEY_KEYPAD_GREATER_THAN (0xC6)                    // Sel
+#define HID_USAGE_KEY_KEYPAD_AMPERSAND (0xC7)                       // Sel
+#define HID_USAGE_KEY_KEYPAD_AMPERSAND_AMPERSAND (0xC8)             // Sel
+#define HID_USAGE_KEY_KEYPAD_PIPE (0xC9)                            // Sel
+#define HID_USAGE_KEY_KEYPAD_PIPE_PIPE (0xCA)                       // Sel
+#define HID_USAGE_KEY_KEYPAD_COLON (0xCB)                           // Sel
+#define HID_USAGE_KEY_KEYPAD_HASH (0xCC)                            // Sel
+#define HID_USAGE_KEY_KEYPAD_SPACE (0xCD)                           // Sel
+#define HID_USAGE_KEY_KEYPAD_AT (0xCE)                              // Sel
+#define HID_USAGE_KEY_KEYPAD_EXCLAMATION (0xCF)                     // Sel
+#define HID_USAGE_KEY_KEYPAD_MEMORY_STORE (0xD0)                    // Sel
+#define HID_USAGE_KEY_KEYPAD_MEMORY_RECALL (0xD1)                   // Sel
+#define HID_USAGE_KEY_KEYPAD_MEMORY_CLEAR (0xD2)                    // Sel
+#define HID_USAGE_KEY_KEYPAD_MEMORY_ADD (0xD3)                      // Sel
+#define HID_USAGE_KEY_KEYPAD_MEMORY_SUBTRACT (0xD4)                 // Sel
+#define HID_USAGE_KEY_KEYPAD_MEMORY_MULTIPLY (0xD5)                 // Sel
+#define HID_USAGE_KEY_KEYPAD_MEMORY_DIVIDE (0xD6)                   // Sel
+#define HID_USAGE_KEY_KEYPAD_PLUS_MINUS (0xD7)                      // Sel
+#define HID_USAGE_KEY_KEYPAD_CLEAR (0xD8)                           // Sel
+#define HID_USAGE_KEY_KEYPAD_CLEAR_ENTRY (0xD9)                     // Sel
+#define HID_USAGE_KEY_KEYPAD_BINARY (0xDA)                          // Sel
+#define HID_USAGE_KEY_KEYPAD_OCTAL (0xDB)                           // Sel
+#define HID_USAGE_KEY_KEYPAD_DECIMAL (0xDC)                         // Sel
+#define HID_USAGE_KEY_KEYPAD_HEXADECIMAL (0xDD)                     // Sel
+#define HID_USAGE_KEY_KEYBOARD_LEFTCONTROL (0xE0)                   // DV
+#define HID_USAGE_KEY_KEYBOARD_LEFTSHIFT (0xE1)                     // DV
+#define HID_USAGE_KEY_KEYBOARD_LEFTALT (0xE2)                       // DV
+#define HID_USAGE_KEY_KEYBOARD_LEFT_GUI (0xE3)                      // DV
+#define HID_USAGE_KEY_KEYBOARD_RIGHTCONTROL (0xE4)                  // DV
+#define HID_USAGE_KEY_KEYBOARD_RIGHTSHIFT (0xE5)                    // DV
+#define HID_USAGE_KEY_KEYBOARD_RIGHTALT (0xE6)                      // DV
+#define HID_USAGE_KEY_KEYBOARD_RIGHT_GUI (0xE7)                     // DV
+
+/* Page 0x08: LED */
+#define HID_USAGE_LED_UNDEFINED (0x00)
+#define HID_USAGE_LED_NUM_LOCK (0x01)                   // OOC
+#define HID_USAGE_LED_CAPS_LOCK (0x02)                  // OOC
+#define HID_USAGE_LED_SCROLL_LOCK (0x03)                // OOC
+#define HID_USAGE_LED_COMPOSE (0x04)                    // OOC
+#define HID_USAGE_LED_KANA (0x05)                       // OOC
+#define HID_USAGE_LED_POWER (0x06)                      // OOC
+#define HID_USAGE_LED_SHIFT (0x07)                      // OOC
+#define HID_USAGE_LED_DO_NOT_DISTURB (0x08)             // OOC
+#define HID_USAGE_LED_MUTE (0x09)                       // OOC
+#define HID_USAGE_LED_TONE_ENABLE (0x0A)                // OOC
+#define HID_USAGE_LED_HIGH_CUT_FILTER (0x0B)            // OOC
+#define HID_USAGE_LED_LOW_CUT_FILTER (0x0C)             // OOC
+#define HID_USAGE_LED_EQUALIZER_ENABLE (0x0D)           // OOC
+#define HID_USAGE_LED_SOUND_FIELD_ON (0x0E)             // OOC
+#define HID_USAGE_LED_SURROUND_ON (0x0F)                // OOC
+#define HID_USAGE_LED_REPEAT (0x10)                     // OOC
+#define HID_USAGE_LED_STEREO (0x11)                     // OOC
+#define HID_USAGE_LED_SAMPLING_RATE_DETECT (0x12)       // OOC
+#define HID_USAGE_LED_SPINNING (0x13)                   // OOC
+#define HID_USAGE_LED_CAV (0x14)                        // OOC
+#define HID_USAGE_LED_CLV (0x15)                        // OOC
+#define HID_USAGE_LED_RECORDING_FORMAT_DETECT (0x16)    // OOC
+#define HID_USAGE_LED_OFF_HOOK (0x17)                   // OOC
+#define HID_USAGE_LED_RING (0x18)                       // OOC
+#define HID_USAGE_LED_MESSAGE_WAITING (0x19)            // OOC
+#define HID_USAGE_LED_DATA_MODE (0x1A)                  // OOC
+#define HID_USAGE_LED_BATTERY_OPERATION (0x1B)          // OOC
+#define HID_USAGE_LED_BATTERY_OK (0x1C)                 // OOC
+#define HID_USAGE_LED_BATTERY_LOW (0x1D)                // OOC
+#define HID_USAGE_LED_SPEAKER (0x1E)                    // OOC
+#define HID_USAGE_LED_HEAD_SET (0x1F)                   // OOC
+#define HID_USAGE_LED_HOLD (0x20)                       // OOC
+#define HID_USAGE_LED_MICROPHONE (0x21)                 // OOC
+#define HID_USAGE_LED_COVERAGE (0x22)                   // OOC
+#define HID_USAGE_LED_NIGHT_MODE (0x23)                 // OOC
+#define HID_USAGE_LED_SEND_CALLS (0x24)                 // OOC
+#define HID_USAGE_LED_CALL_PICKUP (0x25)                // OOC
+#define HID_USAGE_LED_CONFERENCE (0x26)                 // OOC
+#define HID_USAGE_LED_STAND_BY (0x27)                   // OOC
+#define HID_USAGE_LED_CAMERA_ON (0x28)                  // OOC
+#define HID_USAGE_LED_CAMERA_OFF (0x29)                 // OOC
+#define HID_USAGE_LED_ON_LINE (0x2A)                    // OOC
+#define HID_USAGE_LED_OFF_LINE (0x2B)                   // OOC
+#define HID_USAGE_LED_BUSY (0x2C)                       // OOC
+#define HID_USAGE_LED_READY (0x2D)                      // OOC
+#define HID_USAGE_LED_PAPER_OUT (0x2E)                  // OOC
+#define HID_USAGE_LED_PAPER_JAM (0x2F)                  // OOC
+#define HID_USAGE_LED_REMOTE (0x30)                     // OOC
+#define HID_USAGE_LED_FORWARD (0x31)                    // OOC
+#define HID_USAGE_LED_REVERSE (0x32)                    // OOC
+#define HID_USAGE_LED_STOP (0x33)                       // OOC
+#define HID_USAGE_LED_REWIND (0x34)                     // OOC
+#define HID_USAGE_LED_FAST_FORWARD (0x35)               // OOC
+#define HID_USAGE_LED_PLAY (0x36)                       // OOC
+#define HID_USAGE_LED_PAUSE (0x37)                      // OOC
+#define HID_USAGE_LED_RECORD (0x38)                     // OOC
+#define HID_USAGE_LED_ERROR (0x39)                      // OOC
+#define HID_USAGE_LED_USAGE_SELECTED_INDICATOR (0x3A)   // US
+#define HID_USAGE_LED_USAGE_IN_USE_INDICATOR (0x3B)     // US
+#define HID_USAGE_LED_USAGE_MULTI_MODE_INDICATOR (0x3C) // UM
+#define HID_USAGE_LED_INDICATOR_ON (0x3D)               // Sel
+#define HID_USAGE_LED_INDICATOR_FLASH (0x3E)            // Sel
+#define HID_USAGE_LED_INDICATOR_SLOW_BLINK (0x3F)       // Sel
+#define HID_USAGE_LED_INDICATOR_FAST_BLINK (0x40)       // Sel
+#define HID_USAGE_LED_INDICATOR_OFF (0x41)              // Sel
+#define HID_USAGE_LED_FLASH_ON_TIME (0x42)              // DV
+#define HID_USAGE_LED_SLOW_BLINK_ON_TIME (0x43)         // DV
+#define HID_USAGE_LED_SLOW_BLINK_OFF_TIME (0x44)        // DV
+#define HID_USAGE_LED_FAST_BLINK_ON_TIME (0x45)         // DV
+#define HID_USAGE_LED_FAST_BLINK_OFF_TIME (0x46)        // DV
+#define HID_USAGE_LED_USAGE_INDICATOR_COLOR (0x47)      // UM
+#define HID_USAGE_LED_INDICATOR_RED (0x48)              // Sel
+#define HID_USAGE_LED_INDICATOR_GREEN (0x49)            // Sel
+#define HID_USAGE_LED_INDICATOR_AMBER (0x4A)            // Sel
+#define HID_USAGE_LED_GENERIC_INDICATOR (0x4B)          // OOC
+#define HID_USAGE_LED_SYSTEM_SUSPEND (0x4C)             // OOC
+#define HID_USAGE_LED_EXTERNAL_POWER_CONNECTED (0x4D)   // OOC
+#define HID_USAGE_LED_INDICATOR_BLUE (0x4E)             // Sel
+#define HID_USAGE_LED_INDICATOR_ORANGE (0x4F)           // Sel
+#define HID_USAGE_LED_GOOD_STATUS (0x50)                // OOC
+#define HID_USAGE_LED_WARNING_STATUS (0x51)             // OOC
+#define HID_USAGE_LED_RGB_LED (0x52)                    // CL
+#define HID_USAGE_LED_RED_LED_CHANNEL (0x53)            // DV
+#define HID_USAGE_LED_BLUE_LED_CHANNEL (0x54)           // DV
+#define HID_USAGE_LED_GREEN_LED_CHANNEL (0x55)          // DV
+#define HID_USAGE_LED_LED_INTENSITY (0x56)              // DV
+#define HID_USAGE_LED_PLAYER_INDICATOR (0x60)           // NAry
+#define HID_USAGE_LED_PLAYER_1 (0x61)                   // Sel
+#define HID_USAGE_LED_PLAYER_2 (0x62)                   // Sel
+#define HID_USAGE_LED_PLAYER_3 (0x63)                   // Sel
+#define HID_USAGE_LED_PLAYER_4 (0x64)                   // Sel
+#define HID_USAGE_LED_PLAYER_5 (0x65)                   // Sel
+#define HID_USAGE_LED_PLAYER_6 (0x66)                   // Sel
+#define HID_USAGE_LED_PLAYER_7 (0x67)                   // Sel
+#define HID_USAGE_LED_PLAYER_8 (0x68)                   // Sel
+
+/* Page 0x0B: Telephony Device */
+#define HID_USAGE_TELEPHONY_UNDEFINED (0x00)
+#define HID_USAGE_TELEPHONY_PHONE (0x01)                        // CA
+#define HID_USAGE_TELEPHONY_ANSWERING_MACHINE (0x02)            // CA
+#define HID_USAGE_TELEPHONY_MESSAGE_CONTROLS (0x03)             // CL
+#define HID_USAGE_TELEPHONY_HANDSET (0x04)                      // CL
+#define HID_USAGE_TELEPHONY_HEADSET (0x05)                      // CL
+#define HID_USAGE_TELEPHONY_TELEPHONY_KEY_PAD (0x06)            // NAry
+#define HID_USAGE_TELEPHONY_PROGRAMMABLE_BUTTON (0x07)          // NAry
+#define HID_USAGE_TELEPHONY_HOOK_SWITCH (0x20)                  // OOC
+#define HID_USAGE_TELEPHONY_FLASH (0x21)                        // MC
+#define HID_USAGE_TELEPHONY_FEATURE (0x22)                      // OSC
+#define HID_USAGE_TELEPHONY_HOLD (0x23)                         // OOC
+#define HID_USAGE_TELEPHONY_REDIAL (0x24)                       // OSC
+#define HID_USAGE_TELEPHONY_TRANSFER (0x25)                     // OSC
+#define HID_USAGE_TELEPHONY_DROP (0x26)                         // OSC
+#define HID_USAGE_TELEPHONY_PARK (0x27)                         // OOC
+#define HID_USAGE_TELEPHONY_FORWARD_CALLS (0x28)                // OOC
+#define HID_USAGE_TELEPHONY_ALTERNATE_FUNCTION (0x29)           // MC
+#define HID_USAGE_TELEPHONY_LINE (0x2A)                         // OSC, NAry
+#define HID_USAGE_TELEPHONY_SPEAKER_PHONE (0x2B)                // OOC
+#define HID_USAGE_TELEPHONY_CONFERENCE (0x2C)                   // OOC
+#define HID_USAGE_TELEPHONY_RING_ENABLE (0x2D)                  // OOC
+#define HID_USAGE_TELEPHONY_RING_SELECT (0x2E)                  // OSC
+#define HID_USAGE_TELEPHONY_PHONE_MUTE (0x2F)                   // OOC
+#define HID_USAGE_TELEPHONY_CALLER_ID (0x30)                    // MC
+#define HID_USAGE_TELEPHONY_SEND (0x31)                         // OOC
+#define HID_USAGE_TELEPHONY_SPEED_DIAL (0x50)                   // OSC
+#define HID_USAGE_TELEPHONY_STORE_NUMBER (0x51)                 // OSC
+#define HID_USAGE_TELEPHONY_RECALL_NUMBER (0x52)                // OSC
+#define HID_USAGE_TELEPHONY_PHONE_DIRECTORY (0x53)              // OOC
+#define HID_USAGE_TELEPHONY_VOICE_MAIL (0x70)                   // OOC
+#define HID_USAGE_TELEPHONY_SCREEN_CALLS (0x71)                 // OOC
+#define HID_USAGE_TELEPHONY_DO_NOT_DISTURB (0x72)               // OOC
+#define HID_USAGE_TELEPHONY_MESSAGE (0x73)                      // OSC
+#define HID_USAGE_TELEPHONY_ANSWER_ON_OFF (0x74)                // OOC
+#define HID_USAGE_TELEPHONY_INSIDE_DIAL_TONE (0x90)             // MC
+#define HID_USAGE_TELEPHONY_OUTSIDE_DIAL_TONE (0x91)            // MC
+#define HID_USAGE_TELEPHONY_INSIDE_RING_TONE (0x92)             // MC
+#define HID_USAGE_TELEPHONY_OUTSIDE_RING_TONE (0x93)            // MC
+#define HID_USAGE_TELEPHONY_PRIORITY_RING_TONE (0x94)           // MC
+#define HID_USAGE_TELEPHONY_INSIDE_RINGBACK (0x95)              // MC
+#define HID_USAGE_TELEPHONY_PRIORITY_RINGBACK (0x96)            // MC
+#define HID_USAGE_TELEPHONY_LINE_BUSY_TONE (0x97)               // MC
+#define HID_USAGE_TELEPHONY_REORDER_TONE (0x98)                 // MC
+#define HID_USAGE_TELEPHONY_CALL_WAITING_TONE (0x99)            // MC
+#define HID_USAGE_TELEPHONY_CONFIRMATION_TONE_1 (0x9A)          // MC
+#define HID_USAGE_TELEPHONY_CONFIRMATION_TONE_2 (0x9B)          // MC
+#define HID_USAGE_TELEPHONY_TONES_OFF (0x9C)                    // OOC
+#define HID_USAGE_TELEPHONY_OUTSIDE_RINGBACK (0x9D)             // MC
+#define HID_USAGE_TELEPHONY_RINGER (0x9E)                       // OOC
+#define HID_USAGE_TELEPHONY_PHONE_KEY_0 (0xB0)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_1 (0xB1)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_2 (0xB2)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_3 (0xB3)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_4 (0xB4)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_5 (0xB5)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_6 (0xB6)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_7 (0xB7)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_8 (0xB8)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_9 (0xB9)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_STAR (0xBA)               // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_POUND (0xBB)              // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_A (0xBC)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_B (0xBD)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_C (0xBE)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_KEY_D (0xBF)                  // Sel
+#define HID_USAGE_TELEPHONY_PHONE_CALL_HISTORY_KEY (0xC0)       // Sel
+#define HID_USAGE_TELEPHONY_PHONE_CALLER_ID_KEY (0xC1)          // Sel
+#define HID_USAGE_TELEPHONY_PHONE_SETTINGS_KEY (0xC2)           // Sel
+#define HID_USAGE_TELEPHONY_HOST_CONTROL (0xF0)                 // OOC
+#define HID_USAGE_TELEPHONY_HOST_AVAILABLE (0xF1)               // OOC
+#define HID_USAGE_TELEPHONY_HOST_CALL_ACTIVE (0xF2)             // OOC
+#define HID_USAGE_TELEPHONY_ACTIVATE_HANDSET_AUDIO (0xF3)       // OOC
+#define HID_USAGE_TELEPHONY_RING_TYPE (0xF4)                    // NAry
+#define HID_USAGE_TELEPHONY_RE_DIALABLE_PHONE_NUMBER (0xF5)     // OOC
+#define HID_USAGE_TELEPHONY_STOP_RING_TONE (0xF8)               // Sel
+#define HID_USAGE_TELEPHONY_PSTN_RING_TONE (0xF9)               // Sel
+#define HID_USAGE_TELEPHONY_HOST_RING_TONE (0xFA)               // Sel
+#define HID_USAGE_TELEPHONY_ALERT_SOUND_ERROR (0xFB)            // Sel
+#define HID_USAGE_TELEPHONY_ALERT_SOUND_CONFIRM (0xFC)          // Sel
+#define HID_USAGE_TELEPHONY_ALERT_SOUND_NOTIFICATION (0xFD)     // Sel
+#define HID_USAGE_TELEPHONY_SILENT_RING (0xFE)                  // Sel
+#define HID_USAGE_TELEPHONY_EMAIL_MESSAGE_WAITING (0x108)       // OOC
+#define HID_USAGE_TELEPHONY_VOICEMAIL_MESSAGE_WAITING (0x109)   // OOC
+#define HID_USAGE_TELEPHONY_HOST_HOLD (0x10A)                   // OOC
+#define HID_USAGE_TELEPHONY_INCOMING_CALL_HISTORY_COUNT (0x110) // DV
+#define HID_USAGE_TELEPHONY_OUTGOING_CALL_HISTORY_COUNT (0x111) // DV
+#define HID_USAGE_TELEPHONY_INCOMING_CALL_HISTORY (0x112)       // CL
+#define HID_USAGE_TELEPHONY_OUTGOING_CALL_HISTORY (0x113)       // CL
+#define HID_USAGE_TELEPHONY_PHONE_LOCALE (0x114)                // DV
+#define HID_USAGE_TELEPHONY_PHONE_TIME_SECOND (0x140)           // DV
+#define HID_USAGE_TELEPHONY_PHONE_TIME_MINUTE (0x141)           // DV
+#define HID_USAGE_TELEPHONY_PHONE_TIME_HOUR (0x142)             // DV
+#define HID_USAGE_TELEPHONY_PHONE_DATE_DAY (0x143)              // DV
+#define HID_USAGE_TELEPHONY_PHONE_DATE_MONTH (0x144)            // DV
+#define HID_USAGE_TELEPHONY_PHONE_DATE_YEAR (0x145)             // DV
+#define HID_USAGE_TELEPHONY_HANDSET_NICKNAME (0x146)            // DV
+#define HID_USAGE_TELEPHONY_ADDRESS_BOOK_ID (0x147)             // DV
+#define HID_USAGE_TELEPHONY_CALL_DURATION (0x14A)               // DV
+#define HID_USAGE_TELEPHONY_DUAL_MODE_PHONE (0x14B)             // CA
+
+/* Page 0x0C: Consumer */
+#define HID_USAGE_CONSUMER_UNDEFINED (0x00)
+#define HID_USAGE_CONSUMER_CONSUMER_CONTROL (0x01)                            // CA
+#define HID_USAGE_CONSUMER_NUMERIC_KEY_PAD (0x02)                             // NAry
+#define HID_USAGE_CONSUMER_PROGRAMMABLE_BUTTONS (0x03)                        // NAry
+#define HID_USAGE_CONSUMER_MICROPHONE (0x04)                                  // CA
+#define HID_USAGE_CONSUMER_HEADPHONE (0x05)                                   // CA
+#define HID_USAGE_CONSUMER_GRAPHIC_EQUALIZER (0x06)                           // CA
+#define HID_USAGE_CONSUMER_INCREMENT10 (0x20)                                 // OSC
+#define HID_USAGE_CONSUMER_INCREMENT100 (0x21)                                // OSC
+#define HID_USAGE_CONSUMER_AM_PM (0x22)                                       // OSC
+#define HID_USAGE_CONSUMER_POWER (0x30)                                       // OOC
+#define HID_USAGE_CONSUMER_RESET (0x31)                                       // OSC
+#define HID_USAGE_CONSUMER_SLEEP (0x32)                                       // OSC
+#define HID_USAGE_CONSUMER_SLEEP_AFTER (0x33)                                 // OSC
+#define HID_USAGE_CONSUMER_SLEEP_MODE (0x34)                                  // RTC
+#define HID_USAGE_CONSUMER_ILLUMINATION (0x35)                                // OOC
+#define HID_USAGE_CONSUMER_FUNCTION_BUTTONS (0x36)                            // NAry
+#define HID_USAGE_CONSUMER_MENU (0x40)                                        // OOC
+#define HID_USAGE_CONSUMER_MENU_PICK (0x41)                                   // OSC
+#define HID_USAGE_CONSUMER_MENU_UP (0x42)                                     // OSC
+#define HID_USAGE_CONSUMER_MENU_DOWN (0x43)                                   // OSC
+#define HID_USAGE_CONSUMER_MENU_LEFT (0x44)                                   // OSC
+#define HID_USAGE_CONSUMER_MENU_RIGHT (0x45)                                  // OSC
+#define HID_USAGE_CONSUMER_MENU_ESCAPE (0x46)                                 // OSC
+#define HID_USAGE_CONSUMER_MENU_VALUE_INCREASE (0x47)                         // OSC
+#define HID_USAGE_CONSUMER_MENU_VALUE_DECREASE (0x48)                         // OSC
+#define HID_USAGE_CONSUMER_DATA_ON_SCREEN (0x60)                              // OOC
+#define HID_USAGE_CONSUMER_CLOSED_CAPTION (0x61)                              // OOC
+#define HID_USAGE_CONSUMER_CLOSED_CAPTION_SELECT (0x62)                       // OSC
+#define HID_USAGE_CONSUMER_VCR_TV (0x63)                                      // OOC
+#define HID_USAGE_CONSUMER_BROADCAST_MODE (0x64)                              // OSC
+#define HID_USAGE_CONSUMER_SNAPSHOT (0x65)                                    // OSC
+#define HID_USAGE_CONSUMER_STILL (0x66)                                       // OSC
+#define HID_USAGE_CONSUMER_PICTURE_IN_PICTURE_TOGGLE (0x67)                   // OSC
+#define HID_USAGE_CONSUMER_PICTURE_IN_PICTURE_SWAP (0x68)                     // OSC
+#define HID_USAGE_CONSUMER_RED_MENU_BUTTON (0x69)                             // MC
+#define HID_USAGE_CONSUMER_GREEN_MENU_BUTTON (0x6A)                           // MC
+#define HID_USAGE_CONSUMER_BLUE_MENU_BUTTON (0x6B)                            // MC
+#define HID_USAGE_CONSUMER_YELLOW_MENU_BUTTON (0x6C)                          // MC
+#define HID_USAGE_CONSUMER_ASPECT (0x6D)                                      // OSC
+#define HID_USAGE_CONSUMER_3D_MODE_SELECT (0x6E)                              // OSC
+#define HID_USAGE_CONSUMER_DISPLAY_BRIGHTNESS_INCREMENT (0x6F)                // RTC
+#define HID_USAGE_CONSUMER_DISPLAY_BRIGHTNESS_DECREMENT (0x70)                // RTC
+#define HID_USAGE_CONSUMER_DISPLAY_BRIGHTNESS (0x71)                          // LC
+#define HID_USAGE_CONSUMER_DISPLAY_BACKLIGHT_TOGGLE (0x72)                    // OOC
+#define HID_USAGE_CONSUMER_DISPLAY_SET_BRIGHTNESS_TO_MINIMUM (0x73)           // OSC
+#define HID_USAGE_CONSUMER_DISPLAY_SET_BRIGHTNESS_TO_MAXIMUM (0x74)           // OSC
+#define HID_USAGE_CONSUMER_DISPLAY_SET_AUTO_BRIGHTNESS (0x75)                 // OOC
+#define HID_USAGE_CONSUMER_CAMERA_ACCESS_ENABLED (0x76)                       // OOC
+#define HID_USAGE_CONSUMER_CAMERA_ACCESS_DISABLED (0x77)                      // OOC
+#define HID_USAGE_CONSUMER_CAMERA_ACCESS_TOGGLE (0x78)                        // OOC
+#define HID_USAGE_CONSUMER_KEYBOARD_BRIGHTNESS_INCREMENT (0x79)               // OSC
+#define HID_USAGE_CONSUMER_KEYBOARD_BRIGHTNESS_DECREMENT (0x7A)               // OSC
+#define HID_USAGE_CONSUMER_KEYBOARD_BACKLIGHT_SET_LEVEL (0x7B)                // LC
+#define HID_USAGE_CONSUMER_KEYBOARD_BACKLIGHT_OOC (0x7C)                      // OOC
+#define HID_USAGE_CONSUMER_KEYBOARD_BACKLIGHT_SET_MINIMUM (0x7D)              // OSC
+#define HID_USAGE_CONSUMER_KEYBOARD_BACKLIGHT_SET_MAXIMUM (0x7E)              // OSC
+#define HID_USAGE_CONSUMER_KEYBOARD_BACKLIGHT_AUTO (0x7F)                     // OOC
+#define HID_USAGE_CONSUMER_SELECTION (0x80)                                   // NAry
+#define HID_USAGE_CONSUMER_ASSIGN_SELECTION (0x81)                            // OSC
+#define HID_USAGE_CONSUMER_MODE_STEP (0x82)                                   // OSC
+#define HID_USAGE_CONSUMER_RECALL_LAST (0x83)                                 // OSC
+#define HID_USAGE_CONSUMER_ENTER_CHANNEL (0x84)                               // OSC
+#define HID_USAGE_CONSUMER_ORDER_MOVIE (0x85)                                 // OSC
+#define HID_USAGE_CONSUMER_CHANNEL (0x86)                                     // LC
+#define HID_USAGE_CONSUMER_MEDIA_SELECTION (0x87)                             // NAry
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_COMPUTER (0x88)                       // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_TV (0x89)                             // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_WWW (0x8A)                            // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_DVD (0x8B)                            // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_TELEPHONE (0x8C)                      // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_PROGRAM_GUIDE (0x8D)                  // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_VIDEO_PHONE (0x8E)                    // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_GAMES (0x8F)                          // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_MESSAGES (0x90)                       // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_CD (0x91)                             // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_VCR (0x92)                            // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_TUNER (0x93)                          // Sel
+#define HID_USAGE_CONSUMER_QUIT (0x94)                                        // OSC
+#define HID_USAGE_CONSUMER_HELP (0x95)                                        // OOC
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_TAPE (0x96)                           // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_CABLE (0x97)                          // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_SATELLITE (0x98)                      // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_SECURITY (0x99)                       // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_HOME (0x9A)                           // Sel
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_CALL (0x9B)                           // Sel
+#define HID_USAGE_CONSUMER_CHANNEL_INCREMENT (0x9C)                           // OSC
+#define HID_USAGE_CONSUMER_CHANNEL_DECREMENT (0x9D)                           // OSC
+#define HID_USAGE_CONSUMER_MEDIA_SELECT_SAP (0x9E)                            // Sel
+#define HID_USAGE_CONSUMER_VCR_PLUS (0xA0)                                    // OSC
+#define HID_USAGE_CONSUMER_ONCE (0xA1)                                        // OSC
+#define HID_USAGE_CONSUMER_DAILY (0xA2)                                       // OSC
+#define HID_USAGE_CONSUMER_WEEKLY (0xA3)                                      // OSC
+#define HID_USAGE_CONSUMER_MONTHLY (0xA4)                                     // OSC
+#define HID_USAGE_CONSUMER_PLAY (0xB0)                                        // OOC
+#define HID_USAGE_CONSUMER_PAUSE (0xB1)                                       // OOC
+#define HID_USAGE_CONSUMER_RECORD (0xB2)                                      // OOC
+#define HID_USAGE_CONSUMER_FAST_FORWARD (0xB3)                                // OOC
+#define HID_USAGE_CONSUMER_REWIND (0xB4)                                      // OOC
+#define HID_USAGE_CONSUMER_SCAN_NEXT_TRACK (0xB5)                             // OSC
+#define HID_USAGE_CONSUMER_SCAN_PREVIOUS_TRACK (0xB6)                         // OSC
+#define HID_USAGE_CONSUMER_STOP (0xB7)                                        // OSC
+#define HID_USAGE_CONSUMER_EJECT (0xB8)                                       // OSC
+#define HID_USAGE_CONSUMER_RANDOM_PLAY (0xB9)                                 // OOC
+#define HID_USAGE_CONSUMER_SELECT_DISC (0xBA)                                 // NAry
+#define HID_USAGE_CONSUMER_ENTER_DISC (0xBB)                                  // MC
+#define HID_USAGE_CONSUMER_REPEAT (0xBC)                                      // OSC
+#define HID_USAGE_CONSUMER_TRACKING (0xBD)                                    // LC
+#define HID_USAGE_CONSUMER_TRACK_NORMAL (0xBE)                                // OSC
+#define HID_USAGE_CONSUMER_SLOW_TRACKING (0xBF)                               // LC
+#define HID_USAGE_CONSUMER_FRAME_FORWARD (0xC0)                               // RTC
+#define HID_USAGE_CONSUMER_FRAME_BACK (0xC1)                                  // RTC
+#define HID_USAGE_CONSUMER_MARK (0xC2)                                        // OSC
+#define HID_USAGE_CONSUMER_CLEAR_MARK (0xC3)                                  // OSC
+#define HID_USAGE_CONSUMER_REPEAT_FROM_MARK (0xC4)                            // OOC
+#define HID_USAGE_CONSUMER_RETURN_TO_MARK (0xC5)                              // OSC
+#define HID_USAGE_CONSUMER_SEARCH_MARK_FORWARD (0xC6)                         // OSC
+#define HID_USAGE_CONSUMER_SEARCH_MARK_BACKWARDS (0xC7)                       // OSC
+#define HID_USAGE_CONSUMER_COUNTER_RESET (0xC8)                               // OSC
+#define HID_USAGE_CONSUMER_SHOW_COUNTER (0xC9)                                // OSC
+#define HID_USAGE_CONSUMER_TRACKING_INCREMENT (0xCA)                          // RTC
+#define HID_USAGE_CONSUMER_TRACKING_DECREMENT (0xCB)                          // RTC
+#define HID_USAGE_CONSUMER_STOP_EJECT (0xCC)                                  // OSC
+#define HID_USAGE_CONSUMER_PLAY_PAUSE (0xCD)                                  // OSC
+#define HID_USAGE_CONSUMER_PLAY_SKIP (0xCE)                                   // OSC
+#define HID_USAGE_CONSUMER_VOICE_COMMAND (0xCF)                               // OSC
+#define HID_USAGE_CONSUMER_INVOKE_CAPTURE_INTERFACE (0xD0)                    // Sel
+#define HID_USAGE_CONSUMER_START_OR_STOP_GAME_RECORDING (0xD1)                // Sel
+#define HID_USAGE_CONSUMER_HISTORICAL_GAME_CAPTURE (0xD2)                     // Sel
+#define HID_USAGE_CONSUMER_CAPTURE_GAME_SCREENSHOT (0xD3)                     // Sel
+#define HID_USAGE_CONSUMER_SHOW_OR_HIDE_RECORDING_INDICATOR (0xD4)            // Sel
+#define HID_USAGE_CONSUMER_START_OR_STOP_MICROPHONE_CAPTURE (0xD5)            // Sel
+#define HID_USAGE_CONSUMER_START_OR_STOP_CAMERA_CAPTURE (0xD6)                // Sel
+#define HID_USAGE_CONSUMER_START_OR_STOP_GAME_BROADCAST (0xD7)                // Sel
+#define HID_USAGE_CONSUMER_VOLUME (0xE0)                                      // LC
+#define HID_USAGE_CONSUMER_BALANCE (0xE1)                                     // LC
+#define HID_USAGE_CONSUMER_MUTE (0xE2)                                        // OOC
+#define HID_USAGE_CONSUMER_BASS (0xE3)                                        // LC
+#define HID_USAGE_CONSUMER_TREBLE (0xE4)                                      // LC
+#define HID_USAGE_CONSUMER_BASS_BOOST (0xE5)                                  // OOC
+#define HID_USAGE_CONSUMER_SURROUND_MODE (0xE6)                               // OSC
+#define HID_USAGE_CONSUMER_LOUDNESS (0xE7)                                    // OOC
+#define HID_USAGE_CONSUMER_MPX (0xE8)                                         // OOC
+#define HID_USAGE_CONSUMER_VOLUME_INCREMENT (0xE9)                            // RTC
+#define HID_USAGE_CONSUMER_VOLUME_DECREMENT (0xEA)                            // RTC
+#define HID_USAGE_CONSUMER_SPEED_SELECT (0xF0)                                // OSC
+#define HID_USAGE_CONSUMER_PLAYBACK_SPEED (0xF1)                              // NAry
+#define HID_USAGE_CONSUMER_STANDARD_PLAY (0xF2)                               // Sel
+#define HID_USAGE_CONSUMER_LONG_PLAY (0xF3)                                   // Sel
+#define HID_USAGE_CONSUMER_EXTENDED_PLAY (0xF4)                               // Sel
+#define HID_USAGE_CONSUMER_SLOW (0xF5)                                        // OSC
+#define HID_USAGE_CONSUMER_FAN_ENABLE (0x100)                                 // OOC
+#define HID_USAGE_CONSUMER_FAN_SPEED (0x101)                                  // LC
+#define HID_USAGE_CONSUMER_LIGHT_ENABLE (0x102)                               // OOC
+#define HID_USAGE_CONSUMER_LIGHT_ILLUMINATION_LEVEL (0x103)                   // LC
+#define HID_USAGE_CONSUMER_CLIMATE_CONTROL_ENABLE (0x104)                     // OOC
+#define HID_USAGE_CONSUMER_ROOM_TEMPERATURE (0x105)                           // LC
+#define HID_USAGE_CONSUMER_SECURITY_ENABLE (0x106)                            // OOC
+#define HID_USAGE_CONSUMER_FIRE_ALARM (0x107)                                 // OSC
+#define HID_USAGE_CONSUMER_POLICE_ALARM (0x108)                               // OSC
+#define HID_USAGE_CONSUMER_PROXIMITY (0x109)                                  // LC
+#define HID_USAGE_CONSUMER_MOTION (0x10A)                                     // OSC
+#define HID_USAGE_CONSUMER_DURESS_ALARM (0x10B)                               // OSC
+#define HID_USAGE_CONSUMER_HOLDUP_ALARM (0x10C)                               // OSC
+#define HID_USAGE_CONSUMER_MEDICAL_ALARM (0x10D)                              // OSC
+#define HID_USAGE_CONSUMER_BALANCE_RIGHT (0x150)                              // RTC
+#define HID_USAGE_CONSUMER_BALANCE_LEFT (0x151)                               // RTC
+#define HID_USAGE_CONSUMER_BASS_INCREMENT (0x152)                             // RTC
+#define HID_USAGE_CONSUMER_BASS_DECREMENT (0x153)                             // RTC
+#define HID_USAGE_CONSUMER_TREBLE_INCREMENT (0x154)                           // RTC
+#define HID_USAGE_CONSUMER_TREBLE_DECREMENT (0x155)                           // RTC
+#define HID_USAGE_CONSUMER_SPEAKER_SYSTEM (0x160)                             // CL
+#define HID_USAGE_CONSUMER_CHANNEL_LEFT (0x161)                               // CL
+#define HID_USAGE_CONSUMER_CHANNEL_RIGHT (0x162)                              // CL
+#define HID_USAGE_CONSUMER_CHANNEL_CENTER (0x163)                             // CL
+#define HID_USAGE_CONSUMER_CHANNEL_FRONT (0x164)                              // CL
+#define HID_USAGE_CONSUMER_CHANNEL_CENTER_FRONT (0x165)                       // CL
+#define HID_USAGE_CONSUMER_CHANNEL_SIDE (0x166)                               // CL
+#define HID_USAGE_CONSUMER_CHANNEL_SURROUND (0x167)                           // CL
+#define HID_USAGE_CONSUMER_CHANNEL_LOW_FREQUENCY_ENHANCEMENT (0x168)          // CL
+#define HID_USAGE_CONSUMER_CHANNEL_TOP (0x169)                                // CL
+#define HID_USAGE_CONSUMER_CHANNEL_UNKNOWN (0x16A)                            // CL
+#define HID_USAGE_CONSUMER_SUB_CHANNEL (0x170)                                // LC
+#define HID_USAGE_CONSUMER_SUB_CHANNEL_INCREMENT (0x171)                      // OSC
+#define HID_USAGE_CONSUMER_SUB_CHANNEL_DECREMENT (0x172)                      // OSC
+#define HID_USAGE_CONSUMER_ALTERNATE_AUDIO_INCREMENT (0x173)                  // OSC
+#define HID_USAGE_CONSUMER_ALTERNATE_AUDIO_DECREMENT (0x174)                  // OSC
+#define HID_USAGE_CONSUMER_APPLICATION_LAUNCH_BUTTONS (0x180)                 // NAry
+#define HID_USAGE_CONSUMER_AL_LAUNCH_BUTTON_CONFIGURATION_TOOL (0x181)        // Sel
+#define HID_USAGE_CONSUMER_AL_PROGRAMMABLE_BUTTON_CONFIGURATION (0x182)       // Sel
+#define HID_USAGE_CONSUMER_AL_CONSUMER_CONTROL_CONFIGURATION (0x183)          // Sel
+#define HID_USAGE_CONSUMER_AL_WORD_PROCESSOR (0x184)                          // Sel
+#define HID_USAGE_CONSUMER_AL_TEXT_EDITOR (0x185)                             // Sel
+#define HID_USAGE_CONSUMER_AL_SPREADSHEET (0x186)                             // Sel
+#define HID_USAGE_CONSUMER_AL_GRAPHICS_EDITOR (0x187)                         // Sel
+#define HID_USAGE_CONSUMER_AL_PRESENTATION_APP (0x188)                        // Sel
+#define HID_USAGE_CONSUMER_AL_DATABASE_APP (0x189)                            // Sel
+#define HID_USAGE_CONSUMER_AL_EMAIL_READER (0x18A)                            // Sel
+#define HID_USAGE_CONSUMER_AL_NEWSREADER (0x18B)                              // Sel
+#define HID_USAGE_CONSUMER_AL_VOICEMAIL (0x18C)                               // Sel
+#define HID_USAGE_CONSUMER_AL_CONTACTS_ADDRESS_BOOK (0x18D)                   // Sel
+#define HID_USAGE_CONSUMER_AL_CALENDAR_SCHEDULE (0x18E)                       // Sel
+#define HID_USAGE_CONSUMER_AL_TASK_PROJECT_MANAGER (0x18F)                    // Sel
+#define HID_USAGE_CONSUMER_AL_LOG_JOURNAL_TIMECARD (0x190)                    // Sel
+#define HID_USAGE_CONSUMER_AL_CHECKBOOK_FINANCE (0x191)                       // Sel
+#define HID_USAGE_CONSUMER_AL_CALCULATOR (0x192)                              // Sel
+#define HID_USAGE_CONSUMER_AL_A_V_CAPTURE_PLAYBACK (0x193)                    // Sel
+#define HID_USAGE_CONSUMER_AL_LOCAL_MACHINE_BROWSER (0x194)                   // Sel
+#define HID_USAGE_CONSUMER_AL_LAN_WAN_BROWSER (0x195)                         // Sel
+#define HID_USAGE_CONSUMER_AL_INTERNET_BROWSER (0x196)                        // Sel
+#define HID_USAGE_CONSUMER_AL_REMOTE_NETWORKING_ISP_CONNECT (0x197)           // Sel
+#define HID_USAGE_CONSUMER_AL_NETWORK_CONFERENCE (0x198)                      // Sel
+#define HID_USAGE_CONSUMER_AL_NETWORK_CHAT (0x199)                            // Sel
+#define HID_USAGE_CONSUMER_AL_TELEPHONY_DIALER (0x19A)                        // Sel
+#define HID_USAGE_CONSUMER_AL_LOGON (0x19B)                                   // Sel
+#define HID_USAGE_CONSUMER_AL_LOGOFF (0x19C)                                  // Sel
+#define HID_USAGE_CONSUMER_AL_LOGON_LOGOFF (0x19D)                            // Sel
+#define HID_USAGE_CONSUMER_AL_TERMINAL_LOCK_SCREENSAVER (0x19E)               // Sel
+#define HID_USAGE_CONSUMER_AL_CONTROL_PANEL (0x19F)                           // Sel
+#define HID_USAGE_CONSUMER_AL_COMMAND_LINE_PROCESSOR_RUN (0x1A0)              // Sel
+#define HID_USAGE_CONSUMER_AL_PROCESS_TASK_MANAGER (0x1A1)                    // Sel
+#define HID_USAGE_CONSUMER_AL_SELECT_TASK_APPLICATION (0x1A2)                 // Sel
+#define HID_USAGE_CONSUMER_AL_NEXT_TASK_APPLICATION (0x1A3)                   // Sel
+#define HID_USAGE_CONSUMER_AL_PREVIOUS_TASK_APPLICATION (0x1A4)               // Sel
+#define HID_USAGE_CONSUMER_AL_PREEMPTIVE_HALT_TASK_APPLICATION (0x1A5)        // Sel
+#define HID_USAGE_CONSUMER_AL_INTEGRATED_HELP_CENTER (0x1A6)                  // Sel
+#define HID_USAGE_CONSUMER_AL_DOCUMENTS (0x1A7)                               // Sel
+#define HID_USAGE_CONSUMER_AL_THESAURUS (0x1A8)                               // Sel
+#define HID_USAGE_CONSUMER_AL_DICTIONARY (0x1A9)                              // Sel
+#define HID_USAGE_CONSUMER_AL_DESKTOP (0x1AA)                                 // Sel
+#define HID_USAGE_CONSUMER_AL_SPELL_CHECK (0x1AB)                             // Sel
+#define HID_USAGE_CONSUMER_AL_GRAMMAR_CHECK (0x1AC)                           // Sel
+#define HID_USAGE_CONSUMER_AL_WIRELESS_STATUS (0x1AD)                         // Sel
+#define HID_USAGE_CONSUMER_AL_KEYBOARD_LAYOUT (0x1AE)                         // Sel
+#define HID_USAGE_CONSUMER_AL_VIRUS_PROTECTION (0x1AF)                        // Sel
+#define HID_USAGE_CONSUMER_AL_ENCRYPTION (0x1B0)                              // Sel
+#define HID_USAGE_CONSUMER_AL_SCREEN_SAVER (0x1B1)                            // Sel
+#define HID_USAGE_CONSUMER_AL_ALARMS (0x1B2)                                  // Sel
+#define HID_USAGE_CONSUMER_AL_CLOCK (0x1B3)                                   // Sel
+#define HID_USAGE_CONSUMER_AL_FILE_BROWSER (0x1B4)                            // Sel
+#define HID_USAGE_CONSUMER_AL_POWER_STATUS (0x1B5)                            // Sel
+#define HID_USAGE_CONSUMER_AL_IMAGE_BROWSER (0x1B6)                           // Sel
+#define HID_USAGE_CONSUMER_AL_AUDIO_BROWSER (0x1B7)                           // Sel
+#define HID_USAGE_CONSUMER_AL_MOVIE_BROWSER (0x1B8)                           // Sel
+#define HID_USAGE_CONSUMER_AL_DIGITAL_RIGHTS_MANAGER (0x1B9)                  // Sel
+#define HID_USAGE_CONSUMER_AL_DIGITAL_WALLET (0x1BA)                          // Sel
+#define HID_USAGE_CONSUMER_AL_INSTANT_MESSAGING (0x1BC)                       // Sel
+#define HID_USAGE_CONSUMER_AL_OEM_FEATURES_TIPS_TUTORIAL_BROWSER (0x1BD)      // Sel
+#define HID_USAGE_CONSUMER_AL_OEM_HELP (0x1BE)                                // Sel
+#define HID_USAGE_CONSUMER_AL_ONLINE_COMMUNITY (0x1BF)                        // Sel
+#define HID_USAGE_CONSUMER_AL_ENTERTAINMENT_CONTENT_BROWSER (0x1C0)           // Sel
+#define HID_USAGE_CONSUMER_AL_ONLINE_SHOPPING_BROWSER (0x1C1)                 // Sel
+#define HID_USAGE_CONSUMER_AL_SMARTCARD_INFORMATION_HELP (0x1C2)              // Sel
+#define HID_USAGE_CONSUMER_AL_MARKET_MONITOR_FINANCE_BROWSER (0x1C3)          // Sel
+#define HID_USAGE_CONSUMER_AL_CUSTOMIZED_CORPORATE_NEWS_BROWSER (0x1C4)       // Sel
+#define HID_USAGE_CONSUMER_AL_ONLINE_ACTIVITY_BROWSER (0x1C5)                 // Sel
+#define HID_USAGE_CONSUMER_AL_RESEARCH_SEARCH_BROWSER (0x1C6)                 // Sel
+#define HID_USAGE_CONSUMER_AL_AUDIO_PLAYER (0x1C7)                            // Sel
+#define HID_USAGE_CONSUMER_AL_MESSAGE_STATUS (0x1C8)                          // Sel
+#define HID_USAGE_CONSUMER_AL_CONTACT_SYNC (0x1C9)                            // Sel
+#define HID_USAGE_CONSUMER_AL_NAVIGATION (0x1CA)                              // Sel
+#define HID_USAGE_CONSUMER_AL_CONTEXT_AWARE_DESKTOP_ASSISTANT (0x1CB)         // Sel
+#define HID_USAGE_CONSUMER_GENERIC_GUI_APPLICATION_CONTROLS (0x200)           // NAry
+#define HID_USAGE_CONSUMER_AC_NEW (0x201)                                     // Sel
+#define HID_USAGE_CONSUMER_AC_OPEN (0x202)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_CLOSE (0x203)                                   // Sel
+#define HID_USAGE_CONSUMER_AC_EXIT (0x204)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_MAXIMIZE (0x205)                                // Sel
+#define HID_USAGE_CONSUMER_AC_MINIMIZE (0x206)                                // Sel
+#define HID_USAGE_CONSUMER_AC_SAVE (0x207)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_PRINT (0x208)                                   // Sel
+#define HID_USAGE_CONSUMER_AC_PROPERTIES (0x209)                              // Sel
+#define HID_USAGE_CONSUMER_AC_UNDO (0x21A)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_COPY (0x21B)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_CUT (0x21C)                                     // Sel
+#define HID_USAGE_CONSUMER_AC_PASTE (0x21D)                                   // Sel
+#define HID_USAGE_CONSUMER_AC_SELECT_ALL (0x21E)                              // Sel
+#define HID_USAGE_CONSUMER_AC_FIND (0x21F)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_FIND_AND_REPLACE (0x220)                        // Sel
+#define HID_USAGE_CONSUMER_AC_SEARCH (0x221)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_GO_TO (0x222)                                   // Sel
+#define HID_USAGE_CONSUMER_AC_HOME (0x223)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_BACK (0x224)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_FORWARD (0x225)                                 // Sel
+#define HID_USAGE_CONSUMER_AC_STOP (0x226)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_REFRESH (0x227)                                 // Sel
+#define HID_USAGE_CONSUMER_AC_PREVIOUS_LINK (0x228)                           // Sel
+#define HID_USAGE_CONSUMER_AC_NEXT_LINK (0x229)                               // Sel
+#define HID_USAGE_CONSUMER_AC_BOOKMARKS (0x22A)                               // Sel
+#define HID_USAGE_CONSUMER_AC_HISTORY (0x22B)                                 // Sel
+#define HID_USAGE_CONSUMER_AC_SUBSCRIPTIONS (0x22C)                           // Sel
+#define HID_USAGE_CONSUMER_AC_ZOOM_IN (0x22D)                                 // Sel
+#define HID_USAGE_CONSUMER_AC_ZOOM_OUT (0x22E)                                // Sel
+#define HID_USAGE_CONSUMER_AC_ZOOM (0x22F)                                    // LC
+#define HID_USAGE_CONSUMER_AC_FULL_SCREEN_VIEW (0x230)                        // Sel
+#define HID_USAGE_CONSUMER_AC_NORMAL_VIEW (0x231)                             // Sel
+#define HID_USAGE_CONSUMER_AC_VIEW_TOGGLE (0x232)                             // Sel
+#define HID_USAGE_CONSUMER_AC_SCROLL_UP (0x233)                               // Sel
+#define HID_USAGE_CONSUMER_AC_SCROLL_DOWN (0x234)                             // Sel
+#define HID_USAGE_CONSUMER_AC_SCROLL (0x235)                                  // LC
+#define HID_USAGE_CONSUMER_AC_PAN_LEFT (0x236)                                // Sel
+#define HID_USAGE_CONSUMER_AC_PAN_RIGHT (0x237)                               // Sel
+#define HID_USAGE_CONSUMER_AC_PAN (0x238)                                     // LC
+#define HID_USAGE_CONSUMER_AC_NEW_WINDOW (0x239)                              // Sel
+#define HID_USAGE_CONSUMER_AC_TILE_HORIZONTALLY (0x23A)                       // Sel
+#define HID_USAGE_CONSUMER_AC_TILE_VERTICALLY (0x23B)                         // Sel
+#define HID_USAGE_CONSUMER_AC_FORMAT (0x23C)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_EDIT (0x23D)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_BOLD (0x23E)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_ITALICS (0x23F)                                 // Sel
+#define HID_USAGE_CONSUMER_AC_UNDERLINE (0x240)                               // Sel
+#define HID_USAGE_CONSUMER_AC_STRIKETHROUGH (0x241)                           // Sel
+#define HID_USAGE_CONSUMER_AC_SUBSCRIPT (0x242)                               // Sel
+#define HID_USAGE_CONSUMER_AC_SUPERSCRIPT (0x243)                             // Sel
+#define HID_USAGE_CONSUMER_AC_ALL_CAPS (0x244)                                // Sel
+#define HID_USAGE_CONSUMER_AC_ROTATE (0x245)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_RESIZE (0x246)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_FLIP_HORIZONTAL (0x247)                         // Sel
+#define HID_USAGE_CONSUMER_AC_FLIP_VERTICAL (0x248)                           // Sel
+#define HID_USAGE_CONSUMER_AC_MIRROR_HORIZONTAL (0x249)                       // Sel
+#define HID_USAGE_CONSUMER_AC_MIRROR_VERTICAL (0x24A)                         // Sel
+#define HID_USAGE_CONSUMER_AC_FONT_SELECT (0x24B)                             // Sel
+#define HID_USAGE_CONSUMER_AC_FONT_COLOR (0x24C)                              // Sel
+#define HID_USAGE_CONSUMER_AC_FONT_SIZE (0x24D)                               // Sel
+#define HID_USAGE_CONSUMER_AC_JUSTIFY_LEFT (0x24E)                            // Sel
+#define HID_USAGE_CONSUMER_AC_JUSTIFY_CENTER_H (0x24F)                        // Sel
+#define HID_USAGE_CONSUMER_AC_JUSTIFY_RIGHT (0x250)                           // Sel
+#define HID_USAGE_CONSUMER_AC_JUSTIFY_BLOCK_H (0x251)                         // Sel
+#define HID_USAGE_CONSUMER_AC_JUSTIFY_TOP (0x252)                             // Sel
+#define HID_USAGE_CONSUMER_AC_JUSTIFY_CENTER_V (0x253)                        // Sel
+#define HID_USAGE_CONSUMER_AC_JUSTIFY_BOTTOM (0x254)                          // Sel
+#define HID_USAGE_CONSUMER_AC_JUSTIFY_BLOCK_V (0x255)                         // Sel
+#define HID_USAGE_CONSUMER_AC_INDENT_DECREASE (0x256)                         // Sel
+#define HID_USAGE_CONSUMER_AC_INDENT_INCREASE (0x257)                         // Sel
+#define HID_USAGE_CONSUMER_AC_NUMBERED_LIST (0x258)                           // Sel
+#define HID_USAGE_CONSUMER_AC_RESTART_NUMBERING (0x259)                       // Sel
+#define HID_USAGE_CONSUMER_AC_BULLETED_LIST (0x25A)                           // Sel
+#define HID_USAGE_CONSUMER_AC_PROMOTE (0x25B)                                 // Sel
+#define HID_USAGE_CONSUMER_AC_DEMOTE (0x25C)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_YES (0x25D)                                     // Sel
+#define HID_USAGE_CONSUMER_AC_NO (0x25E)                                      // Sel
+#define HID_USAGE_CONSUMER_AC_CANCEL (0x25F)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_CATALOG (0x260)                                 // Sel
+#define HID_USAGE_CONSUMER_AC_BUY_CHECKOUT (0x261)                            // Sel
+#define HID_USAGE_CONSUMER_AC_ADD_TO_CART (0x262)                             // Sel
+#define HID_USAGE_CONSUMER_AC_EXPAND (0x263)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_EXPAND_ALL (0x264)                              // Sel
+#define HID_USAGE_CONSUMER_AC_COLLAPSE (0x265)                                // Sel
+#define HID_USAGE_CONSUMER_AC_COLLAPSE_ALL (0x266)                            // Sel
+#define HID_USAGE_CONSUMER_AC_PRINT_PREVIEW (0x267)                           // Sel
+#define HID_USAGE_CONSUMER_AC_PASTE_SPECIAL (0x268)                           // Sel
+#define HID_USAGE_CONSUMER_AC_INSERT_MODE (0x269)                             // Sel
+#define HID_USAGE_CONSUMER_AC_DELETE (0x26A)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_LOCK (0x26B)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_UNLOCK (0x26C)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_PROTECT (0x26D)                                 // Sel
+#define HID_USAGE_CONSUMER_AC_UNPROTECT (0x26E)                               // Sel
+#define HID_USAGE_CONSUMER_AC_ATTACH_COMMENT (0x26F)                          // Sel
+#define HID_USAGE_CONSUMER_AC_DELETE_COMMENT (0x270)                          // Sel
+#define HID_USAGE_CONSUMER_AC_VIEW_COMMENT (0x271)                            // Sel
+#define HID_USAGE_CONSUMER_AC_SELECT_WORD (0x272)                             // Sel
+#define HID_USAGE_CONSUMER_AC_SELECT_SENTENCE (0x273)                         // Sel
+#define HID_USAGE_CONSUMER_AC_SELECT_PARAGRAPH (0x274)                        // Sel
+#define HID_USAGE_CONSUMER_AC_SELECT_COLUMN (0x275)                           // Sel
+#define HID_USAGE_CONSUMER_AC_SELECT_ROW (0x276)                              // Sel
+#define HID_USAGE_CONSUMER_AC_SELECT_TABLE (0x277)                            // Sel
+#define HID_USAGE_CONSUMER_AC_SELECT_OBJECT (0x278)                           // Sel
+#define HID_USAGE_CONSUMER_AC_REDO_REPEAT (0x279)                             // Sel
+#define HID_USAGE_CONSUMER_AC_SORT (0x27A)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_SORT_ASCENDING (0x27B)                          // Sel
+#define HID_USAGE_CONSUMER_AC_SORT_DESCENDING (0x27C)                         // Sel
+#define HID_USAGE_CONSUMER_AC_FILTER (0x27D)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_SET_CLOCK (0x27E)                               // Sel
+#define HID_USAGE_CONSUMER_AC_VIEW_CLOCK (0x27F)                              // Sel
+#define HID_USAGE_CONSUMER_AC_SELECT_TIME_ZONE (0x280)                        // Sel
+#define HID_USAGE_CONSUMER_AC_EDIT_TIME_ZONES (0x281)                         // Sel
+#define HID_USAGE_CONSUMER_AC_SET_ALARM (0x282)                               // Sel
+#define HID_USAGE_CONSUMER_AC_CLEAR_ALARM (0x283)                             // Sel
+#define HID_USAGE_CONSUMER_AC_SNOOZE_ALARM (0x284)                            // Sel
+#define HID_USAGE_CONSUMER_AC_RESET_ALARM (0x285)                             // Sel
+#define HID_USAGE_CONSUMER_AC_SYNCHRONIZE (0x286)                             // Sel
+#define HID_USAGE_CONSUMER_AC_SEND_RECEIVE (0x287)                            // Sel
+#define HID_USAGE_CONSUMER_AC_SEND_TO (0x288)                                 // Sel
+#define HID_USAGE_CONSUMER_AC_REPLY (0x289)                                   // Sel
+#define HID_USAGE_CONSUMER_AC_REPLY_ALL (0x28A)                               // Sel
+#define HID_USAGE_CONSUMER_AC_FORWARD_MSG (0x28B)                             // Sel
+#define HID_USAGE_CONSUMER_AC_SEND (0x28C)                                    // Sel
+#define HID_USAGE_CONSUMER_AC_ATTACH_FILE (0x28D)                             // Sel
+#define HID_USAGE_CONSUMER_AC_UPLOAD (0x28E)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_DOWNLOAD_SAVE_TARGET_AS (0x28F)                 // Sel
+#define HID_USAGE_CONSUMER_AC_SET_BORDERS (0x290)                             // Sel
+#define HID_USAGE_CONSUMER_AC_INSERT_ROW (0x291)                              // Sel
+#define HID_USAGE_CONSUMER_AC_INSERT_COLUMN (0x292)                           // Sel
+#define HID_USAGE_CONSUMER_AC_INSERT_FILE (0x293)                             // Sel
+#define HID_USAGE_CONSUMER_AC_INSERT_PICTURE (0x294)                          // Sel
+#define HID_USAGE_CONSUMER_AC_INSERT_OBJECT (0x295)                           // Sel
+#define HID_USAGE_CONSUMER_AC_INSERT_SYMBOL (0x296)                           // Sel
+#define HID_USAGE_CONSUMER_AC_SAVE_AND_CLOSE (0x297)                          // Sel
+#define HID_USAGE_CONSUMER_AC_RENAME (0x298)                                  // Sel
+#define HID_USAGE_CONSUMER_AC_MERGE (0x299)                                   // Sel
+#define HID_USAGE_CONSUMER_AC_SPLIT (0x29A)                                   // Sel
+#define HID_USAGE_CONSUMER_AC_DISRIBUTE_HORIZONTALLY (0x29B)                  // Sel
+#define HID_USAGE_CONSUMER_AC_DISTRIBUTE_VERTICALLY (0x29C)                   // Sel
+#define HID_USAGE_CONSUMER_AC_NEXT_KEYBOARD_LAYOUT_SELECT (0x29D)             // Sel
+#define HID_USAGE_CONSUMER_AC_NAVIGATION_GUIDANCE (0x29E)                     // Sel
+#define HID_USAGE_CONSUMER_AC_DESKTOP_SHOW_ALL_WINDOWS (0x29F)                // Sel
+#define HID_USAGE_CONSUMER_AC_SOFT_KEY_LEFT (0x2A0)                           // Sel
+#define HID_USAGE_CONSUMER_AC_SOFT_KEY_RIGHT (0x2A1)                          // Sel
+#define HID_USAGE_CONSUMER_AC_DESKTOP_SHOW_ALL_APPLICATIONS (0x2A2)           // Sel
+#define HID_USAGE_CONSUMER_AC_IDLE_KEEP_ALIVE (0x2B0)                         // Sel
+#define HID_USAGE_CONSUMER_EXTENDED_KEYBOARD_ATTRIBUTES_COLLECTION (0x2C0)    // CL
+#define HID_USAGE_CONSUMER_KEYBOARD_FORM_FACTOR (0x2C1)                       // SV
+#define HID_USAGE_CONSUMER_KEYBOARD_KEY_TYPE (0x2C2)                          // SV
+#define HID_USAGE_CONSUMER_KEYBOARD_PHYSICAL_LAYOUT (0x2C3)                   // SV
+#define HID_USAGE_CONSUMER_VENDOR_SPECIFIC_KEYBOARD_PHYSICAL_LAYOUT (0x2C4)   // SV
+#define HID_USAGE_CONSUMER_KEYBOARD_IETF_LANGUAGE_TAG_INDEX (0x2C5)           // SV
+#define HID_USAGE_CONSUMER_IMPLEMENTED_KEYBOARD_INPUT_ASSIST_CONTROLS (0x2C6) // SV
+#define HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_PREVIOUS (0x2C7)             // Sel
+#define HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_NEXT (0x2C8)                 // Sel
+#define HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_PREVIOUS_GROUP (0x2C9)       // Sel
+#define HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_NEXT_GROUP (0x2CA)           // Sel
+#define HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_ACCEPT (0x2CB)               // Sel
+#define HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_CANCEL (0x2CC)               // Sel
+#define HID_USAGE_CONSUMER_PRIVACY_SCREEN_TOGGLE (0x2D0)                      // OOC
+#define HID_USAGE_CONSUMER_PRIVACY_SCREEN_LEVEL_DECREMENT (0x2D1)             // RTC
+#define HID_USAGE_CONSUMER_PRIVACY_SCREEN_LEVEL_INCREMENT (0x2D2)             // RTC
+#define HID_USAGE_CONSUMER_PRIVACY_SCREEN_LEVEL_MINIMUM (0x2D3)               // OSC
+#define HID_USAGE_CONSUMER_PRIVACY_SCREEN_LEVEL_MAXIMUM (0x2D4)               // OSC
+#define HID_USAGE_CONSUMER_CONTACT_EDITED (0x500)                             // OOC
+#define HID_USAGE_CONSUMER_CONTACT_ADDED (0x501)                              // OOC
+#define HID_USAGE_CONSUMER_CONTACT_RECORD_ACTIVE (0x502)                      // OOC
+#define HID_USAGE_CONSUMER_CONTACT_INDEX (0x503)                              // DV
+#define HID_USAGE_CONSUMER_CONTACT_NICKNAME (0x504)                           // DV
+#define HID_USAGE_CONSUMER_CONTACT_FIRST_NAME (0x505)                         // DV
+#define HID_USAGE_CONSUMER_CONTACT_LAST_NAME (0x506)                          // DV
+#define HID_USAGE_CONSUMER_CONTACT_FULL_NAME (0x507)                          // DV
+#define HID_USAGE_CONSUMER_CONTACT_PHONE_NUMBER_PERSONAL (0x508)              // DV
+#define HID_USAGE_CONSUMER_CONTACT_PHONE_NUMBER_BUSINESS (0x509)              // DV
+#define HID_USAGE_CONSUMER_CONTACT_PHONE_NUMBER_MOBILE (0x50A)                // DV
+#define HID_USAGE_CONSUMER_CONTACT_PHONE_NUMBER_PAGER (0x50B)                 // DV
+#define HID_USAGE_CONSUMER_CONTACT_PHONE_NUMBER_FAX (0x50C)                   // DV
+#define HID_USAGE_CONSUMER_CONTACT_PHONE_NUMBER_OTHER (0x50D)                 // DV
+#define HID_USAGE_CONSUMER_CONTACT_EMAIL_PERSONAL (0x50E)                     // DV
+#define HID_USAGE_CONSUMER_CONTACT_EMAIL_BUSINESS (0x50F)                     // DV
+#define HID_USAGE_CONSUMER_CONTACT_EMAIL_OTHER (0x510)                        // DV
+#define HID_USAGE_CONSUMER_CONTACT_EMAIL_MAIN (0x511)                         // DV
+#define HID_USAGE_CONSUMER_CONTACT_SPEED_DIAL_NUMBER (0x512)                  // DV
+#define HID_USAGE_CONSUMER_CONTACT_STATUS_FLAG (0x513)                        // DV
+#define HID_USAGE_CONSUMER_CONTACT_MISC (0x514)                               // DV
+
+/* Page 0x0D: Digitizers */
+#define HID_USAGE_DIGITIZERS_UNDEFINED (0x00)
+#define HID_USAGE_DIGITIZERS_DIGITIZER (0x01)                                      // CA
+#define HID_USAGE_DIGITIZERS_PEN (0x02)                                            // CA
+#define HID_USAGE_DIGITIZERS_LIGHT_PEN (0x03)                                      // CA
+#define HID_USAGE_DIGITIZERS_TOUCH_SCREEN (0x04)                                   // CA
+#define HID_USAGE_DIGITIZERS_TOUCH_PAD (0x05)                                      // CA
+#define HID_USAGE_DIGITIZERS_WHITEBOARD (0x06)                                     // CA
+#define HID_USAGE_DIGITIZERS_COORDINATE_MEASURING_MACHINE (0x07)                   // CA
+#define HID_USAGE_DIGITIZERS_3D_DIGITIZER (0x08)                                   // CA
+#define HID_USAGE_DIGITIZERS_STEREO_PLOTTER (0x09)                                 // CA
+#define HID_USAGE_DIGITIZERS_ARTICULATED_ARM (0x0A)                                // CA
+#define HID_USAGE_DIGITIZERS_ARMATURE (0x0B)                                       // CA
+#define HID_USAGE_DIGITIZERS_MULTIPLE_POINT_DIGITIZER (0x0C)                       // CA
+#define HID_USAGE_DIGITIZERS_FREE_SPACE_WAND (0x0D)                                // CA
+#define HID_USAGE_DIGITIZERS_DEVICE_CONFIGURATION (0x0E)                           // CA
+#define HID_USAGE_DIGITIZERS_CAPACITIVE_HEAT_MAP_DIGITIZER (0x0F)                  // CA
+#define HID_USAGE_DIGITIZERS_STYLUS (0x20)                                         // CA, CL
+#define HID_USAGE_DIGITIZERS_PUCK (0x21)                                           // CL
+#define HID_USAGE_DIGITIZERS_FINGER (0x22)                                         // CL
+#define HID_USAGE_DIGITIZERS_DEVICE_SETTINGS (0x23)                                // CL
+#define HID_USAGE_DIGITIZERS_CHARACTER_GESTURE (0x24)                              // CL
+#define HID_USAGE_DIGITIZERS_TIP_PRESSURE (0x30)                                   // DV
+#define HID_USAGE_DIGITIZERS_BARREL_PRESSURE (0x31)                                // DV
+#define HID_USAGE_DIGITIZERS_IN_RANGE (0x32)                                       // MC
+#define HID_USAGE_DIGITIZERS_TOUCH (0x33)                                          // MC
+#define HID_USAGE_DIGITIZERS_UNTOUCH (0x34)                                        // OSC
+#define HID_USAGE_DIGITIZERS_TAP (0x35)                                            // OSC
+#define HID_USAGE_DIGITIZERS_QUALITY (0x36)                                        // DV
+#define HID_USAGE_DIGITIZERS_DATA_VALID (0x37)                                     // MC
+#define HID_USAGE_DIGITIZERS_TRANSDUCER_INDEX (0x38)                               // DV
+#define HID_USAGE_DIGITIZERS_TABLET_FUNCTION_KEYS (0x39)                           // CL
+#define HID_USAGE_DIGITIZERS_PROGRAM_CHANGE_KEYS (0x3A)                            // CL
+#define HID_USAGE_DIGITIZERS_BATTERY_STRENGTH (0x3B)                               // DV
+#define HID_USAGE_DIGITIZERS_INVERT (0x3C)                                         // MC
+#define HID_USAGE_DIGITIZERS_X_TILT (0x3D)                                         // DV
+#define HID_USAGE_DIGITIZERS_Y_TILT (0x3E)                                         // DV
+#define HID_USAGE_DIGITIZERS_AZIMUTH (0x3F)                                        // DV
+#define HID_USAGE_DIGITIZERS_ALTITUDE (0x40)                                       // DV
+#define HID_USAGE_DIGITIZERS_TWIST (0x41)                                          // DV
+#define HID_USAGE_DIGITIZERS_TIP_SWITCH (0x42)                                     // MC
+#define HID_USAGE_DIGITIZERS_SECONDARY_TIP_SWITCH (0x43)                           // MC
+#define HID_USAGE_DIGITIZERS_BARREL_SWITCH (0x44)                                  // MC
+#define HID_USAGE_DIGITIZERS_ERASER (0x45)                                         // MC
+#define HID_USAGE_DIGITIZERS_TABLET_PICK (0x46)                                    // MC
+#define HID_USAGE_DIGITIZERS_TOUCH_VALID (0x47)                                    // MC
+#define HID_USAGE_DIGITIZERS_WIDTH (0x48)                                          // DV
+#define HID_USAGE_DIGITIZERS_HEIGHT (0x49)                                         // DV
+#define HID_USAGE_DIGITIZERS_CONTACT_IDENTIFIER (0x51)                             // DV
+#define HID_USAGE_DIGITIZERS_DEVICE_MODE (0x52)                                    // DV
+#define HID_USAGE_DIGITIZERS_DEVICE_IDENTIFIER (0x53)                              // DV, SV
+#define HID_USAGE_DIGITIZERS_CONTACT_COUNT (0x54)                                  // DV
+#define HID_USAGE_DIGITIZERS_CONTACT_COUNT_MAXIMUM (0x55)                          // SV
+#define HID_USAGE_DIGITIZERS_SCAN_TIME (0x56)                                      // DV
+#define HID_USAGE_DIGITIZERS_SURFACE_SWITCH (0x57)                                 // DF
+#define HID_USAGE_DIGITIZERS_BUTTON_SWITCH (0x58)                                  // DF
+#define HID_USAGE_DIGITIZERS_PAD_TYPE (0x59)                                       // SF
+#define HID_USAGE_DIGITIZERS_SECONDARY_BARREL_SWITCH (0x5A)                        // MC
+#define HID_USAGE_DIGITIZERS_TRANSDUCER_SERIAL_NUMBER (0x5B)                       // SV
+#define HID_USAGE_DIGITIZERS_PREFERRED_COLOR (0x5C)                                // DV
+#define HID_USAGE_DIGITIZERS_PREFERRED_COLOR_IS_LOCKED (0x5D)                      // MC
+#define HID_USAGE_DIGITIZERS_PREFERRED_LINE_WIDTH (0x5E)                           // DV
+#define HID_USAGE_DIGITIZERS_PREFERRED_LINE_WIDTH_IS_LOCKED (0x5F)                 // MC
+#define HID_USAGE_DIGITIZERS_LATENCY_MODE (0x60)                                   // DF
+#define HID_USAGE_DIGITIZERS_GESTURE_CHARACTER_QUALITY (0x61)                      // DV
+#define HID_USAGE_DIGITIZERS_CHARACTER_GESTURE_DATA_LENGTH (0x62)                  // DV
+#define HID_USAGE_DIGITIZERS_CHARACTER_GESTURE_DATA (0x63)                         // DV
+#define HID_USAGE_DIGITIZERS_GESTURE_CHARACTER_ENCODING (0x64)                     // NAry
+#define HID_USAGE_DIGITIZERS_UTF8_CHARACTER_GESTURE_ENCODING (0x65)                // Sel
+#define HID_USAGE_DIGITIZERS_UTF16_LITTLE_ENDIAN_CHARACTER_GESTURE_ENCODING (0x66) // Sel
+#define HID_USAGE_DIGITIZERS_UTF16_BIG_ENDIAN_CHARACTER_GESTURE_ENCODING (0x67)    // Sel
+#define HID_USAGE_DIGITIZERS_UTF32_LITTLE_ENDIAN_CHARACTER_GESTURE_ENCODING (0x68) // Sel
+#define HID_USAGE_DIGITIZERS_UTF32_BIG_ENDIAN_CHARACTER_GESTURE_ENCODING (0x69)    // Sel
+#define HID_USAGE_DIGITIZERS_CAPACITIVE_HEAT_MAP_PROTOCOL_VENDOR_ID (0x6A)         // SV
+#define HID_USAGE_DIGITIZERS_CAPACITIVE_HEAT_MAP_PROTOCOL_VERSION (0x6B)           // SV
+#define HID_USAGE_DIGITIZERS_CAPACITIVE_HEAT_MAP_FRAME_DATA (0x6C)                 // DV
+#define HID_USAGE_DIGITIZERS_GESTURE_CHARACTER_ENABLE (0x6D)                       // DF
+#define HID_USAGE_DIGITIZERS_PREFERRED_LINE_STYLE (0x70)                           // NAry
+#define HID_USAGE_DIGITIZERS_PREFERRED_LINE_STYLE_IS_LOCKED (0x71)                 // MC
+#define HID_USAGE_DIGITIZERS_INK (0x72)                                            // Sel
+#define HID_USAGE_DIGITIZERS_PENCIL (0x73)                                         // Sel
+#define HID_USAGE_DIGITIZERS_HIGHLIGHTER (0x74)                                    // Sel
+#define HID_USAGE_DIGITIZERS_CHISEL_MARKER (0x75)                                  // Sel
+#define HID_USAGE_DIGITIZERS_BRUSH (0x76)                                          // Sel
+#define HID_USAGE_DIGITIZERS_NO_PREFERENCE (0x77)                                  // Sel
+#define HID_USAGE_DIGITIZERS_DIGITIZER_DIAGNOSTIC (0x80)                           // CL
+#define HID_USAGE_DIGITIZERS_DIGITIZER_ERROR (0x81)                                // NAry
+#define HID_USAGE_DIGITIZERS_ERR_NORMAL_STATUS (0x82)                              // Sel
+#define HID_USAGE_DIGITIZERS_ERR_TRANSDUCERS_EXCEEDED (0x83)                       // Sel
+#define HID_USAGE_DIGITIZERS_ERR_FULL_TRANS_FEATURES_UNAVAILABLE (0x84)            // Sel
+#define HID_USAGE_DIGITIZERS_ERR_CHARGE_LOW (0x85)                                 // Sel
+#define HID_USAGE_DIGITIZERS_TRANSDUCER_SOFTWARE_INFO (0x90)                       // CL
+#define HID_USAGE_DIGITIZERS_TRANSDUCER_VENDOR_ID (0x91)                           // SV
+#define HID_USAGE_DIGITIZERS_TRANSDUCER_PRODUCT_ID (0x92)                          // SV
+#define HID_USAGE_DIGITIZERS_DEVICE_SUPPORTED_PROTOCOLS (0x93)                     // NAry, CL
+#define HID_USAGE_DIGITIZERS_TRANSDUCER_SUPPORTED_PROTOCOLS (0x94)                 // NAry, CL
+#define HID_USAGE_DIGITIZERS_NO_PROTOCOL (0x95)                                    // Sel
+#define HID_USAGE_DIGITIZERS_WACOM_AES_PROTOCOL (0x96)                             // Sel
+#define HID_USAGE_DIGITIZERS_USI_PROTOCOL (0x97)                                   // Sel
+#define HID_USAGE_DIGITIZERS_MICROSOFT_PEN_PROTOCOL (0x98)                         // Sel
+#define HID_USAGE_DIGITIZERS_SUPPORTED_REPORT_RATES (0xA0)                         // SV, CL
+#define HID_USAGE_DIGITIZERS_REPORT_RATE (0xA1)                                    // DV
+#define HID_USAGE_DIGITIZERS_TRANSDUCER_CONNECTED (0xA2)                           // SF
+#define HID_USAGE_DIGITIZERS_SWITCH_DISABLED (0xA3)                                // Sel
+#define HID_USAGE_DIGITIZERS_SWITCH_UNIMPLEMENTED (0xA4)                           // Sel
+#define HID_USAGE_DIGITIZERS_TRANSDUCER_SWITCHES (0xA5)                            // Sel
+
+/* Page 0x0E: Haptics */
+#define HID_USAGE_HAPTICS_UNDEFINED (0x00)
+#define HID_USAGE_HAPTICS_SIMPLE_HAPTIC_CONTROLLER (0x01)        // CA, CL
+#define HID_USAGE_HAPTICS_WAVEFORM_LIST (0x10)                   // NAry
+#define HID_USAGE_HAPTICS_DURATION_LIST (0x11)                   // NAry
+#define HID_USAGE_HAPTICS_AUTO_TRIGGER (0x20)                    // DV
+#define HID_USAGE_HAPTICS_MANUAL_TRIGGER (0x21)                  // DV
+#define HID_USAGE_HAPTICS_AUTO_TRIGGER_ASSOCIATED_CONTROL (0x22) // SV
+#define HID_USAGE_HAPTICS_INTENSITY (0x23)                       // DV
+#define HID_USAGE_HAPTICS_REPEAT_COUNT (0x24)                    // DV
+#define HID_USAGE_HAPTICS_RETRIGGER_PERIOD (0x25)                // DV
+#define HID_USAGE_HAPTICS_WAVEFORM_VENDOR_PAGE (0x26)            // SV
+#define HID_USAGE_HAPTICS_WAVEFORM_VENDOR_ID (0x27)              // SV
+#define HID_USAGE_HAPTICS_WAVEFORM_CUTOFF_TIME (0x28)            // SV
+#define HID_USAGE_HAPTICS_WAVEFORM_NONE (0x1001)                 // SV
+#define HID_USAGE_HAPTICS_WAVEFORM_STOP (0x1002)                 // SV
+#define HID_USAGE_HAPTICS_WAVEFORM_CLICK (0x1003)                // SV
+#define HID_USAGE_HAPTICS_WAVEFORM_BUZZ_CONTINUOUS (0x1004)      // SV
+#define HID_USAGE_HAPTICS_WAVEFORM_RUMBLE_CONTINUOUS (0x1005)    // SV
+#define HID_USAGE_HAPTICS_WAVEFORM_PRESS (0x1006)                // SV
+#define HID_USAGE_HAPTICS_WAVEFORM_RELEASE (0x1007)              // SV
+
+/* Page 0x0F: PID */
+#define HID_USAGE_PID_UNDEFINED (0x00)
+#define HID_USAGE_PID_PHYSICAL_INTERFACE_DEVICE (0x01)
+#define HID_USAGE_PID_NORMAL (0x20)
+#define HID_USAGE_PID_SET_EFFECT_REPORT (0x21)
+#define HID_USAGE_PID_EFFECT_BLOCK_INDEX (0x22)
+#define HID_USAGE_PID_PARAMETER_BLOCK_OFFSET (0x23)
+#define HID_USAGE_PID_ROM_FLAG (0x24)
+#define HID_USAGE_PID_EFFECT_TYPE (0x25)
+#define HID_USAGE_PID_ET_CONSTANT_FORCE (0x26)
+#define HID_USAGE_PID_ET_RAMP (0x27)
+#define HID_USAGE_PID_ET_CUSTOM_FORCE_DATA (0x28)
+#define HID_USAGE_PID_ET_SQUARE (0x30)
+#define HID_USAGE_PID_ET_SINE (0x31)
+#define HID_USAGE_PID_ET_TRIANGLE (0x32)
+#define HID_USAGE_PID_ET_SAWTOOTH_UP (0x33)
+#define HID_USAGE_PID_ET_SAWTOOTH_DOWN (0x34)
+#define HID_USAGE_PID_ET_SPRING (0x40)
+#define HID_USAGE_PID_ET_DAMPER (0x41)
+#define HID_USAGE_PID_ET_INERTIA (0x42)
+#define HID_USAGE_PID_ET_FRICTION (0x43)
+#define HID_USAGE_PID_DURATION (0x50)
+#define HID_USAGE_PID_SAMPLE_PERIOD (0x51)
+#define HID_USAGE_PID_GAIN (0x52)
+#define HID_USAGE_PID_TRIGGER_BUTTON (0x53)
+#define HID_USAGE_PID_TRIGGER_REPEAT_INTERVAL (0x54)
+#define HID_USAGE_PID_AXES_ENABLE (0x55)
+#define HID_USAGE_PID_DIRECTION_ENABLE (0x56)
+#define HID_USAGE_PID_DIRECTION (0x57)
+#define HID_USAGE_PID_TYPE_SPECIFIC_BLOCK_OFFSET (0x58)
+#define HID_USAGE_PID_BLOCK_TYPE (0x59)
+#define HID_USAGE_PID_SET_ENVELOPE_REPORT (0x5A)
+#define HID_USAGE_PID_ATTACK_LEVEL (0x5B)
+#define HID_USAGE_PID_ATTACK_TIME (0x5C)
+#define HID_USAGE_PID_FADE_LEVEL (0x5D)
+#define HID_USAGE_PID_FADE_TIME (0x5E)
+#define HID_USAGE_PID_SET_CONDITION_REPORT (0x5F)
+#define HID_USAGE_PID_CP_OFFSET (0x60)
+#define HID_USAGE_PID_POSITIVE_COEFFICIENT (0x61)
+#define HID_USAGE_PID_NEGATIVE_COEFFICIENT (0x62)
+#define HID_USAGE_PID_POSITIVE_SATURATION (0x63)
+#define HID_USAGE_PID_NEGATIVE_SATURATION (0x64)
+#define HID_USAGE_PID_DEAD_BAND (0x65)
+#define HID_USAGE_PID_DOWNLOAD_FORCE_SAMPLE (0x66)
+#define HID_USAGE_PID_ISOCH_CUSTOM_FORCE_ENABLE (0x67)
+#define HID_USAGE_PID_CUSTOM_FORCE_DATA_REPORT (0x68)
+#define HID_USAGE_PID_CUSTOM_FORCE_DATA (0x69)
+#define HID_USAGE_PID_CUSTOM_FORCE_VENDOR_DEFINED_DATA (0x6A)
+#define HID_USAGE_PID_SET_CUSTOM_FORCE_REPORT (0x6B)
+#define HID_USAGE_PID_CUSTOM_FORCE_DATA_OFFSET (0x6C)
+#define HID_USAGE_PID_SAMPLE_COUNT (0x6D)
+#define HID_USAGE_PID_SET_PERIODIC_REPORT (0x6E)
+#define HID_USAGE_PID_OFFSET (0x6F)
+#define HID_USAGE_PID_MAGNITUDE (0x70)
+#define HID_USAGE_PID_PHASE (0x71)
+#define HID_USAGE_PID_PERIOD (0x72)
+#define HID_USAGE_PID_SET_CONSTANT_FORCE_REPORT (0x73)
+#define HID_USAGE_PID_SET_RAMP_FORCE_REPORT (0x74)
+#define HID_USAGE_PID_RAMP_START (0x75)
+#define HID_USAGE_PID_RAMP_END (0x76)
+#define HID_USAGE_PID_EFFECT_OPERATION_REPORT (0x77)
+#define HID_USAGE_PID_EFFECT_OPERATION (0x78)
+#define HID_USAGE_PID_OP_EFFECT_START (0x79)
+#define HID_USAGE_PID_OP_EFFECT_START_SOLO (0x7A)
+#define HID_USAGE_PID_OP_EFFECT_STOP (0x7B)
+#define HID_USAGE_PID_LOOP_COUNT (0x7C)
+#define HID_USAGE_PID_DEVICE_GAIN_REPORT (0x7D)
+#define HID_USAGE_PID_DEVICE_GAIN (0x7E)
+#define HID_USAGE_PID_PID_POOL_REPORT (0x7F)
+#define HID_USAGE_PID_RAM_POOL_SIZE (0x80)
+#define HID_USAGE_PID_ROM_POOL_SIZE (0x81)
+#define HID_USAGE_PID_ROM_EFFECT_BLOCK_COUNT (0x82)
+#define HID_USAGE_PID_SIMULTANEOUS_EFFECTS_MAX (0x83)
+#define HID_USAGE_PID_POOL_ALIGNMENT (0x84)
+#define HID_USAGE_PID_PID_POOL_MOVE_REPORT (0x85)
+#define HID_USAGE_PID_MOVE_SOURCE (0x86)
+#define HID_USAGE_PID_MOVE_DESTINATION (0x87)
+#define HID_USAGE_PID_MOVE_LENGTH (0x88)
+#define HID_USAGE_PID_PID_BLOCK_LOAD_REPORT (0x89)
+#define HID_USAGE_PID_BLOCK_LOAD_STATUS (0x8B)
+#define HID_USAGE_PID_BLOCK_LOAD_SUCCESS (0x8C)
+#define HID_USAGE_PID_BLOCK_LOAD_FULL (0x8D)
+#define HID_USAGE_PID_BLOCK_LOAD_ERROR (0x8E)
+#define HID_USAGE_PID_BLOCK_HANDLE (0x8F)
+#define HID_USAGE_PID_PID_BLOCK_FREE_REPORT (0x90)
+#define HID_USAGE_PID_TYPE_SPECIFIC_BLOCK_HANDLE (0x91)
+#define HID_USAGE_PID_PID_STATE_REPORT (0x92)
+#define HID_USAGE_PID_EFFECT_PLAYING (0x94)
+#define HID_USAGE_PID_PID_DEVICE_CONTROL_REPORT (0x95)
+#define HID_USAGE_PID_PID_DEVICE_CONTROL (0x96)
+#define HID_USAGE_PID_DC_ENABLE_ACTUATORS (0x97)
+#define HID_USAGE_PID_DC_DISABLE_ACTUATORS (0x98)
+#define HID_USAGE_PID_DC_STOP_ALL_EFFECTS (0x99)
+#define HID_USAGE_PID_DC_DEVICE_RESET (0x9A)
+#define HID_USAGE_PID_DC_DEVICE_PAUSE (0x9B)
+#define HID_USAGE_PID_DC_DEVICE_CONTINUE (0x9C)
+#define HID_USAGE_PID_DEVICE_PAUSED (0x9F)
+#define HID_USAGE_PID_ACTUATORS_ENABLED (0xA0)
+#define HID_USAGE_PID_SAFETY_SWITCH (0xA4)
+#define HID_USAGE_PID_ACTUATOR_OVERRIDE_SWITCH (0xA5)
+#define HID_USAGE_PID_ACTUATOR_POWER (0xA6)
+#define HID_USAGE_PID_START_DELAY (0xA7)
+#define HID_USAGE_PID_PARAMETER_BLOCK_SIZE (0xA8)
+#define HID_USAGE_PID_DEVICE_MANAGED_POOL (0xA9)
+#define HID_USAGE_PID_SHARED_PARAMETER_BLOCKS (0xAA)
+#define HID_USAGE_PID_CREATE_NEW_EFFECT_REPORT (0xAB)
+#define HID_USAGE_PID_RAM_POOL_AVAILABLE (0xAC)
+
+/* Page 0x12: Eye and Head Trackers */
+#define HID_USAGE_EHT_UNDEFINED (0x00)
+#define HID_USAGE_EHT_EYE_TRACKER (0x01)                  // CA
+#define HID_USAGE_EHT_HEAD_TRACKER (0x02)                 // CA
+#define HID_USAGE_EHT_TRACKING_DATA (0x10)                // CP
+#define HID_USAGE_EHT_CAPABILITIES (0x11)                 // CL
+#define HID_USAGE_EHT_CONFIGURATION (0x12)                // CL
+#define HID_USAGE_EHT_STATUS (0x13)                       // CL
+#define HID_USAGE_EHT_CONTROL (0x14)                      // CL
+#define HID_USAGE_EHT_SENSOR_TIMESTAMP (0x20)             // DV
+#define HID_USAGE_EHT_POSITION_X (0x21)                   // DV
+#define HID_USAGE_EHT_POSITION_Y (0x22)                   // DV
+#define HID_USAGE_EHT_POSITION_Z (0x23)                   // DV
+#define HID_USAGE_EHT_GAZE_POINT (0x24)                   // CP
+#define HID_USAGE_EHT_LEFT_EYE_POSITION (0x25)            // CP
+#define HID_USAGE_EHT_RIGHT_EYE_POSITION (0x26)           // CP
+#define HID_USAGE_EHT_HEAD_POSITION (0x27)                // CP
+#define HID_USAGE_EHT_HEAD_DIRECTION_POINT (0x28)         // CP
+#define HID_USAGE_EHT_ROTATION_ABOUT_X_AXIS (0x29)        // DV
+#define HID_USAGE_EHT_ROTATION_ABOUT_Y_AXIS (0x2A)        // DV
+#define HID_USAGE_EHT_ROTATION_ABOUT_Z_AXIS (0x2B)        // DV
+#define HID_USAGE_EHT_TRACKER_QUALITY (0x100)             // SV
+#define HID_USAGE_EHT_MINIMUM_TRACKING_DISTANCE (0x101)   // SV
+#define HID_USAGE_EHT_OPTIMUM_TRACKING_DISTANCE (0x102)   // SV
+#define HID_USAGE_EHT_MAXIMUM_TRACKING_DISTANCE (0x103)   // SV
+#define HID_USAGE_EHT_MAXIMUM_SCREEN_PLANE_WIDTH (0x104)  // SV
+#define HID_USAGE_EHT_MAXIMUM_SCREEN_PLANE_HEIGHT (0x105) // SV
+#define HID_USAGE_EHT_DISPLAY_MANUFACTURER_ID (0x200)     // SV
+#define HID_USAGE_EHT_DISPLAY_PRODUCT_ID (0x201)          // SV
+#define HID_USAGE_EHT_DISPLAY_SERIAL_NUMBER (0x202)       // SV
+#define HID_USAGE_EHT_DISPLAY_MANUFACTURER_DATE (0x203)   // SV
+#define HID_USAGE_EHT_CALIBRATED_SCREEN_WIDTH (0x204)     // SV
+#define HID_USAGE_EHT_CALIBRATED_SCREEN_HEIGHT (0x205)    // SV
+#define HID_USAGE_EHT_SAMPLING_FREQUENCY (0x300)          // DV
+#define HID_USAGE_EHT_CONFIGURATION_STATUS (0x301)        // DV
+#define HID_USAGE_EHT_DEVICE_MODE_REQUEST (0x400)         // DV
+
+/* Page 0x14: Auxiliary Display */
+#define HID_USAGE_AUXDISP_UNDEFINED (0x00)
+#define HID_USAGE_AUXDISP_ALPHANUMERIC_DISPLAY (0x01)         // CA
+#define HID_USAGE_AUXDISP_AUXILIARY_DISPLAY (0x02)            // CA
+#define HID_USAGE_AUXDISP_DISPLAY_ATTRIBUTES_REPORT (0x20)    // CL
+#define HID_USAGE_AUXDISP_ASCII_CHARACTER_SET (0x21)          // SF
+#define HID_USAGE_AUXDISP_DATA_READ_BACK (0x22)               // SF
+#define HID_USAGE_AUXDISP_FONT_READ_BACK (0x23)               // SF
+#define HID_USAGE_AUXDISP_DISPLAY_CONTROL_REPORT (0x24)       // CL
+#define HID_USAGE_AUXDISP_CLEAR_DISPLAY (0x25)                // DF
+#define HID_USAGE_AUXDISP_DISPLAY_ENABLE (0x26)               // DF
+#define HID_USAGE_AUXDISP_SCREEN_SAVER_DELAY (0x27)           // SV, DV
+#define HID_USAGE_AUXDISP_SCREEN_SAVER_ENABLE (0x28)          // DF
+#define HID_USAGE_AUXDISP_VERTICAL_SCROLL (0x29)              // SF, DF
+#define HID_USAGE_AUXDISP_HORIZONTAL_SCROLL (0x2A)            // SF, DF
+#define HID_USAGE_AUXDISP_CHARACTER_REPORT (0x2B)             // CL
+#define HID_USAGE_AUXDISP_DISPLAY_DATA (0x2C)                 // DV
+#define HID_USAGE_AUXDISP_DISPLAY_STATUS (0x2D)               // CL
+#define HID_USAGE_AUXDISP_STAT_NOT_READY (0x2E)               // Sel
+#define HID_USAGE_AUXDISP_STAT_READY (0x2F)                   // Sel
+#define HID_USAGE_AUXDISP_ERR_NOT_A_LOADABLE_CHARACTER (0x30) // Sel
+#define HID_USAGE_AUXDISP_ERR_FONT_DATA_CANNOT_BE_READ (0x31) // Sel
+#define HID_USAGE_AUXDISP_CURSOR_POSITION_REPORT (0x32)       // Sel
+#define HID_USAGE_AUXDISP_ROW (0x33)                          // DV
+#define HID_USAGE_AUXDISP_COLUMN (0x34)                       // DV
+#define HID_USAGE_AUXDISP_ROWS (0x35)                         // SV
+#define HID_USAGE_AUXDISP_COLUMNS (0x36)                      // SV
+#define HID_USAGE_AUXDISP_CURSOR_PIXEL_POSITIONING (0x37)     // SF
+#define HID_USAGE_AUXDISP_CURSOR_MODE (0x38)                  // DF
+#define HID_USAGE_AUXDISP_CURSOR_ENABLE (0x39)                // DF
+#define HID_USAGE_AUXDISP_CURSOR_BLINK (0x3A)                 // DF
+#define HID_USAGE_AUXDISP_FONT_REPORT (0x3B)                  // CL
+#define HID_USAGE_AUXDISP_FONT_DATA (0x3C)                    // Buffered Bytes
+#define HID_USAGE_AUXDISP_CHARACTER_WIDTH (0x3D)              // SV
+#define HID_USAGE_AUXDISP_CHARACTER_HEIGHT (0x3E)             // SV
+#define HID_USAGE_AUXDISP_CHARACTER_SPACING_HORIZONTAL (0x3F) // SV
+#define HID_USAGE_AUXDISP_CHARACTER_SPACING_VERTICAL (0x40)   // SV
+#define HID_USAGE_AUXDISP_UNICODE_CHARACTER_SET (0x41)        // SF
+#define HID_USAGE_AUXDISP_FONT_7_SEGMENT (0x42)               // SF
+#define HID_USAGE_AUXDISP_7_SEGMENT_DIRECT_MAP (0x43)         // SF
+#define HID_USAGE_AUXDISP_FONT_14_SEGMENT (0x44)              // SF
+#define HID_USAGE_AUXDISP_14_SEGMENT_DIRECT_MAP (0x45)        // SF
+#define HID_USAGE_AUXDISP_DISPLAY_BRIGHTNESS (0x46)           // DV
+#define HID_USAGE_AUXDISP_DISPLAY_CONTRAST (0x47)             // DV
+#define HID_USAGE_AUXDISP_CHARACTER_ATTRIBUTE (0x48)          // CL
+#define HID_USAGE_AUXDISP_ATTRIBUTE_READBACK (0x49)           // SF
+#define HID_USAGE_AUXDISP_ATTRIBUTE_DATA (0x4A)               // DV
+#define HID_USAGE_AUXDISP_CHAR_ATTR_ENHANCE (0x4B)            // OOC
+#define HID_USAGE_AUXDISP_CHAR_ATTR_UNDERLINE (0x4C)          // OOC
+#define HID_USAGE_AUXDISP_CHAR_ATTR_BLINK (0x4D)              // OOC
+#define HID_USAGE_AUXDISP_BITMAP_SIZE_X (0x80)                // SV
+#define HID_USAGE_AUXDISP_BITMAP_SIZE_Y (0x81)                // SV
+#define HID_USAGE_AUXDISP_MAX_BLIT_SIZE (0x82)                // SV
+#define HID_USAGE_AUXDISP_BIT_DEPTH_FORMAT (0x83)             // SV
+#define HID_USAGE_AUXDISP_DISPLAY_ORIENTATION (0x84)          // DV
+#define HID_USAGE_AUXDISP_PALETTE_REPORT (0x85)               // CL
+#define HID_USAGE_AUXDISP_PALETTE_DATA_SIZE (0x86)            // SV
+#define HID_USAGE_AUXDISP_PALETTE_DATA_OFFSET (0x87)          // SV
+#define HID_USAGE_AUXDISP_PALETTE_DATA (0x88)                 // Buffered Bytes
+#define HID_USAGE_AUXDISP_BLIT_REPORT (0x8A)                  // CL
+#define HID_USAGE_AUXDISP_BLIT_RECTANGLE_X1 (0x8B)            // SV
+#define HID_USAGE_AUXDISP_BLIT_RECTANGLE_Y1 (0x8C)            // SV
+#define HID_USAGE_AUXDISP_BLIT_RECTANGLE_X2 (0x8D)            // SV
+#define HID_USAGE_AUXDISP_BLIT_RECTANGLE_Y2 (0x8E)            // SV
+#define HID_USAGE_AUXDISP_BLIT_DATA (0x8F)                    // Buffered Bytes
+#define HID_USAGE_AUXDISP_SOFT_BUTTON (0x90)                  // CL
+#define HID_USAGE_AUXDISP_SOFT_BUTTON_ID (0x91)               // SV
+#define HID_USAGE_AUXDISP_SOFT_BUTTON_SIDE (0x92)             // SV
+#define HID_USAGE_AUXDISP_SOFT_BUTTON_OFFSET_1 (0x93)         // SV
+#define HID_USAGE_AUXDISP_SOFT_BUTTON_OFFSET_2 (0x94)         // SV
+#define HID_USAGE_AUXDISP_SOFT_BUTTON_REPORT (0x95)           // SV
+#define HID_USAGE_AUXDISP_SOFT_KEYS (0xC2)                    // SV
+#define HID_USAGE_AUXDISP_DISPLAY_DATA_EXTENSIONS (0xCC)      // SF
+#define HID_USAGE_AUXDISP_CHARACTER_MAPPING (0xCF)            // SV
+#define HID_USAGE_AUXDISP_UNICODE_EQUIVALENT (0xDD)           // SV
+#define HID_USAGE_AUXDISP_CHARACTER_PAGE_MAPPING (0xDF)       // SV
+#define HID_USAGE_AUXDISP_REQUEST_REPORT (0xFF)               // DV
+
+/* Page 0x20: Sensors */
+#define HID_USAGE_SENSORS_UNDEFINED (0x00)
+#define HID_USAGE_SENSORS_SENSOR (0x01)                                                // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC (0x10)                                             // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC_HUMAN_PRESENCE (0x11)                              // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC_HUMAN_PROXIMITY (0x12)                             // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC_HUMAN_TOUCH (0x13)                                 // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC_BLOOD_PRESSURE (0x14)                              // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC_BODY_TEMPERATURE (0x15)                            // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC_HEART_RATE (0x16)                                  // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC_HEART_RATE_VARIABILITY (0x17)                      // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC_PERIPHERAL_OXYGEN_SATURATION (0x18)                // CA, CP
+#define HID_USAGE_SENSORS_BIOMETRIC_RESPIRATORY_RATE (0x19)                            // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL (0x20)                                            // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL_CAPACITANCE (0x21)                                // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL_CURRENT (0x22)                                    // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL_POWER (0x23)                                      // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL_INDUCTANCE (0x24)                                 // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL_RESISTANCE (0x25)                                 // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL_VOLTAGE (0x26)                                    // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL_POTENTIOMETER (0x27)                              // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL_FREQUENCY (0x28)                                  // CA, CP
+#define HID_USAGE_SENSORS_ELECTRICAL_PERIOD (0x29)                                     // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL (0x30)                                         // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_ATMOSPHERIC_PRESSURE (0x31)                    // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_HUMIDITY (0x32)                                // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_TEMPERATURE (0x33)                             // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_WIND_DIRECTION (0x34)                          // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_WIND_SPEED (0x35)                              // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_AIR_QUALITY (0x36)                             // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_HEAT_INDEX (0x37)                              // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_SURFACE_TEMPERATURE (0x38)                     // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_VOLATILE_ORGANIC_COMPOUNDS (0x39)              // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_OBJECT_PRESENCE (0x3A)                         // CA, CP
+#define HID_USAGE_SENSORS_ENVIRONMENTAL_OBJECT_PROXIMITY (0x3B)                        // CA, CP
+#define HID_USAGE_SENSORS_LIGHT (0x40)                                                 // CA, CP
+#define HID_USAGE_SENSORS_LIGHT_AMBIENT_LIGHT (0x41)                                   // CA, CP
+#define HID_USAGE_SENSORS_LIGHT_CONSUMER_INFRARED (0x42)                               // CA, CP
+#define HID_USAGE_SENSORS_LIGHT_INFRARED_LIGHT (0x43)                                  // CA, CP
+#define HID_USAGE_SENSORS_LIGHT_VISIBLE_LIGHT (0x44)                                   // CA, CP
+#define HID_USAGE_SENSORS_LIGHT_ULTRAVIOLET_LIGHT (0x45)                               // CA, CP
+#define HID_USAGE_SENSORS_LOCATION (0x50)                                              // CA, CP
+#define HID_USAGE_SENSORS_LOCATION_BROADCAST (0x51)                                    // CA, CP
+#define HID_USAGE_SENSORS_LOCATION_DEAD_RECKONING (0x52)                               // CA, CP
+#define HID_USAGE_SENSORS_LOCATION_GPS_GLOBAL_POSITIONING_SYSTEM (0x53)                // CA, CP
+#define HID_USAGE_SENSORS_LOCATION_LOOKUP (0x54)                                       // CA, CP
+#define HID_USAGE_SENSORS_LOCATION_OTHER (0x55)                                        // CA, CP
+#define HID_USAGE_SENSORS_LOCATION_STATIC (0x56)                                       // CA, CP
+#define HID_USAGE_SENSORS_LOCATION_TRIANGULATION (0x57)                                // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL (0x60)                                            // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL_BOOLEAN_SWITCH (0x61)                             // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL_BOOLEAN_SWITCH_ARRAY (0x62)                       // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL_MULTIVALUE_SWITCH (0x63)                          // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL_FORCE (0x64)                                      // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL_PRESSURE (0x65)                                   // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL_STRAIN (0x66)                                     // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL_WEIGHT (0x67)                                     // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL_HAPTIC_VIBRATOR (0x68)                            // CA, CP
+#define HID_USAGE_SENSORS_MECHANICAL_HALL_EFFECT_SWITCH (0x69)                         // CA, CP
+#define HID_USAGE_SENSORS_MOTION (0x70)                                                // CA, CP
+#define HID_USAGE_SENSORS_MOTION_ACCELEROMETER_1D (0x71)                               // CA, CP
+#define HID_USAGE_SENSORS_MOTION_ACCELEROMETER_2D (0x72)                               // CA, CP
+#define HID_USAGE_SENSORS_MOTION_ACCELEROMETER_3D (0x73)                               // CA, CP
+#define HID_USAGE_SENSORS_MOTION_GYROMETER_1D (0x74)                                   // CA, CP
+#define HID_USAGE_SENSORS_MOTION_GYROMETER_2D (0x75)                                   // CA, CP
+#define HID_USAGE_SENSORS_MOTION_GYROMETER_3D (0x76)                                   // CA, CP
+#define HID_USAGE_SENSORS_MOTION_MOTION_DETECTOR (0x77)                                // CA, CP
+#define HID_USAGE_SENSORS_MOTION_SPEEDOMETER (0x78)                                    // CA, CP
+#define HID_USAGE_SENSORS_MOTION_ACCELEROMETER (0x79)                                  // CA, CP
+#define HID_USAGE_SENSORS_MOTION_GYROMETER (0x7A)                                      // CA, CP
+#define HID_USAGE_SENSORS_MOTION_GRAVITY_VECTOR (0x7B)                                 // CA, CP
+#define HID_USAGE_SENSORS_MOTION_LINEAR_ACCELEROMETER (0x7C)                           // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION (0x80)                                           // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_COMPASS_1D (0x81)                                // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_COMPASS_2D (0x82)                                // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_COMPASS_3D (0x83)                                // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_INCLINOMETER_1D (0x84)                           // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_INCLINOMETER_2D (0x85)                           // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_INCLINOMETER_3D (0x86)                           // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_DISTANCE_1D (0x87)                               // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_DISTANCE_2D (0x88)                               // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_DISTANCE_3D (0x89)                               // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_DEVICE_ORIENTATION (0x8A)                        // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_COMPASS (0x8B)                                   // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_INCLINOMETER (0x8C)                              // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_DISTANCE (0x8D)                                  // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_RELATIVE_ORIENTATION (0x8E)                      // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_SIMPLE_ORIENTATION (0x8F)                        // CA, CP
+#define HID_USAGE_SENSORS_SCANNER (0x90)                                               // CA, CP
+#define HID_USAGE_SENSORS_SCANNER_BARCODE (0x91)                                       // CA, CP
+#define HID_USAGE_SENSORS_SCANNER_RFID (0x92)                                          // CA, CP
+#define HID_USAGE_SENSORS_SCANNER_NFC (0x93)                                           // CA, CP
+#define HID_USAGE_SENSORS_TIME (0xA0)                                                  // CA, CP
+#define HID_USAGE_SENSORS_TIME_ALARM_TIMER (0xA1)                                      // CA, CP
+#define HID_USAGE_SENSORS_TIME_REAL_TIME_CLOCK (0xA2)                                  // CA, CP
+#define HID_USAGE_SENSORS_PERSONAL_ACTIVITY (0xB0)                                     // CA, CP
+#define HID_USAGE_SENSORS_PERSONAL_ACTIVITY_ACTIVITY_DETECTION (0xB1)                  // CA, CP
+#define HID_USAGE_SENSORS_PERSONAL_ACTIVITY_DEVICE_POSITION (0xB2)                     // CA, CP
+#define HID_USAGE_SENSORS_PERSONAL_ACTIVITY_PEDOMETER (0xB3)                           // CA, CP
+#define HID_USAGE_SENSORS_PERSONAL_ACTIVITY_STEP_DETECTION (0xB4)                      // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_EXTENDED (0xC0)                                  // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_EXTENDED_GEOMAGNETIC_ORIENTATION (0xC1)          // CA, CP
+#define HID_USAGE_SENSORS_ORIENTATION_EXTENDED_MAGNETOMETER (0xC2)                     // CA, CP
+#define HID_USAGE_SENSORS_GESTURE (0xD0)                                               // CA, CP
+#define HID_USAGE_SENSORS_GESTURE_CHASSIS_FLIP_GESTURE (0xD1)                          // CA, CP
+#define HID_USAGE_SENSORS_GESTURE_HINGE_FOLD_GESTURE (0xD2)                            // CA, CP
+#define HID_USAGE_SENSORS_OTHER (0xE0)                                                 // CA, CP
+#define HID_USAGE_SENSORS_OTHER_CUSTOM (0xE1)                                          // CA, CP
+#define HID_USAGE_SENSORS_OTHER_GENERIC (0xE2)                                         // CA, CP
+#define HID_USAGE_SENSORS_OTHER_GENERIC_ENUMERATOR (0xE3)                              // CA, CP
+#define HID_USAGE_SENSORS_OTHER_HINGE_ANGLE (0xE4)                                     // CA, CP
+#define HID_USAGE_SENSORS_EVENT (0x200)                                                // DV
+#define HID_USAGE_SENSORS_EVENT_SENSOR_STATE (0x201)                                   // NAry
+#define HID_USAGE_SENSORS_EVENT_SENSOR_EVENT (0x202)                                   // NAry
+#define HID_USAGE_SENSORS_PROPERTY (0x300)                                             // DV
+#define HID_USAGE_SENSORS_PROPERTY_FRIENDLY_NAME (0x301)                               // SV
+#define HID_USAGE_SENSORS_PROPERTY_PERSISTENT_UNIQUE_ID (0x302)                        // DV
+#define HID_USAGE_SENSORS_PROPERTY_SENSOR_STATUS (0x303)                               // DV
+#define HID_USAGE_SENSORS_PROPERTY_MINIMUM_REPORT_INTERVAL (0x304)                     // SV
+#define HID_USAGE_SENSORS_PROPERTY_SENSOR_MANUFACTURER (0x305)                         // SV
+#define HID_USAGE_SENSORS_PROPERTY_SENSOR_MODEL (0x306)                                // SV
+#define HID_USAGE_SENSORS_PROPERTY_SENSOR_SERIAL_NUMBER (0x307)                        // SV
+#define HID_USAGE_SENSORS_PROPERTY_SENSOR_DESCRIPTION (0x308)                          // SV
+#define HID_USAGE_SENSORS_PROPERTY_SENSOR_CONNECTION_TYPE (0x309)                      // NAry
+#define HID_USAGE_SENSORS_PROPERTY_SENSOR_DEVICE_PATH (0x30A)                          // DV
+#define HID_USAGE_SENSORS_PROPERTY_HARDWARE_REVISION (0x30B)                           // SV
+#define HID_USAGE_SENSORS_PROPERTY_FIRMWARE_VERSION (0x30C)                            // SV
+#define HID_USAGE_SENSORS_PROPERTY_RELEASE_DATE (0x30D)                                // SV
+#define HID_USAGE_SENSORS_PROPERTY_REPORT_INTERVAL (0x30E)                             // DV
+#define HID_USAGE_SENSORS_PROPERTY_CHANGE_SENSITIVITY_ABSOLUTE (0x30F)                 // DV
+#define HID_USAGE_SENSORS_PROPERTY_CHANGE_SENSITIVITY_PERCENT_OF_RANGE (0x310)         // DV
+#define HID_USAGE_SENSORS_PROPERTY_CHANGE_SENSITIVITY_PERCENT_RELATIVE (0x311)         // DV
+#define HID_USAGE_SENSORS_PROPERTY_ACCURACY (0x312)                                    // DV
+#define HID_USAGE_SENSORS_PROPERTY_RESOLUTION (0x313)                                  // DV
+#define HID_USAGE_SENSORS_PROPERTY_MAXIMUM (0x314)                                     // DV
+#define HID_USAGE_SENSORS_PROPERTY_MINIMUM (0x315)                                     // DV
+#define HID_USAGE_SENSORS_PROPERTY_REPORTING_STATE (0x316)                             // NAry
+#define HID_USAGE_SENSORS_PROPERTY_SAMPLING_RATE (0x317)                               // DV
+#define HID_USAGE_SENSORS_PROPERTY_RESPONSE_CURVE (0x318)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_POWER_STATE (0x319)                                 // NAry
+#define HID_USAGE_SENSORS_PROPERTY_MAXIMUM_FIFO_EVENTS (0x31A)                         // SV
+#define HID_USAGE_SENSORS_PROPERTY_REPORT_LATENCY (0x31B)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_FLUSH_FIFO_EVENTS (0x31C)                           // DF
+#define HID_USAGE_SENSORS_PROPERTY_MAXIMUM_POWER_CONSUMPTION (0x31D)                   // DV
+#define HID_USAGE_SENSORS_PROPERTY_IS_PRIMARY (0x31E)                                  // DF
+#define HID_USAGE_SENSORS_DATA_FIELD_LOCATION (0x400)                                  // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_ALTITUDE_ANTENNA_SEA_LEVEL (0x402)                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_DIFFERENTIAL_REFERENCE_STATION_ID (0x403)         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ALTITUDE_ELLIPSOID_ERROR (0x404)                  // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ALTITUDE_ELLIPSOID (0x405)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ALTITUDE_SEA_LEVEL_ERROR (0x406)                  // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ALTITUDE_SEA_LEVEL (0x407)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_DIFFERENTIAL_GPS_DATA_AGE (0x408)                 // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ERROR_RADIUS (0x409)                              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_FIX_QUALITY (0x40A)                               // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_FIX_TYPE (0x40B)                                  // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_GEOIDAL_SEPARATION (0x40C)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GPS_OPERATION_MODE (0x40D)                        // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_GPS_SELECTION_MODE (0x40E)                        // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_GPS_STATUS (0x40F)                                // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_POSITION_DILUTION_OF_PRECISION (0x410)            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HORIZONTAL_DILUTION_OF_PRECISION (0x411)          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_VERTICAL_DILUTION_OF_PRECISION (0x412)            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_LATITUDE (0x413)                                  // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_LONGITUDE (0x414)                                 // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_TRUE_HEADING (0x415)                              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MAGNETIC_HEADING (0x416)                          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MAGNETIC_VARIATION (0x417)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SPEED (0x418)                                     // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SATELLITES_IN_VIEW (0x419)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SATELLITES_IN_VIEW_AZIMUTH (0x41A)                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SATELLITES_IN_VIEW_ELEVATION (0x41B)              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SATELLITES_IN_VIEW_IDS (0x41C)                    // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SATELLITES_IN_VIEW_PRNS (0x41D)                   // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SATELLITES_IN_VIEW_S_N_RATIOS (0x41E)             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SATELLITES_USED_COUNT (0x41F)                     // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SATELLITES_USED_PRNS (0x420)                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_NMEA_SENTENCE (0x421)                             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ADDRESS_LINE_1 (0x422)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ADDRESS_LINE_2 (0x423)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CITY (0x424)                                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_STATE_OR_PROVINCE (0x425)                         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_COUNTRY_OR_REGION (0x426)                         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_POSTAL_CODE (0x427)                               // SV
+#define HID_USAGE_SENSORS_PROPERTY_LOCATION (0x42A)                                    // DV
+#define HID_USAGE_SENSORS_PROPERTY_LOCATION_DESIRED_ACCURACY (0x42B)                   // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_ENVIRONMENTAL (0x430)                             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ATMOSPHERIC_PRESSURE (0x431)                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_RELATIVE_HUMIDITY (0x433)                         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_TEMPERATURE (0x434)                               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_WIND_DIRECTION (0x435)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_WIND_SPEED (0x436)                                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_AIR_QUALITY_INDEX (0x437)                         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_EQUIVALENT_CO2 (0x438)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_VOLATILE_ORGANIC_COMPOUND_CONCENTRATION (0x439)   // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_OBJECT_PRESENCE (0x43A)                           // SF
+#define HID_USAGE_SENSORS_DATA_FIELD_OBJECT_PROXIMITY_RANGE (0x43B)                    // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_OBJECT_PROXIMITY_OUT_OF_RANGE (0x43C)             // SF
+#define HID_USAGE_SENSORS_PROPERTY_ENVIRONMENTAL (0x440)                               // SV
+#define HID_USAGE_SENSORS_PROPERTY_REFERENCE_PRESSURE (0x441)                          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MOTION (0x450)                                    // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_MOTION_STATE (0x451)                              // SF
+#define HID_USAGE_SENSORS_DATA_FIELD_ACCELERATION (0x452)                              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ACCELERATION_AXIS_X (0x453)                       // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ACCELERATION_AXIS_Y (0x454)                       // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ACCELERATION_AXIS_Z (0x455)                       // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ANGULAR_VELOCITY (0x456)                          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ANGULAR_VELOCITY_ABOUT_X_AXIS (0x457)             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ANGULAR_VELOCITY_ABOUT_Y_AXIS (0x458)             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ANGULAR_VELOCITY_ABOUT_Z_AXIS (0x459)             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ANGULAR_POSITION (0x45A)                          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ANGULAR_POSITION_ABOUT_X_AXIS (0x45B)             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ANGULAR_POSITION_ABOUT_Y_AXIS (0x45C)             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ANGULAR_POSITION_ABOUT_Z_AXIS (0x45D)             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MOTION_SPEED (0x45E)                              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MOTION_INTENSITY (0x45F)                          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ORIENTATION (0x470)                               // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEADING (0x471)                                   // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEADING_X_AXIS (0x472)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEADING_Y_AXIS (0x473)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEADING_Z_AXIS (0x474)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEADING_COMPENSATED_MAGNETIC_NORTH (0x475)        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEADING_COMPENSATED_TRUE_NORTH (0x476)            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEADING_MAGNETIC_NORTH (0x477)                    // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEADING_TRUE_NORTH (0x478)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_DISTANCE (0x479)                                  // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_DISTANCE_X_AXIS (0x47A)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_DISTANCE_Y_AXIS (0x47B)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_DISTANCE_Z_AXIS (0x47C)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_DISTANCE_OUT_OF_RANGE (0x47D)                     // SF
+#define HID_USAGE_SENSORS_DATA_FIELD_TILT (0x47E)                                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_TILT_X_AXIS (0x47F)                               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_TILT_Y_AXIS (0x480)                               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_TILT_Z_AXIS (0x481)                               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ROTATION_MATRIX (0x482)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_QUATERNION (0x483)                                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MAGNETIC_FLUX (0x484)                             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MAGNETIC_FLUX_X_AXIS (0x485)                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MAGNETIC_FLUX_Y_AXIS (0x486)                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MAGNETIC_FLUX_Z_AXIS (0x487)                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MAGNETOMETER_ACCURACY (0x488)                     // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_SIMPLE_ORIENTATION_DIRECTION (0x489)              // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_MECHANICAL (0x490)                                // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_BOOLEAN_SWITCH_STATE (0x491)                      // SF
+#define HID_USAGE_SENSORS_DATA_FIELD_BOOLEAN_SWITCH_ARRAY_STATES (0x492)               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MULTIVALUE_SWITCH_VALUE (0x493)                   // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_FORCE (0x494)                                     // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ABSOLUTE_PRESSURE (0x495)                         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GAUGE_PRESSURE (0x496)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_STRAIN (0x497)                                    // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_WEIGHT (0x498)                                    // SV
+#define HID_USAGE_SENSORS_PROPERTY_MECHANICAL (0x4A0)                                  // DV
+#define HID_USAGE_SENSORS_PROPERTY_VIBRATION_STATE (0x4A1)                             // DF
+#define HID_USAGE_SENSORS_PROPERTY_FORWARD_VIBRATION_SPEED (0x4A2)                     // DV
+#define HID_USAGE_SENSORS_PROPERTY_BACKWARD_VIBRATION_SPEED (0x4A3)                    // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_BIOMETRIC (0x4B0)                                 // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_HUMAN_PRESENCE (0x4B1)                            // SF
+#define HID_USAGE_SENSORS_DATA_FIELD_HUMAN_PROXIMITY_RANGE (0x4B2)                     // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HUMAN_PROXIMITY_OUT_OF_RANGE (0x4B3)              // SF
+#define HID_USAGE_SENSORS_DATA_FIELD_HUMAN_TOUCH_STATE (0x4B4)                         // SF
+#define HID_USAGE_SENSORS_DATA_FIELD_BLOOD_PRESSURE (0x4B5)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_BLOOD_PRESSURE_DIASTOLIC (0x4B6)                  // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_BLOOD_PRESSURE_SYSTOLIC (0x4B7)                   // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEART_RATE (0x4B8)                                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_RESTING_HEART_RATE (0x4B9)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HEARTBEAT_INTERVAL (0x4BA)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_RESPIRATORY_RATE (0x4BB)                          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SPO2 (0x4BC)                                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_LIGHT (0x4D0)                                     // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_ILLUMINANCE (0x4D1)                               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_COLOR_TEMPERATURE (0x4D2)                         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CHROMATICITY (0x4D3)                              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CHROMATICITY_X (0x4D4)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CHROMATICITY_Y (0x4D5)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CONSUMER_IR_SENTENCE_RECEIVE (0x4D6)              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_INFRARED_LIGHT (0x4D7)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_RED_LIGHT (0x4D8)                                 // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GREEN_LIGHT (0x4D9)                               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_BLUE_LIGHT (0x4DA)                                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ULTRAVIOLET_A_LIGHT (0x4DB)                       // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ULTRAVIOLET_B_LIGHT (0x4DC)                       // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ULTRAVIOLET_INDEX (0x4DD)                         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_NEAR_INFRARED_LIGHT (0x4DE)                       // SV
+#define HID_USAGE_SENSORS_PROPERTY_LIGHT (0x4DF)                                       // DV
+#define HID_USAGE_SENSORS_PROPERTY_CONSUMER_IR_SENTENCE_SEND (0x4E0)                   // DV
+#define HID_USAGE_SENSORS_PROPERTY_AUTO_BRIGHTNESS_PREFERRED (0x4E2)                   // DF
+#define HID_USAGE_SENSORS_PROPERTY_AUTO_COLOR_PREFERRED (0x4E3)                        // DF
+#define HID_USAGE_SENSORS_DATA_FIELD_SCANNER (0x4F0)                                   // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_RFID_TAG_40_BIT (0x4F1)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_NFC_SENTENCE_RECEIVE (0x4F2)                      // SV
+#define HID_USAGE_SENSORS_PROPERTY_SCANNER (0x4F8)                                     // DV
+#define HID_USAGE_SENSORS_PROPERTY_NFC_SENTENCE_SEND (0x4F9)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ELECTRICAL (0x500)                                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CAPACITANCE (0x501)                               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CURRENT (0x502)                                   // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ELECTRICAL_POWER (0x503)                          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_INDUCTANCE (0x504)                                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_RESISTANCE (0x505)                                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_VOLTAGE (0x506)                                   // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_FREQUENCY (0x507)                                 // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_PERIOD (0x508)                                    // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_PERCENT_OF_RANGE (0x509)                          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_TIME (0x520)                                      // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_YEAR (0x521)                                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MONTH (0x522)                                     // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_DAY (0x523)                                       // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_DAY_OF_WEEK (0x524)                               // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_HOUR (0x525)                                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MINUTE (0x526)                                    // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_SECOND (0x527)                                    // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_MILLISECOND (0x528)                               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_TIMESTAMP (0x529)                                 // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_JULIAN_DAY_OF_YEAR (0x52A)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_TIME_SINCE_SYSTEM_BOOT (0x52B)                    // SV
+#define HID_USAGE_SENSORS_PROPERTY_TIME (0x530)                                        // DV
+#define HID_USAGE_SENSORS_PROPERTY_TIME_ZONE_OFFSET_FROM_UTC (0x531)                   // DV
+#define HID_USAGE_SENSORS_PROPERTY_TIME_ZONE_NAME (0x532)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_DAYLIGHT_SAVINGS_TIME_OBSERVED (0x533)              // DF
+#define HID_USAGE_SENSORS_PROPERTY_TIME_TRIM_ADJUSTMENT (0x534)                        // DV
+#define HID_USAGE_SENSORS_PROPERTY_ARM_ALARM (0x535)                                   // DF
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM (0x540)                                    // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_USAGE (0x541)                              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_BOOLEAN_ARRAY (0x542)                      // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE (0x543)                              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_1 (0x544)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_2 (0x545)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_3 (0x546)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_4 (0x547)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_5 (0x548)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_6 (0x549)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_7 (0x54A)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_8 (0x54B)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_9 (0x54C)                            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_10 (0x54D)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_11 (0x54E)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_12 (0x54F)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_13 (0x550)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_14 (0x551)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_15 (0x552)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_16 (0x553)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_17 (0x554)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_18 (0x555)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_19 (0x556)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_20 (0x557)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_21 (0x558)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_22 (0x559)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_23 (0x55A)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_24 (0x55B)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_25 (0x55C)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_26 (0x55D)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_27 (0x55E)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_VALUE_28 (0x55F)                           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC (0x560)                                   // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_GUID_OR_PROPERTYKEY (0x561)               // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_CATEGORY_GUID (0x562)                     // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_TYPE_GUID (0x563)                         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_EVENT_PROPERTYKEY (0x564)                 // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_PROPERTY_PROPERTYKEY (0x565)              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_DATA_FIELD_PROPERTYKEY (0x566)            // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_EVENT (0x567)                             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_PROPERTY (0x568)                          // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_DATA_FIELD (0x569)                        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ENUMERATOR_TABLE_ROW_INDEX (0x56A)                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_ENUMERATOR_TABLE_ROW_COUNT (0x56B)                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_GUID_OR_PROPERTYKEY_KIND (0x56C)          // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_GUID (0x56D)                              // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_PROPERTYKEY (0x56E)                       // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_TOP_LEVEL_COLLECTION_ID (0x56F)           // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_REPORT_ID (0x570)                         // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_REPORT_ITEM_POSITION_INDEX (0x571)        // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_FIRMWARE_VARTYPE (0x572)                  // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_UNIT_OF_MEASURE (0x573)                   // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_UNIT_EXPONENT (0x574)                     // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_REPORT_SIZE (0x575)                       // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_GENERIC_REPORT_COUNT (0x576)                      // SV
+#define HID_USAGE_SENSORS_PROPERTY_GENERIC (0x580)                                     // DV
+#define HID_USAGE_SENSORS_PROPERTY_ENUMERATOR_TABLE_ROW_INDEX (0x581)                  // DV
+#define HID_USAGE_SENSORS_PROPERTY_ENUMERATOR_TABLE_ROW_COUNT (0x582)                  // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_PERSONAL_ACTIVITY (0x590)                         // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_ACTIVITY_TYPE (0x591)                             // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_ACTIVITY_STATE (0x592)                            // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_DEVICE_POSITION (0x593)                           // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_STEP_COUNT (0x594)                                // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_STEP_COUNT_RESET (0x595)                          // DF
+#define HID_USAGE_SENSORS_DATA_FIELD_STEP_DURATION (0x596)                             // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_STEP_TYPE (0x597)                                 // NAry
+#define HID_USAGE_SENSORS_PROPERTY_MINIMUM_ACTIVITY_DETECTION_INTERVAL (0x5A0)         // DV
+#define HID_USAGE_SENSORS_PROPERTY_SUPPORTED_ACTIVITY_TYPES (0x5A1)                    // NAry
+#define HID_USAGE_SENSORS_PROPERTY_SUBSCRIBED_ACTIVITY_TYPES (0x5A2)                   // NAry
+#define HID_USAGE_SENSORS_PROPERTY_SUPPORTED_STEP_TYPES (0x5A3)                        // NAry
+#define HID_USAGE_SENSORS_PROPERTY_SUBSCRIBED_STEP_TYPES (0x5A4)                       // NAry
+#define HID_USAGE_SENSORS_PROPERTY_FLOOR_HEIGHT (0x5A5)                                // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_CUSTOM_TYPE_ID (0x5B0)                            // SV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM (0x5C0)                                      // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_1 (0x5C1)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_2 (0x5C2)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_3 (0x5C3)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_4 (0x5C4)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_5 (0x5C5)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_6 (0x5C6)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_7 (0x5C7)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_8 (0x5C8)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_9 (0x5C9)                              // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_10 (0x5CA)                             // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_11 (0x5CB)                             // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_12 (0x5CC)                             // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_13 (0x5CD)                             // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_14 (0x5CE)                             // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_15 (0x5CF)                             // DV
+#define HID_USAGE_SENSORS_PROPERTY_CUSTOM_VALUE_16 (0x5D0)                             // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_HINGE (0x5E0)                                     // SV, DV
+#define HID_USAGE_SENSORS_DATA_FIELD_HINGE_ANGLE (0x5E1)                               // SV, DV
+#define HID_USAGE_SENSORS_DATA_FIELD_GESTURE_SENSOR (0x5F0)                            // DV
+#define HID_USAGE_SENSORS_DATA_FIELD_GESTURE_STATE (0x5F1)                             // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_HINGE_FOLD_INITIAL_ANGLE (0x5F2)                  // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HINGE_FOLD_FINAL_ANGLE (0x5F3)                    // SV
+#define HID_USAGE_SENSORS_DATA_FIELD_HINGE_FOLD_CONTRIBUTING_PANEL (0x5F4)             // NAry
+#define HID_USAGE_SENSORS_DATA_FIELD_HINGE_FOLD_TYPE (0x5F5)                           // NAry
+#define HID_USAGE_SENSORS_SENSOR_STATE_UNDEFINED (0x800)                               // Sel
+#define HID_USAGE_SENSORS_SENSOR_STATE_READY (0x801)                                   // Sel
+#define HID_USAGE_SENSORS_SENSOR_STATE_NOT_AVAILABLE (0x802)                           // Sel
+#define HID_USAGE_SENSORS_SENSOR_STATE_NO_DATA (0x803)                                 // Sel
+#define HID_USAGE_SENSORS_SENSOR_STATE_INITIALIZING (0x804)                            // Sel
+#define HID_USAGE_SENSORS_SENSOR_STATE_ACCESS_DENIED (0x805)                           // Sel
+#define HID_USAGE_SENSORS_SENSOR_STATE_ERROR (0x806)                                   // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_UNKNOWN (0x810)                                 // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_STATE_CHANGED (0x811)                           // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_PROPERTY_CHANGED (0x812)                        // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_DATA_UPDATED (0x813)                            // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_POLL_RESPONSE (0x814)                           // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_CHANGE_SENSITIVITY (0x815)                      // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_RANGE_MAXIMUM_REACHED (0x816)                   // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_RANGE_MINIMUM_REACHED (0x817)                   // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_HIGH_THRESHOLD_CROSS_UPWARD (0x818)             // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_HIGH_THRESHOLD_CROSS_DOWNWARD (0x819)           // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_LOW_THRESHOLD_CROSS_UPWARD (0x81A)              // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_LOW_THRESHOLD_CROSS_DOWNWARD (0x81B)            // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_ZERO_THRESHOLD_CROSS_UPWARD (0x81C)             // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_ZERO_THRESHOLD_CROSS_DOWNWARD (0x81D)           // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_PERIOD_EXCEEDED (0x81E)                         // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_FREQUENCY_EXCEEDED (0x81F)                      // Sel
+#define HID_USAGE_SENSORS_SENSOR_EVENT_COMPLEX_TRIGGER (0x820)                         // Sel
+#define HID_USAGE_SENSORS_CONNECTION_TYPE_PC_INTEGRATED (0x830)                        // Sel
+#define HID_USAGE_SENSORS_CONNECTION_TYPE_PC_ATTACHED (0x831)                          // Sel
+#define HID_USAGE_SENSORS_CONNECTION_TYPE_PC_EXTERNAL (0x832)                          // Sel
+#define HID_USAGE_SENSORS_REPORTING_STATE_REPORT_NO_EVENTS (0x840)                     // Sel
+#define HID_USAGE_SENSORS_REPORTING_STATE_REPORT_ALL_EVENTS (0x841)                    // Sel
+#define HID_USAGE_SENSORS_REPORTING_STATE_REPORT_THRESHOLD_EVENTS (0x842)              // Sel
+#define HID_USAGE_SENSORS_REPORTING_STATE_WAKE_ON_NO_EVENTS (0x843)                    // Sel
+#define HID_USAGE_SENSORS_REPORTING_STATE_WAKE_ON_ALL_EVENTS (0x844)                   // Sel
+#define HID_USAGE_SENSORS_REPORTING_STATE_WAKE_ON_THRESHOLD_EVENTS (0x845)             // Sel
+#define HID_USAGE_SENSORS_POWER_STATE_UNDEFINED (0x850)                                // Sel
+#define HID_USAGE_SENSORS_POWER_STATE_D0_FULL_POWER (0x851)                            // Sel
+#define HID_USAGE_SENSORS_POWER_STATE_D1_LOW_POWER (0x852)                             // Sel
+#define HID_USAGE_SENSORS_POWER_STATE_D2_STANDBY_POWER_WITH_WAKEUP (0x853)             // Sel
+#define HID_USAGE_SENSORS_POWER_STATE_D3_SLEEP_WITH_WAKEUP (0x854)                     // Sel
+#define HID_USAGE_SENSORS_POWER_STATE_D4_POWER_OFF (0x855)                             // Sel
+#define HID_USAGE_SENSORS_FIX_QUALITY_NO_FIX (0x870)                                   // Sel
+#define HID_USAGE_SENSORS_FIX_QUALITY_GPS (0x871)                                      // Sel
+#define HID_USAGE_SENSORS_FIX_QUALITY_DGPS (0x872)                                     // Sel
+#define HID_USAGE_SENSORS_FIX_TYPE_NO_FIX (0x880)                                      // Sel
+#define HID_USAGE_SENSORS_FIX_TYPE_GPS_SPS_MODE_FIX_VALID (0x881)                      // Sel
+#define HID_USAGE_SENSORS_FIX_TYPE_DGPS_SPS_MODE_FIX_VALID (0x882)                     // Sel
+#define HID_USAGE_SENSORS_FIX_TYPE_GPS_PPS_MODE_FIX_VALID (0x883)                      // Sel
+#define HID_USAGE_SENSORS_FIX_TYPE_REAL_TIME_KINEMATIC (0x884)                         // Sel
+#define HID_USAGE_SENSORS_FIX_TYPE_FLOAT_RTK (0x885)                                   // Sel
+#define HID_USAGE_SENSORS_FIX_TYPE_ESTIMATED_DEAD_RECKONED (0x886)                     // Sel
+#define HID_USAGE_SENSORS_FIX_TYPE_MANUAL_INPUT_MODE (0x887)                           // Sel
+#define HID_USAGE_SENSORS_FIX_TYPE_SIMULATOR_MODE (0x888)                              // Sel
+#define HID_USAGE_SENSORS_GPS_OPERATION_MODE_MANUAL (0x890)                            // Sel
+#define HID_USAGE_SENSORS_GPS_OPERATION_MODE_AUTOMATIC (0x891)                         // Sel
+#define HID_USAGE_SENSORS_GPS_SELECTION_MODE_AUTONOMOUS (0x8A0)                        // Sel
+#define HID_USAGE_SENSORS_GPS_SELECTION_MODE_DGPS (0x8A1)                              // Sel
+#define HID_USAGE_SENSORS_GPS_SELECTION_MODE_ESTIMATED_DEAD_RECKONED (0x8A2)           // Sel
+#define HID_USAGE_SENSORS_GPS_SELECTION_MODE_MANUAL_INPUT (0x8A3)                      // Sel
+#define HID_USAGE_SENSORS_GPS_SELECTION_MODE_SIMULATOR (0x8A4)                         // Sel
+#define HID_USAGE_SENSORS_GPS_SELECTION_MODE_DATA_NOT_VALID (0x8A5)                    // Sel
+#define HID_USAGE_SENSORS_GPS_STATUS_DATA_VALID (0x8B0)                                // Sel
+#define HID_USAGE_SENSORS_GPS_STATUS_DATA_NOT_VALID (0x8B1)                            // Sel
+#define HID_USAGE_SENSORS_ACCURACY_DEFAULT (0x860)                                     // Sel
+#define HID_USAGE_SENSORS_ACCURACY_HIGH (0x861)                                        // Sel
+#define HID_USAGE_SENSORS_ACCURACY_MEDIUM (0x862)                                      // Sel
+#define HID_USAGE_SENSORS_ACCURACY_LOW (0x863)                                         // Sel
+#define HID_USAGE_SENSORS_DAY_OF_WEEK_SUNDAY (0x8C0)                                   // Sel
+#define HID_USAGE_SENSORS_DAY_OF_WEEK_MONDAY (0x8C1)                                   // Sel
+#define HID_USAGE_SENSORS_DAY_OF_WEEK_TUESDAY (0x8C2)                                  // Sel
+#define HID_USAGE_SENSORS_DAY_OF_WEEK_WEDNESDAY (0x8C3)                                // Sel
+#define HID_USAGE_SENSORS_DAY_OF_WEEK_THURSDAY (0x8C4)                                 // Sel
+#define HID_USAGE_SENSORS_DAY_OF_WEEK_FRIDAY (0x8C5)                                   // Sel
+#define HID_USAGE_SENSORS_DAY_OF_WEEK_SATURDAY (0x8C6)                                 // Sel
+#define HID_USAGE_SENSORS_KIND_CATEGORY (0x8D0)                                        // Sel
+#define HID_USAGE_SENSORS_KIND_TYPE (0x8D1)                                            // Sel
+#define HID_USAGE_SENSORS_KIND_EVENT (0x8D2)                                           // Sel
+#define HID_USAGE_SENSORS_KIND_PROPERTY (0x8D3)                                        // Sel
+#define HID_USAGE_SENSORS_KIND_DATA_FIELD (0x8D4)                                      // Sel
+#define HID_USAGE_SENSORS_MAGNETOMETER_ACCURACY_LOW (0x8E0)                            // Sel
+#define HID_USAGE_SENSORS_MAGNETOMETER_ACCURACY_MEDIUM (0x8E1)                         // Sel
+#define HID_USAGE_SENSORS_MAGNETOMETER_ACCURACY_HIGH (0x8E2)                           // Sel
+#define HID_USAGE_SENSORS_SIMPLE_ORIENTATION_DIRECTION_NOT_ROTATED (0x8F0)             // Sel
+#define HID_USAGE_SENSORS_SIMPLE_ORIENTATION_DIRECTION_ROTATED_90_DEGREES_CCW (0x8F1)  // Sel
+#define HID_USAGE_SENSORS_SIMPLE_ORIENTATION_DIRECTION_ROTATED_180_DEGREES_CCW (0x8F2) // Sel
+#define HID_USAGE_SENSORS_SIMPLE_ORIENTATION_DIRECTION_ROTATED_270_DEGREES_CCW (0x8F3) // Sel
+#define HID_USAGE_SENSORS_SIMPLE_ORIENTATION_DIRECTION_FACE_UP (0x8F4)                 // Sel
+#define HID_USAGE_SENSORS_SIMPLE_ORIENTATION_DIRECTION_FACE_DOWN (0x8F5)               // Sel
+#define HID_USAGE_SENSORS_VT_NULL (0x900)                                              // Sel
+#define HID_USAGE_SENSORS_VT_BOOL (0x901)                                              // Sel
+#define HID_USAGE_SENSORS_VT_UI1 (0x902)                                               // Sel
+#define HID_USAGE_SENSORS_VT_I1 (0x903)                                                // Sel
+#define HID_USAGE_SENSORS_VT_UI2 (0x904)                                               // Sel
+#define HID_USAGE_SENSORS_VT_I2 (0x905)                                                // Sel
+#define HID_USAGE_SENSORS_VT_UI4 (0x906)                                               // Sel
+#define HID_USAGE_SENSORS_VT_I4 (0x907)                                                // Sel
+#define HID_USAGE_SENSORS_VT_UI8 (0x908)                                               // Sel
+#define HID_USAGE_SENSORS_VT_I8 (0x909)                                                // Sel
+#define HID_USAGE_SENSORS_VT_R4 (0x90A)                                                // Sel
+#define HID_USAGE_SENSORS_VT_R8 (0x90B)                                                // Sel
+#define HID_USAGE_SENSORS_VT_WSTR (0x90C)                                              // Sel
+#define HID_USAGE_SENSORS_VT_STR (0x90D)                                               // Sel
+#define HID_USAGE_SENSORS_VT_CLSID (0x90E)                                             // Sel
+#define HID_USAGE_SENSORS_VT_VECTOR_VT_UI1 (0x90F)                                     // Sel
+#define HID_USAGE_SENSORS_VT_F16E0 (0x910)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16E1 (0x911)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16E2 (0x912)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16E3 (0x913)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16E4 (0x914)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16E5 (0x915)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16E6 (0x916)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16E7 (0x917)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16E8 (0x918)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16E9 (0x919)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16EA (0x91A)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16EB (0x91B)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16EC (0x91C)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16ED (0x91D)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16EE (0x91E)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F16EF (0x91F)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E0 (0x920)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E1 (0x921)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E2 (0x922)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E3 (0x923)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E4 (0x924)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E5 (0x925)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E6 (0x926)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E7 (0x927)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E8 (0x928)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32E9 (0x929)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32EA (0x92A)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32EB (0x92B)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32EC (0x92C)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32ED (0x92D)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32EE (0x92E)                                             // Sel
+#define HID_USAGE_SENSORS_VT_F32EF (0x92F)                                             // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_TYPE_UNKNOWN (0x930)                                // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_TYPE_STATIONARY (0x931)                             // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_TYPE_FIDGETING (0x932)                              // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_TYPE_WALKING (0x933)                                // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_TYPE_RUNNING (0x934)                                // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_TYPE_IN_VEHICLE (0x935)                             // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_TYPE_BIKING (0x936)                                 // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_TYPE_IDLE (0x937)                                   // Sel
+#define HID_USAGE_SENSORS_UNIT_NOT_SPECIFIED (0x940)                                   // Sel
+#define HID_USAGE_SENSORS_UNIT_LUX (0x941)                                             // Sel
+#define HID_USAGE_SENSORS_UNIT_DEGREES_KELVIN (0x942)                                  // Sel
+#define HID_USAGE_SENSORS_UNIT_DEGREES_CELSIUS (0x943)                                 // Sel
+#define HID_USAGE_SENSORS_UNIT_PASCAL (0x944)                                          // Sel
+#define HID_USAGE_SENSORS_UNIT_NEWTON (0x945)                                          // Sel
+#define HID_USAGE_SENSORS_UNIT_METERS_SECOND (0x946)                                   // Sel
+#define HID_USAGE_SENSORS_UNIT_KILOGRAM (0x947)                                        // Sel
+#define HID_USAGE_SENSORS_UNIT_METER (0x948)                                           // Sel
+#define HID_USAGE_SENSORS_UNIT_METERS_SECOND_SECOND (0x949)                            // Sel
+#define HID_USAGE_SENSORS_UNIT_FARAD (0x94A)                                           // Sel
+#define HID_USAGE_SENSORS_UNIT_AMPERE (0x94B)                                          // Sel
+#define HID_USAGE_SENSORS_UNIT_WATT (0x94C)                                            // Sel
+#define HID_USAGE_SENSORS_UNIT_HENRY (0x94D)                                           // Sel
+#define HID_USAGE_SENSORS_UNIT_OHM (0x94E)                                             // Sel
+#define HID_USAGE_SENSORS_UNIT_VOLT (0x94F)                                            // Sel
+#define HID_USAGE_SENSORS_UNIT_HERTZ (0x950)                                           // Sel
+#define HID_USAGE_SENSORS_UNIT_BAR (0x951)                                             // Sel
+#define HID_USAGE_SENSORS_UNIT_DEGREES_ANTI_CLOCKWISE (0x952)                          // Sel
+#define HID_USAGE_SENSORS_UNIT_DEGREES_CLOCKWISE (0x953)                               // Sel
+#define HID_USAGE_SENSORS_UNIT_DEGREES (0x954)                                         // Sel
+#define HID_USAGE_SENSORS_UNIT_DEGREES_SECOND (0x955)                                  // Sel
+#define HID_USAGE_SENSORS_UNIT_DEGREES_SECOND_SECOND (0x956)                           // Sel
+#define HID_USAGE_SENSORS_UNIT_KNOT (0x957)                                            // Sel
+#define HID_USAGE_SENSORS_UNIT_PERCENT (0x958)                                         // Sel
+#define HID_USAGE_SENSORS_UNIT_SECOND (0x959)                                          // Sel
+#define HID_USAGE_SENSORS_UNIT_MILLISECOND (0x95A)                                     // Sel
+#define HID_USAGE_SENSORS_UNIT_G (0x95B)                                               // Sel
+#define HID_USAGE_SENSORS_UNIT_BYTES (0x95C)                                           // Sel
+#define HID_USAGE_SENSORS_UNIT_MILLIGAUSS (0x95D)                                      // Sel
+#define HID_USAGE_SENSORS_UNIT_BITS (0x95E)                                            // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_STATE_NO_STATE_CHANGE (0x960)                       // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_STATE_START_ACTIVITY (0x961)                        // Sel
+#define HID_USAGE_SENSORS_ACTIVITY_STATE_END_ACTIVITY (0x962)                          // Sel
+#define HID_USAGE_SENSORS_EXPONENT_0 (0x970)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_1 (0x971)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_2 (0x972)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_3 (0x973)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_4 (0x974)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_5 (0x975)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_6 (0x976)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_7 (0x977)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_8 (0x978)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_9 (0x979)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_A (0x97A)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_B (0x97B)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_C (0x97C)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_D (0x97D)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_E (0x97E)                                           // Sel
+#define HID_USAGE_SENSORS_EXPONENT_F (0x97F)                                           // Sel
+#define HID_USAGE_SENSORS_DEVICE_POSITION_UNKNOWN (0x980)                              // Sel
+#define HID_USAGE_SENSORS_DEVICE_POSITION_UNCHANGED (0x981)                            // Sel
+#define HID_USAGE_SENSORS_DEVICE_POSITION_ON_DESK (0x982)                              // Sel
+#define HID_USAGE_SENSORS_DEVICE_POSITION_IN_HAND (0x983)                              // Sel
+#define HID_USAGE_SENSORS_DEVICE_POSITION_MOVING_IN_BAG (0x984)                        // Sel
+#define HID_USAGE_SENSORS_DEVICE_POSITION_STATIONARY_IN_BAG (0x985)                    // Sel
+#define HID_USAGE_SENSORS_STEP_TYPE_UNKNOWN (0x990)                                    // Sel
+#define HID_USAGE_SENSORS_STEP_TYPE_RUNNING (0x991)                                    // Sel
+#define HID_USAGE_SENSORS_STEP_TYPE_WALKING (0x992)                                    // Sel
+#define HID_USAGE_SENSORS_GESTURE_STATE_UNKNOWN (0x9A0)                                // Sel
+#define HID_USAGE_SENSORS_GESTURE_STATE_STARTED (0x9A1)                                // Sel
+#define HID_USAGE_SENSORS_GESTURE_STATE_COMPLETED (0x9A2)                              // Sel
+#define HID_USAGE_SENSORS_GESTURE_STATE_CANCELLED (0x9A3)                              // Sel
+#define HID_USAGE_SENSORS_HINGE_FOLD_CONTRIBUTING_PANEL_UNKNOWN (0x9B0)                // Sel
+#define HID_USAGE_SENSORS_HINGE_FOLD_CONTRIBUTING_PANEL_PANEL_1 (0x9B1)                // Sel
+#define HID_USAGE_SENSORS_HINGE_FOLD_CONTRIBUTING_PANEL_PANEL_2 (0x9B2)                // Sel
+#define HID_USAGE_SENSORS_HINGE_FOLD_CONTRIBUTING_PANEL_BOTH (0x9B3)                   // Sel
+#define HID_USAGE_SENSORS_HINGE_FOLD_TYPE_UNKNOWN (0x9B4)                              // Sel
+#define HID_USAGE_SENSORS_HINGE_FOLD_TYPE_INCREASING (0x9B5)                           // Sel
+#define HID_USAGE_SENSORS_HINGE_FOLD_TYPE_DECREASING (0x9B6)                           // Sel
+#define HID_USAGE_SENSORS_MODIFIER_CHANGE_SENSITIVITY_ABSOLUTE (0x1000)                // US
+#define HID_USAGE_SENSORS_MODIFIER_MAXIMUM (0x2000)                                    // US
+#define HID_USAGE_SENSORS_MODIFIER_MINIMUM (0x3000)                                    // US
+#define HID_USAGE_SENSORS_MODIFIER_ACCURACY (0x4000)                                   // US
+#define HID_USAGE_SENSORS_MODIFIER_RESOLUTION (0x5000)                                 // US
+#define HID_USAGE_SENSORS_MODIFIER_THRESHOLD_HIGH (0x6000)                             // US
+#define HID_USAGE_SENSORS_MODIFIER_THRESHOLD_LOW (0x7000)                              // US
+#define HID_USAGE_SENSORS_MODIFIER_CALIBRATION_OFFSET (0x8000)                         // US
+#define HID_USAGE_SENSORS_MODIFIER_CALIBRATION_MULTIPLIER (0x9000)                     // US
+#define HID_USAGE_SENSORS_MODIFIER_REPORT_INTERVAL (0xA000)                            // US
+#define HID_USAGE_SENSORS_MODIFIER_FREQUENCY_MAX (0xB000)                              // US
+#define HID_USAGE_SENSORS_MODIFIER_PERIOD_MAX (0xC000)                                 // US
+#define HID_USAGE_SENSORS_MODIFIER_CHANGE_SENSITIVITY_PERCENT_OF_RANGE (0xD000)        // US
+#define HID_USAGE_SENSORS_MODIFIER_CHANGE_SENSITIVITY_PERCENT_RELATIVE (0xE000)        // US
+
+/* Page 0x40: Medical Instrument */
+#define HID_USAGE_MEDICAL_UNDEFINED (0x00)
+#define HID_USAGE_MEDICAL_MEDICAL_ULTRASOUND (0x01)           // CA
+#define HID_USAGE_MEDICAL_VCR_ACQUISITION (0x20)              // OOC
+#define HID_USAGE_MEDICAL_FREEZE_THAW (0x21)                  // OOC
+#define HID_USAGE_MEDICAL_CLIP_STORE (0x22)                   // OSC
+#define HID_USAGE_MEDICAL_UPDATE (0x23)                       // OSC
+#define HID_USAGE_MEDICAL_NEXT (0x24)                         // OSC
+#define HID_USAGE_MEDICAL_SAVE (0x25)                         // OSC
+#define HID_USAGE_MEDICAL_PRINT (0x26)                        // OSC
+#define HID_USAGE_MEDICAL_MICROPHONE_ENABLE (0x27)            // OSC
+#define HID_USAGE_MEDICAL_CINE (0x40)                         // LC
+#define HID_USAGE_MEDICAL_TRANSMIT_POWER (0x41)               // LC
+#define HID_USAGE_MEDICAL_VOLUME (0x42)                       // LC
+#define HID_USAGE_MEDICAL_FOCUS (0x43)                        // LC
+#define HID_USAGE_MEDICAL_DEPTH (0x44)                        // LC
+#define HID_USAGE_MEDICAL_SOFT_STEP_MINUS_PRIMARY (0x60)      // LC
+#define HID_USAGE_MEDICAL_SOFT_STEP_MINUS_SECONDARY (0x61)    // LC
+#define HID_USAGE_MEDICAL_DEPTH_GAIN_COMPENSATION (0x70)      // LC
+#define HID_USAGE_MEDICAL_ZOOM_SELECT (0x80)                  // OSC
+#define HID_USAGE_MEDICAL_ZOOM_ADJUST (0x81)                  // LC
+#define HID_USAGE_MEDICAL_SPECTRAL_DOPPLER_MODE_SELECT (0x82) // OSC
+#define HID_USAGE_MEDICAL_SPECTRAL_DOPPLER_ADJUST (0x83)      // LC
+#define HID_USAGE_MEDICAL_COLOR_DOPPLER_MODE_SELECT (0x84)    // OSC
+#define HID_USAGE_MEDICAL_COLOR_DOPPLER_ADJUST (0x85)         // LC
+#define HID_USAGE_MEDICAL_MOTION_MODE_SELECT (0x86)           // OSC
+#define HID_USAGE_MEDICAL_MOTION_MODE_ADJUST (0x87)           // LC
+#define HID_USAGE_MEDICAL_2_D_MODE_SELECT (0x88)              // OSC
+#define HID_USAGE_MEDICAL_2_D_MODE_ADJUST (0x89)              // LC
+#define HID_USAGE_MEDICAL_SOFT_CONTROL_SELECT (0xA0)          // OSC
+#define HID_USAGE_MEDICAL_SOFT_CONTROL_ADJUST (0xA1)          // LC
+
+/* Page 0x41: Braille Display */
+#define HID_USAGE_BRAILLE_UNDEFINED (0x00)
+#define HID_USAGE_BRAILLE_BRAILLE_DISPLAY (0x01)               // CA
+#define HID_USAGE_BRAILLE_BRAILLE_ROW (0x02)                   // NAry
+#define HID_USAGE_BRAILLE_8_DOT_BRAILLE_CELL (0x03)            // DV
+#define HID_USAGE_BRAILLE_6_DOT_BRAILLE_CELL (0x04)            // DV
+#define HID_USAGE_BRAILLE_NUMBER_OF_BRAILLE_CELLS (0x05)       // DV
+#define HID_USAGE_BRAILLE_SCREEN_READER_CONTROL (0x06)         // NAry
+#define HID_USAGE_BRAILLE_SCREEN_READER_IDENTIFIER (0x07)      // DV
+#define HID_USAGE_BRAILLE_ROUTER_SET_1 (0xFA)                  // NAry
+#define HID_USAGE_BRAILLE_ROUTER_SET_2 (0xFB)                  // NAry
+#define HID_USAGE_BRAILLE_ROUTER_SET_3 (0xFC)                  // Nary
+#define HID_USAGE_BRAILLE_ROUTER_KEY (0x100)                   // Sel
+#define HID_USAGE_BRAILLE_ROW_ROUTER_KEY (0x101)               // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_BUTTONS (0x200)              // NAry
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_DOT_1 (0x201)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_DOT_2 (0x202)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_DOT_3 (0x203)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_DOT_4 (0x204)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_DOT_5 (0x205)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_DOT_6 (0x206)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_DOT_7 (0x207)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_DOT_8 (0x208)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_SPACE (0x209)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_LEFT_SPACE (0x20A)  // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_KEYBOARD_RIGHT_SPACE (0x20B) // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_FACE_CONTROLS (0x20C)        // NAry
+#define HID_USAGE_BRAILLE_BRAILLE_LEFT_CONTROLS (0x20D)        // NAry
+#define HID_USAGE_BRAILLE_BRAILLE_RIGHT_CONTROLS (0x20E)       // NAry
+#define HID_USAGE_BRAILLE_BRAILLE_TOP_CONTROLS (0x20F)         // NAry
+#define HID_USAGE_BRAILLE_BRAILLE_JOYSTICK_CENTER (0x210)      // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_JOYSTICK_UP (0x211)          // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_JOYSTICK_DOWN (0x212)        // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_JOYSTICK_LEFT (0x213)        // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_JOYSTICK_RIGHT (0x214)       // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_D_PAD_CENTER (0x215)         // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_D_PAD_UP (0x216)             // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_D_PAD_DOWN (0x217)           // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_D_PAD_LEFT (0x218)           // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_D_PAD_RIGHT (0x219)          // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_PAN_LEFT (0x21A)             // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_PAN_RIGHT (0x21B)            // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_ROCKER_UP (0x21C)            // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_ROCKER_DOWN (0x21D)          // Sel
+#define HID_USAGE_BRAILLE_BRAILLE_ROCKER_PRESS (0x21E)         // Sel
+
+/* Page 0x59: Lighting And Illumination */
+#define HID_USAGE_LIGHT_UNDEFINED (0x00)
+#define HID_USAGE_LIGHT_LAMP_ARRAY (0x01)                          // CA
+#define HID_USAGE_LIGHT_LAMP_ARRAY_ATTRIBUTES_REPORT (0x02)        // CL
+#define HID_USAGE_LIGHT_LAMP_COUNT (0x03)                          // SV, DV
+#define HID_USAGE_LIGHT_BOUNDING_BOX_WIDTH_IN_MICROMETERS (0x04)   // SV
+#define HID_USAGE_LIGHT_BOUNDING_BOX_HEIGHT_IN_MICROMETERS (0x05)  // SV
+#define HID_USAGE_LIGHT_BOUNDING_BOX_DEPTH_IN_MICROMETERS (0x06)   // SV
+#define HID_USAGE_LIGHT_LAMP_ARRAY_KIND (0x07)                     // SV
+#define HID_USAGE_LIGHT_MIN_UPDATE_INTERVAL_IN_MICROSECONDS (0x08) // SV
+#define HID_USAGE_LIGHT_LAMP_ATTRIBUTES_REQUEST_REPORT (0x20)      // CL
+#define HID_USAGE_LIGHT_LAMP_ID (0x21)                             // SV, DV
+#define HID_USAGE_LIGHT_LAMP_ATTRIBUTES_RESPONSE_REPORT (0x22)     // CL
+#define HID_USAGE_LIGHT_POSITION_X_IN_MICROMETERS (0x23)           // DV
+#define HID_USAGE_LIGHT_POSITION_Y_IN_MICROMETERS (0x24)           // DV
+#define HID_USAGE_LIGHT_POSITION_Z_IN_MICROMETERS (0x25)           // DV
+#define HID_USAGE_LIGHT_LAMP_PURPOSES (0x26)                       // DV
+#define HID_USAGE_LIGHT_UPDATE_LATENCY_IN_MICROSECONDS (0x27)      // DV
+#define HID_USAGE_LIGHT_RED_LEVEL_COUNT (0x28)                     // DV
+#define HID_USAGE_LIGHT_GREEN_LEVEL_COUNT (0x29)                   // DV
+#define HID_USAGE_LIGHT_BLUE_LEVEL_COUNT (0x2A)                    // DV
+#define HID_USAGE_LIGHT_INTENSITY_LEVEL_COUNT (0x2B)               // DV
+#define HID_USAGE_LIGHT_IS_PROGRAMMABLE (0x2C)                     // DV
+#define HID_USAGE_LIGHT_INPUT_BINDING (0x2D)                       // DV
+#define HID_USAGE_LIGHT_LAMP_MULTI_UPDATE_REPORT (0x50)            // CL
+#define HID_USAGE_LIGHT_RED_UPDATE_CHANNEL (0x51)                  // DV
+#define HID_USAGE_LIGHT_GREEN_UPDATE_CHANNEL (0x52)                // DV
+#define HID_USAGE_LIGHT_BLUE_UPDATE_CHANNEL (0x53)                 // DV
+#define HID_USAGE_LIGHT_INTENSITY_UPDATE_CHANNEL (0x54)            // DV
+#define HID_USAGE_LIGHT_LAMP_UPDATE_FLAGS (0x55)                   // DV
+#define HID_USAGE_LIGHT_LAMP_RANGE_UPDATE_REPORT (0x60)            // CL
+#define HID_USAGE_LIGHT_LAMP_ID_START (0x61)                       // DV
+#define HID_USAGE_LIGHT_LAMP_ID_END (0x62)                         // DV
+#define HID_USAGE_LIGHT_LAMP_ARRAY_CONTROL_REPORT (0x70)           // CL
+#define HID_USAGE_LIGHT_AUTONOMOUS_MODE (0x71)                     // DV
+
+/* Page 0x80: USB Monitor */
+#define HID_USAGE_MONITOR_MONITOR_CONTROL (0x01)
+#define HID_USAGE_MONITOR_EDID_INFORMATION (0x02)
+#define HID_USAGE_MONITOR_VDIF_INFORMATION (0x03)
+#define HID_USAGE_MONITOR_VESA_VERSION (0x04)
+
+/* Page 0x82: VESA Virtual Control */
+#define HID_USAGE_MONITOR_VESA_BRIGHTNESS (0x10)
+#define HID_USAGE_MONITOR_VESA_CONTRAST (0x12)
+#define HID_USAGE_MONITOR_VESA_RED_VIDEO_GAIN (0x16)
+#define HID_USAGE_MONITOR_VESA_GREEN_VIDEO_GAIN (0x18)
+#define HID_USAGE_MONITOR_VESA_BLUE_VIDEO_GAIN (0x1A)
+#define HID_USAGE_MONITOR_VESA_FOCUS (0x1C)
+#define HID_USAGE_MONITOR_VESA_HORIZONTAL_POSITION (0x20)
+#define HID_USAGE_MONITOR_VESA_HORIZONTAL_SIZE (0x22)
+#define HID_USAGE_MONITOR_VESA_HORIZONTAL_PINCUSHION (0x24)
+#define HID_USAGE_MONITOR_VESA_HORIZONTAL_PINCUSHION_BALANCE (0x26)
+#define HID_USAGE_MONITOR_VESA_HORIZONTAL_MISCONVERGENCE (0x28)
+#define HID_USAGE_MONITOR_VESA_HORIZONTAL_LINEARITY (0x2A)
+#define HID_USAGE_MONITOR_VESA_HORIZONTAL_LINEARITY_BALANCE (0x2C)
+#define HID_USAGE_MONITOR_VESA_VERTICAL_POSITION (0x30)
+#define HID_USAGE_MONITOR_VESA_VERTICAL_SIZE (0x32)
+#define HID_USAGE_MONITOR_VESA_VERTICAL_PINCUSHION (0x34)
+#define HID_USAGE_MONITOR_VESA_VERTICAL_PINCUSHION_BALANCE (0x36)
+#define HID_USAGE_MONITOR_VESA_VERTICAL_MISCONVERGENCE (0x38)
+#define HID_USAGE_MONITOR_VESA_VERTICAL_LINEARITY (0x3A)
+#define HID_USAGE_MONITOR_VESA_VERTICAL_LINEARITY_BALANCE (0x3C)
+#define HID_USAGE_MONITOR_VESA_PARALLELOGRAM_DISTORTION_KEY_BALANCE (0x40)
+#define HID_USAGE_MONITOR_VESA_TRAPEZOIDAL_DISTORTION_KEY (0x42)
+#define HID_USAGE_MONITOR_VESA_TILT_ROTATION (0x44)
+#define HID_USAGE_MONITOR_VESA_TOP_CORNER_DISTORTION_CONTROL (0x46)
+#define HID_USAGE_MONITOR_VESA_TOP_CORNER_DISTORTION_BALANCE (0x48)
+#define HID_USAGE_MONITOR_VESA_BOTTOM_CORNER_DISTORTION_CONTROL (0x4A)
+#define HID_USAGE_MONITOR_VESA_BOTTOM_CORNER_DISTORTION_BALANCE (0x4C)
+#define HID_USAGE_MONITOR_VESA_HORIZONTAL_MOIR (0x56)
+#define HID_USAGE_MONITOR_VESA_VERTICAL_MOIR (0x58)
+#define HID_USAGE_MONITOR_VESA_RED_VIDEO_BLACK_LEVEL (0x6C)
+#define HID_USAGE_MONITOR_VESA_GREEN_VIDEO_BLACK_LEVEL (0x6E)
+#define HID_USAGE_MONITOR_VESA_BLUE_VIDEO_BLACK_LEVEL (0x70)
+#define HID_USAGE_MONITOR_VESA_INPUT_LEVEL_SELECT (0x5E)
+#define HID_USAGE_MONITOR_VESA_INPUT_SOURCE_SELECT (0x60)
+#define HID_USAGE_MONITOR_VESA_ON_SCREEN_DISPLAY (0xCA)
+#define HID_USAGE_MONITOR_VESA_STEREOMODE (0xD4)
+#define HID_USAGE_MONITOR_VESA_AUTO_SIZE_CENTER (0xA2)
+#define HID_USAGE_MONITOR_VESA_POLARITY_HORIZONTAL_SYNCHRONIZATION (0xA4)
+#define HID_USAGE_MONITOR_VESA_POLARITY_VERTICAL_SYNCHRONIZATION (0xA6)
+#define HID_USAGE_MONITOR_VESA_SYNCHRONIZATION_TYPE (0xA8)
+#define HID_USAGE_MONITOR_VESA_SCREEN_ORIENTATION (0xAA)
+#define HID_USAGE_MONITOR_VESA_HORIZONTAL_FREQUENCY (0xAC)
+#define HID_USAGE_MONITOR_VESA_VERTICAL_FREQUENCY (0xAE)
+#define HID_USAGE_MONITOR_VESA_DEGAUSS (0x01)
+#define HID_USAGE_MONITOR_VESA_SETTINGS (0xB0)
+
+/* Page 0x8C: Bar Code Scanner */
+#define HID_USAGE_POS_BARCODE_UNDEFINED (0x00)
+#define HID_USAGE_POS_BARCODE_BAR_CODE_BADGE_READER (0x01)                             // CA
+#define HID_USAGE_POS_BARCODE_BAR_CODE_SCANNER (0x02)                                  // CA
+#define HID_USAGE_POS_BARCODE_DUMB_BAR_CODE_SCANNER (0x03)                             // CA
+#define HID_USAGE_POS_BARCODE_CORDLESS_SCANNER_BASE (0x04)                             // CA
+#define HID_USAGE_POS_BARCODE_BAR_CODE_SCANNER_CRADLE (0x05)                           // CA
+#define HID_USAGE_POS_BARCODE_ATTRIBUTE_REPORT (0x10)                                  // CL
+#define HID_USAGE_POS_BARCODE_SETTINGS_REPORT (0x11)                                   // CL
+#define HID_USAGE_POS_BARCODE_SCANNED_DATA_REPORT (0x12)                               // CL
+#define HID_USAGE_POS_BARCODE_RAW_SCANNED_DATA_REPORT (0x13)                           // CL
+#define HID_USAGE_POS_BARCODE_TRIGGER_REPORT (0x14)                                    // CL
+#define HID_USAGE_POS_BARCODE_STATUS_REPORT (0x15)                                     // CL
+#define HID_USAGE_POS_BARCODE_UPC_EAN_CONTROL_REPORT (0x16)                            // CL
+#define HID_USAGE_POS_BARCODE_EAN_2_3_LABEL_CONTROL_REPORT (0x17)                      // CL
+#define HID_USAGE_POS_BARCODE_CODE_39_CONTROL_REPORT (0x18)                            // CL
+#define HID_USAGE_POS_BARCODE_INTERLEAVED_2_OF_5_CONTROL_REPORT (0x19)                 // CL
+#define HID_USAGE_POS_BARCODE_STANDARD_2_OF_5_CONTROL_REPORT (0x1A)                    // CL
+#define HID_USAGE_POS_BARCODE_MSI_PLESSEY_CONTROL_REPORT (0x1B)                        // CL
+#define HID_USAGE_POS_BARCODE_CODABAR_CONTROL_REPORT (0x1C)                            // CL
+#define HID_USAGE_POS_BARCODE_CODE_128_CONTROL_REPORT (0x1D)                           // CL
+#define HID_USAGE_POS_BARCODE_MISC_1D_CONTROL_REPORT (0x1E)                            // CL
+#define HID_USAGE_POS_BARCODE_2D_CONTROL_REPORT (0x1F)                                 // CL
+#define HID_USAGE_POS_BARCODE_AIMING_POINTER_MODE (0x30)                               // SF
+#define HID_USAGE_POS_BARCODE_BAR_CODE_PRESENT_SENSOR (0x31)                           // SF
+#define HID_USAGE_POS_BARCODE_CLASS_1A_LASER (0x32)                                    // SF
+#define HID_USAGE_POS_BARCODE_CLASS_2_LASER (0x33)                                     // SF
+#define HID_USAGE_POS_BARCODE_HEATER_PRESENT (0x34)                                    // SF
+#define HID_USAGE_POS_BARCODE_CONTACT_SCANNER (0x35)                                   // SF
+#define HID_USAGE_POS_BARCODE_ELECTRONIC_ARTICLE_SURVEILLANCE_NOTIFICATION (0x36)      // SF
+#define HID_USAGE_POS_BARCODE_CONSTANT_ELECTRONIC_ARTICLE_SURVEILLANCE (0x37)          // SF
+#define HID_USAGE_POS_BARCODE_ERROR_INDICATION (0x38)                                  // SF
+#define HID_USAGE_POS_BARCODE_FIXED_BEEPER (0x39)                                      // SF
+#define HID_USAGE_POS_BARCODE_GOOD_DECODE_INDICATION (0x3A)                            // SF
+#define HID_USAGE_POS_BARCODE_HANDS_FREE_SCANNING (0x3B)                               // SF
+#define HID_USAGE_POS_BARCODE_INTRINSICALLY_SAFE (0x3C)                                // SF
+#define HID_USAGE_POS_BARCODE_KLASSE_EINS_LASER (0x3D)                                 // SF
+#define HID_USAGE_POS_BARCODE_LONG_RANGE_SCANNER (0x3E)                                // SF
+#define HID_USAGE_POS_BARCODE_MIRROR_SPEED_CONTROL (0x3F)                              // SF
+#define HID_USAGE_POS_BARCODE_NOT_ON_FILE_INDICATION (0x40)                            // SF
+#define HID_USAGE_POS_BARCODE_PROGRAMMABLE_BEEPER (0x41)                               // SF
+#define HID_USAGE_POS_BARCODE_TRIGGERLESS (0x42)                                       // SF
+#define HID_USAGE_POS_BARCODE_WAND (0x43)                                              // SF
+#define HID_USAGE_POS_BARCODE_WATER_RESISTANT (0x44)                                   // SF
+#define HID_USAGE_POS_BARCODE_MULTI_RANGE_SCANNER (0x45)                               // SF
+#define HID_USAGE_POS_BARCODE_PROXIMITY_SENSOR (0x46)                                  // SF
+#define HID_USAGE_POS_BARCODE_FRAGMENT_DECODING (0x4D)                                 // DF
+#define HID_USAGE_POS_BARCODE_SCANNER_READ_CONFIDENCE (0x4E)                           // DV
+#define HID_USAGE_POS_BARCODE_DATA_PREFIX (0x4F)                                       // NAry
+#define HID_USAGE_POS_BARCODE_PREFIX_AIMI (0x50)                                       // SEL
+#define HID_USAGE_POS_BARCODE_PREFIX_NONE (0x51)                                       // SEL
+#define HID_USAGE_POS_BARCODE_PREFIX_PROPRIETARY (0x52)                                // SEL
+#define HID_USAGE_POS_BARCODE_ACTIVE_TIME (0x55)                                       // DV
+#define HID_USAGE_POS_BARCODE_AIMING_LASER_PATTERN (0x56)                              // DF
+#define HID_USAGE_POS_BARCODE_BAR_CODE_PRESENT (0x57)                                  // OOC
+#define HID_USAGE_POS_BARCODE_BEEPER_STATE (0x58)                                      // OOC
+#define HID_USAGE_POS_BARCODE_LASER_ON_TIME (0x59)                                     // DV
+#define HID_USAGE_POS_BARCODE_LASER_STATE (0x5A)                                       // OOC
+#define HID_USAGE_POS_BARCODE_LOCKOUT_TIME (0x5B)                                      // DV
+#define HID_USAGE_POS_BARCODE_MOTOR_STATE (0x5C)                                       // OOC
+#define HID_USAGE_POS_BARCODE_MOTOR_TIMEOUT (0x5D)                                     // DV
+#define HID_USAGE_POS_BARCODE_POWER_ON_RESET_SCANNER (0x5E)                            // DF
+#define HID_USAGE_POS_BARCODE_PREVENT_READ_OF_BARCODES (0x5F)                          // DF
+#define HID_USAGE_POS_BARCODE_INITIATE_BARCODE_READ (0x60)                             // DF
+#define HID_USAGE_POS_BARCODE_TRIGGER_STATE (0x61)                                     // OOC
+#define HID_USAGE_POS_BARCODE_TRIGGER_MODE (0x62)                                      // NAry
+#define HID_USAGE_POS_BARCODE_TRIGGER_MODE_BLINKING_LASER_ON (0x63)                    // SEL
+#define HID_USAGE_POS_BARCODE_TRIGGER_MODE_CONTINUOUS_LASER_ON (0x64)                  // SEL
+#define HID_USAGE_POS_BARCODE_TRIGGER_MODE_LASER_ON_WHILE_PULLED (0x65)                // SEL
+#define HID_USAGE_POS_BARCODE_TRIGGER_MODE_LASER_STAYS_ON_AFTER_TRIGGER_RELEASE (0x66) // SEL
+#define HID_USAGE_POS_BARCODE_COMMIT_PARAMETERS_TO_NVM (0x6D)                          // DF
+#define HID_USAGE_POS_BARCODE_PARAMETER_SCANNING (0x6E)                                // DF
+#define HID_USAGE_POS_BARCODE_PARAMETERS_CHANGED (0x6F)                                // OOC
+#define HID_USAGE_POS_BARCODE_SET_PARAMETER_DEFAULT_VALUES (0x70)                      // DF
+#define HID_USAGE_POS_BARCODE_SCANNER_IN_CRADLE (0x75)                                 // OOC
+#define HID_USAGE_POS_BARCODE_SCANNER_IN_RANGE (0x76)                                  // OOC
+#define HID_USAGE_POS_BARCODE_AIM_DURATION (0x7A)                                      // DV
+#define HID_USAGE_POS_BARCODE_GOOD_READ_LAMP_DURATION (0x7B)                           // DV
+#define HID_USAGE_POS_BARCODE_GOOD_READ_LAMP_INTENSITY (0x7C)                          // DV
+#define HID_USAGE_POS_BARCODE_GOOD_READ_LED (0x7D)                                     // DF
+#define HID_USAGE_POS_BARCODE_GOOD_READ_TONE_FREQUENCY (0x7E)                          // DV
+#define HID_USAGE_POS_BARCODE_GOOD_READ_TONE_LENGTH (0x7F)                             // DV
+#define HID_USAGE_POS_BARCODE_GOOD_READ_TONE_VOLUME (0x80)                             // DV
+#define HID_USAGE_POS_BARCODE_NO_READ_MESSAGE (0x82)                                   // DF
+#define HID_USAGE_POS_BARCODE_NOT_ON_FILE_VOLUME (0x83)                                // DV
+#define HID_USAGE_POS_BARCODE_POWERUP_BEEP (0x84)                                      // DF
+#define HID_USAGE_POS_BARCODE_SOUND_ERROR_BEEP (0x85)                                  // DF
+#define HID_USAGE_POS_BARCODE_SOUND_GOOD_READ_BEEP (0x86)                              // DF
+#define HID_USAGE_POS_BARCODE_SOUND_NOT_ON_FILE_BEEP (0x87)                            // DF
+#define HID_USAGE_POS_BARCODE_GOOD_READ_WHEN_TO_WRITE (0x88)                           // NAry
+#define HID_USAGE_POS_BARCODE_GRWTI_AFTER_DECODE (0x89)                                // SEL
+#define HID_USAGE_POS_BARCODE_GRWTI_BEEP_LAMP_AFTER_TRANSMIT (0x8A)                    // SEL
+#define HID_USAGE_POS_BARCODE_GRWTI_NO_BEEP_LAMP_USE_AT_ALL (0x8B)                     // SEL
+#define HID_USAGE_POS_BARCODE_BOOKLAND_EAN (0x91)                                      // DF
+#define HID_USAGE_POS_BARCODE_CONVERT_EAN_8_TO_13_TYPE (0x92)                          // DF
+#define HID_USAGE_POS_BARCODE_CONVERT_UPC_A_TO_EAN_13 (0x93)                           // DF
+#define HID_USAGE_POS_BARCODE_CONVERT_UPC_E_TO_A (0x94)                                // DF
+#define HID_USAGE_POS_BARCODE_EAN_13 (0x95)                                            // DF
+#define HID_USAGE_POS_BARCODE_EAN_8 (0x96)                                             // DF
+#define HID_USAGE_POS_BARCODE_EAN_99_128_MANDATORY (0x97)                              // DF
+#define HID_USAGE_POS_BARCODE_EAN_99_P5_128_OPTIONAL (0x98)                            // DF
+#define HID_USAGE_POS_BARCODE_UPC_EAN (0x9A)                                           // DF
+#define HID_USAGE_POS_BARCODE_UPC_EAN_COUPON_CODE (0x9B)                               // DF
+#define HID_USAGE_POS_BARCODE_UPC_EAN_PERIODICALS (0x9C)                               // DV
+#define HID_USAGE_POS_BARCODE_UPC_A (0x9D)                                             // DF
+#define HID_USAGE_POS_BARCODE_UPC_A_WITH_128_MANDATORY (0x9E)                          // DF
+#define HID_USAGE_POS_BARCODE_UPC_A_WITH_128_OPTIONAL (0x9F)                           // DF
+#define HID_USAGE_POS_BARCODE_UPC_A_WITH_P5_OPTIONAL (0xA0)                            // DF
+#define HID_USAGE_POS_BARCODE_UPC_E (0xA1)                                             // DF
+#define HID_USAGE_POS_BARCODE_UPC_E1 (0xA2)                                            // DF
+#define HID_USAGE_POS_BARCODE_PERIODICAL (0xA9)                                        // NAry
+#define HID_USAGE_POS_BARCODE_PERIODICAL_AUTO_DISCRIMINATE_PLUS_2 (0xAA)               // SEL
+#define HID_USAGE_POS_BARCODE_PERIODICAL_ONLY_DECODE_WITH_PLUS_2 (0xAB)                // SEL
+#define HID_USAGE_POS_BARCODE_PERIODICAL_IGNORE_PLUS_2 (0xAC)                          // SEL
+#define HID_USAGE_POS_BARCODE_PERIODICAL_AUTO_DISCRIMINATE_PLUS_5 (0xAD)               // SEL
+#define HID_USAGE_POS_BARCODE_PERIODICAL_ONLY_DECODE_WITH_PLUS_5 (0xAE)                // SEL
+#define HID_USAGE_POS_BARCODE_PERIODICAL_IGNORE_PLUS_5 (0xAF)                          // SEL
+#define HID_USAGE_POS_BARCODE_CHECK (0xB0)                                             // NAry
+#define HID_USAGE_POS_BARCODE_CHECK_DISABLE_PRICE (0xB1)                               // SEL
+#define HID_USAGE_POS_BARCODE_CHECK_ENABLE_4_DIGIT_PRICE (0xB2)                        // SEL
+#define HID_USAGE_POS_BARCODE_CHECK_ENABLE_5_DIGIT_PRICE (0xB3)                        // SEL
+#define HID_USAGE_POS_BARCODE_CHECK_ENABLE_EUROPEAN_4_DIGIT_PRICE (0xB4)               // SEL
+#define HID_USAGE_POS_BARCODE_CHECK_ENABLE_EUROPEAN_5_DIGIT_PRICE (0xB5)               // SEL
+#define HID_USAGE_POS_BARCODE_EAN_TWO_LABEL (0xB7)                                     // DF
+#define HID_USAGE_POS_BARCODE_EAN_THREE_LABEL (0xB8)                                   // DF
+#define HID_USAGE_POS_BARCODE_EAN_8_FLAG_DIGIT_1 (0xB9)                                // DV
+#define HID_USAGE_POS_BARCODE_EAN_8_FLAG_DIGIT_2 (0xBA)                                // DV
+#define HID_USAGE_POS_BARCODE_EAN_8_FLAG_DIGIT_3 (0xBB)                                // DV
+#define HID_USAGE_POS_BARCODE_EAN_13_FLAG_DIGIT_1 (0xBC)                               // DV
+#define HID_USAGE_POS_BARCODE_EAN_13_FLAG_DIGIT_2 (0xBD)                               // DV
+#define HID_USAGE_POS_BARCODE_TRANSMIT_CHECK_DIGIT (0xF0)                              // NAry
+#define HID_USAGE_POS_BARCODE_DISABLE_CHECK_DIGIT_TRANSMIT (0xF1)                      // SEL
+#define HID_USAGE_POS_BARCODE_ENABLE_CHECK_DIGIT_TRANSMIT (0xF2)                       // SEL
+#define HID_USAGE_POS_BARCODE_SYMBOLOGY_IDENTIFIER_1 (0xFB)                            // DV
+#define HID_USAGE_POS_BARCODE_SYMBOLOGY_IDENTIFIER_2 (0xFC)                            // DV
+#define HID_USAGE_POS_BARCODE_SYMBOLOGY_IDENTIFIER_3 (0xFD)                            // DV
+#define HID_USAGE_POS_BARCODE_DECODED_DATA (0xFE)                                      // DV
+#define HID_USAGE_POS_BARCODE_DECODE_DATA_CONTINUED (0xFF)                             // DF
+#define HID_USAGE_POS_BARCODE_BAR_SPACE_DATA (0x100)                                   // DV
+#define HID_USAGE_POS_BARCODE_SCANNER_DATA_ACCURACY (0x101)                            // DV
+#define HID_USAGE_POS_BARCODE_RAW_DATA_POLARITY (0x102)                                // NAry
+#define HID_USAGE_POS_BARCODE_POLARITY_INVERTED_BAR_CODE (0x103)                       // SEL
+#define HID_USAGE_POS_BARCODE_POLARITY_NORMAL_BAR_CODE (0x104)                         // SEL
+#define HID_USAGE_POS_BARCODE_MINIMUM_LENGTH_TO_DECODE (0x106)                         // DV
+#define HID_USAGE_POS_BARCODE_MAXIMUM_LENGTH_TO_DECODE (0x107)                         // DV
+#define HID_USAGE_POS_BARCODE_FIRST_DISCRETE_LENGTH_TO_DECODE (0x108)                  // DV
+#define HID_USAGE_POS_BARCODE_SECOND_DISCRETE_LENGTH_TO_DECODE (0x109)                 // DV
+#define HID_USAGE_POS_BARCODE_DATA_LENGTH_METHOD (0x10A)                               // NAry
+#define HID_USAGE_POS_BARCODE_DL_METHOD_READ_ANY (0x10B)                               // SEL
+#define HID_USAGE_POS_BARCODE_DL_METHOD_CHECK_IN_RANGE (0x10C)                         // SEL
+#define HID_USAGE_POS_BARCODE_DL_METHOD_CHECK_FOR_DISCRETE (0x10D)                     // SEL
+#define HID_USAGE_POS_BARCODE_AZTEC_CODE (0x110)                                       // DF
+#define HID_USAGE_POS_BARCODE_BC412 (0x111)                                            // DF
+#define HID_USAGE_POS_BARCODE_CHANNEL_CODE (0x112)                                     // DF
+#define HID_USAGE_POS_BARCODE_CODE_16 (0x113)                                          // DF
+#define HID_USAGE_POS_BARCODE_CODE_32 (0x114)                                          // DF
+#define HID_USAGE_POS_BARCODE_CODE_49 (0x115)                                          // DF
+#define HID_USAGE_POS_BARCODE_CODE_ONE (0x116)                                         // DF
+#define HID_USAGE_POS_BARCODE_COLORCODE (0x117)                                        // DF
+#define HID_USAGE_POS_BARCODE_DATA_MATRIX (0x118)                                      // DF
+#define HID_USAGE_POS_BARCODE_MAXICODE (0x119)                                         // DF
+#define HID_USAGE_POS_BARCODE_MICROPDF (0x11A)                                         // DF
+#define HID_USAGE_POS_BARCODE_PDF_417 (0x11B)                                          // DF
+#define HID_USAGE_POS_BARCODE_POSICODE (0x11C)                                         // DF
+#define HID_USAGE_POS_BARCODE_QR_CODE (0x11D)                                          // DF
+#define HID_USAGE_POS_BARCODE_SUPERCODE (0x11E)                                        // DF
+#define HID_USAGE_POS_BARCODE_ULTRACODE (0x11F)                                        // DF
+#define HID_USAGE_POS_BARCODE_USD_5_SLUG_CODE (0x120)                                  // DF
+#define HID_USAGE_POS_BARCODE_VERICODE (0x121)                                         // DF
+
+/* Page 0x8D: Scale */
+#define HID_USAGE_POS_SCALE_UNDEFINED (0x00)
+#define HID_USAGE_POS_SCALE_WEIGHING_DEVICE (0x01)                       // CA
+#define HID_USAGE_POS_SCALE_SCALE_DEVICE (0x20)                          // CL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_I_METRIC (0x21)                  // CL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_I_METRIC_2 (0x22)                // SEL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_II_METRIC (0x23)                 // SEL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_III_METRIC (0x24)                // SEL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_IIIL_METRIC (0x25)               // SEL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_IV_METRIC (0x26)                 // SEL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_III_ENGLISH (0x27)               // SEL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_IIIL_ENGLISH (0x28)              // SEL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_IV_ENGLISH (0x29)                // SEL
+#define HID_USAGE_POS_SCALE_SCALE_CLASS_GENERIC (0x2A)                   // SEL
+#define HID_USAGE_POS_SCALE_SCALE_ATTRIBUTE_REPORT (0x30)                // CL
+#define HID_USAGE_POS_SCALE_SCALE_CONTROL_REPORT (0x31)                  // CL
+#define HID_USAGE_POS_SCALE_SCALE_DATA_REPORT (0x32)                     // CL
+#define HID_USAGE_POS_SCALE_SCALE_STATUS_REPORT (0x33)                   // CL
+#define HID_USAGE_POS_SCALE_SCALE_WEIGHT_LIMIT_REPORT (0x34)             // CL
+#define HID_USAGE_POS_SCALE_SCALE_STATISTICS_REPORT (0x35)               // CL
+#define HID_USAGE_POS_SCALE_DATA_WEIGHT (0x40)                           // DV
+#define HID_USAGE_POS_SCALE_DATA_SCALING (0x41)                          // CV
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT (0x50)                           // CL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_MILLIGRAM (0x51)                 // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_GRAM (0x52)                      // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_KILOGRAM (0x53)                  // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_CARATS (0x54)                    // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_TAELS (0x55)                     // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_GRAINS (0x56)                    // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_PENNYWEIGHTS (0x57)              // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_METRIC_TON (0x58)                // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_AVOIR_TON (0x59)                 // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_TROY_OUNCE (0x5A)                // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_OUNCE (0x5B)                     // SEL
+#define HID_USAGE_POS_SCALE_WEIGHT_UNIT_POUND (0x5C)                     // SEL
+#define HID_USAGE_POS_SCALE_CALIBRATION_COUNT (0x60)                     // DV
+#define HID_USAGE_POS_SCALE_RE_ZERO_COUNT (0x61)                         // DV
+#define HID_USAGE_POS_SCALE_SCALE_STATUS (0x70)                          // CL
+#define HID_USAGE_POS_SCALE_SCALE_STATUS_FAULT (0x71)                    // SEL
+#define HID_USAGE_POS_SCALE_SCALE_STATUS_STABLE_AT_CENTER_OF_ZERO (0x72) // SEL
+#define HID_USAGE_POS_SCALE_SCALE_STATUS_IN_MOTION (0x73)                // SEL
+#define HID_USAGE_POS_SCALE_SCALE_STATUS_WEIGHT_STABLE (0x74)            // SEL
+#define HID_USAGE_POS_SCALE_SCALE_STATUS_UNDER_ZERO (0x75)               // SEL
+#define HID_USAGE_POS_SCALE_SCALE_STATUS_OVER_WEIGHT_LIMIT (0x76)        // SEL
+#define HID_USAGE_POS_SCALE_SCALE_STATUS_REQUIRES_CALIBRATION (0x77)     // SEL
+#define HID_USAGE_POS_SCALE_SCALE_STATUS_REQUIRES_RE_ZEROING (0x78)      // SEL
+#define HID_USAGE_POS_SCALE_ZERO_SCALE (0x80)                            // OOC
+#define HID_USAGE_POS_SCALE_ENFORCED_ZERO_RETURN (0x81)                  // OOC
+
+/* Page 0x8E: Magnetic Stripe Reading (MSR) Devices */
+#define HID_USAGE_POS_MSR_UNDEFINED (0x00)
+#define HID_USAGE_POS_MSR_MSR_DEVICE_READ_ONLY (0x01) // CA
+#define HID_USAGE_POS_MSR_TRACK_1_LENGTH (0x11)       // SF, DF, SEL
+#define HID_USAGE_POS_MSR_TRACK_2_LENGTH (0x12)       // SF, DF, SEL
+#define HID_USAGE_POS_MSR_TRACK_3_LENGTH (0x13)       // SF, DF, SEL
+#define HID_USAGE_POS_MSR_TRACK_JIS_LENGTH (0x14)     // SF, DF, SEL
+#define HID_USAGE_POS_MSR_TRACK_DATA (0x20)           // SF, DF, SEL
+#define HID_USAGE_POS_MSR_TRACK_1_DATA (0x21)         // SF, DF, SEL
+#define HID_USAGE_POS_MSR_TRACK_2_DATA (0x22)         // SF, DF, SEL
+#define HID_USAGE_POS_MSR_TRACK_3_DATA (0x23)         // SF, DF, SEL
+#define HID_USAGE_POS_MSR_TRACK_JIS_DATA (0x24)       // SF, DF, SEL
+
+/* Page 0x90: Camera Control */
+#define HID_USAGE_CAMERA_UNDEFINED (0x00)
+#define HID_USAGE_CAMERA_CAMERA_AUTO_FOCUS (0x20) // OSC
+#define HID_USAGE_CAMERA_CAMERA_SHUTTER (0x21)    // OSC
+
+/* Page 0xF1D0: FIDO Alliance */
+#define HID_USAGE_FIDO_UNDEFINED (0x00)
+#define HID_USAGE_FIDO_U2F_AUTHENTICATOR_DEVICE (0x01) // CA
+#define HID_USAGE_FIDO_INPUT_REPORT_DATA (0x20)        // DV
+#define HID_USAGE_FIDO_OUTPUT_REPORT_DATA (0x21)       // DV

--- a/app/include/dt-bindings/zmk/hid_usage_pages.h
+++ b/app/include/dt-bindings/zmk/hid_usage_pages.h
@@ -10,6 +10,10 @@
 
 #pragma once
 
+/* WARNING: DEPRECATED from dt-bindings/zmk/keys.h */
+#define USAGE_KEYPAD (0x07)   // WARNING: DEPRECATED (DO NOT USE)
+#define USAGE_CONSUMER (0x0C) // WARNING: DEPRECATED (DO NOT USE)
+
 #define HID_USAGE_GD (0x01)             // Generic Desktop
 #define HID_USAGE_SIM (0x02)            // Simulation Controls
 #define HID_USAGE_VR (0x03)             // VR Controls

--- a/app/include/dt-bindings/zmk/hid_usage_pages.h
+++ b/app/include/dt-bindings/zmk/hid_usage_pages.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Based on HID Usage Tables 1.21,
+ * Copyright © 1996-2020, USB Implementers Forum,
+ * https://www.usb.org/sites/default/files/hut1_21.pdf
+ */
+
+#pragma once
+
+#define HID_USAGE_GD (0x01)             // Generic Desktop
+#define HID_USAGE_SIM (0x02)            // Simulation Controls
+#define HID_USAGE_VR (0x03)             // VR Controls
+#define HID_USAGE_SPORT (0x04)          // Sport Controls
+#define HID_USAGE_GAME (0x05)           // Game Controls
+#define HID_USAGE_GDV (0x06)            // Generic Device Controls
+#define HID_USAGE_KEY (0x07)            // Keyboard/Keypad
+#define HID_USAGE_LED (0x08)            // LED
+#define HID_USAGE_TELEPHONY (0x0B)      // Telephony Device
+#define HID_USAGE_CONSUMER (0x0C)       // Consumer
+#define HID_USAGE_DIGITIZERS (0x0D)     // Digitizers
+#define HID_USAGE_HAPTICS (0x0E)        // Haptics
+#define HID_USAGE_PID (0x0F)            // PID
+#define HID_USAGE_EHT (0x12)            // Eye and Head Trackers
+#define HID_USAGE_AUXDISP (0x14)        // Auxiliary Display
+#define HID_USAGE_SENSORS (0x20)        // Sensors
+#define HID_USAGE_MEDICAL (0x40)        // Medical Instrument
+#define HID_USAGE_BRAILLE (0x41)        // Braille Display
+#define HID_USAGE_LIGHT (0x59)          // Lighting And Illumination
+#define HID_USAGE_MONITOR (0x80)        // USB Monitor
+#define HID_USAGE_MONITOR_VALUES (0x81) // Monitor Enumerated Values
+#define HID_USAGE_MONITOR_VESA (0x82)   // VESA Virtual Control
+#define HID_USAGE_POWER (0x84)          // Power
+#define HID_USAGE_POS_BARCODE (0x8C)    // Bar Code Scanner
+#define HID_USAGE_POS_SCALE (0x8D)      // Scale
+#define HID_USAGE_POS_MSR (0x8E)        // Magnetic Stripe Reading (MSR) Devices
+#define HID_USAGE_POS_RESV (0x8F)       // Reserved Point of Sale
+#define HID_USAGE_CAMERA (0x90)         // Camera Control
+#define HID_USAGE_ARCADE (0x91)         // Arcade
+#define HID_USAGE_GAMING (0x92)         // Gaming Device
+#define HID_USAGE_FIDO (0xF1D0)         // FIDO Alliance

--- a/app/include/dt-bindings/zmk/keys.h
+++ b/app/include/dt-bindings/zmk/keys.h
@@ -6,10 +6,6 @@
 #pragma once
 
 #include <dt-bindings/zmk/modifiers.h>
-
-#define USAGE_KEYPAD 0x07
-#define USAGE_CONSUMER 0x0C
-
 #define A 0x04
 #define B 0x05
 #define C 0x06

--- a/app/include/dt-bindings/zmk/keys.h
+++ b/app/include/dt-bindings/zmk/keys.h
@@ -5,138 +5,1385 @@
  */
 #pragma once
 
+#include <dt-bindings/zmk/hid_usage.h>
 #include <dt-bindings/zmk/modifiers.h>
-#define A 0x04
-#define B 0x05
-#define C 0x06
-#define D 0x07
-#define E 0x08
-#define F 0x09
-#define G 0x0A
-#define H 0x0B
-#define I 0x0C
-#define J 0x0D
-#define K 0x0E
-#define L 0x0F
-#define M 0x10
-#define N 0x11
-#define O 0x12
-#define P 0x13
-#define Q 0x14
-#define R 0x15
-#define S 0x16
-#define T 0x17
-#define U 0x18
-#define V 0x19
-#define W 0x1A
-#define X 0x1B
-#define Y 0x1C
-#define Z 0x1D
-#define NUM_1 0x1E
-#define NUM_2 0x1F
-#define NUM_3 0x20
-#define NUM_4 0x21
-#define NUM_5 0x22
-#define NUM_6 0x23
-#define NUM_7 0x24
-#define NUM_8 0x25
-#define NUM_9 0x26
-#define NUM_0 0x27
-#define RET 0x28
-#define ESC 0x29
-#define BKSP 0x2A
-#define TAB 0x2B
-#define SPC 0x2C
-#define MINUS 0x2D
-#define EQL 0x2E
-#define LBKT 0x2F
-#define RBKT 0x30
-#define BSLH 0x31
-#define TILD 0x32
-#define SCLN 0x33
-#define QUOT 0x34
-#define GRAV 0x35
-#define CMMA 0x36
-#define DOT 0x37
-#define FSLH 0x38
-#define CLCK 0x39
-#define F1 0x3A
-#define F2 0x3B
-#define F3 0x3C
-#define F4 0x3D
-#define F5 0x3E
-#define F6 0x3F
-#define F7 0x40
-#define F8 0x41
-#define F9 0x42
-#define F10 0x43
-#define F11 0x44
-#define F12 0x45
 
-#define PRSC 0x46
-#define SCLK 0x47
-#define PAUS 0x48
-#define INS 0x49
-#define HOME 0x4A
-#define PGUP 0x4B
-#define DEL 0x4C
-#define END 0x4D
-#define PGDN 0x4E
-#define RARW 0x4F
-#define LARW 0x50
-#define DARW 0x51
-#define UARW 0x52
+/* System Power Down */
+#define SYSTEM_POWER (HID_USAGE_GD_SYSTEM_POWER_DOWN)
+#define SYS_PWR (SYSTEM_POWER)
 
-#define KDIV 0x54
-#define KMLT 0x55
-#define KMIN 0x56
-#define KPLS 0x57
+/* System Sleep */
+#define SYSTEM_SLEEP (HID_USAGE_GD_SYSTEM_SLEEP)
+#define SYS_SLEEP (SYSTEM_SLEEP)
 
-#define GUI 0x65
+/* System Wake Up */
+#define SYSTEM_WAKE_UP (HID_USAGE_GD_SYSTEM_WAKE_UP)
+#define SYS_WAKE (SYSTEM_WAKE_UP)
 
-#define UNDO 0x7A
-#define CUT 0x7B
-#define COPY 0x7C
-#define PSTE 0x7D
+/* Keyboard a and A */
+#define A (HID_USAGE_KEY_KEYBOARD_A)
 
-#define CURU 0xB4
+/* Keyboard b and B */
+#define B (HID_USAGE_KEY_KEYBOARD_B)
 
-#define LPRN 0xB6
-#define RPRN 0xB7
-#define LCUR 0xB8
-#define RCUR 0xB9
+/* Keyboard c and C */
+#define C (HID_USAGE_KEY_KEYBOARD_C)
 
-#define CRRT 0xC3
-#define PRCT 0xC4
-#define LABT 0xC5
-#define RABT 0xC6
-#define AMPS 0xC7
-#define PIPE 0xC9
-#define COLN 0xCB
-#define HASH 0xCC
-#define KSPC 0xCD
-#define ATSN 0xCE
-#define BANG 0xCF
+/* Keyboard d and D */
+#define D (HID_USAGE_KEY_KEYBOARD_D)
 
-#define LCTL 0xE0
-#define LSFT 0xE1
-#define LALT 0xE2
-#define LGUI 0xE3
-#define RCTL 0xE4
-#define RSFT 0xE5
-#define RALT 0xE6
-#define RGUI 0xE7
+/* Keyboard e and E */
+#define E (HID_USAGE_KEY_KEYBOARD_E)
 
-#define VOLU 0x80
-#define VOLD 0x81
+/* Keyboard f and F */
+#define F (HID_USAGE_KEY_KEYBOARD_F)
 
-/* The following are select consumer page usages */
+/* Keyboard g and G */
+#define G (HID_USAGE_KEY_KEYBOARD_G)
 
-#define M_NEXT 0xB5
-#define M_PREV 0xB6
-#define M_STOP 0xB7
-#define M_EJCT 0xB8
-#define M_PLAY 0xCD
-#define M_MUTE 0xE2
-#define M_VOLU 0xE9
-#define M_VOLD 0xEA
+/* Keyboard h and H */
+#define H (HID_USAGE_KEY_KEYBOARD_H)
+
+/* Keyboard i and I */
+#define I (HID_USAGE_KEY_KEYBOARD_I)
+
+/* Keyboard j and J */
+#define J (HID_USAGE_KEY_KEYBOARD_J)
+
+/* Keyboard k and K */
+#define K (HID_USAGE_KEY_KEYBOARD_K)
+
+/* Keyboard l and L */
+#define L (HID_USAGE_KEY_KEYBOARD_L)
+
+/* Keyboard m and M */
+#define M (HID_USAGE_KEY_KEYBOARD_M)
+
+/* Keyboard n and N */
+#define N (HID_USAGE_KEY_KEYBOARD_N)
+
+/* Keyboard o and O */
+#define O (HID_USAGE_KEY_KEYBOARD_O)
+
+/* Keyboard p and P */
+#define P (HID_USAGE_KEY_KEYBOARD_P)
+
+/* Keyboard q and Q */
+#define Q (HID_USAGE_KEY_KEYBOARD_Q)
+
+/* Keyboard r and R */
+#define R (HID_USAGE_KEY_KEYBOARD_R)
+
+/* Keyboard s and S */
+#define S (HID_USAGE_KEY_KEYBOARD_S)
+
+/* Keyboard t and T */
+#define T (HID_USAGE_KEY_KEYBOARD_T)
+
+/* Keyboard u and U */
+#define U (HID_USAGE_KEY_KEYBOARD_U)
+
+/* Keyboard v and V */
+#define V (HID_USAGE_KEY_KEYBOARD_V)
+
+/* Keyboard w and W */
+#define W (HID_USAGE_KEY_KEYBOARD_W)
+
+/* Keyboard x and X */
+#define X (HID_USAGE_KEY_KEYBOARD_X)
+
+/* Keyboard y and Y */
+#define Y (HID_USAGE_KEY_KEYBOARD_Y)
+
+/* Keyboard z and Z */
+#define Z (HID_USAGE_KEY_KEYBOARD_Z)
+
+/* Keyboard 1 and ! (Exclamation) */
+#define NUMBER_1 (HID_USAGE_KEY_KEYBOARD_1_AND_EXCLAMATION)
+#define N1 (NUMBER_1)
+#define NUM_1 (NUMBER_1) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard ! (Exclamation) */
+#define EXCLAMATION (LS(HID_USAGE_KEY_KEYBOARD_1_AND_EXCLAMATION))
+#define EXCL (EXCLAMATION)
+#define BANG (EXCLAMATION) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard 2 and @ (At sign) */
+#define NUMBER_2 (HID_USAGE_KEY_KEYBOARD_2_AND_AT)
+#define N2 (NUMBER_2)
+#define NUM_2 (NUMBER_2) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard @ (At sign) */
+#define AT_SIGN (LS(HID_USAGE_KEY_KEYBOARD_2_AND_AT))
+#define AT (AT_SIGN)
+#define ATSN (AT_SIGN) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard 3 and # (Hash/Number) */
+#define NUMBER_3 (HID_USAGE_KEY_KEYBOARD_3_AND_HASH)
+#define N3 (NUMBER_3)
+#define NUM_3 (NUMBER_3) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard # (Hash/Number) */
+#define HASH (LS(HID_USAGE_KEY_KEYBOARD_3_AND_HASH))
+#define POUND (HASH)
+
+/* Keyboard 4 and $ (Dollar) */
+#define NUMBER_4 (HID_USAGE_KEY_KEYBOARD_4_AND_DOLLAR)
+#define N4 (NUMBER_4)
+#define NUM_4 (NUMBER_4) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard $ (Dollar) */
+#define DOLLAR (LS(HID_USAGE_KEY_KEYBOARD_4_AND_DOLLAR))
+#define DLLR (DOLLAR)
+
+/* Keyboard 5 and % (Percent) */
+#define NUMBER_5 (HID_USAGE_KEY_KEYBOARD_5_AND_PERCENT)
+#define N5 (NUMBER_5)
+#define NUM_5 (NUMBER_5) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard % (Percent) */
+#define PERCENT (LS(HID_USAGE_KEY_KEYBOARD_5_AND_PERCENT))
+#define PRCNT (PERCENT)
+#define PRCT (PERCENT) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard 6 and ^ (Caret) */
+#define NUMBER_6 (HID_USAGE_KEY_KEYBOARD_6_AND_CARET)
+#define N6 (NUMBER_6)
+#define NUM_6 (NUMBER_6) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard ^ (Caret) */
+#define CARET (LS(HID_USAGE_KEY_KEYBOARD_6_AND_CARET))
+#define CRRT (CARET) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard 7 and & (Ampersand) */
+#define NUMBER_7 (HID_USAGE_KEY_KEYBOARD_7_AND_AMPERSAND)
+#define N7 (NUMBER_7)
+#define NUM_7 (NUMBER_7) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard & (Ampersand) */
+#define AMPERSAND (LS(HID_USAGE_KEY_KEYBOARD_7_AND_AMPERSAND))
+#define AMPS (AMPERSAND)
+
+/* Keyboard 8 and * (Asterisk) */
+#define NUMBER_8 (HID_USAGE_KEY_KEYBOARD_8_AND_ASTERISK)
+#define N8 (NUMBER_8)
+#define NUM_8 (NUMBER_8) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard * (Asterisk) */
+#define ASTERISK (LS(HID_USAGE_KEY_KEYBOARD_8_AND_ASTERISK))
+#define ASTRK (ASTERISK)
+#define STAR (ASTERISK)
+
+/* Keyboard 9 and ( (Left Parenthesis) */
+#define NUMBER_9 (HID_USAGE_KEY_KEYBOARD_9_AND_LEFT_PARENTHESIS)
+#define N9 (NUMBER_9)
+#define NUM_9 (NUMBER_9) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard ( (Left Parenthesis) */
+#define LEFT_PARENTHESIS (LS(HID_USAGE_KEY_KEYBOARD_9_AND_LEFT_PARENTHESIS))
+#define LPAR (LEFT_PARENTHESIS)
+#define LPRN (LEFT_PARENTHESIS) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard 0 and ) (Right Parenthesis) */
+#define NUMBER_0 (HID_USAGE_KEY_KEYBOARD_0_AND_RIGHT_PARENTHESIS)
+#define N0 (NUMBER_0)
+#define NUM_0 (NUMBER_0) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard ) (Right Parenthesis) */
+#define RIGHT_PARENTHESIS (LS(HID_USAGE_KEY_KEYBOARD_0_AND_RIGHT_PARENTHESIS))
+#define RPAR (RIGHT_PARENTHESIS)
+#define RPRN (RIGHT_PARENTHESIS) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Return (Enter) */
+#define RETURN (HID_USAGE_KEY_KEYBOARD_RETURN_ENTER)
+#define ENTER (RETURN)
+#define RET (RETURN)
+
+/* Keyboard Escape */
+#define ESCAPE (HID_USAGE_KEY_KEYBOARD_ESCAPE)
+#define ESC (ESCAPE)
+
+/* Keyboard Backspace */
+#define BACKSPACE (HID_USAGE_KEY_KEYBOARD_DELETE_BACKSPACE)
+#define BSPC (BACKSPACE)
+#define BKSP (BACKSPACE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Tab */
+#define TAB (HID_USAGE_KEY_KEYBOARD_TAB)
+
+/* Keyboard Space */
+#define SPACE (HID_USAGE_KEY_KEYBOARD_SPACEBAR)
+#define SPC (SPACE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard - and _ (Minus and Underscore) */
+#define MINUS (HID_USAGE_KEY_KEYBOARD_MINUS_AND_UNDERSCORE)
+
+/* Keyboard _ (Underscore) */
+#define UNDERSCORE (LS(HID_USAGE_KEY_KEYBOARD_MINUS_AND_UNDERSCORE))
+#define UNDER (UNDERSCORE)
+
+/* Keyboard = and + (Equal and Plus) */
+#define EQUAL (HID_USAGE_KEY_KEYBOARD_EQUAL_AND_PLUS)
+#define EQL (EQUAL) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard + (Plus) */
+#define PLUS (LS(HID_USAGE_KEY_KEYBOARD_EQUAL_AND_PLUS))
+
+/* Keyboard [ and { (Left Bracket and Left Brace) */
+#define LEFT_BRACKET (HID_USAGE_KEY_KEYBOARD_LEFT_BRACKET_AND_LEFT_BRACE)
+#define LBKT (LEFT_BRACKET)
+
+/* Keyboard { (Left Brace) */
+#define LEFT_BRACE (LS(HID_USAGE_KEY_KEYBOARD_LEFT_BRACKET_AND_LEFT_BRACE))
+#define LBRC (LEFT_BRACE)
+#define LCUR (LEFT_BRACE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard ] and } (Right Bracket and Right Brace) */
+#define RIGHT_BRACKET (HID_USAGE_KEY_KEYBOARD_RIGHT_BRACKET_AND_RIGHT_BRACE)
+#define RBKT (RIGHT_BRACKET)
+
+/* Keyboard } (Right Brace) */
+#define RIGHT_BRACE (LS(HID_USAGE_KEY_KEYBOARD_RIGHT_BRACKET_AND_RIGHT_BRACE))
+#define RBRC (RIGHT_BRACE)
+#define RCUR (RIGHT_BRACE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard \ and | (Backslash and Pipe) */
+#define BACKSLASH (HID_USAGE_KEY_KEYBOARD_BACKSLASH_AND_PIPE)
+#define BSLH (BACKSLASH)
+
+/* Keyboard | (Pipe) */
+#define PIPE (LS(HID_USAGE_KEY_KEYBOARD_BACKSLASH_AND_PIPE))
+
+/* Keyboard Non-US # and ~ (Non-US Hash/Number and Tilde) */
+#define NON_US_HASH (HID_USAGE_KEY_KEYBOARD_NON_US_HASH_AND_TILDE)
+
+/* Keyboard ~ (Tilde) */
+#define TILDE2 (LS(HID_USAGE_KEY_KEYBOARD_NON_US_HASH_AND_TILDE))
+
+/* Keyboard ; and : (Semicolon and Colon) */
+#define SEMICOLON (HID_USAGE_KEY_KEYBOARD_SEMICOLON_AND_COLON)
+#define SEMI (SEMICOLON)
+#define SCLN (SEMICOLON) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard : (Colon) */
+#define COLON (LS(HID_USAGE_KEY_KEYBOARD_SEMICOLON_AND_COLON))
+#define COLN (COLON) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard ' and " (Apostrophe and Quote) */
+#define SINGLE_QUOTE (HID_USAGE_KEY_KEYBOARD_APOSTROPHE_AND_QUOTE)
+#define SQT (SINGLE_QUOTE)
+#define APOSTROPHE (SINGLE_QUOTE)
+#define APOS (SINGLE_QUOTE)
+#define QUOT (SINGLE_QUOTE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard " (Quote) */
+#define DOUBLE_QUOTES (LS(HID_USAGE_KEY_KEYBOARD_APOSTROPHE_AND_QUOTE))
+#define DQT (DOUBLE_QUOTES)
+
+/* Keyboard ` and ~ (Grave Accent and Tilde) */
+#define GRAVE (HID_USAGE_KEY_KEYBOARD_GRAVE_ACCENT_AND_TILDE)
+#define GRAV (GRAVE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard ~ (Tilde) */
+#define TILDE (LS(HID_USAGE_KEY_KEYBOARD_GRAVE_ACCENT_AND_TILDE))
+#define TILD (TILDE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard , and < (Comma and Less Than) */
+#define COMMA (HID_USAGE_KEY_KEYBOARD_COMMA_AND_LESS_THAN)
+#define CMMA (COMMA) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard < (Less Than) */
+#define LESS_THAN (LS(HID_USAGE_KEY_KEYBOARD_COMMA_AND_LESS_THAN))
+#define LT (LESS_THAN)
+#define LABT (LESS_THAN) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard . and > (Period and Greater Than) */
+#define PERIOD (HID_USAGE_KEY_KEYBOARD_PERIOD_AND_GREATER_THAN)
+#define DOT (PERIOD)
+
+/* Keyboard > (Greater Than) */
+#define GREATER_THAN (LS(HID_USAGE_KEY_KEYBOARD_PERIOD_AND_GREATER_THAN))
+#define GT (GREATER_THAN)
+#define RABT (GREATER_THAN) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard / and ? (Forward Slash and Question) */
+#define SLASH (HID_USAGE_KEY_KEYBOARD_SLASH_AND_QUESTION_MARK)
+#define FSLH (SLASH)
+
+/* Keyboard ? (Question) */
+#define QUESTION (LS(HID_USAGE_KEY_KEYBOARD_SLASH_AND_QUESTION_MARK))
+#define QMARK (QUESTION)
+
+/* Keyboard Caps Lock */
+#define CAPSLOCK (HID_USAGE_KEY_KEYBOARD_CAPS_LOCK)
+#define CAPS (CAPSLOCK)
+#define CLCK (CAPSLOCK)
+
+/* Keyboard F1 */
+#define F1 (HID_USAGE_KEY_KEYBOARD_F1)
+
+/* Keyboard F2 */
+#define F2 (HID_USAGE_KEY_KEYBOARD_F2)
+
+/* Keyboard F3 */
+#define F3 (HID_USAGE_KEY_KEYBOARD_F3)
+
+/* Keyboard F4 */
+#define F4 (HID_USAGE_KEY_KEYBOARD_F4)
+
+/* Keyboard F5 */
+#define F5 (HID_USAGE_KEY_KEYBOARD_F5)
+
+/* Keyboard F6 */
+#define F6 (HID_USAGE_KEY_KEYBOARD_F6)
+
+/* Keyboard F7 */
+#define F7 (HID_USAGE_KEY_KEYBOARD_F7)
+
+/* Keyboard F8 */
+#define F8 (HID_USAGE_KEY_KEYBOARD_F8)
+
+/* Keyboard F9 */
+#define F9 (HID_USAGE_KEY_KEYBOARD_F9)
+
+/* Keyboard F10 */
+#define F10 (HID_USAGE_KEY_KEYBOARD_F10)
+
+/* Keyboard F11 */
+#define F11 (HID_USAGE_KEY_KEYBOARD_F11)
+
+/* Keyboard F12 */
+#define F12 (HID_USAGE_KEY_KEYBOARD_F12)
+
+/* Keyboard Print Screen */
+#define PRINTSCREEN (HID_USAGE_KEY_KEYBOARD_PRINTSCREEN)
+#define PSCRN (PRINTSCREEN)
+#define PRSC (PRINTSCREEN) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Scroll Lock */
+#define SCROLLLOCK (HID_USAGE_KEY_KEYBOARD_SCROLL_LOCK)
+#define SLCK (SCROLLLOCK)
+#define SCLK (SCROLLLOCK) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Pause/Break */
+#define PAUSE_BREAK (HID_USAGE_KEY_KEYBOARD_PAUSE)
+#define PAUS (PAUSE_BREAK) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Insert */
+#define INSERT (HID_USAGE_KEY_KEYBOARD_INSERT)
+#define INS (INSERT)
+
+/* Keyboard Home */
+#define HOME (HID_USAGE_KEY_KEYBOARD_HOME)
+
+/* Keyboard Page Up */
+#define PAGE_UP (HID_USAGE_KEY_KEYBOARD_PAGEUP)
+#define PG_UP (PAGE_UP)
+#define PGUP (PAGE_UP) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Delete */
+#define DELETE (HID_USAGE_KEY_KEYBOARD_DELETE_FORWARD)
+#define DEL (DELETE)
+
+/* Keyboard End */
+#define END (HID_USAGE_KEY_KEYBOARD_END)
+
+/* Keyboard Page Down */
+#define PAGE_DOWN (HID_USAGE_KEY_KEYBOARD_PAGEDOWN)
+#define PG_DN (PAGE_DOWN)
+#define PGDN (PAGE_DOWN) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Right Arrow */
+#define RIGHT_ARROW (HID_USAGE_KEY_KEYBOARD_RIGHTARROW)
+#define RIGHT (RIGHT_ARROW)
+#define RARW (RIGHT_ARROW) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Left Arrow */
+#define LEFT_ARROW (HID_USAGE_KEY_KEYBOARD_LEFTARROW)
+#define LEFT (LEFT_ARROW)
+#define LARW (LEFT_ARROW) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Down Arrow */
+#define DOWN_ARROW (HID_USAGE_KEY_KEYBOARD_DOWNARROW)
+#define DOWN (DOWN_ARROW)
+#define DARW (DOWN_ARROW) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Up Arrow */
+#define UP_ARROW (HID_USAGE_KEY_KEYBOARD_UPARROW)
+#define UP (UP_ARROW)
+#define UARW (UP_ARROW) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keypad Numlock and Clear */
+#define KP_NUMLOCK (HID_USAGE_KEY_KEYPAD_NUM_LOCK_AND_CLEAR)
+#define KP_NUM (KP_NUMLOCK)
+#define KP_NLCK (KP_NUMLOCK)
+
+/* Keypad Clear */
+#define CLEAR2 (LS(HID_USAGE_KEY_KEYPAD_NUM_LOCK_AND_CLEAR))
+
+/* Keypad / (Slash/Divide) */
+#define KP_DIVIDE (HID_USAGE_KEY_KEYPAD_SLASH)
+#define KP_SLASH (KP_DIVIDE)
+#define KDIV (KP_DIVIDE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keypad * (Multiply) */
+#define KP_MULTIPLY (HID_USAGE_KEY_KEYPAD_ASTERISK)
+#define KP_ASTERISK (KP_MULTIPLY)
+#define KMLT (KP_MULTIPLY) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keypad - (Minus) */
+#define KP_MINUS (HID_USAGE_KEY_KEYPAD_MINUS)
+#define KP_SUBTRACT (KP_MINUS)
+#define KMIN (KP_MINUS) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keypad + (Plus) */
+#define KP_PLUS (HID_USAGE_KEY_KEYPAD_PLUS)
+#define KPLS (KP_PLUS) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keypad Enter */
+#define KP_ENTER (HID_USAGE_KEY_KEYPAD_ENTER)
+
+/* Keypad 1 */
+#define KP_NUMBER_1 (HID_USAGE_KEY_KEYPAD_1_AND_END)
+#define KP_N1 (KP_NUMBER_1)
+
+/* Keypad 2 */
+#define KP_NUMBER_2 (HID_USAGE_KEY_KEYPAD_2_AND_DOWN_ARROW)
+#define KP_N2 (KP_NUMBER_2)
+
+/* Keypad 3 */
+#define KP_NUMBER_3 (HID_USAGE_KEY_KEYPAD_3_AND_PAGEDN)
+#define KP_N3 (KP_NUMBER_3)
+
+/* Keypad 4 */
+#define KP_NUMBER_4 (HID_USAGE_KEY_KEYPAD_4_AND_LEFT_ARROW)
+#define KP_N4 (KP_NUMBER_4)
+
+/* Keypad 5 */
+#define KP_NUMBER_5 (HID_USAGE_KEY_KEYPAD_5)
+#define KP_N5 (KP_NUMBER_5)
+
+/* Keypad 6 */
+#define KP_NUMBER_6 (HID_USAGE_KEY_KEYPAD_6_AND_RIGHT_ARROW)
+#define KP_N6 (KP_NUMBER_6)
+
+/* Keypad 7 */
+#define KP_NUMBER_7 (HID_USAGE_KEY_KEYPAD_7_AND_HOME)
+#define KP_N7 (KP_NUMBER_7)
+
+/* Keypad 8 */
+#define KP_NUMBER_8 (HID_USAGE_KEY_KEYPAD_8_AND_UP_ARROW)
+#define KP_N8 (KP_NUMBER_8)
+
+/* Keypad 9 */
+#define KP_NUMBER_9 (HID_USAGE_KEY_KEYPAD_9_AND_PAGEUP)
+#define KP_N9 (KP_NUMBER_9)
+
+/* Keypad 0 */
+#define KP_NUMBER_0 (HID_USAGE_KEY_KEYPAD_0_AND_INSERT)
+#define KP_N0 (KP_NUMBER_0)
+
+/* Keypad . (Dot) */
+#define KP_DOT (HID_USAGE_KEY_KEYPAD_PERIOD_AND_DELETE)
+
+/* Keyboard Non-US \ and | (Non-us Backslash and Pipe) */
+#define NON_US_BACKSLASH (HID_USAGE_KEY_KEYBOARD_NON_US_BACKSLASH_AND_PIPE)
+#define NON_US_BSLH (NON_US_BACKSLASH)
+
+/* Keyboard Pipe */
+#define PIPE2 (LS(HID_USAGE_KEY_KEYBOARD_NON_US_BACKSLASH_AND_PIPE))
+
+/* Keyboard GUI (Windows / Command / Meta) */
+#define GUI (HID_USAGE_KEY_KEYBOARD_APPLICATION)
+#define WIN (GUI)
+#define COMMAND (GUI)
+#define CMD (GUI)
+#define META (GUI)
+
+/* Keyboard Power */
+#define K_POWER (HID_USAGE_KEY_KEYBOARD_POWER)
+#define K_PWR (K_POWER)
+
+/* Keypad = (Equal) */
+#define KP_EQUAL (HID_USAGE_KEY_KEYPAD_EQUAL)
+
+/* Keyboard F13 */
+#define F13 (HID_USAGE_KEY_KEYBOARD_F13)
+
+/* Keyboard F14 */
+#define F14 (HID_USAGE_KEY_KEYBOARD_F14)
+
+/* Keyboard F15 */
+#define F15 (HID_USAGE_KEY_KEYBOARD_F15)
+
+/* Keyboard F16 */
+#define F16 (HID_USAGE_KEY_KEYBOARD_F16)
+
+/* Keyboard F17 */
+#define F17 (HID_USAGE_KEY_KEYBOARD_F17)
+
+/* Keyboard F18 */
+#define F18 (HID_USAGE_KEY_KEYBOARD_F18)
+
+/* Keyboard F19 */
+#define F19 (HID_USAGE_KEY_KEYBOARD_F19)
+
+/* Keyboard F20 */
+#define F20 (HID_USAGE_KEY_KEYBOARD_F20)
+
+/* Keyboard F21 */
+#define F21 (HID_USAGE_KEY_KEYBOARD_F21)
+
+/* Keyboard F22 */
+#define F22 (HID_USAGE_KEY_KEYBOARD_F22)
+
+/* Keyboard F23 */
+#define F23 (HID_USAGE_KEY_KEYBOARD_F23)
+
+/* Keyboard F24 */
+#define F24 (HID_USAGE_KEY_KEYBOARD_F24)
+
+/* Keyboard Execute */
+#define K_EXECUTE (HID_USAGE_KEY_KEYBOARD_EXECUTE)
+#define K_EXEC (K_EXECUTE)
+
+/* Keyboard Help */
+#define K_HELP (HID_USAGE_KEY_KEYBOARD_HELP)
+
+/* Keyboard Menu */
+#define K_MENU (HID_USAGE_KEY_KEYBOARD_MENU)
+
+/* Keyboard Select */
+#define K_SELECT (HID_USAGE_KEY_KEYBOARD_SELECT)
+
+/* Keyboard Stop */
+#define K_STOP (HID_USAGE_KEY_KEYBOARD_STOP)
+
+/* Keyboard Again */
+#define K_AGAIN (HID_USAGE_KEY_KEYBOARD_AGAIN)
+#define K_REDO (K_AGAIN)
+
+/* Keyboard Undo */
+#define K_UNDO (HID_USAGE_KEY_KEYBOARD_UNDO)
+#define UNDO (K_UNDO) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Cut */
+#define K_CUT (HID_USAGE_KEY_KEYBOARD_CUT)
+#define CUT (K_CUT) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Copy */
+#define K_COPY (HID_USAGE_KEY_KEYBOARD_COPY)
+#define COPY (K_COPY) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Paste */
+#define K_PASTE (HID_USAGE_KEY_KEYBOARD_PASTE)
+#define PSTE (K_PASTE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Find */
+#define K_FIND (HID_USAGE_KEY_KEYBOARD_FIND)
+
+/* Keyboard Mute */
+#define K_MUTE (HID_USAGE_KEY_KEYBOARD_MUTE)
+
+/* Keyboard Volume Up */
+#define K_VOLUME_UP (HID_USAGE_KEY_KEYBOARD_VOLUME_UP)
+#define K_VOL_UP (K_VOLUME_UP)
+#define VOLU (K_VOLUME_UP) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Volume Down */
+#define K_VOLUME_DOWN (HID_USAGE_KEY_KEYBOARD_VOLUME_DOWN)
+#define K_VOL_DN (K_VOLUME_DOWN)
+#define VOLD (K_VOLUME_DOWN) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Locking Caps Lock */
+#define LOCKING_CAPS (HID_USAGE_KEY_KEYBOARD_LOCKING_CAPS_LOCK)
+#define LCAPS (LOCKING_CAPS)
+
+/* Keyboard Locking Num Lock */
+#define LOCKING_NUM (HID_USAGE_KEY_KEYBOARD_LOCKING_NUM_LOCK)
+#define LNLCK (LOCKING_NUM)
+
+/* Keyboard Locking Scroll Lock */
+#define LOCKING_SCROLL (HID_USAGE_KEY_KEYBOARD_LOCKING_SCROLL_LOCK)
+#define LSLCK (LOCKING_SCROLL)
+
+/* Keypad , (Comma) */
+#define KP_COMMA (HID_USAGE_KEY_KEYPAD_COMMA)
+
+/* Keypad = (Equal) AS/400 */
+#define KP_EQUAL_AS400 (HID_USAGE_KEY_KEYPAD_EQUAL_SIGN)
+
+/* Keyboard International 1 */
+#define INTERNATIONAL_1 (HID_USAGE_KEY_KEYBOARD_INTERNATIONAL1)
+#define INT1 (INTERNATIONAL_1)
+#define INT_RO (INTERNATIONAL_1)
+
+/* Keyboard International 2 */
+#define INTERNATIONAL_2 (HID_USAGE_KEY_KEYBOARD_INTERNATIONAL2)
+#define INT2 (INTERNATIONAL_2)
+#define INT_KATAKANAHIRAGANA (INTERNATIONAL_2)
+#define INT_KANA (INTERNATIONAL_2)
+
+/* Keyboard International 3 */
+#define INTERNATIONAL_3 (HID_USAGE_KEY_KEYBOARD_INTERNATIONAL3)
+#define INT3 (INTERNATIONAL_3)
+#define INT_YEN (INTERNATIONAL_3)
+
+/* Keyboard International 4 */
+#define INTERNATIONAL_4 (HID_USAGE_KEY_KEYBOARD_INTERNATIONAL4)
+#define INT4 (INTERNATIONAL_4)
+#define INT_HENKAN (INTERNATIONAL_4)
+
+/* Keyboard International 5 */
+#define INTERNATIONAL_5 (HID_USAGE_KEY_KEYBOARD_INTERNATIONAL5)
+#define INT5 (INTERNATIONAL_5)
+#define INT_MUHENKAN (INTERNATIONAL_5)
+
+/* Keyboard International 6 */
+#define INTERNATIONAL_6 (HID_USAGE_KEY_KEYBOARD_INTERNATIONAL6)
+#define INT6 (INTERNATIONAL_6)
+#define INT_KPJPCOMMA (INTERNATIONAL_6)
+
+/* Keyboard International 7 */
+#define INTERNATIONAL_7 (HID_USAGE_KEY_KEYBOARD_INTERNATIONAL7)
+#define INT7 (INTERNATIONAL_7)
+
+/* Keyboard International 8 */
+#define INTERNATIONAL_8 (HID_USAGE_KEY_KEYBOARD_INTERNATIONAL8)
+#define INT8 (INTERNATIONAL_8)
+
+/* Keyboard International 9 */
+#define INTERNATIONAL_9 (HID_USAGE_KEY_KEYBOARD_INTERNATIONAL9)
+#define INT9 (INTERNATIONAL_9)
+
+/* Keyboard Language 1 */
+#define LANGUAGE_1 (HID_USAGE_KEY_KEYBOARD_LANG1)
+#define LANG1 (LANGUAGE_1)
+#define LANG_HANGEUL (LANGUAGE_1)
+
+/* Keyboard Language 2 */
+#define LANGUAGE_2 (HID_USAGE_KEY_KEYBOARD_LANG2)
+#define LANG2 (LANGUAGE_2)
+#define LANG_HANJA (LANGUAGE_2)
+
+/* Keyboard Language 3 */
+#define LANGUAGE_3 (HID_USAGE_KEY_KEYBOARD_LANG3)
+#define LANG3 (LANGUAGE_3)
+#define LANG_KATAKANA (LANGUAGE_3)
+
+/* Keyboard Language 4 */
+#define LANGUAGE_4 (HID_USAGE_KEY_KEYBOARD_LANG4)
+#define LANG4 (LANGUAGE_4)
+#define LANG_HIRAGANA (LANGUAGE_4)
+
+/* Keyboard Language 5 */
+#define LANGUAGE_5 (HID_USAGE_KEY_KEYBOARD_LANG5)
+#define LANG5 (LANGUAGE_5)
+#define LANG_ZENKAKUHANKAKU (LANGUAGE_5)
+
+/* Keyboard Language 6 */
+#define LANGUAGE_6 (HID_USAGE_KEY_KEYBOARD_LANG6)
+#define LANG6 (LANGUAGE_6)
+
+/* Keyboard Language 7 */
+#define LANGUAGE_7 (HID_USAGE_KEY_KEYBOARD_LANG7)
+#define LANG7 (LANGUAGE_7)
+
+/* Keyboard Language 8 */
+#define LANGUAGE_8 (HID_USAGE_KEY_KEYBOARD_LANG8)
+#define LANG8 (LANGUAGE_8)
+
+/* Keyboard Language 9 */
+#define LANGUAGE_9 (HID_USAGE_KEY_KEYBOARD_LANG9)
+#define LANG9 (LANGUAGE_9)
+
+/* Keyboard Alternate Erase */
+#define ALT_ERASE (HID_USAGE_KEY_KEYBOARD_ALTERNATE_ERASE)
+
+/* Keyboard SysReq/Attention */
+#define SYSREQ (HID_USAGE_KEY_KEYBOARD_SYSREQ_ATTENTION)
+#define ATTENTION (SYSREQ)
+
+/* Keyboard Cancel */
+#define K_CANCEL (HID_USAGE_KEY_KEYBOARD_CANCEL)
+
+/* Keyboard Clear */
+#define CLEAR (HID_USAGE_KEY_KEYBOARD_CLEAR)
+
+/* Keyboard Prior */
+#define PRIOR (HID_USAGE_KEY_KEYBOARD_PRIOR)
+
+/* Keyboard Return */
+#define RETURN2 (HID_USAGE_KEY_KEYBOARD_RETURN)
+#define RET2 (RETURN2)
+
+/* Keyboard Separator */
+#define SEPARATOR (HID_USAGE_KEY_KEYBOARD_SEPARATOR)
+
+/* Keyboard Out */
+#define OUT (HID_USAGE_KEY_KEYBOARD_OUT)
+
+/* Keyboard Oper */
+#define OPER (HID_USAGE_KEY_KEYBOARD_OPER)
+
+/* Keyboard Clear/Again */
+#define CLEAR_AGAIN (HID_USAGE_KEY_KEYBOARD_CLEAR_AGAIN)
+
+/* Keyboard CrSel/Props */
+#define CRSEL (HID_USAGE_KEY_KEYBOARD_CRSEL_PROPS)
+
+/* Keyboard ExSel */
+#define EXSEL (HID_USAGE_KEY_KEYBOARD_EXSEL)
+
+/* Keyboard Currency Unit */
+#define CURU (HID_USAGE_KEY_CURRENCY_UNIT) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keypad ( (Left Parenthesis) */
+#define KP_LEFT_PARENTHESIS (HID_USAGE_KEY_KEYPAD_LEFT_PARENTHESIS)
+#define KP_LPAR (KP_LEFT_PARENTHESIS)
+
+/* Keypad ) (Right Parenthesis) */
+#define KP_RIGHT_PARENTHESIS (HID_USAGE_KEY_KEYPAD_RIGHT_PARENTHESIS)
+#define KP_RPAR (KP_RIGHT_PARENTHESIS)
+
+/* Keypad Space */
+#define KSPC (HID_USAGE_KEY_KEYPAD_SPACE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keypad Clear */
+#define KP_CLEAR (HID_USAGE_KEY_KEYPAD_CLEAR)
+
+/* Keyboard Left Control */
+#define LEFT_CONTROL (HID_USAGE_KEY_KEYBOARD_LEFTCONTROL)
+#define LCTRL (LEFT_CONTROL)
+#define LCTL (LEFT_CONTROL) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Left Shift */
+#define LEFT_SHIFT (HID_USAGE_KEY_KEYBOARD_LEFTSHIFT)
+#define LSHFT (LEFT_SHIFT)
+#define LSFT (LEFT_SHIFT) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Left Alt */
+#define LEFT_ALT (HID_USAGE_KEY_KEYBOARD_LEFTALT)
+#define LALT (LEFT_ALT)
+
+/* Keyboard Left GUI (Windows / Command / Meta) */
+#define LEFT_GUI (HID_USAGE_KEY_KEYBOARD_LEFT_GUI)
+#define LGUI (LEFT_GUI)
+#define LEFT_WIN (LEFT_GUI)
+#define LWIN (LEFT_GUI)
+#define LEFT_COMMAND (LEFT_GUI)
+#define LCMD (LEFT_GUI)
+#define LEFT_META (LEFT_GUI)
+#define LMETA (LEFT_GUI)
+
+/* Keyboard Right Control */
+#define RIGHT_CONTROL (HID_USAGE_KEY_KEYBOARD_RIGHTCONTROL)
+#define RCTRL (RIGHT_CONTROL)
+#define RCTL (RIGHT_CONTROL) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Right Shift */
+#define RIGHT_SHIFT (HID_USAGE_KEY_KEYBOARD_RIGHTSHIFT)
+#define RSHFT (RIGHT_SHIFT)
+#define RSFT (RIGHT_SHIFT) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Keyboard Right Alt */
+#define RIGHT_ALT (HID_USAGE_KEY_KEYBOARD_RIGHTALT)
+#define RALT (RIGHT_ALT)
+
+/* Keyboard Right GUI (Windows / Command / Meta) */
+#define RIGHT_GUI (HID_USAGE_KEY_KEYBOARD_RIGHT_GUI)
+#define RGUI (RIGHT_GUI)
+#define RIGHT_WIN (RIGHT_GUI)
+#define RWIN (RIGHT_GUI)
+#define RIGHT_COMMAND (RIGHT_GUI)
+#define RCMD (RIGHT_GUI)
+#define RIGHT_META (RIGHT_GUI)
+#define RMETA (RIGHT_GUI)
+
+/* Keyboard Play/Pause */
+#define K_PLAY_PAUSE (0xE8)
+#define K_PP (K_PLAY_PAUSE)
+
+/* Keyboard Stop */
+#define K_STOP2 (0xE9)
+
+/* Keyboard Previous */
+#define K_PREVIOUS (0xEA)
+#define K_PREV (K_PREVIOUS)
+
+/* Keyboard Next */
+#define K_NEXT (0xEB)
+
+/* Keyboard Eject */
+#define K_EJECT (0xEC)
+
+/* Keyboard Volume Up */
+#define K_VOLUME_UP2 (0xED)
+#define K_VOL_UP2 (K_VOLUME_UP2)
+
+/* Keyboard Volume Down */
+#define K_VOLUME_DOWN2 (0xEE)
+#define K_VOL_DN2 (K_VOLUME_DOWN2)
+
+/* Keyboard Mute */
+#define K_MUTE2 (0xEF)
+
+/* Keyboard WWW */
+#define K_WWW (0xF0)
+
+/* Keyboard Back */
+#define K_BACK (0xF1)
+
+/* Keyboard Forward */
+#define K_FORWARD (0xF2)
+
+/* Keyboard Stop */
+#define K_STOP3 (0xF3)
+
+/* Keyboard Find */
+#define K_FIND2 (0xF4)
+
+/* Keyboard Scroll Up */
+#define K_SCROLL_UP (0xF5)
+
+/* Keyboard Scroll Down */
+#define K_SCROLL_DOWN (0xF6)
+
+/* Keyboard Edit */
+#define K_EDIT (0xF7)
+
+/* Keyboard Sleep */
+#define K_SLEEP (0xF8)
+
+/* Keyboard Lock */
+#define K_LOCK (0xF9)
+#define K_SCREENSAVER (K_LOCK)
+#define K_COFFEE (K_LOCK)
+
+/* Keyboard Refresh */
+#define K_REFRESH (0xFA)
+
+/* Keyboard Calculator */
+#define K_CALCULATOR (0xFB)
+#define K_CALC (K_CALCULATOR)
+
+/* Consumer Power */
+#define C_POWER (HID_USAGE_CONSUMER_POWER)
+#define C_PWR (C_POWER)
+
+/* Consumer Reset */
+#define C_RESET (HID_USAGE_CONSUMER_RESET)
+
+/* Consumer Sleep */
+#define C_SLEEP (HID_USAGE_CONSUMER_SLEEP)
+
+/* Consumer Sleep Mode */
+#define C_SLEEP_MODE (HID_USAGE_CONSUMER_SLEEP_MODE)
+
+/* Consumer Menu */
+#define C_MENU (HID_USAGE_CONSUMER_MENU)
+
+/* Consumer Menu Pick */
+#define C_MENU_PICK (HID_USAGE_CONSUMER_MENU_PICK)
+#define C_MENU_SELECT (C_MENU_PICK)
+
+/* Consumer Menu Up */
+#define C_MENU_UP (HID_USAGE_CONSUMER_MENU_UP)
+
+/* Consumer Menu Down */
+#define C_MENU_DOWN (HID_USAGE_CONSUMER_MENU_DOWN)
+
+/* Consumer Menu Left */
+#define C_MENU_LEFT (HID_USAGE_CONSUMER_MENU_LEFT)
+
+/* Consumer Menu Right */
+#define C_MENU_RIGHT (HID_USAGE_CONSUMER_MENU_RIGHT)
+
+/* Consumer Menu Escape */
+#define C_MENU_ESCAPE (HID_USAGE_CONSUMER_MENU_ESCAPE)
+#define C_MENU_ESC (C_MENU_ESCAPE)
+
+/* Consumer Menu Value Increase */
+#define C_MENU_INCREASE (HID_USAGE_CONSUMER_MENU_VALUE_INCREASE)
+#define C_MENU_INC (C_MENU_INCREASE)
+
+/* Consumer Menu Value Decrease */
+#define C_MENU_DECREASE (HID_USAGE_CONSUMER_MENU_VALUE_DECREASE)
+#define C_MENU_DEC (C_MENU_DECREASE)
+
+/* Consumer Data On Screen */
+#define C_DATA_ON_SCREEN (HID_USAGE_CONSUMER_DATA_ON_SCREEN)
+
+/* Consumer Closed Caption */
+#define C_CAPTIONS (HID_USAGE_CONSUMER_CLOSED_CAPTION)
+#define C_SUBTITILES (C_CAPTIONS)
+
+/* Consumer Snapshot */
+#define C_SNAPSHOT (HID_USAGE_CONSUMER_SNAPSHOT)
+
+/* Consumer Picture-in-Picture Toggle */
+#define C_PIP (HID_USAGE_CONSUMER_PICTURE_IN_PICTURE_TOGGLE)
+
+/* Consumer Red Menu Button */
+#define C_RED_BUTTON (HID_USAGE_CONSUMER_RED_MENU_BUTTON)
+#define C_RED (C_RED_BUTTON)
+
+/* Consumer Green Menu Button */
+#define C_GREEN_BUTTON (HID_USAGE_CONSUMER_GREEN_MENU_BUTTON)
+#define C_GREEN (C_GREEN_BUTTON)
+
+/* Consumer Blue Menu Button */
+#define C_BLUE_BUTTON (HID_USAGE_CONSUMER_BLUE_MENU_BUTTON)
+#define C_BLUE (C_BLUE_BUTTON)
+
+/* Consumer Yellow Menu Button */
+#define C_YELLOW_BUTTON (HID_USAGE_CONSUMER_YELLOW_MENU_BUTTON)
+#define C_YELLOW (C_YELLOW_BUTTON)
+
+/* Consumer Aspect */
+#define C_ASPECT (HID_USAGE_CONSUMER_ASPECT)
+
+/* Consumer Display Brightness Increment */
+#define C_BRIGHTNESS_INC (HID_USAGE_CONSUMER_DISPLAY_BRIGHTNESS_INCREMENT)
+#define C_BRI_INC (C_BRIGHTNESS_INC)
+#define C_BRI_UP (C_BRIGHTNESS_INC)
+
+/* Consumer Display Brightness Decrement */
+#define C_BRIGHTNESS_DEC (HID_USAGE_CONSUMER_DISPLAY_BRIGHTNESS_DECREMENT)
+#define C_BRI_DEC (C_BRIGHTNESS_DEC)
+#define C_BRI_DN (C_BRIGHTNESS_DEC)
+
+/* Consumer Display Backlight Toggle */
+#define C_BACKLIGHT_TOGGLE (HID_USAGE_CONSUMER_DISPLAY_BACKLIGHT_TOGGLE)
+#define C_BKLT_TOG (C_BACKLIGHT_TOGGLE)
+
+/* Consumer Display Set Brightness to Minimum */
+#define C_BRIGHTNESS_MINIMUM (HID_USAGE_CONSUMER_DISPLAY_SET_BRIGHTNESS_TO_MINIMUM)
+#define C_BRI_MIN (C_BRIGHTNESS_MINIMUM)
+
+/* Consumer Display Set Brightness to Maximum */
+#define C_BRIGHTNESS_MAXIMUM (HID_USAGE_CONSUMER_DISPLAY_SET_BRIGHTNESS_TO_MAXIMUM)
+#define C_BRI_MAX (C_BRIGHTNESS_MAXIMUM)
+
+/* Consumer Display Set Auto Brightness */
+#define C_BRIGHTNESS_AUTO (HID_USAGE_CONSUMER_DISPLAY_SET_AUTO_BRIGHTNESS)
+#define C_BRI_AUTO (C_BRIGHTNESS_AUTO)
+
+/* Consumer Mode Step */
+#define C_MEDIA_STEP (HID_USAGE_CONSUMER_MODE_STEP)
+#define C_MODE_STEP (C_MEDIA_STEP)
+
+/* Consumer Recall Last */
+#define C_RECALL_LAST (HID_USAGE_CONSUMER_RECALL_LAST)
+#define C_CHAN_LAST (C_RECALL_LAST)
+
+/* Consumer Media Select Computer */
+#define C_MEDIA_COMPUTER (HID_USAGE_CONSUMER_MEDIA_SELECT_COMPUTER)
+
+/* Consumer Media Select TV */
+#define C_MEDIA_TV (HID_USAGE_CONSUMER_MEDIA_SELECT_TV)
+
+/* Consumer Media Select WWW */
+#define C_MEDIA_WWW (HID_USAGE_CONSUMER_MEDIA_SELECT_WWW)
+
+/* Consumer Media Select DVD */
+#define C_MEDIA_DVD (HID_USAGE_CONSUMER_MEDIA_SELECT_DVD)
+
+/* Consumer Media Select Telephone */
+#define C_MEDIA_PHONE (HID_USAGE_CONSUMER_MEDIA_SELECT_TELEPHONE)
+
+/* Consumer Media Select Program Guide */
+#define C_MEDIA_GUIDE (HID_USAGE_CONSUMER_MEDIA_SELECT_PROGRAM_GUIDE)
+
+/* Consumer Media Select Video Phone */
+#define C_MEDIA_VIDEOPHONE (HID_USAGE_CONSUMER_MEDIA_SELECT_VIDEO_PHONE)
+
+/* Consumer Media Select Games */
+#define C_MEDIA_GAMES (HID_USAGE_CONSUMER_MEDIA_SELECT_GAMES)
+
+/* Consumer Media Select Messages */
+#define C_MEDIA_MESSAGES (HID_USAGE_CONSUMER_MEDIA_SELECT_MESSAGES)
+
+/* Consumer Media Select CD */
+#define C_MEDIA_CD (HID_USAGE_CONSUMER_MEDIA_SELECT_CD)
+
+/* Consumer Media Select VCR */
+#define C_MEDIA_VCR (HID_USAGE_CONSUMER_MEDIA_SELECT_VCR)
+
+/* Consumer Media Select Tuner */
+#define C_MEDIA_TUNER (HID_USAGE_CONSUMER_MEDIA_SELECT_TUNER)
+
+/* Consumer Quit */
+#define C_QUIT (HID_USAGE_CONSUMER_QUIT)
+
+/* Consumer Help */
+#define C_HELP (HID_USAGE_CONSUMER_HELP)
+
+/* Consumer Media Select Tape */
+#define C_MEDIA_TAPE (HID_USAGE_CONSUMER_MEDIA_SELECT_TAPE)
+
+/* Consumer Media Select Cable */
+#define C_MEDIA_CABLE (HID_USAGE_CONSUMER_MEDIA_SELECT_CABLE)
+
+/* Consumer Media Select Satellite */
+#define C_MEDIA_SATELLITE (HID_USAGE_CONSUMER_MEDIA_SELECT_SATELLITE)
+
+/* Consumer Media Select Home */
+#define C_MEDIA_HOME (HID_USAGE_CONSUMER_MEDIA_SELECT_HOME)
+
+/* Consumer Channel Increment */
+#define C_CHANNEL_INC (HID_USAGE_CONSUMER_CHANNEL_INCREMENT)
+#define C_CHAN_INC (C_CHANNEL_INC)
+
+/* Consumer Channel Decrement */
+#define C_CHANNEL_DEC (HID_USAGE_CONSUMER_CHANNEL_DECREMENT)
+#define C_CHAN_DEC (C_CHANNEL_DEC)
+
+/* Consumer VCR Plus */
+#define C_MEDIA_VCR_PLUS (HID_USAGE_CONSUMER_VCR_PLUS)
+
+/* Consumer Play */
+#define C_PLAY (HID_USAGE_CONSUMER_PLAY)
+
+/* Consumer Pause */
+#define C_PAUSE (HID_USAGE_CONSUMER_PAUSE)
+
+/* Consumer Record */
+#define C_RECORD (HID_USAGE_CONSUMER_RECORD)
+#define C_REC (C_RECORD)
+
+/* Consumer Fast Forward */
+#define C_FAST_FORWARD (HID_USAGE_CONSUMER_FAST_FORWARD)
+#define C_FF (C_FAST_FORWARD)
+
+/* Consumer Rewind */
+#define C_REWIND (HID_USAGE_CONSUMER_REWIND)
+#define C_RW (C_REWIND)
+
+/* Consumer Scan Next Track */
+#define C_NEXT (HID_USAGE_CONSUMER_SCAN_NEXT_TRACK)
+#define M_NEXT (C_NEXT) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Consumer Scan Previous Track */
+#define C_PREVIOUS (HID_USAGE_CONSUMER_SCAN_PREVIOUS_TRACK)
+#define C_PREV (C_PREVIOUS)
+#define M_PREV (C_PREVIOUS) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Consumer Stop */
+#define C_STOP (HID_USAGE_CONSUMER_STOP)
+#define M_STOP (C_STOP) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Consumer Eject */
+#define C_EJECT (HID_USAGE_CONSUMER_EJECT)
+#define M_EJCT (C_EJECT) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Consumer Random Play */
+#define C_RANDOM_PLAY (HID_USAGE_CONSUMER_RANDOM_PLAY)
+#define C_SHUFFLE (C_RANDOM_PLAY)
+
+/* Consumer Repeat */
+#define C_REPEAT (HID_USAGE_CONSUMER_REPEAT)
+
+/* Consumer Slow Tracking */
+#define C_SLOW_TRACKING (HID_USAGE_CONSUMER_SLOW_TRACKING)
+#define C_SLOW2 (C_SLOW_TRACKING)
+
+/* Consumer Stop/Eject */
+#define C_STOP_EJECT (HID_USAGE_CONSUMER_STOP_EJECT)
+
+/* Consumer Play/Pause */
+#define C_PLAY_PAUSE (HID_USAGE_CONSUMER_PLAY_PAUSE)
+#define C_PP (C_PLAY_PAUSE)
+#define M_PLAY (C_PLAY_PAUSE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Consumer Voice Command */
+#define C_VOICE_COMMAND (HID_USAGE_CONSUMER_VOICE_COMMAND)
+
+/* Consumer Mute */
+#define C_MUTE (HID_USAGE_CONSUMER_MUTE)
+#define M_MUTE (C_MUTE) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Consumer Bass Boost */
+#define C_BASS_BOOST (HID_USAGE_CONSUMER_BASS_BOOST)
+
+/* Consumer Volume Increment */
+#define C_VOLUME_UP (HID_USAGE_CONSUMER_VOLUME_INCREMENT)
+#define C_VOL_UP (C_VOLUME_UP)
+#define M_VOLU (C_VOLUME_UP) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Consumer Volume Decrement */
+#define C_VOLUME_DOWN (HID_USAGE_CONSUMER_VOLUME_DECREMENT)
+#define C_VOL_DN (C_VOLUME_DOWN)
+#define M_VOLD (C_VOLUME_DOWN) // WARNING: DEPRECATED (DO NOT USE)
+
+/* Consumer Slow */
+#define C_SLOW (HID_USAGE_CONSUMER_SLOW)
+
+/* Consumer Alternate Audio Increment */
+#define C_ALTERNATE_AUDIO_INCREMENT (HID_USAGE_CONSUMER_ALTERNATE_AUDIO_INCREMENT)
+#define C_ALT_AUDIO_INC (C_ALTERNATE_AUDIO_INCREMENT)
+
+/* Consumer AL Consumer Control Configuration */
+#define C_AL_CCC (HID_USAGE_CONSUMER_AL_CONSUMER_CONTROL_CONFIGURATION)
+
+/* Consumer AL Word Processor */
+#define C_AL_WORD (HID_USAGE_CONSUMER_AL_WORD_PROCESSOR)
+
+/* Consumer AL Text Editor */
+#define C_AL_TEXT_EDITOR (HID_USAGE_CONSUMER_AL_TEXT_EDITOR)
+
+/* Consumer AL Spreadsheet */
+#define C_AL_SPREADSHEET (HID_USAGE_CONSUMER_AL_SPREADSHEET)
+#define C_AL_SHEET (C_AL_SPREADSHEET)
+
+/* Consumer AL Graphics Editor */
+#define C_AL_GRAPHICS_EDITOR (HID_USAGE_CONSUMER_AL_GRAPHICS_EDITOR)
+
+/* Consumer AL Presentation App */
+#define C_AL_PRESENTATION (HID_USAGE_CONSUMER_AL_PRESENTATION_APP)
+
+/* Consumer AL Database App */
+#define C_AL_DATABASE (HID_USAGE_CONSUMER_AL_DATABASE_APP)
+#define C_AL_DB (C_AL_DATABASE)
+
+/* Consumer AL Email Reader */
+#define C_AL_EMAIL (HID_USAGE_CONSUMER_AL_EMAIL_READER)
+#define C_AL_MAIL (C_AL_EMAIL)
+
+/* Consumer AL Newsreader */
+#define C_AL_NEWS (HID_USAGE_CONSUMER_AL_NEWSREADER)
+
+/* Consumer AL Voicemail */
+#define C_AL_VOICEMAIL (HID_USAGE_CONSUMER_AL_VOICEMAIL)
+
+/* Consumer AL Contacts/Address Book */
+#define C_AL_CONTACTS (HID_USAGE_CONSUMER_AL_CONTACTS_ADDRESS_BOOK)
+#define C_AL_ADDRESS_BOOK (C_AL_CONTACTS)
+
+/* Consumer AL Calendar/Schedule */
+#define C_AL_CALENDAR (HID_USAGE_CONSUMER_AL_CALENDAR_SCHEDULE)
+#define C_AL_CAL (C_AL_CALENDAR)
+
+/* Consumer AL Task/Project Manager */
+#define C_AL_TASK_MANAGER (HID_USAGE_CONSUMER_AL_TASK_PROJECT_MANAGER)
+
+/* Consumer AL Log/Journal/Timecard */
+#define C_AL_JOURNAL (HID_USAGE_CONSUMER_AL_LOG_JOURNAL_TIMECARD)
+
+/* Consumer AL Checkbook/Finance */
+#define C_AL_FINANCE (HID_USAGE_CONSUMER_AL_CHECKBOOK_FINANCE)
+
+/* Consumer AL Calculator */
+#define C_AL_CALCULATOR (HID_USAGE_CONSUMER_AL_CALCULATOR)
+#define C_AL_CALC (C_AL_CALCULATOR)
+
+/* Consumer AL A/V Capture/Playback */
+#define C_AL_AV_CAPTURE_PLAYBACK (HID_USAGE_CONSUMER_AL_A_V_CAPTURE_PLAYBACK)
+
+/* Consumer AL Local Machine Browser */
+#define C_AL_MY_COMPUTER (HID_USAGE_CONSUMER_AL_LOCAL_MACHINE_BROWSER)
+
+/* Consumer AL Internet Browser */
+#define C_AL_WWW (HID_USAGE_CONSUMER_AL_INTERNET_BROWSER)
+
+/* Consumer AL Network Chat */
+#define C_AL_NETWORK_CHAT (HID_USAGE_CONSUMER_AL_NETWORK_CHAT)
+#define C_AL_CHAT (C_AL_NETWORK_CHAT)
+
+/* Consumer AL Logoff */
+#define C_AL_LOGOFF (HID_USAGE_CONSUMER_AL_LOGOFF)
+
+/* Consumer AL Terminal Lock/Screensaver */
+#define C_AL_LOCK (HID_USAGE_CONSUMER_AL_TERMINAL_LOCK_SCREENSAVER)
+#define C_AL_SCREENSAVER (C_AL_LOCK)
+#define C_AL_COFFEE (C_AL_LOCK)
+
+/* Consumer AL Control Panel */
+#define C_AL_CONTROL_PANEL (HID_USAGE_CONSUMER_AL_CONTROL_PANEL)
+
+/* Consumer AL Select Task/Application */
+#define C_AL_SELECT_TASK (HID_USAGE_CONSUMER_AL_SELECT_TASK_APPLICATION)
+
+/* Consumer AL Next Task/Application */
+#define C_AL_NEXT_TASK (HID_USAGE_CONSUMER_AL_NEXT_TASK_APPLICATION)
+
+/* Consumer AL Previous Task/Application */
+#define C_AL_PREVIOUS_TASK (HID_USAGE_CONSUMER_AL_PREVIOUS_TASK_APPLICATION)
+#define C_AL_PREV_TASK (C_AL_PREVIOUS_TASK)
+
+/* Consumer AL Integrated Help Center */
+#define C_AL_HELP (HID_USAGE_CONSUMER_AL_INTEGRATED_HELP_CENTER)
+
+/* Consumer AL Documents */
+#define C_AL_DOCUMENTS (HID_USAGE_CONSUMER_AL_DOCUMENTS)
+#define C_AL_DOCS (C_AL_DOCUMENTS)
+
+/* Consumer AL Spell Check */
+#define C_AL_SPELLCHECK (HID_USAGE_CONSUMER_AL_SPELL_CHECK)
+#define C_AL_SPELL (C_AL_SPELLCHECK)
+
+/* Consumer AL Keyboard Layout */
+#define C_AL_KEYBOARD_LAYOUT (HID_USAGE_CONSUMER_AL_KEYBOARD_LAYOUT)
+
+/* Consumer AL Screen Saver */
+#define C_AL_SCREEN_SAVER (HID_USAGE_CONSUMER_AL_SCREEN_SAVER)
+
+/* Consumer AL File Browser */
+#define C_AL_FILE_BROWSER (HID_USAGE_CONSUMER_AL_FILE_BROWSER)
+#define C_AL_FILES (C_AL_FILE_BROWSER)
+
+/* Consumer AL Image Browser */
+#define C_AL_IMAGE_BROWSER (HID_USAGE_CONSUMER_AL_IMAGE_BROWSER)
+#define C_AL_IMAGES (C_AL_IMAGE_BROWSER)
+
+/* Consumer AL Audio Browser */
+#define C_AL_AUDIO_BROWSER (HID_USAGE_CONSUMER_AL_AUDIO_BROWSER)
+#define C_AL_AUDIO (C_AL_AUDIO_BROWSER)
+#define C_AL_MUSIC (C_AL_AUDIO_BROWSER)
+
+/* Consumer AL Movie Browser */
+#define C_AL_MOVIE_BROWSER (HID_USAGE_CONSUMER_AL_MOVIE_BROWSER)
+#define C_AL_MOVIES (C_AL_MOVIE_BROWSER)
+
+/* Consumer AL Instant Messaging */
+#define C_AL_INSTANT_MESSAGING (HID_USAGE_CONSUMER_AL_INSTANT_MESSAGING)
+#define C_AL_IM (C_AL_INSTANT_MESSAGING)
+
+/* Consumer AL OEM Features/Tips/Tutorial Browser */
+#define C_AL_OEM_FEATURES (HID_USAGE_CONSUMER_AL_OEM_FEATURES_TIPS_TUTORIAL_BROWSER)
+#define C_AL_TIPS (C_AL_OEM_FEATURES)
+#define C_AL_TUTORIAL (C_AL_OEM_FEATURES)
+
+/* Consumer AC New */
+#define C_AC_NEW (HID_USAGE_CONSUMER_AC_NEW)
+
+/* Consumer AC Open */
+#define C_AC_OPEN (HID_USAGE_CONSUMER_AC_OPEN)
+
+/* Consumer AC Close */
+#define C_AC_CLOSE (HID_USAGE_CONSUMER_AC_CLOSE)
+
+/* Consumer AC Exit */
+#define C_AC_EXIT (HID_USAGE_CONSUMER_AC_EXIT)
+
+/* Consumer AC Save */
+#define C_AC_SAVE (HID_USAGE_CONSUMER_AC_SAVE)
+
+/* Consumer AC Print */
+#define C_AC_PRINT (HID_USAGE_CONSUMER_AC_PRINT)
+
+/* Consumer AC Properties */
+#define C_AC_PROPERTIES (HID_USAGE_CONSUMER_AC_PROPERTIES)
+#define C_AC_PROPS (C_AC_PROPERTIES)
+
+/* Consumer AC Undo */
+#define C_AC_UNDO (HID_USAGE_CONSUMER_AC_UNDO)
+
+/* Consumer AC Copy */
+#define C_AC_COPY (HID_USAGE_CONSUMER_AC_COPY)
+
+/* Consumer AC Cut */
+#define C_AC_CUT (HID_USAGE_CONSUMER_AC_CUT)
+
+/* Consumer AC Paste */
+#define C_AC_PASTE (HID_USAGE_CONSUMER_AC_PASTE)
+
+/* Consumer AC Find */
+#define C_AC_FIND (HID_USAGE_CONSUMER_AC_FIND)
+
+/* Consumer AC Search */
+#define C_AC_SEARCH (HID_USAGE_CONSUMER_AC_SEARCH)
+
+/* Consumer AC Go To */
+#define C_AC_GOTO (HID_USAGE_CONSUMER_AC_GO_TO)
+
+/* Consumer AC Home */
+#define C_AC_HOME (HID_USAGE_CONSUMER_AC_HOME)
+
+/* Consumer AC Back */
+#define C_AC_BACK (HID_USAGE_CONSUMER_AC_BACK)
+
+/* Consumer AC Forward */
+#define C_AC_FORWARD (HID_USAGE_CONSUMER_AC_FORWARD)
+
+/* Consumer AC Stop */
+#define C_AC_STOP (HID_USAGE_CONSUMER_AC_STOP)
+
+/* Consumer AC Refresh */
+#define C_AC_REFRESH (HID_USAGE_CONSUMER_AC_REFRESH)
+
+/* Consumer AC Bookmarks */
+#define C_AC_BOOKMARKS (HID_USAGE_CONSUMER_AC_BOOKMARKS)
+#define C_AC_FAVORITES (C_AC_BOOKMARKS)
+#define C_AC_FAVOURITES (C_AC_BOOKMARKS)
+
+/* Consumer AC Zoom In */
+#define C_AC_ZOOM_IN (HID_USAGE_CONSUMER_AC_ZOOM_IN)
+
+/* Consumer AC Zoom Out */
+#define C_AC_ZOOM_OUT (HID_USAGE_CONSUMER_AC_ZOOM_OUT)
+
+/* Consumer AC Zoom */
+#define C_AC_ZOOM (HID_USAGE_CONSUMER_AC_ZOOM)
+
+/* Consumer AC View Toggle */
+#define C_AC_VIEW_TOGGLE (HID_USAGE_CONSUMER_AC_VIEW_TOGGLE)
+
+/* Consumer AC Scroll Up */
+#define C_AC_SCROLL_UP (HID_USAGE_CONSUMER_AC_SCROLL_UP)
+
+/* Consumer AC Scroll Down */
+#define C_AC_SCROLL_DOWN (HID_USAGE_CONSUMER_AC_SCROLL_DOWN)
+
+/* Consumer AC Edit */
+#define C_AC_EDIT (HID_USAGE_CONSUMER_AC_EDIT)
+
+/* Consumer AC Cancel */
+#define C_AC_CANCEL (HID_USAGE_CONSUMER_AC_CANCEL)
+
+/* Consumer AC Insert Mode */
+#define C_AC_INSERT (HID_USAGE_CONSUMER_AC_INSERT_MODE)
+#define C_AC_INS (C_AC_INSERT)
+
+/* Consumer AC Delete */
+#define C_AC_DEL (HID_USAGE_CONSUMER_AC_DELETE)
+
+/* Consumer AC Redo/Repeat */
+#define C_AC_REDO (HID_USAGE_CONSUMER_AC_REDO_REPEAT)
+
+/* Consumer AC Reply */
+#define C_AC_REPLY (HID_USAGE_CONSUMER_AC_REPLY)
+
+/* Consumer AC Forward Msg */
+#define C_AC_FORWARD_MAIL (HID_USAGE_CONSUMER_AC_FORWARD_MSG)
+
+/* Consumer AC Send */
+#define C_AC_SEND (HID_USAGE_CONSUMER_AC_SEND)
+
+/* Consumer AC Desktop Show All Windows */
+#define C_AC_DESKTOP_SHOW_ALL_WINDOWS (HID_USAGE_CONSUMER_AC_DESKTOP_SHOW_ALL_WINDOWS)
+
+/* Consumer Keyboard Input Assist Previous */
+#define C_KEYBOARD_INPUT_ASSIST_PREVIOUS (HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_PREVIOUS)
+#define C_KBIA_PREV (C_KEYBOARD_INPUT_ASSIST_PREVIOUS)
+
+/* Consumer Keyboard Input Assist Next */
+#define C_KEYBOARD_INPUT_ASSIST_NEXT (HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_NEXT)
+#define C_KBIA_NEXT (C_KEYBOARD_INPUT_ASSIST_NEXT)
+
+/* Consumer Keyboard Input Assist Previous Group */
+#define C_KEYBOARD_INPUT_ASSIST_PREVIOUS_GROUP                                                     \
+    (HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_PREVIOUS_GROUP)
+#define C_KBIA_PREV_GRP (C_KEYBOARD_INPUT_ASSIST_PREVIOUS_GROUP)
+
+/* Consumer Keyboard Input Assist Next Group */
+#define C_KEYBOARD_INPUT_ASSIST_NEXT_GROUP (HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_NEXT_GROUP)
+#define C_KBIA_NEXT_GRP (C_KEYBOARD_INPUT_ASSIST_NEXT_GROUP)
+
+/* Consumer Keyboard Input Assist Accept */
+#define C_KEYBOARD_INPUT_ASSIST_ACCEPT (HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_ACCEPT)
+#define C_KBIA_ACCEPT (C_KEYBOARD_INPUT_ASSIST_ACCEPT)
+
+/* Consumer Keyboard Input Assist Cancel */
+#define C_KEYBOARD_INPUT_ASSIST_CANCEL (HID_USAGE_CONSUMER_KEYBOARD_INPUT_ASSIST_CANCEL)
+#define C_KBIA_CANCEL (C_KEYBOARD_INPUT_ASSIST_CANCEL)

--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -116,18 +116,20 @@ static const u8_t zmk_hid_report_desc[] = {
     /* LOGICAL_MINIMUM (0) */
     HID_GI_LOGICAL_MIN(1),
     0x00,
-    /* LOGICAL_MAXIMUM (1) */
-    HID_GI_LOGICAL_MAX(1),
+    /* LOGICAL_MAXIMUM (0xFFFF) */
+    HID_GI_LOGICAL_MAX(2),
+    0xFF,
     0xFF,
     HID_LI_USAGE_MIN(1),
     0x00,
-    /* USAGE_MAXIMUM (Keyboard Application) */
-    HID_LI_USAGE_MAX(1),
+    /* USAGE_MAXIMUM (0xFFFF) */
+    HID_LI_USAGE_MAX(2),
+    0xFF,
     0xFF,
     /* INPUT (Data,Ary,Abs) */
-    /* REPORT_SIZE (8) */
+    /* REPORT_SIZE (16) */
     HID_GI_REPORT_SIZE,
-    0x08,
+    0x10,
     /* REPORT_COUNT (ZMK_HID_CONSUMER_NKRO_SIZE) */
     HID_GI_REPORT_COUNT,
     ZMK_HID_CONSUMER_NKRO_SIZE,
@@ -156,7 +158,7 @@ struct zmk_hid_keypad_report {
 } __packed;
 
 struct zmk_hid_consumer_report_body {
-    u8_t keys[ZMK_HID_CONSUMER_NKRO_SIZE];
+    u16_t keys[ZMK_HID_CONSUMER_NKRO_SIZE];
 } __packed;
 
 struct zmk_hid_consumer_report {

--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -10,6 +10,8 @@
 #include <usb/class/usb_hid.h>
 
 #include <zmk/keys.h>
+#include <dt-bindings/zmk/hid_usage.h>
+#include <dt-bindings/zmk/hid_usage_pages.h>
 
 #define COLLECTION_REPORT 0x03
 
@@ -20,19 +22,19 @@
 static const u8_t zmk_hid_report_desc[] = {
     /* USAGE_PAGE (Generic Desktop) */
     HID_GI_USAGE_PAGE,
-    USAGE_GEN_DESKTOP,
+    HID_USAGE_GD,
     /* USAGE (Keyboard) */
     HID_LI_USAGE,
-    USAGE_GEN_DESKTOP_KEYBOARD,
+    HID_USAGE_GD_KEYBOARD,
     /* COLLECTION (Application) */
     HID_MI_COLLECTION,
     COLLECTION_APPLICATION,
     /* REPORT ID (1) */
     HID_GI_REPORT_ID,
     0x01,
-    /* USAGE_PAGE (Keypad) */
+    /* USAGE_PAGE (Keyboard/Keypad) */
     HID_GI_USAGE_PAGE,
-    USAGE_GEN_DESKTOP_KEYPAD,
+    HID_USAGE_KEY,
     /* USAGE_MINIMUM (Keyboard LeftControl) */
     HID_LI_USAGE_MIN(1),
     0xE0,
@@ -56,9 +58,9 @@ static const u8_t zmk_hid_report_desc[] = {
     HID_MI_INPUT,
     0x02,
 
-    /* USAGE_PAGE (Keypad) */
+    /* USAGE_PAGE (Keyboard/Keypad) */
     HID_GI_USAGE_PAGE,
-    USAGE_GEN_DESKTOP_KEYPAD,
+    HID_USAGE_KEY,
     /* REPORT_SIZE (8) */
     HID_GI_REPORT_SIZE,
     0x08,
@@ -69,9 +71,9 @@ static const u8_t zmk_hid_report_desc[] = {
     HID_MI_INPUT,
     0x03,
 
-    /* USAGE_PAGE (Keypad) */
+    /* USAGE_PAGE (Keyboard/Keypad) */
     HID_GI_USAGE_PAGE,
-    USAGE_GEN_DESKTOP_KEYPAD,
+    HID_USAGE_KEY,
     /* LOGICAL_MINIMUM (0) */
     HID_GI_LOGICAL_MIN(1),
     0x00,
@@ -98,7 +100,7 @@ static const u8_t zmk_hid_report_desc[] = {
     HID_MI_COLLECTION_END,
     /* USAGE_PAGE (Consumer) */
     HID_GI_USAGE_PAGE,
-    0x0C,
+    HID_USAGE_CONSUMER,
     /* USAGE (Consumer Control) */
     HID_LI_USAGE,
     0x01,
@@ -110,7 +112,7 @@ static const u8_t zmk_hid_report_desc[] = {
     0x02,
     /* USAGE_PAGE (Consumer) */
     HID_GI_USAGE_PAGE,
-    0x0C,
+    HID_USAGE_CONSUMER,
     /* LOGICAL_MINIMUM (0) */
     HID_GI_LOGICAL_MIN(1),
     0x00,

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -429,7 +429,8 @@ static int position_state_changed_listener(const struct zmk_event_header *eh) {
 }
 
 static inline bool only_mods(struct keycode_state_changed *ev) {
-    return ev->usage_page == HID_USAGE_KEY && ev->keycode >= LCTL && ev->keycode <= RGUI;
+    return ev->usage_page == HID_USAGE_KEY && ev->keycode >= LEFT_CONTROL &&
+           ev->keycode <= RIGHT_GUI;
 }
 
 static int keycode_state_changed_listener(const struct zmk_event_header *eh) {

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -9,6 +9,7 @@
 #include <device.h>
 #include <drivers/behavior.h>
 #include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/hid_usage_pages.h>
 #include <logging/log.h>
 #include <zmk/behavior.h>
 #include <zmk/matrix.h>
@@ -428,7 +429,7 @@ static int position_state_changed_listener(const struct zmk_event_header *eh) {
 }
 
 static inline bool only_mods(struct keycode_state_changed *ev) {
-    return ev->usage_page == USAGE_KEYPAD && ev->keycode >= LCTL && ev->keycode <= RGUI;
+    return ev->usage_page == HID_USAGE_KEY && ev->keycode >= LCTL && ev->keycode <= RGUI;
 }
 
 static int keycode_state_changed_listener(const struct zmk_event_header *eh) {

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -572,11 +572,11 @@ bool zmk_ble_handle_key_user(struct zmk_key_event *key_event) {
         return true;
     }
 
-    if (key < NUM_1 || key > NUM_0) {
+    if (key < NUMBER_1 || key > NUMBER_0) {
         return true;
     }
 
-    u32_t val = (key == NUM_0) ? 0 : (key - NUM_1 + 1);
+    u32_t val = (key == NUMBER_0) ? 0 : (key - NUMBER_1 + 1);
 
     passkey_entries[passkey_digit++] = val;
 

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -10,6 +10,7 @@
 #include <zmk/ble.h>
 #include <zmk/endpoints.h>
 #include <zmk/hid.h>
+#include <dt-bindings/zmk/hid_usage_pages.h>
 #include <zmk/usb.h>
 #include <zmk/hog.h>
 #include <zmk/event-manager.h>
@@ -116,9 +117,9 @@ int zmk_endpoints_send_report(u8_t usage_page) {
 
     LOG_DBG("usage page 0x%02X", usage_page);
     switch (usage_page) {
-    case USAGE_KEYPAD:
+    case HID_USAGE_KEY:
         return send_keypad_report();
-    case USAGE_CONSUMER:
+    case HID_USAGE_CONSUMER:
         return send_consumer_report();
     default:
         LOG_ERR("Unsupported usage page %d", usage_page);
@@ -209,8 +210,8 @@ static void disconnect_current_endpoint() {
     zmk_hid_keypad_clear();
     zmk_hid_consumer_clear();
 
-    zmk_endpoints_send_report(USAGE_KEYPAD);
-    zmk_endpoints_send_report(USAGE_CONSUMER);
+    zmk_endpoints_send_report(HID_USAGE_KEY);
+    zmk_endpoints_send_report(HID_USAGE_CONSUMER);
 }
 
 static void update_current_endpoint() {

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -78,16 +78,16 @@ int zmk_hid_implicit_modifiers_release() {
 }
 
 int zmk_hid_keypad_press(zmk_key code) {
-    if (code >= LCTL && code <= RGUI) {
-        return zmk_hid_register_mod(code - LCTL);
+    if (code >= LEFT_CONTROL && code <= RIGHT_GUI) {
+        return zmk_hid_register_mod(code - LEFT_CONTROL);
     }
     TOGGLE_KEYPAD(0U, code);
     return 0;
 };
 
 int zmk_hid_keypad_release(zmk_key code) {
-    if (code >= LCTL && code <= RGUI) {
-        return zmk_hid_unregister_mod(code - LCTL);
+    if (code >= LEFT_CONTROL && code <= RIGHT_GUI) {
+        return zmk_hid_unregister_mod(code - LEFT_CONTROL);
     }
     TOGGLE_KEYPAD(code, 0U);
     return 0;

--- a/app/src/hid_listener.c
+++ b/app/src/hid_listener.c
@@ -13,6 +13,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/events/keycode-state-changed.h>
 #include <zmk/events/modifiers-state-changed.h>
 #include <zmk/hid.h>
+#include <dt-bindings/zmk/hid_usage_pages.h>
 #include <zmk/endpoints.h>
 
 static int hid_listener_keycode_pressed(u8_t usage_page, u32_t keycode,
@@ -21,14 +22,14 @@ static int hid_listener_keycode_pressed(u8_t usage_page, u32_t keycode,
     LOG_DBG("usage_page 0x%02X keycode 0x%02X mods 0x%02X", usage_page, keycode,
             implicit_modifiers);
     switch (usage_page) {
-    case USAGE_KEYPAD:
+    case HID_USAGE_KEY:
         err = zmk_hid_keypad_press(keycode);
         if (err) {
             LOG_ERR("Unable to press keycode");
             return err;
         }
         break;
-    case USAGE_CONSUMER:
+    case HID_USAGE_CONSUMER:
         err = zmk_hid_consumer_press(keycode);
         if (err) {
             LOG_ERR("Unable to press keycode");
@@ -46,14 +47,14 @@ static int hid_listener_keycode_released(u8_t usage_page, u32_t keycode,
     LOG_DBG("usage_page 0x%02X keycode 0x%02X mods 0x%02X", usage_page, keycode,
             implicit_modifiers);
     switch (usage_page) {
-    case USAGE_KEYPAD:
+    case HID_USAGE_KEY:
         err = zmk_hid_keypad_release(keycode);
         if (err) {
             LOG_ERR("Unable to release keycode");
             return err;
         }
         break;
-    case USAGE_CONSUMER:
+    case HID_USAGE_CONSUMER:
         err = zmk_hid_consumer_release(keycode);
         if (err) {
             LOG_ERR("Unable to release keycode");

--- a/app/tests/hold-tap/balanced/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/balanced/behavior_keymap.dtsi
@@ -20,8 +20,8 @@
 
 		default_layer {
 			bindings = <
-				&ht_bal LSFT F &ht_bal LCTL J
-				&kp D &kp RCTL>;
+				&ht_bal LEFT_SHIFT F &ht_bal LEFT_CONTROL J
+				&kp D &kp RIGHT_CONTROL>;
 		};
 	};
 };

--- a/app/tests/hold-tap/balanced/many-nested/native_posix.keymap
+++ b/app/tests/hold-tap/balanced/many-nested/native_posix.keymap
@@ -20,8 +20,8 @@
 
 		default_layer {
 			bindings = <
-				&ht_bal LSFT F &ht_bal LCTL J 
-				&ht_bal LGUI H &ht_bal LALT L
+				&ht_bal LEFT_SHIFT F &ht_bal LEFT_CONTROL J 
+				&ht_bal LEFT_GUI H &ht_bal LEFT_ALT L
 			>;
 		};
 	};

--- a/app/tests/hold-tap/hold-preferred/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/hold-preferred/behavior_keymap.dtsi
@@ -22,8 +22,8 @@
 
 		default_layer {
 			bindings = <
-				&ht_hold LSFT F &ht_hold LCTL J
-				&kp D &kp RCTL>;
+				&ht_hold LEFT_SHIFT F &ht_hold LEFT_CONTROL J
+				&kp D &kp RIGHT_CONTROL>;
 		};
 	};
 };

--- a/app/tests/hold-tap/tap-preferred/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-preferred/behavior_keymap.dtsi
@@ -20,8 +20,8 @@
 
 		default_layer {
 			bindings = <
-				&tp LSFT F &tp LCTL J
-				&kp D &kp RCTL>;
+				&tp LEFT_SHIFT F &tp LEFT_CONTROL J
+				&kp D &kp RIGHT_CONTROL>;
 		};
 	};
 };

--- a/app/tests/keypress/behavior_keymap.dtsi
+++ b/app/tests/keypress/behavior_keymap.dtsi
@@ -10,7 +10,7 @@
 		default_layer {
 			bindings = <
 				&kp B &none
-				&cp M_NEXT &none>;
+				&cp C_NEXT &none>;
 		};
 	};
 };

--- a/app/tests/modifiers/explicit/kp-lctl-dn-lctl-dn-lctl-up-lctl-up/native_posix.keymap
+++ b/app/tests/modifiers/explicit/kp-lctl-dn-lctl-dn-lctl-up-lctl-up/native_posix.keymap
@@ -19,8 +19,8 @@
 
 		default_layer {
 			bindings = <
-				&kp LCTL &kp LCTL
-				&kp LSFT &none
+				&kp LEFT_CONTROL &kp LEFT_CONTROL
+				&kp LEFT_SHIFT &none
 			>;
 		};
 	};

--- a/app/tests/modifiers/explicit/kp-lctl-dn-lctl-up/native_posix.keymap
+++ b/app/tests/modifiers/explicit/kp-lctl-dn-lctl-up/native_posix.keymap
@@ -17,8 +17,8 @@
 
 		default_layer {
 			bindings = <
-				&kp LCTL &kp LCTL
-				&kp LSFT &none
+				&kp LEFT_CONTROL &kp LEFT_CONTROL
+				&kp LEFT_SHIFT &none
 			>;
 		};
 	};

--- a/app/tests/modifiers/explicit/kp-lctl-dn-lsft-dn-lctl-up-lsft-up/native_posix.keymap
+++ b/app/tests/modifiers/explicit/kp-lctl-dn-lsft-dn-lctl-up-lsft-up/native_posix.keymap
@@ -19,8 +19,8 @@
 
 		default_layer {
 			bindings = <
-				&kp LCTL &kp LCTL
-				&kp LSFT &none
+				&kp LEFT_CONTROL &kp LEFT_CONTROL
+				&kp LEFT_SHIFT &none
 			>;
 		};
 	};

--- a/app/tests/modifiers/explicit/kp-lctl-dn-lsft-dn-lsft-up-lctl-up/native_posix.keymap
+++ b/app/tests/modifiers/explicit/kp-lctl-dn-lsft-dn-lsft-up-lctl-up/native_posix.keymap
@@ -20,8 +20,8 @@
 
 		default_layer {
 			bindings = <
-				&kp LCTL &kp LCTL
-				&kp LSFT &none
+				&kp LEFT_CONTROL &kp LEFT_CONTROL
+				&kp LEFT_SHIFT &none
 			>;
 		};
 	};

--- a/app/tests/modifiers/implicit/kp-mod1-dn-mod2-dn-mod1-up-mod2-up/native_posix.keymap
+++ b/app/tests/modifiers/implicit/kp-mod1-dn-mod2-dn-mod1-up-mod2-up/native_posix.keymap
@@ -20,7 +20,7 @@
 		default_layer {
 			bindings = <
 				&kp LC(A) &kp LS(B)
-				&kp LCTL &none
+				&kp LEFT_CONTROL &none
 			>;
 		};
 	};

--- a/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-lctl-up-mod-up/native_posix.keymap
+++ b/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-lctl-up-mod-up/native_posix.keymap
@@ -20,7 +20,7 @@
 		default_layer {
 			bindings = <
 				&kp LC(A) &kp LS(B)
-				&kp LCTL &none
+				&kp LEFT_CONTROL &none
 			>;
 		};
 	};

--- a/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-mod-up-lctl-up/native_posix.keymap
+++ b/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-mod-up-lctl-up/native_posix.keymap
@@ -20,7 +20,7 @@
 		default_layer {
 			bindings = <
 				&kp LC(A) &kp LS(B)
-				&kp LCTL &none
+				&kp LEFT_CONTROL &none
 			>;
 		};
 	};

--- a/app/tests/momentary-layer/behavior_keymap.dtsi
+++ b/app/tests/momentary-layer/behavior_keymap.dtsi
@@ -15,7 +15,7 @@
 
 		lower_layer {
 			bindings = <
-				&cp M_NEXT &trans
+				&cp C_NEXT &trans
 				&kp L  &kp J>;
 		};
 

--- a/app/tests/toggle-layer/behavior_keymap.dtsi
+++ b/app/tests/toggle-layer/behavior_keymap.dtsi
@@ -15,7 +15,7 @@
 
 		lower_layer {
 			bindings = <
-				&cp M_NEXT &trans
+				&cp C_NEXT &trans
 				&kp L  &kp J>;
 		};
 

--- a/docs/docs/behavior/hold-tap.md
+++ b/docs/docs/behavior/hold-tap.md
@@ -52,7 +52,7 @@ A code example which configures a mod-tap setting that works with homerow mods:
 
 		default_layer {
 			bindings = <
-	            &hm LCTL A &hm LGUI S &hm LALT D &hm LSFT F
+	            &hm LCTRL A &hm LGUI S &hm LALT D &hm LSHFT F
 			>;
 		};
 	};

--- a/docs/docs/behavior/key-press.md
+++ b/docs/docs/behavior/key-press.md
@@ -53,15 +53,15 @@ The "consumer key press" behavior allows you to send "consumer" usage page keyco
 These are mostly used for media and power related keycodes, such as sending "Pause", "Scan Track Next",
 "Scan Track Previous", etc.
 
-There are a subset of the full consumer usage IDs found in the `keys.h` include, prefixed with `M_`, e.g. `M_PREV`.
+There are a subset of the full consumer usage IDs found in the `keys.h` include, prefixed with `C_`, e.g. `C_PREV`.
 
 ### Behavior Binding
 
 - Reference: `&cp`
-- Parameter: The keycode usage ID from the consumer usage page, e.g. `M_PREV` or `M_EJCT`
+- Parameter: The keycode usage ID from the consumer usage page, e.g. `C_PREV` or `C_EJECT`
 
 Example:
 
 ```
-&cp M_PREV
+&cp C_PREV
 ```

--- a/docs/docs/behavior/layers.md
+++ b/docs/docs/behavior/layers.md
@@ -54,7 +54,7 @@ The "layer-tap" behavior enables a layer when a key is held, and output another 
 Example:
 
 ```
-&lt LOWER SPC
+&lt LOWER SPACE
 ```
 
 ## Toggle Layer
@@ -86,21 +86,21 @@ Example:
 
 		default_layer {
 			bindings = <
-                &tog NAVI &kp KDIV  &kp KMLT  &kp KMIN
-                &kp NUM_7 &kp NUM_8 &kp NUM_9 &kp KPLS
-                &kp NUM_4 &kp NUM_5 &kp NUM_6 &kp KPLS
-                &kp NUM_1 &kp NUM_2 &kp NUM_3 &kp RET
-                &kp NUM_0 &kp NUM_0 &kp DOT   &kp RET
+                &tog NAVI &kp KP_DIVIDE  &kp KP_MULTIPLY  &kp KP_MINUS
+                &kp NUMBER_7 &kp NUMBER_8 &kp NUMBER_9 &kp KP_PLUS
+                &kp NUMBER_4 &kp NUMBER_5 &kp NUMBER_6 &kp KP_PLUS
+                &kp NUMBER_1 &kp NUMBER_2 &kp NUMBER_3 &kp RETURN
+                &kp NUMBER_0 &kp NUMBER_0 &kp DOT   &kp RETURN
 			>;
 		};
 
 		nav_layer {
 			bindings = <
-                &tog NAVI &kp KDIV  &kp KMLT  &kp KMIN
-                &kp HOME  &kp UARW  &kp PGUP  &kp KPLS
-                &kp LARW  &none     &kp RARW  &kp KPLS
-                &kp END   &kp DARW  &kp PGDN  &kp RET
-                &kp INS   &kp INS   &kp DEL   &kp RET
+                &tog NAVI &kp KP_DIVIDE  &kp KP_MULTIPLY  &kp KP_MINUS
+                &kp HOME  &kp UP  &kp PAGE_UP  &kp KP_PLUS
+                &kp LEFT  &none     &kp RIGHT  &kp KP_PLUS
+                &kp END   &kp DOWN  &kp PAGE_DOWN  &kp RETURN
+                &kp INSERT   &kp INSERT   &kp DEL   &kp RETURN
             >;
 		};
 	};

--- a/docs/docs/behavior/layers.md
+++ b/docs/docs/behavior/layers.md
@@ -86,21 +86,21 @@ Example:
 
 		default_layer {
 			bindings = <
-                &tog NAVI &kp KP_DIVIDE  &kp KP_MULTIPLY  &kp KP_MINUS
-                &kp NUMBER_7 &kp NUMBER_8 &kp NUMBER_9 &kp KP_PLUS
-                &kp NUMBER_4 &kp NUMBER_5 &kp NUMBER_6 &kp KP_PLUS
-                &kp NUMBER_1 &kp NUMBER_2 &kp NUMBER_3 &kp RETURN
-                &kp NUMBER_0 &kp NUMBER_0 &kp DOT   &kp RETURN
+                &tog NAVI       &kp KP_DIVIDE   &kp KP_MULTIPLY &kp KP_MINUS
+                &kp NUMBER_7    &kp NUMBER_8    &kp NUMBER_9    &kp KP_PLUS
+                &kp NUMBER_4    &kp NUMBER_5    &kp NUMBER_6    &kp KP_PLUS
+                &kp NUMBER_1    &kp NUMBER_2    &kp NUMBER_3    &kp RETURN
+                &kp NUMBER_0    &kp NUMBER_0    &kp DOT         &kp RETURN
 			>;
 		};
 
 		nav_layer {
 			bindings = <
-                &tog NAVI &kp KP_DIVIDE  &kp KP_MULTIPLY  &kp KP_MINUS
-                &kp HOME  &kp UP  &kp PAGE_UP  &kp KP_PLUS
-                &kp LEFT  &none     &kp RIGHT  &kp KP_PLUS
-                &kp END   &kp DOWN  &kp PAGE_DOWN  &kp RETURN
-                &kp INSERT   &kp INSERT   &kp DEL   &kp RETURN
+                &tog NAVI       &kp KP_DIVIDE   &kp KP_MULTIPLY &kp KP_MINUS
+                &kp HOME        &kp UP          &kp PAGE_UP     &kp KP_PLUS
+                &kp LEFT        &none           &kp RIGHT       &kp KP_PLUS
+                &kp END         &kp DOWN        &kp PAGE_DOWN   &kp RETURN
+                &kp INSERT      &kp INSERT      &kp DEL         &kp RETURN
             >;
 		};
 	};

--- a/docs/docs/behavior/mod-tap.md
+++ b/docs/docs/behavior/mod-tap.md
@@ -16,13 +16,13 @@ The Mod-Tap behavior either acts as a held modifier, or as a tapped keycode.
 ### Behavior Binding
 
 - Reference: `&mt`
-- Parameter #1: The keycode to be sent when activating as a modifier, e.g. `LSFT`
+- Parameter #1: The keycode to be sent when activating as a modifier, e.g. `LSHFT`
 - Parameter #2: The keycode to sent when used as a tap, e.g. `A`, `B`.
 
 Example:
 
 ```
-&mt LSFT A
+&mt LSHFT A
 ```
 
 ### Configuration

--- a/docs/docs/dev-guide-new-shield.md
+++ b/docs/docs/dev-guide-new-shield.md
@@ -365,16 +365,16 @@ Here is an example simple keymap for the Kyria, with only one layer:
 		compatible = "zmk,keymap";
 
 		default_layer {
-// ---------------------------------------------------------------------------------------------------------------------------------
-// |  ESC  |  Q  |  W  |  E   |  R   |  T   |                                          |  Y   |  U    |  I    |  O   |   P   |   \  |
-// |  TAB  |  A  |  S  |  D   |  F   |  G   |                                          |  H   |  J    |  K    |  L   |   ;   |   '  |
-// | SHIFT |  Z  |  X  |  C   |  V   |  B   | L SHIFT | L SHIFT |  | L SHIFT | L SHIFT |  N   |  M    |  ,    |  .   |   /   | CTRL |
-//                     | GUI  | DEL  | RET  |  SPACE  |   ESC   |  |   RET   |  SPACE  | TAB  | BSPC  | R-ALT |
+// --------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// |   ESC   |    Q    |    W    |    E    |    R    |    T    |                                          |    Y    |    U    |    I    |    O    |    P    |    \    |
+// |   TAB   |    A    |    S    |    D    |    F    |    G    |                                          |    H    |    J    |    K    |    L    |    ;    |    '    |
+// |  SHIFT  |    Z    |    X    |    C    |    V    |    B    | L SHIFT | L SHIFT |  | L SHIFT | L SHIFT |    N    |    M    |    ,    |    .    |    /    |  R CTRL |
+//                               |   GUI   |   DEL   | RETURN  |  SPACE  | ESCAPE  |  |  RETURN |  SPACE  |   TAB   |   BSPC  |  R ALT  |
 			bindings = <
-	&kp ESC  &kp Q &kp W &kp E &kp R &kp T                                            &kp Y &kp U  &kp I    &kp O   &kp P    &kp BSLH
-	&kp TAB  &kp A &kp S &kp D &kp F &kp G                                            &kp H &kp J  &kp K    &kp L   &kp SEMI &kp QUOTE
-	&kp LSHFT &kp Z &kp X &kp C &kp V &kp B &kp LSHFT &kp LSHFT        &kp LSHFT &kp LSHFT &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp RCTRL
-	              &kp LGUI &kp DEL &kp RET &kp SPACE &kp ESC            &kp RET  &kp SPACE  &kp TAB &kp BSPC &kp RALT
+    &kp ESC   &kp Q     &kp W    &kp E     &kp R     &kp T                                                 &kp Y     &kp U     &kp I     &kp O     &kp P    &kp BSLH
+    &kp TAB   &kp A     &kp S    &kp D     &kp F     &kp G                                                 &kp H     &kp J     &kp K     &kp L     &kp SEMI &kp QUOTE
+    &kp LSHFT &kp Z     &kp X    &kp C     &kp V     &kp B      &kp LSHFT &kp LSHFT    &kp LSHFT &kp LSHFT &kp N     &kp M     &kp COMMA &kp DOT   &kp FSLH &kp RCTRL
+                                 &kp LGUI  &kp DEL   &kp RET    &kp SPACE &kp ESC      &kp RET   &kp SPACE &kp TAB   &kp BSPC  &kp RALT
 			>;
 
 			sensor-bindings = <&inc_dec_cp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;

--- a/docs/docs/dev-guide-new-shield.md
+++ b/docs/docs/dev-guide-new-shield.md
@@ -372,12 +372,12 @@ Here is an example simple keymap for the Kyria, with only one layer:
 //                     | GUI  | DEL  | RET  |  SPACE  |   ESC   |  |   RET   |  SPACE  | TAB  | BSPC  | R-ALT |
 			bindings = <
 	&kp ESC  &kp Q &kp W &kp E &kp R &kp T                                            &kp Y &kp U  &kp I    &kp O   &kp P    &kp BSLH
-	&kp TAB  &kp A &kp S &kp D &kp F &kp G                                            &kp H &kp J  &kp K    &kp L   &kp SCLN &kp QUOT
-	&kp LSFT &kp Z &kp X &kp C &kp V &kp B &kp LSFT &kp LSFT        &kp LSFT &kp LSFT &kp N &kp M  &kp CMMA &kp DOT &kp FSLH &kp RCTL
-	              &kp LGUI &kp DEL &kp RET &kp SPC &kp ESC            &kp RET  &kp SPC  &kp TAB &kp BKSP &kp RALT
+	&kp TAB  &kp A &kp S &kp D &kp F &kp G                                            &kp H &kp J  &kp K    &kp L   &kp SEMI &kp QUOTE
+	&kp LSHFT &kp Z &kp X &kp C &kp V &kp B &kp LSHFT &kp LSHFT        &kp LSHFT &kp LSHFT &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp RCTRL
+	              &kp LGUI &kp DEL &kp RET &kp SPACE &kp ESC            &kp RET  &kp SPACE  &kp TAB &kp BSPC &kp RALT
 			>;
 
-			sensor-bindings = <&inc_dec_cp M_VOLU M_VOLD &inc_dec_kp PGUP PGDN>;
+			sensor-bindings = <&inc_dec_cp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
 		};
 	};
 };
@@ -385,7 +385,7 @@ Here is an example simple keymap for the Kyria, with only one layer:
 ```
 
 :::note
-The two `#include` lines at the top of the keymap are required in order to bring in the default set of behaviors to make them available to bind, and to import a set of defines for the HID keycodes, so keymaps can use parameters like `NUM_2` or `K` instead of the raw keycode numeric values.
+The two `#include` lines at the top of the keymap are required in order to bring in the default set of behaviors to make them available to bind, and to import a set of defines for the HID keycodes, so keymaps can use parameters like `N2` or `K` instead of the raw keycode numeric values.
 :::
 
 ### Keymap Behaviors
@@ -476,7 +476,7 @@ For split keyboards, make sure to add left hand encoders to the left .overlay fi
 Add the following line to your keymap file to add default encoder behavior bindings:
 
 ```
-sensor-bindings = <&inc_dec_cp M_VOLU M_VOLD>;
+sensor-bindings = <&inc_dec_cp C_VOL_UP C_VOL_DN>;
 ```
 
 Add additional bindings as necessary to match the default number of encoders on your board. See the [Encoders](/docs/feature/encoders) and [Keymap](/docs/feature/keymaps) feature documentation for more details.

--- a/docs/docs/feature/encoders.md
+++ b/docs/docs/feature/encoders.md
@@ -34,7 +34,7 @@ Additional encoders can be configured by adding more `BINDING CW_KEY CCW_KEY` se
 As an example, a complete `sensor-bindings` for a Kyria with two encoders could look like:
 
 ```
-sensor-bindings = <&inc_dec_cp M_VOLU M_VOLD &inc_dec_kp PGUP PGDN>;
+sensor-bindings = <&inc_dec_cp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
 ```
 
 Here, the left encoder is configured to control volume up and down while the right encoder sends either Page Up or Page Down.

--- a/docs/docs/feature/keymaps.md
+++ b/docs/docs/feature/keymaps.md
@@ -127,16 +127,16 @@ that defines just one layer for this keymap:
 		compatible = "zmk,keymap";
 
 		default_layer {
-// ---------------------------------------------------------------------------------------------------------------------------------
-// |  ESC  |  Q  |  W  |  E   |  R   |  T   |                                          |  Y   |  U    |  I    |  O   |   P   |   \  |
-// |  TAB  |  A  |  S  |  D   |  F   |  G   |                                          |  H   |  J    |  K    |  L   |   ;   |   '  |
-// | SHIFT |  Z  |  X  |  C   |  V   |  B   | L SHIFT | L SHIFT |  | L SHIFT | L SHIFT |  N   |  M    |  ,    |  .   |   /   | CTRL |
-//                     | GUI  | DEL  | RET  |  SPACE  |   ESC   |  |   RET   |  SPACE  | TAB  | BSPC  | R-ALT |
+// --------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// |   ESC   |    Q    |    W    |    E    |    R    |    T    |                                          |    Y    |    U    |    I    |    O    |    P    |    \    |
+// |   TAB   |    A    |    S    |    D    |    F    |    G    |                                          |    H    |    J    |    K    |    L    |    ;    |    '    |
+// |  SHIFT  |    Z    |    X    |    C    |    V    |    B    | L SHIFT | L SHIFT |  | L SHIFT | L SHIFT |    N    |    M    |    ,    |    .    |    /    |  R CTRL |
+//                               |   GUI   |   DEL   | RETURN  |  SPACE  | ESCAPE  |  |  RETURN |  SPACE  |   TAB   |   BSPC  |  R ALT  |
 			bindings = <
-	&kp ESC  &kp Q &kp W &kp E &kp R &kp T                                            &kp Y &kp U  &kp I    &kp O   &kp P    &kp BSLH
-	&kp TAB  &kp A &kp S &kp D &kp F &kp G                                            &kp H &kp J  &kp K    &kp L   &kp SEMI &kp QUOTE
-	&kp LSHFT &kp Z &kp X &kp C &kp V &kp B &kp LSHFT &kp LSHFT        &kp LSHFT &kp LSHFT &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp RCTRL
-	              &kp LGUI &kp DEL &kp RET &kp SPACE &kp ESC            &kp RET  &kp SPACE  &kp TAB &kp BSPC &kp RALT
+    &kp ESC   &kp Q     &kp W    &kp E     &kp R     &kp T                                                 &kp Y     &kp U     &kp I     &kp O     &kp P    &kp BSLH
+    &kp TAB   &kp A     &kp S    &kp D     &kp F     &kp G                                                 &kp H     &kp J     &kp K     &kp L     &kp SEMI &kp QUOTE
+    &kp LSHFT &kp Z     &kp X    &kp C     &kp V     &kp B      &kp LSHFT &kp LSHFT    &kp LSHFT &kp LSHFT &kp N     &kp M     &kp COMMA &kp DOT   &kp FSLH &kp RCTRL
+                                 &kp LGUI  &kp DEL   &kp RET    &kp SPACE &kp ESC      &kp RET   &kp SPACE &kp TAB   &kp BSPC  &kp RALT
 			>;
 
 			sensor-bindings = <&inc_dec_cp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
@@ -164,16 +164,16 @@ Putting this all together, a complete [`kyria.keymap`](https://github.com/zmkfir
 		compatible = "zmk,keymap";
 
 		default_layer {
-// ---------------------------------------------------------------------------------------------------------------------------------
-// |  ESC  |  Q  |  W  |  E   |  R   |  T   |                                          |  Y   |  U    |  I    |  O   |   P   |   \  |
-// |  TAB  |  A  |  S  |  D   |  F   |  G   |                                          |  H   |  J    |  K    |  L   |   ;   |   '  |
-// | SHIFT |  Z  |  X  |  C   |  V   |  B   | L SHIFT | L SHIFT |  | L SHIFT | L SHIFT |  N   |  M    |  ,    |  .   |   /   | CTRL |
-//                     | GUI  | DEL  | RET  |  SPACE  |   ESC   |  |   RET   |  SPACE  | TAB  | BSPC  | R-ALT |
+// --------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// |   ESC   |    Q    |    W    |    E    |    R    |    T    |                                          |    Y    |    U    |    I    |    O    |    P    |    \    |
+// |   TAB   |    A    |    S    |    D    |    F    |    G    |                                          |    H    |    J    |    K    |    L    |    ;    |    '    |
+// |  SHIFT  |    Z    |    X    |    C    |    V    |    B    | L SHIFT | L SHIFT |  | L SHIFT | L SHIFT |    N    |    M    |    ,    |    .    |    /    |  R CTRL |
+//                               |   GUI   |   DEL   | RETURN  |  SPACE  | ESCAPE  |  |  RETURN |  SPACE  |   TAB   |   BSPC  |  R ALT  |
 			bindings = <
-	&kp ESC  &kp Q &kp W &kp E &kp R &kp T                                            &kp Y &kp U  &kp I    &kp O   &kp P    &kp BSLH
-	&kp TAB  &kp A &kp S &kp D &kp F &kp G                                            &kp H &kp J  &kp K    &kp L   &kp SEMI &kp QUOTE
-	&kp LSHFT &kp Z &kp X &kp C &kp V &kp B &kp LSHFT &kp LSHFT        &kp LSHFT &kp LSHFT &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp RCTRL
-	              &kp LGUI &kp DEL &kp RET &kp SPACE &kp ESC            &kp RET  &kp SPACE  &kp TAB &kp BSPC &kp RALT
+    &kp ESC   &kp Q     &kp W    &kp E     &kp R     &kp T                                                 &kp Y     &kp U     &kp I     &kp O     &kp P    &kp BSLH
+    &kp TAB   &kp A     &kp S    &kp D     &kp F     &kp G                                                 &kp H     &kp J     &kp K     &kp L     &kp SEMI &kp QUOTE
+    &kp LSHFT &kp Z     &kp X    &kp C     &kp V     &kp B      &kp LSHFT &kp LSHFT    &kp LSHFT &kp LSHFT &kp N     &kp M     &kp COMMA &kp DOT   &kp FSLH &kp RCTRL
+                                 &kp LGUI  &kp DEL   &kp RET    &kp SPACE &kp ESC      &kp RET   &kp SPACE &kp TAB   &kp BSPC  &kp RALT
 			>;
 
 			sensor-bindings = <&inc_dec_cp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;

--- a/docs/docs/feature/keymaps.md
+++ b/docs/docs/feature/keymaps.md
@@ -68,7 +68,7 @@ In this case, the `A` is actually a define for the raw HID keycode, to make keym
 For example of a binding that uses two parameters, you can see how "mod-tap" (`mt`) is bound:
 
 ```
-&mt LSFT D
+&mt LSHFT D
 ```
 
 Here, the first parameter is the set of modifiers that should be used for the "hold" behavior, and the second
@@ -92,7 +92,7 @@ The top two lines of most keymaps should include:
 
 The first defines the nodes for all the available behaviors in ZMK, which will be referenced in the behavior bindings. This is how bindings like `&kp` can reference the key press behavior defined with an anchor name of `kp`.
 
-The second include brings in the defines for all the keycodes (e.g. `A`, `NUM_1`, `M_PLAY`) and the modifiers (e.g. `LSFT`) used for various behavior bindings.
+The second include brings in the defines for all the keycodes (e.g. `A`, `N1`, `C_PLAY`) and the modifiers (e.g. `LSHFT`) used for various behavior bindings.
 
 ### Root devicetree Node
 
@@ -134,14 +134,14 @@ that defines just one layer for this keymap:
 //                     | GUI  | DEL  | RET  |  SPACE  |   ESC   |  |   RET   |  SPACE  | TAB  | BSPC  | R-ALT |
 			bindings = <
 	&kp ESC  &kp Q &kp W &kp E &kp R &kp T                                            &kp Y &kp U  &kp I    &kp O   &kp P    &kp BSLH
-	&kp TAB  &kp A &kp S &kp D &kp F &kp G                                            &kp H &kp J  &kp K    &kp L   &kp SCLN &kp QUOT
-	&kp LSFT &kp Z &kp X &kp C &kp V &kp B &kp LSFT &kp LSFT        &kp LSFT &kp LSFT &kp N &kp M  &kp CMMA &kp DOT &kp FSLH &kp RCTL
-	              &kp LGUI &kp DEL &kp RET &kp SPC &kp ESC            &kp RET  &kp SPC  &kp TAB &kp BKSP &kp RALT
+	&kp TAB  &kp A &kp S &kp D &kp F &kp G                                            &kp H &kp J  &kp K    &kp L   &kp SEMI &kp QUOTE
+	&kp LSHFT &kp Z &kp X &kp C &kp V &kp B &kp LSHFT &kp LSHFT        &kp LSHFT &kp LSHFT &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp RCTRL
+	              &kp LGUI &kp DEL &kp RET &kp SPACE &kp ESC            &kp RET  &kp SPACE  &kp TAB &kp BSPC &kp RALT
 			>;
 
-			sensor-bindings = <&inc_dec_cp M_VOLU M_VOLD &inc_dec_kp PGUP PGDN>;
+			sensor-bindings = <&inc_dec_cp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
 		};
-    };
+	};
 ```
 
 Each layer should have:
@@ -171,12 +171,12 @@ Putting this all together, a complete [`kyria.keymap`](https://github.com/zmkfir
 //                     | GUI  | DEL  | RET  |  SPACE  |   ESC   |  |   RET   |  SPACE  | TAB  | BSPC  | R-ALT |
 			bindings = <
 	&kp ESC  &kp Q &kp W &kp E &kp R &kp T                                            &kp Y &kp U  &kp I    &kp O   &kp P    &kp BSLH
-	&kp TAB  &kp A &kp S &kp D &kp F &kp G                                            &kp H &kp J  &kp K    &kp L   &kp SCLN &kp QUOT
-	&kp LSFT &kp Z &kp X &kp C &kp V &kp B &kp LSFT &kp LSFT        &kp LSFT &kp LSFT &kp N &kp M  &kp CMMA &kp DOT &kp FSLH &kp RCTL
-	              &kp LGUI &kp DEL &kp RET &kp SPC &kp ESC            &kp RET  &kp SPC  &kp TAB &kp BKSP &kp RALT
+	&kp TAB  &kp A &kp S &kp D &kp F &kp G                                            &kp H &kp J  &kp K    &kp L   &kp SEMI &kp QUOTE
+	&kp LSHFT &kp Z &kp X &kp C &kp V &kp B &kp LSHFT &kp LSHFT        &kp LSHFT &kp LSHFT &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp RCTRL
+	              &kp LGUI &kp DEL &kp RET &kp SPACE &kp ESC            &kp RET  &kp SPACE  &kp TAB &kp BSPC &kp RALT
 			>;
 
-			sensor-bindings = <&inc_dec_cp M_VOLU M_VOLD &inc_dec_kp PGUP PGDN>;
+			sensor-bindings = <&inc_dec_cp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
 		};
 	};
 };

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -59,9 +59,9 @@ After opening the `<board>.dts.pre.tmp:<line number>` and scrolling down to the 
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | An incorrectly defined keymap unable to compile. As shown in red, `&kp SPAC` is not a valid reference to the [USB HID Usage ID](https://www.usb.org/document-library/hid-usage-tables-12) used for "Keyboard Spacebar" |
 
-|                                                                              ![Healthy Keymap Temp](../docs/assets/troubleshooting/keymaps/healthyEDIT.png)                                                                              |
-| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| A properly defined keymap with successful compilation. As shown in red, the corrected keycode (`&kp SPC`) references the proper Usage ID defined in the [USB HID Usage Tables](https://www.usb.org/document-library/hid-usage-tables-12) |
+|                                                                               ![Healthy Keymap Temp](../docs/assets/troubleshooting/keymaps/healthyEDIT.png)                                                                               |
+| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| A properly defined keymap with successful compilation. As shown in red, the corrected keycode (`&kp SPACE`) references the proper Usage ID defined in the [USB HID Usage Tables](https://www.usb.org/document-library/hid-usage-tables-12) |
 
 ### Split Keyboard Halves Unable to Pair
 


### PR DESCRIPTION
- Adds HID Usages for ZMK (#217).
- Standardizes key aliases/codes (#21 - still open for RFC).
- Enhances HID reports to take advantage of the new codes (#234).

### Issues
- Closes #217.
- Closes #21.
- Closes #234.
- Supersedes and closes #246.
- Supersedes and closes #158.
- Supersedes and closes #161.

### Testing
- End-to-end tests covering:
  - all key aliases
  - both the keyboard (keypad) and consumer HID reports
- ZMK on Nordic's nRF52840 Dongle.
  - `kscan-mock` running on dongle systematically pressed and released each key.
- Node scripts on Raspberry Pi (Raspbian Buster)
   - Scripts running on the Pi parsed events from `/dev/hidrawX` and `/dev/input/...` devices and compared incoming data against expected key usage codes.
   - Scripts not included in PR because end-to-end framework isn't generic enough and some of the code is my own.
- Test logs:
  - [e2e-2020-10-04T12-14-37-usb.log](https://github.com/zmkfirmware/zmk/files/5323138/e2e-2020-10-04T12-14-37-usb.log)
  - [e2e-2020-10-04T12-14-37-ble.log](https://github.com/zmkfirmware/zmk/files/5323139/e2e-2020-10-04T12-14-37-ble.log)
- Once HID reports were enhanced, usage codes themselves never caused any errors.
- Untested usage codes should also be viable for the future as everything was developed systematically via scripting.