### PR TITLE
Add support for wget to setup.sh

### DIFF
--- a/docs/docs/user-setup.md
+++ b/docs/docs/user-setup.md
@@ -74,7 +74,7 @@ bash -c "$(curl -fsSL https://zmkfirmware.dev/setup.sh)"
 <TabItem value="wget">
 
 ```
-bash -c "$(wget https://zmkfirmware.dev/setup.sh -O -)"
+bash -c "$(wget https://zmkfirmware.dev/setup.sh -O -)" '' --wget
 ```
 
 </TabItem>

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -39,21 +39,21 @@ if [ ! -w `pwd` ]; then
     exit 1
 fi
 
+# Parse all commandline options
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -w|--wget) force_wget="true"; break;;
+        *) echo "Unknown parameter: $1"; exit 1;;
+    esac
+    shift
+done
+
 if [[ $curl_exists == "true" && $wget_exists == "true" ]]; then
-    prompt="Detected both curl and wget, which one would you like to use? [default is curl]"
-    options=("curl" "wget")
-    PS3="$prompt "
-    select opt in "${options[@]}" "Quit"; do
-        case "$REPLY" in
-        
-        1 ) download_command="curl -O "; break;;
-        2 ) download_command="wget "; break;;
-
-        $(( ${#options[@]}+1 )) ) echo "Goodbye!"; exit 1;;
-        *) download_command="curl -O "; break;;
-
-        esac
-    done
+    if [[ $force_wget == "true" ]]; then
+        download_command="wget "
+    else
+        download_command="curl -O "
+    fi
 elif [[ $curl_exists == "true" ]]; then
     download_command="curl -O "
 elif [[ $wget_exists == "true" ]]; then


### PR DESCRIPTION
I have added the ability to use either `wget` or `curl` to `setup.sh`. If the user only has one installed, then the script will use that one. I give the user the choice between the two if both are present, but realized that many users may not care which one gets used. I can remove that option and default to `curl` if both are present if that would make things simpler for the user.

Should close #200.