### PR TITLE
Tweak devcontainer setups for GitHub Codespaces

### DIFF
--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -1,6 +1,8 @@
 export LS_OPTIONS='-F --color=auto'
-eval "`dircolors`"
 alias ls='ls $LS_OPTIONS'
+if [ "${CODESPACES}" = "true" ]; then
+  export WORKSPACE_DIR="$HOME/workspace/zmk"
+fi
 if [ -f "$WORKSPACE_DIR/zephyr/zephyr-env.sh" ]; then
   source "$WORKSPACE_DIR/zephyr/zephyr-env.sh"
 fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
   "dockerFile": "Dockerfile",
   "extensions": ["ms-vscode.cpptools"],
   "runArgs": ["--security-opt", "label=disable"],
-  "containerEnv": {"WORKSPACE_DIR": "${containerWorkspaceFolder}"}
+  "containerEnv": {"WORKSPACE_DIR": "${containerWorkspaceFolder}"},
+  "settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
 }
 


### PR DESCRIPTION
Properly detect if we're running inside a codespace, and set up correct defaults so it works.

The reason for this change is that [`${containerWorkspaceFolder}` variable is not supported by Codespaces](https://code.visualstudio.com/docs/remote/devcontainerjson-reference#_variables-in-devcontainerjson).

This will probably almost certainly break if someone forks into a repository that is _not_ called `zmk`, but I think this is an acceptable tradeoff for right now. Hopefully we can find a more robust solution in the future.

cf. #209 for the original work on this. 