### PR TITLE
changed bt behavior binding to select prev prof from BT_NXT to BT_PRV.

### DIFF
--- a/docs/docs/behavior/bluetooth.md
+++ b/docs/docs/behavior/bluetooth.md
@@ -66,7 +66,7 @@ The bluetooth behavior completes an bluetooth action given on press.
 1. Behavior binding to select the previous profile:
 
    ```
-   &bt BT_NXT
+   &bt BT_PRV
    ```
 
 1. Behavior binding to select the 2nd profile (passed parameters are [zero based](https://en.wikipedia.org/wiki/Zero-based_numbering)):


### PR DESCRIPTION
In the Bluetooth Behaviors docs, the example for Behavior binding to select previous profile shows the binding to be `&bt BT_NXT` instead of `&bt BT_PRV`.
Sorry, for the small change. 