### PR TITLE
Exit setup if no write permissions in directory

### DIFF
--- a/docs/static/setup.ps1
+++ b/docs/static/setup.ps1
@@ -59,6 +59,19 @@ catch [System.Management.Automation.CommandNotFoundException] {
 Test-Git-Config -Option "user.name" -ErrMsg "Git username not set!`nRun: git config --global user.name 'My Name'"
 Test-Git-Config -Option "user.email" -ErrMsg "Git email not set!`nRun: git config --global user.name 'example@myemail.com'"
 
+$permission = (Get-Acl $PSScriptRoot).Access | 
+?{$_.IdentityReference -match $env:UserName `
+	-and $_.FileSystemRights -match "Read" `
+		-or $_.FileSystemRights -match "Write"	} | 
+			
+		Select IdentityReference,FileSystemRights
+
+If (-Not $permission){
+    Write-Host "Sorry, you do not have write permissions in this directory."
+    Write-Host "Please try running this script again from a directory that you do have write permissions for."
+    exit 1
+}
+
 $repo_path = "https://github.com/zmkfirmware/zmk-config-split-template.git"
 
 $title = "ZMK Config Setup:"

--- a/docs/static/setup.ps1
+++ b/docs/static/setup.ps1
@@ -57,11 +57,11 @@ catch [System.Management.Automation.CommandNotFoundException] {
 }
 
 Test-Git-Config -Option "user.name" -ErrMsg "Git username not set!`nRun: git config --global user.name 'My Name'"
-Test-Git-Config -Option "user.email" -ErrMsg "Git email not set!`nRun: git config --global user.name 'example@myemail.com'"
+Test-Git-Config -Option "user.email" -ErrMsg "Git email not set!`nRun: git config --global user.email 'example@myemail.com'"
 
-$permission = (Get-Acl $PSScriptRoot).Access | 
+$permission = (Get-Acl $pwd).Access | 
 ?{$_.IdentityReference -match $env:UserName `
-	-and $_.FileSystemRights -match "Read" `
+	-and $_.FileSystemRights -match "FullControl" `
 		-or $_.FileSystemRights -match "Write"	} | 
 			
 		Select IdentityReference,FileSystemRights

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -22,6 +22,13 @@ check_exists "command -v curl" "curl is not installed, and is required for this 
 check_exists "git config user.name" "Git username not set!\nRun: git config --global user.name 'My Name'"
 check_exists "git config user.email" "Git email not set!\nRun: git config --global user.email 'example@myemail.com'"
 
+# Check to see if the user has write permissions in this directory to prevent a cryptic error later on
+if [ ! -w `pwd` ]; then
+    echo 'Sorry, you do not have write permissions in this directory.';
+    echo 'Please try running this script again from a directory that you do have write permissions for.';
+    exit 1
+fi
+
 repo_path="https://github.com/zmkfirmware/zmk-config-split-template.git"
 title="ZMK Config Setup:"
 


### PR DESCRIPTION
Added a check in `setup.sh` that will print a message and exit if the user does not have write permissions in the current directory. Should close #178.

I haven't ever used powershell, but I would be happy to try something similar if a similar issue exists in Windows.  