### PR TITLE
fix: allow nested zmk-config for dev container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /modules
 /tools
 /zephyr
+/zmk-config
 /build
 *.DS_Store


### PR DESCRIPTION
VS Code can't share two folders with a Docker container at the same time, so to build with `-DZMK_CONFIG` the zmk-config repo needs to be a subfolder of the zmk repo. Added zmk-config to .gitignore to allow this.