### PR TITLE
Add Boardsource 3x4 shield

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         board: [proton_c, nice_nano, bluemicro840_v1, nrfmicro_13]
         shield:
+          - boardsource3x4
           - corne_left
           - corne_right
           - kyria_left

--- a/app/boards/shields/boardsource3x4/Kconfig.defconfig
+++ b/app/boards/shields/boardsource3x4/Kconfig.defconfig
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+
+if SHIELD_BOARDSOURCE3X4
+
+config ZMK_KEYBOARD_NAME
+    default "Boardsource 3x4"
+
+endif

--- a/app/boards/shields/boardsource3x4/Kconfig.defconfig
+++ b/app/boards/shields/boardsource3x4/Kconfig.defconfig
@@ -1,9 +1,5 @@
-/*
- * Copyright (c) 2020 The ZMK Contributors
- *
- * SPDX-License-Identifier: MIT
- */
-
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
 
 if SHIELD_BOARDSOURCE3X4
 

--- a/app/boards/shields/boardsource3x4/Kconfig.shield
+++ b/app/boards/shields/boardsource3x4/Kconfig.shield
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+config SHIELD_BOARDSOURCE3X4
+	def_bool $(shields_list_contains,boardsource3x4)
+

--- a/app/boards/shields/boardsource3x4/Kconfig.shield
+++ b/app/boards/shields/boardsource3x4/Kconfig.shield
@@ -1,8 +1,5 @@
-/*
- * Copyright (c) 2020 The ZMK Contributors
- *
- * SPDX-License-Identifier: MIT
- */
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
 
 config SHIELD_BOARDSOURCE3X4
 	def_bool $(shields_list_contains,boardsource3x4)

--- a/app/boards/shields/boardsource3x4/boardsource3x4.keymap
+++ b/app/boards/shields/boardsource3x4/boardsource3x4.keymap
@@ -24,9 +24,9 @@
 
         num_layer {
             bindings = <
-    &tog 1       &kp NUM_7 &kp NUM_8 &kp NUM_9
-    &mo 2        &kp NUM_4 &kp NUM_5 &kp NUM_6
-    &lt 3 NUM_0  &kp NUM_1 &kp NUM_2 &kp NUM_3
+    &trans      &kp NUM_7 &kp NUM_8 &kp NUM_9
+    &trans      &kp NUM_4 &kp NUM_5 &kp NUM_6
+    &lt 3 NUM_0 &kp NUM_1 &kp NUM_2 &kp NUM_3
             >;
         };
 

--- a/app/boards/shields/boardsource3x4/boardsource3x4.keymap
+++ b/app/boards/shields/boardsource3x4/boardsource3x4.keymap
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+
+            bindings = <
+    &tog 1 &cp M_PREV &cp M_PLAY &cp M_NEXT
+    &mo 2  &cp M_VOLD &kp UARW   &cp M_VOLU
+    &mo 3  &kp LARW   &kp DARW   &kp RARW
+            >;
+
+        };
+
+        num_layer {
+            bindings = <
+    &tog 1       &kp NUM_7 &kp NUM_8 &kp NUM_9
+    &mo 2        &kp NUM_4 &kp NUM_5 &kp NUM_6
+    &lt 3 NUM_0  &kp NUM_1 &kp NUM_2 &kp NUM_3
+            >;
+        };
+
+        lower_layer {
+            bindings = <
+    &bt BT_CLR &none        &reset       &bootloader
+    &trans     &bt BT_SEL 3 &bt BT_SEL 4 &none
+    &none      &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2
+            >;
+        };
+
+        raise_layer {
+            bindings = <
+    &kp 0x68 &kp 0x69 &kp 0x6A &kp 0x6B
+    &kp 0x6C &kp 0x6D &kp 0x6E &kp 0x6F
+    &trans   &kp 0x70 &kp 0x71 &kp 0x72
+            >;
+        };
+    };
+};

--- a/app/boards/shields/boardsource3x4/boardsource3x4.overlay
+++ b/app/boards/shields/boardsource3x4/boardsource3x4.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix-transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "col2row";
+
+         row-gpios
+            = <&pro_micro_a 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_a 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_a 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+
+        col-gpios
+            = <&pro_micro_d 10 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 16 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>
+            ;
+
+    };
+
+    bt_unpair_combo: bt_unpair_combo {
+		compatible = "zmk,bt-unpair-combo";
+		key-positions = <0 11>;
+	};
+};

--- a/app/boards/shields/boardsource3x4/boardsource3x4.overlay
+++ b/app/boards/shields/boardsource3x4/boardsource3x4.overlay
@@ -28,11 +28,5 @@
             , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>
             , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>
             ;
-
     };
-
-    bt_unpair_combo: bt_unpair_combo {
-		compatible = "zmk,bt-unpair-combo";
-		key-positions = <0 11>;
-	};
 };


### PR DESCRIPTION
The included keymap contains 4 layers - a nav laver, a num(pad) layer, a bluetooth layer, and an extended F-layer (F13-F23)

This shield has been tested with a nice!nano board. Thanks to the awesome documentation, this implementation was relatively painless!