### PR TITLE
fix: check out Bash scripts with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+
+# Always use Unix-style line endings for Bash scripts so they work in
+# Docker on Windows.
+.bashrc text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
Always check out Bashs scripts with Unix-style line endings so they work if you run them inside Docker on Windows.