### PR TITLE
feat(kscan_mock): Increase max number of events

### DIFF
--- a/app/src/kscan_mock.c
+++ b/app/src/kscan_mock.c
@@ -18,7 +18,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 struct kscan_mock_data {
     kscan_callback_t callback;
 
-    u8_t event_index;
+    u32_t event_index;
     struct k_delayed_work work;
     struct device *dev;
 };


### PR DESCRIPTION
This is necessary for testing a large number of events (e.g. every key code) within a single build/pass.

The `u8_t` limitation became apparent during end-to-end testing of #21.

Tested on the Nordic nRF52840 Dongle.