### PR TITLE
Add zmk_kscan_gpio_demux kscan driver & NIBBLE keyboard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
           - settings_reset
           - quefrency_left
           - quefrency_right
+          - nibble
         include:
           - board: proton_c
             shield: clueboard_california

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,5 @@
   "files.associations": {
     "*.overlay": "dts",
     "*.keymap": "dts"
-  },
-  "C_Cpp.dimInactiveRegions": false,
-  "C_Cpp.errorSquiggles": "Disabled"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,7 @@
   "files.associations": {
     "*.overlay": "dts",
     "*.keymap": "dts"
-  }
+  },
+  "C_Cpp.dimInactiveRegions": false,
+  "C_Cpp.errorSquiggles": "Disabled"
 }

--- a/app/boards/shields/nibble/Kconfig.defconfig
+++ b/app/boards/shields/nibble/Kconfig.defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_NIBBLE
+
+config ZMK_KEYBOARD_NAME
+	default "NIBBLE_BLE"
+
+config ZMK_USB
+	default y
+
+endif
+

--- a/app/boards/shields/nibble/Kconfig.defconfig
+++ b/app/boards/shields/nibble/Kconfig.defconfig
@@ -4,7 +4,7 @@
 if SHIELD_NIBBLE
 
 config ZMK_KEYBOARD_NAME
-	default "NIBBLE_BLE"
+	default "NIBBLE"
 
 config ZMK_USB
 	default y

--- a/app/boards/shields/nibble/Kconfig.shield
+++ b/app/boards/shields/nibble/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_NIBBLE
+	def_bool $(shields_list_contains,nibble)

--- a/app/boards/shields/nibble/nibble.keymap
+++ b/app/boards/shields/nibble/nibble.keymap
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+#define DEFAULT 0
+#define FUNC 1
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+        
+        default_layer {
+            bindings = <
+           &kp ESC  &kp NUM_1 &kp NUM_2 &kp NUM_3 &kp NUM_4 &kp NUM_5 &kp NUM_6 &kp NUM_7 &kp NUM_8 &kp NUM_9 &kp NUM_0 &kp MINUS &kp EQL  &kp BKSP &kp HOME
+&cp M_VOLU &kp TAB  &kp Q     &kp W     &kp E     &kp R     &kp T     &kp Y     &kp U     &kp I     &kp O     &kp P     &kp LBKT  &kp RBKT &kp BSLH &kp DEL  
+&cp M_VOLD &kp CLCK &kp A     &kp S     &kp D     &kp F     &kp G     &kp H     &kp J     &kp K     &kp L     &kp SCLN  &kp QUOT           &kp RET  &kp PGUP  
+&trans     &kp LSFT &kp Z     &kp X     &kp C     &kp V     &kp B     &kp N     &kp M     &kp CMMA  &kp DOT   &kp FSLH  &kp RSFT           &kp UARW &kp PGDN
+&trans     &kp LCTL &kp LGUI  &kp LALT                      &kp SPC                       &mo FUNC  &kp RALT  &kp RCTL  &kp LARW           &kp DARW &kp RARW
+            >;
+        };
+        func {
+            bindings = <
+            &kp TILD    &kp F1    &kp F2    &kp F3    &kp F4    &kp F5    &kp F6    &kp F7    &kp F8    &kp F9    &kp F10   &kp F11   &kp F12 &trans      &kp END
+&bt BT_CLR  &trans      &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans  &trans      &bootloader   
+&trans      &trans      &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans            &trans      &trans   
+&bt BT_PRV  &trans      &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans            &trans      &trans
+&bt BT_NXT  &trans      &trans    &trans                        &trans                        &trans    &trans    &trans    &cp M_PREV        &cp M_PLAY  &cp M_NEXT
+            >;
+        };
+    };
+};

--- a/app/boards/shields/nibble/nibble.overlay
+++ b/app/boards/shields/nibble/nibble.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix-transform.h>
+
+/ {
+	chosen {
+		zmk,kscan = &kscan0;
+		zmk,matrix_transform = &default_transform;
+	};
+
+	kscan0: kscan {
+		compatible = "zmk,kscan-gpio-demux";
+		label = "KSCAN";
+		polling-interval-msec = <25>;
+		input-gpios
+			= <&pro_micro_d 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+			, <&pro_micro_d 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+			, <&pro_micro_d 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+			, <&pro_micro_d 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+			, <&pro_micro_d 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+			;
+		output-gpios
+			= <&pro_micro_a 3 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_a 2 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_a 1 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_a 0 GPIO_ACTIVE_HIGH>
+			;
+	};
+
+	default_transform: keymap_transform_0 {
+		compatible = "zmk,matrix-transform";
+		columns = <16>;
+		rows = <5>;
+
+		//TODO: Add a keymap graphic here
+
+		map = <
+		RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9)  RC(0,10) RC(0,11) RC(0,12) RC(0,13) RC(0,14) RC(0,15)
+RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9)  RC(1,10) RC(1,11) RC(1,12) RC(1,13) RC(1,14) RC(1,15)
+RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9)  RC(2,10) RC(2,11) RC(2,12) 	     RC(2,14) RC(2,15)
+RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9)  RC(3,10) RC(3,11) RC(3,12)          RC(3,14) RC(3,15)
+RC(4,0) RC(4,1) RC(4,2) RC(4,3)                 RC(4,6)                 RC(4,9)  RC(4,10) RC(4,11) RC(4,12)          RC(4,14) RC(4,15) 
+		>;
+	};
+};

--- a/app/drivers/zephyr/CMakeLists.txt
+++ b/app/drivers/zephyr/CMakeLists.txt
@@ -5,6 +5,7 @@ if(CONFIG_ZMK_KSCAN_GPIO_DRIVER)
   zephyr_library_sources(
     kscan_gpio_matrix.c
     kscan_gpio_direct.c
+    kscan_gpio_demux.c
     )
 
   zephyr_library_sources_ifdef(CONFIG_EC11 ec11.c)

--- a/app/drivers/zephyr/dts/bindings/zmk,kscan-gpio-demux.yaml
+++ b/app/drivers/zephyr/dts/bindings/zmk,kscan-gpio-demux.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2020, The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: GPIO keyboard demux controller
+
+compatible: "zmk,kscan-gpio-demux"
+
+include: kscan.yaml
+
+properties:
+  input-gpios:
+    type: phandle-array
+    required: true
+  output-gpios:
+    type: phandle-array
+    required: true
+  debounce-period:
+    type: int
+    default: 5
+  polling-interval-msec:
+    type: int
+    default: 25

--- a/app/drivers/zephyr/kscan_gpio_demux.c
+++ b/app/drivers/zephyr/kscan_gpio_demux.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#define DT_DRV_COMPAT zmk_kscan_gpio_demux
+
+#include <device.h>
+#include <drivers/kscan.h>
+#include <drivers/gpio.h>
+#include <logging/log.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+
+struct kscan_gpio_item_config {
+    char *label;
+    gpio_pin_t pin;
+    gpio_flags_t flags;
+};
+
+// Helper macro
+#define PWR_TWO(x) (1 << (x))
+
+// Define GPIO cfg
+#define _KSCAN_GPIO_ITEM_CFG_INIT(n, prop, idx)                                                    \
+    {                                                                                              \
+        .label = DT_INST_GPIO_LABEL_BY_IDX(n, prop, idx),                                          \
+        .pin = DT_INST_GPIO_PIN_BY_IDX(n, prop, idx),                                              \
+        .flags = DT_INST_GPIO_FLAGS_BY_IDX(n, prop, idx),                                          \
+    },
+
+// Define row and col cfg
+#define _KSCAN_GPIO_INPUT_CFG_INIT(idx, n) _KSCAN_GPIO_ITEM_CFG_INIT(n, input_gpios, idx)
+#define _KSCAN_GPIO_OUTPUT_CFG_INIT(idx, n) _KSCAN_GPIO_ITEM_CFG_INIT(n, output_gpios, idx)
+
+// Check debounce config
+#define CHECK_DEBOUNCE_CFG(n, a, b) COND_CODE_0(DT_INST_PROP(n, debounce_period), a, b)
+
+// Define the row and column lengths
+#define INST_MATRIX_INPUTS(n) DT_INST_PROP_LEN(n, input_gpios)
+#define INST_DEMUX_GPIOS(n) DT_INST_PROP_LEN(n, output_gpios)
+#define INST_MATRIX_OUTPUTS(n) PWR_TWO(INST_DEMUX_GPIOS(n))
+#define POLL_INTERVAL(n) DT_INST_PROP(n, polling_interval_msec)
+
+#define GPIO_INST_INIT(n)                                                                          \
+    struct kscan_gpio_irq_callback_##n {                                                           \
+        struct CHECK_DEBOUNCE_CFG(n, (k_work), (k_delayed_work)) * work;                           \
+        struct gpio_callback callback;                                                             \
+        struct device *dev;                                                                        \
+    };                                                                                             \
+                                                                                                   \
+    static struct kscan_gpio_irq_callback_##n irq_callbacks_##n[INST_MATRIX_INPUTS(n)];            \
+                                                                                                   \
+    struct kscan_gpio_config_##n {                                                                 \
+        struct kscan_gpio_item_config rows[INST_MATRIX_INPUTS(n)];                                 \
+        struct kscan_gpio_item_config cols[INST_DEMUX_GPIOS(n)];                                   \
+    };                                                                                             \
+                                                                                                   \
+    struct kscan_gpio_data_##n {                                                                   \
+        kscan_callback_t callback;                                                                 \
+        struct k_timer poll_timer;                                                                 \
+        struct CHECK_DEBOUNCE_CFG(n, (k_work), (k_delayed_work)) work;                             \
+        bool matrix_state[INST_MATRIX_INPUTS(n)][INST_MATRIX_OUTPUTS(n)];                          \
+        struct device *rows[INST_MATRIX_INPUTS(n)];                                                \
+        struct device *cols[INST_MATRIX_OUTPUTS(n)];                                               \
+        struct device *dev;                                                                        \
+    };                                                                                             \
+    /* IO/GPIO SETUP */                                                                            \
+    /* gpio_input_devices are PHYSICAL IO devices */                                               \
+    static struct device **kscan_gpio_input_devices_##n(struct device *dev) {                      \
+        struct kscan_gpio_data_##n *data = dev->driver_data;                                       \
+        return data->rows;                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    static const struct kscan_gpio_item_config *kscan_gpio_input_configs_##n(struct device *dev) { \
+        const struct kscan_gpio_config_##n *cfg = dev->config_info;                                \
+        return cfg->rows;                                                                          \
+    }                                                                                              \
+                                                                                                   \
+    /* gpio_output_devices are PHYSICAL IO devices */                                              \
+    static struct device **kscan_gpio_output_devices_##n(struct device *dev) {                     \
+        struct kscan_gpio_data_##n *data = dev->driver_data;                                       \
+        return data->cols;                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    static const struct kscan_gpio_item_config *kscan_gpio_output_configs_##n(                     \
+        struct device *dev) {                                                                      \
+        const struct kscan_gpio_config_##n *cfg = dev->config_info;                                \
+        /* If row2col, rows = outputs & cols = inputs */                                           \
+        return cfg->cols;                                                                          \
+    }                                                                                              \
+    /* POLLING SETUP */                                                                            \
+    static void kscan_gpio_timer_handler(struct k_timer *timer) {                                  \
+        struct kscan_gpio_data_##n *data =                                                         \
+            CONTAINER_OF(timer, struct kscan_gpio_data_##n, poll_timer);                           \
+        k_work_submit(&data->work.work);                                                           \
+    }                                                                                              \
+                                                                                                   \
+    /* Read the state of the input GPIOs */                                                        \
+    /* This is the core matrix_scan func */                                                        \
+    static int kscan_gpio_read_##n(struct device *dev) {                                           \
+        bool submit_follow_up_read = false;                                                        \
+        struct kscan_gpio_data_##n *data = dev->driver_data;                                       \
+        static bool read_state[INST_MATRIX_INPUTS(n)][INST_MATRIX_OUTPUTS(n)];                     \
+        for (int o = 0; o < INST_MATRIX_OUTPUTS(n); o++) {                                         \
+            /* Iterate over bits and set GPIOs accordingly */                                      \
+            for (u8_t bit = 0; bit < INST_DEMUX_GPIOS(n); bit++) {                                 \
+                u8_t state = (o & (0b1 << bit)) >> bit;                                            \
+                struct device *out_dev = kscan_gpio_output_devices_##n(dev)[bit];                  \
+                const struct kscan_gpio_item_config *out_cfg =                                     \
+                    &kscan_gpio_output_configs_##n(dev)[bit];                                      \
+                gpio_pin_set(out_dev, out_cfg->pin, state);                                        \
+            }                                                                                      \
+                                                                                                   \
+            for (int i = 0; i < INST_MATRIX_INPUTS(n); i++) {                                      \
+                /* Get the input device (port) */                                                  \
+                struct device *in_dev = kscan_gpio_input_devices_##n(dev)[i];                      \
+                /* Get the input device config (pin) */                                            \
+                const struct kscan_gpio_item_config *in_cfg =                                      \
+                    &kscan_gpio_input_configs_##n(dev)[i];                                         \
+                read_state[i][o] = gpio_pin_get(in_dev, in_cfg->pin) > 0;                          \
+            }                                                                                      \
+        }                                                                                          \
+        for (int r = 0; r < INST_MATRIX_INPUTS(n); r++) {                                          \
+            for (int c = 0; c < INST_MATRIX_OUTPUTS(n); c++) {                                     \
+                bool pressed = read_state[r][c];                                                   \
+                submit_follow_up_read = (submit_follow_up_read || pressed);                        \
+                if (pressed != data->matrix_state[r][c]) {                                         \
+                    LOG_DBG("Sending event at %d,%d state %s", r, c, (pressed ? "on" : "off"));    \
+                    data->matrix_state[r][c] = pressed;                                            \
+                    data->callback(dev, r, c, pressed);                                            \
+                }                                                                                  \
+            }                                                                                      \
+        }                                                                                          \
+        if (submit_follow_up_read) {                                                               \
+            CHECK_DEBOUNCE_CFG(n, ({ k_work_submit(&data->work); }), ({                            \
+                                   k_delayed_work_cancel(&data->work);                             \
+                                   k_delayed_work_submit(&data->work, K_MSEC(5));                  \
+                               }))                                                                 \
+        }                                                                                          \
+        return 0;                                                                                  \
+    }                                                                                              \
+                                                                                                   \
+    static void kscan_gpio_work_handler_##n(struct k_work *work) {                                 \
+        struct kscan_gpio_data_##n *data = CONTAINER_OF(work, struct kscan_gpio_data_##n, work);   \
+        kscan_gpio_read_##n(data->dev);                                                            \
+    }                                                                                              \
+                                                                                                   \
+    static void kscan_gpio_irq_callback_handler_##n(struct device *dev, struct gpio_callback *cb,  \
+                                                    gpio_port_pins_t pin) {                        \
+        struct kscan_gpio_irq_callback_##n *data =                                                 \
+            CONTAINER_OF(cb, struct kscan_gpio_irq_callback_##n, callback);                        \
+        CHECK_DEBOUNCE_CFG(n, ({ k_work_submit(data->work); }), ({                                 \
+                               k_delayed_work_cancel(data->work);                                  \
+                               k_delayed_work_submit(data->work,                                   \
+                                                     K_MSEC(DT_INST_PROP(n, debounce_period)));    \
+                           }))                                                                     \
+    }                                                                                              \
+                                                                                                   \
+    static struct kscan_gpio_data_##n kscan_gpio_data_##n = {                                      \
+        .rows = {[INST_MATRIX_INPUTS(n) - 1] = NULL}, .cols = {[INST_DEMUX_GPIOS(n) - 1] = NULL}}; \
+                                                                                                   \
+    /* KSCAN API configure function */                                                             \
+    static int kscan_gpio_configure_##n(struct device *dev, kscan_callback_t callback) {           \
+        LOG_DBG("KSCAN API configure");                                                            \
+        struct kscan_gpio_data_##n *data = dev->driver_data;                                       \
+        if (!callback) {                                                                           \
+            return -EINVAL;                                                                        \
+        }                                                                                          \
+        data->callback = callback;                                                                 \
+        LOG_DBG("Configured GPIO %d", n);                                                          \
+        return 0;                                                                                  \
+    };                                                                                             \
+                                                                                                   \
+    /* KSCAN API enable function */                                                                \
+    static int kscan_gpio_enable_##n(struct device *dev) {                                         \
+        LOG_DBG("KSCAN API enable");                                                               \
+        struct kscan_gpio_data_##n *data = dev->driver_data;                                       \
+        k_timer_start(&data->poll_timer, K_MSEC(POLL_INTERVAL(n)), K_MSEC(POLL_INTERVAL(n)));      \
+        return 0;                                                                                  \
+    };                                                                                             \
+                                                                                                   \
+    /* KSCAN API disable function */                                                               \
+    static int kscan_gpio_disable_##n(struct device *dev) {                                        \
+        LOG_DBG("KSCAN API disable");                                                              \
+        struct kscan_gpio_data_##n *data = dev->driver_data;                                       \
+        k_timer_stop(&data->poll_timer);                                                           \
+        return 0;                                                                                  \
+    };                                                                                             \
+                                                                                                   \
+    /* GPIO init function*/                                                                        \
+    static int kscan_gpio_init_##n(struct device *dev) {                                           \
+        LOG_DBG("KSCAN GPIO init");                                                                \
+        struct kscan_gpio_data_##n *data = dev->driver_data;                                       \
+        int err;                                                                                   \
+        /* configure input devices*/                                                               \
+        struct device **input_devices = kscan_gpio_input_devices_##n(dev);                         \
+        for (int i = 0; i < INST_MATRIX_INPUTS(n); i++) {                                          \
+            const struct kscan_gpio_item_config *in_cfg = &kscan_gpio_input_configs_##n(dev)[i];   \
+            input_devices[i] = device_get_binding(in_cfg->label);                                  \
+            if (!input_devices[i]) {                                                               \
+                LOG_ERR("Unable to find input GPIO device");                                       \
+                return -EINVAL;                                                                    \
+            }                                                                                      \
+            err = gpio_pin_configure(input_devices[i], in_cfg->pin, GPIO_INPUT | in_cfg->flags);   \
+            if (err) {                                                                             \
+                LOG_ERR("Unable to configure pin %d on %s for input", in_cfg->pin, in_cfg->label); \
+                return err;                                                                        \
+            } else {                                                                               \
+                LOG_DBG("Configured pin %d on %s for input", in_cfg->pin, in_cfg->label);          \
+            }                                                                                      \
+            irq_callbacks_##n[i].work = &data->work;                                               \
+            irq_callbacks_##n[i].dev = dev;                                                        \
+            gpio_init_callback(&irq_callbacks_##n[i].callback,                                     \
+                               kscan_gpio_irq_callback_handler_##n, BIT(in_cfg->pin));             \
+            err = gpio_add_callback(input_devices[i], &irq_callbacks_##n[i].callback);             \
+            if (err) {                                                                             \
+                LOG_ERR("Error adding the callback to the column device");                         \
+                return err;                                                                        \
+            }                                                                                      \
+        }                                                                                          \
+        /* configure output devices*/                                                              \
+        struct device **output_devices = kscan_gpio_output_devices_##n(dev);                       \
+        for (int o = 0; o < INST_DEMUX_GPIOS(n); o++) {                                            \
+            const struct kscan_gpio_item_config *out_cfg = &kscan_gpio_output_configs_##n(dev)[o]; \
+            output_devices[o] = device_get_binding(out_cfg->label);                                \
+            if (!output_devices[o]) {                                                              \
+                LOG_ERR("Unable to find output GPIO device");                                      \
+                return -EINVAL;                                                                    \
+            }                                                                                      \
+            err = gpio_pin_configure(output_devices[o], out_cfg->pin,                              \
+                                     GPIO_OUTPUT_ACTIVE | out_cfg->flags);                         \
+            if (err) {                                                                             \
+                LOG_ERR("Unable to configure pin %d on %s for output", out_cfg->pin,               \
+                        out_cfg->label);                                                           \
+                return err;                                                                        \
+            } else {                                                                               \
+                LOG_DBG("Configured pin %d on %s for output", out_cfg->pin, out_cfg->label);       \
+            }                                                                                      \
+        }                                                                                          \
+        data->dev = dev;                                                                           \
+                                                                                                   \
+        k_timer_init(&data->poll_timer, kscan_gpio_timer_handler, NULL);                           \
+                                                                                                   \
+        (CHECK_DEBOUNCE_CFG(n, (k_work_init), (k_delayed_work_init)))(                             \
+            &data->work, kscan_gpio_work_handler_##n);                                             \
+        return 0;                                                                                  \
+    }                                                                                              \
+                                                                                                   \
+    static const struct kscan_driver_api gpio_driver_api_##n = {                                   \
+        .config = kscan_gpio_configure_##n,                                                        \
+        .enable_callback = kscan_gpio_enable_##n,                                                  \
+        .disable_callback = kscan_gpio_disable_##n,                                                \
+    };                                                                                             \
+                                                                                                   \
+    static const struct kscan_gpio_config_##n kscan_gpio_config_##n = {                            \
+        .rows = {UTIL_LISTIFY(INST_MATRIX_INPUTS(n), _KSCAN_GPIO_INPUT_CFG_INIT, n)},              \
+        .cols = {UTIL_LISTIFY(INST_DEMUX_GPIOS(n), _KSCAN_GPIO_OUTPUT_CFG_INIT, n)},               \
+    };                                                                                             \
+                                                                                                   \
+    DEVICE_AND_API_INIT(kscan_gpio_##n, DT_INST_LABEL(n), kscan_gpio_init_##n,                     \
+                        &kscan_gpio_data_##n, &kscan_gpio_config_##n, APPLICATION,                 \
+                        CONFIG_APPLICATION_INIT_PRIORITY, &gpio_driver_api_##n);
+
+DT_INST_FOREACH_STATUS_OKAY(GPIO_INST_INIT)
+
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/docs/static/setup.ps1
+++ b/docs/static/setup.ps1
@@ -91,9 +91,9 @@ Write-Host "Keyboard Shield Selection:"
 $prompt = "Pick a keyboard"
 
 # TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
-$options = "Kyria", "Lily58", "Corne", "Splitreus62", "Sofle", "Iris", "Reviung41", "RoMac", "RoMac+", "makerdiary M60", "Microdox", "TG4X", "QAZ"
-$names = "kyria", "lily58", "corne", "splitreus62", "sofle", "iris", "reviung41", "romac", "romac_plus", "m60", "microdox", "tg4x", "qaz"
-$splits = "y", "y", "y", "y", "y", "y", "n", "n", "n", "n", "y", "n", "n"
+$options = "Kyria", "Lily58", "Corne", "Splitreus62", "Sofle", "Iris", "Reviung41", "RoMac", "RoMac+", "makerdiary M60", "Microdox", "TG4X", "QAZ", "NIBBLE"
+$names = "kyria", "lily58", "corne", "splitreus62", "sofle", "iris", "reviung41", "romac", "romac_plus", "m60", "microdox", "tg4x", "qaz", "nibble"
+$splits = "y", "y", "y", "y", "y", "y", "n", "n", "n", "n", "y", "n", "n", "n"
 
 $choice = Get-Choice-From-Options -Options $options -Prompt $prompt
 $shield_title = $($options[$choice])

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -114,6 +114,7 @@ select opt in "${options[@]}" "Quit"; do
     11 ) shield_title="Microdox" shield="microdox"; split="y"; break;;
     12 ) shield_title="TG4X" shield="tg4x"; split="n"; break;;
     13 ) shield_title="QAZ" shield="qaz"; split="n"; break;;
+    14 ) shield_title="NIBBLE" shield="nibble"; split="n"; break;;
 
     # Add link to docs on adding your own custom shield in your ZMK config!
     # $(( ${#options[@]}+1 )) ) echo "Other!"; break;;


### PR DESCRIPTION
Added NIBBLE keyboard folder and keymap. The biggest change is the addition of a new kscan driver, zmk_kscan_gpio_demux, along with some driver cleanup while porting from the standard matrix driver. I also added some comments to the driver.

The demux chip is active-low ~~and the driver allows for both row2col and col2row configurations. Currently, polling is the only method that has been tested as working, but hooks for interrupt-based scanning were left in as well for the future.~~

Tested locally on a NIBBLE keyboard with nice!nano MCU.