### PR TITLE
Explicitly license documentation as CC-BY-NC-SA.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
 
+## License
+
+The ZMK Documentation is licensed [CC-BY-NC-SA](http://creativecommons.org/licenses/by-nc-sa/4.0/).
+
 ### Installation
 
 ```
@@ -23,4 +27,3 @@ $ npm build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
-

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -89,7 +89,7 @@ module.exports = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} ZMK Project Contributors, Built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} ZMK Project Contributors. <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" /></a>`,
     },
     algolia: {
       apiKey: "75325855fc90356828fe212d38e5ca34",


### PR DESCRIPTION
Adding an explicit license to our documentation content, using the Creative Commons CC-BY-NC-SA license.