### PR TITLE
Fix direct GPIO when using interrupts

### DIFF
--- a/app/drivers/zephyr/kscan_gpio_direct.c
+++ b/app/drivers/zephyr/kscan_gpio_direct.c
@@ -173,7 +173,7 @@ static const struct kscan_driver_api gpio_driver_api = {
 #define INST_INPUT_LEN(n) DT_INST_PROP_LEN(n, input_gpios)
 
 #define GPIO_INST_INIT(n)                                                                          \
-    COND_CODE_0(CONFIG_ZMK_KSCAN_DIRECT_POLLING,                                                   \
+    COND_CODE_0(IS_ENABLED(CONFIG_ZMK_KSCAN_DIRECT_POLLING),                                       \
                 (static struct kscan_gpio_irq_callback irq_callbacks_##n[INST_INPUT_LEN(n)];), ()) \
     static struct kscan_gpio_data kscan_gpio_data_##n = {                                          \
         .inputs = {[INST_INPUT_LEN(n) - 1] = NULL}};                                               \
@@ -195,7 +195,7 @@ static const struct kscan_driver_api gpio_driver_api = {
                 return err;                                                                        \
             }                                                                                      \
             COND_CODE_0(                                                                           \
-                CONFIG_ZMK_KSCAN_DIRECT_POLLING,                                                   \
+                IS_ENABLED(CONFIG_ZMK_KSCAN_DIRECT_POLLING),                                       \
                 (irq_callbacks_##n[i].work = &data->work;                                          \
                  irq_callbacks_##n[i].debounce_period = cfg->debounce_period;                      \
                  gpio_init_callback(&irq_callbacks_##n[i].callback,                                \
@@ -208,7 +208,7 @@ static const struct kscan_driver_api gpio_driver_api = {
                 ())                                                                                \
         }                                                                                          \
         data->dev = dev;                                                                           \
-        COND_CODE_1(CONFIG_ZMK_KSCAN_DIRECT_POLLING,                                               \
+        COND_CODE_1(IS_ENABLED(CONFIG_ZMK_KSCAN_DIRECT_POLLING),                                   \
                     (k_timer_init(&data->poll_timer, kscan_gpio_timer_handler, NULL);), ())        \
         if (cfg->debounce_period > 0) {                                                            \
             k_delayed_work_init(&data->work.delayed, kscan_gpio_work_handler);                     \

--- a/app/src/kscan_composite.c
+++ b/app/src/kscan_composite.c
@@ -38,8 +38,7 @@ struct kscan_composite_data {
 };
 
 static int kscan_composite_enable_callback(struct device *dev) {
-    for (int i = 0; i < sizeof(kscan_composite_children) / sizeof(kscan_composite_children[0]);
-         i++) {
+    for (int i = 0; i < ARRAY_SIZE(kscan_composite_children); i++) {
         const struct kscan_composite_child_config *cfg = &kscan_composite_children[i];
 
         kscan_enable_callback(device_get_binding(cfg->label));
@@ -48,8 +47,7 @@ static int kscan_composite_enable_callback(struct device *dev) {
 }
 
 static int kscan_composite_disable_callback(struct device *dev) {
-    for (int i = 0; i < sizeof(kscan_composite_children) / sizeof(kscan_composite_children[0]);
-         i++) {
+    for (int i = 0; i < ARRAY_SIZE(kscan_composite_children); i++) {
         const struct kscan_composite_child_config *cfg = &kscan_composite_children[i];
 
         kscan_disable_callback(device_get_binding(cfg->label));
@@ -63,8 +61,7 @@ static void kscan_composite_child_callback(struct device *child_dev, u32_t row, 
     struct device *dev = device_get_binding(DT_INST_LABEL(0));
     struct kscan_composite_data *data = dev->driver_data;
 
-    for (int i = 0; i < sizeof(kscan_composite_children) / sizeof(kscan_composite_children[0]);
-         i++) {
+    for (int i = 0; i < ARRAY_SIZE(kscan_composite_children); i++) {
         const struct kscan_composite_child_config *cfg = &kscan_composite_children[i];
 
         if (device_get_binding(cfg->label) != child_dev) {
@@ -82,8 +79,7 @@ static int kscan_composite_configure(struct device *dev, kscan_callback_t callba
         return -EINVAL;
     }
 
-    for (int i = 0; i < sizeof(kscan_composite_children) / sizeof(kscan_composite_children[0]);
-         i++) {
+    for (int i = 0; i < ARRAY_SIZE(kscan_composite_children); i++) {
         const struct kscan_composite_child_config *cfg = &kscan_composite_children[i];
 
         kscan_config(device_get_binding(cfg->label), &kscan_composite_child_callback);


### PR DESCRIPTION
The changes to kscan_composite.c are just a code improvement I noticed while debugging this code. I can split that out into a separate PR if you'd like.