### PR TITLE
refactor(hid): configurable NKRO integer arrays & boot friendly

### DIFF
--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -9,13 +9,11 @@
 #include <usb/usb_device.h>
 #include <usb/class/usb_hid.h>
 
-#include <dt-bindings/zmk/keys.h>
-
 #include <zmk/keys.h>
 
 #define COLLECTION_REPORT 0x03
 
-#define ZMK_HID_MAX_KEYCODE GUI
+#define ZMK_HID_KEYPAD_NKRO_SIZE 6
 
 static const u8_t zmk_hid_report_desc[] = {
     /* USAGE_PAGE (Generic Desktop) */
@@ -62,36 +60,25 @@ static const u8_t zmk_hid_report_desc[] = {
     /* LOGICAL_MINIMUM (0) */
     HID_GI_LOGICAL_MIN(1),
     0x00,
-    /* LOGICAL_MAXIMUM (1) */
+    /* LOGICAL_MAXIMUM (0xFF) */
     HID_GI_LOGICAL_MAX(1),
-    0x01,
+    0xFF,
     /* USAGE_MINIMUM (Reserved) */
     HID_LI_USAGE_MIN(1),
     0x00,
     /* USAGE_MAXIMUM (Keyboard Application) */
     HID_LI_USAGE_MAX(1),
-    ZMK_HID_MAX_KEYCODE,
-    /* REPORT_SIZE (8) */
+    0xFF,
+    /* REPORT_SIZE (1) */
     HID_GI_REPORT_SIZE,
-    0x01,
-    /* REPORT_COUNT (6) */
+    0x08,
+    /* REPORT_COUNT (ZMK_HID_KEYPAD_NKRO_SIZE) */
     HID_GI_REPORT_COUNT,
-    ZMK_HID_MAX_KEYCODE + 1,
+    ZMK_HID_KEYPAD_NKRO_SIZE,
     /* INPUT (Data,Ary,Abs) */
     HID_MI_INPUT,
-    0x02,
-    /* USAGE_PAGE (Keypad) */
-    HID_GI_USAGE_PAGE,
-    USAGE_GEN_DESKTOP_KEYPAD,
-    /* REPORT_SIZE (8) */
-    HID_GI_REPORT_SIZE,
-    0x02,
-    /* REPORT_COUNT (6) */
-    HID_GI_REPORT_COUNT,
-    0x01,
-    /* INPUT (Cnst,Var,Abs) */
-    HID_MI_INPUT,
-    0x03,
+    0x00,
+
     /* END_COLLECTION */
     HID_MI_COLLECTION_END,
     /* USAGE_PAGE (Consumer) */
@@ -142,7 +129,7 @@ static const u8_t zmk_hid_report_desc[] = {
 
 struct zmk_hid_keypad_report_body {
     zmk_mod_flags modifiers;
-    u8_t keys[13];
+    u8_t keys[ZMK_HID_KEYPAD_NKRO_SIZE];
 } __packed;
 
 struct zmk_hid_keypad_report {

--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -59,6 +59,19 @@ static const u8_t zmk_hid_report_desc[] = {
     /* USAGE_PAGE (Keypad) */
     HID_GI_USAGE_PAGE,
     USAGE_GEN_DESKTOP_KEYPAD,
+    /* REPORT_SIZE (8) */
+    HID_GI_REPORT_SIZE,
+    0x08,
+    /* REPORT_COUNT (1) */
+    HID_GI_REPORT_COUNT,
+    0x01,
+    /* INPUT (Cnst,Var,Abs) */
+    HID_MI_INPUT,
+    0x03,
+
+    /* USAGE_PAGE (Keypad) */
+    HID_GI_USAGE_PAGE,
+    USAGE_GEN_DESKTOP_KEYPAD,
     /* LOGICAL_MINIMUM (0) */
     HID_GI_LOGICAL_MIN(1),
     0x00,
@@ -131,6 +144,7 @@ static const u8_t zmk_hid_report_desc[] = {
 
 struct zmk_hid_keypad_report_body {
     zmk_mod_flags modifiers;
+    u8_t _reserved;
     u8_t keys[ZMK_HID_KEYPAD_NKRO_SIZE];
 } __packed;
 

--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -15,6 +15,8 @@
 
 #define ZMK_HID_KEYPAD_NKRO_SIZE 6
 
+#define ZMK_HID_CONSUMER_NKRO_SIZE 6
+
 static const u8_t zmk_hid_report_desc[] = {
     /* USAGE_PAGE (Generic Desktop) */
     HID_GI_USAGE_PAGE,
@@ -111,9 +113,9 @@ static const u8_t zmk_hid_report_desc[] = {
     /* REPORT_SIZE (8) */
     HID_GI_REPORT_SIZE,
     0x08,
-    /* REPORT_COUNT (8) */
+    /* REPORT_COUNT (ZMK_HID_CONSUMER_NKRO_SIZE) */
     HID_GI_REPORT_COUNT,
-    0x06,
+    ZMK_HID_CONSUMER_NKRO_SIZE,
     HID_MI_INPUT,
     0x00,
     /* END COLLECTION */
@@ -138,7 +140,7 @@ struct zmk_hid_keypad_report {
 } __packed;
 
 struct zmk_hid_consumer_report_body {
-    u8_t keys[6];
+    u8_t keys[ZMK_HID_CONSUMER_NKRO_SIZE];
 } __packed;
 
 struct zmk_hid_consumer_report {

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -9,8 +9,8 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include <zmk/hid.h>
 
-static struct zmk_hid_keypad_report kp_report = {
-    .report_id = 1, .body = {.modifiers = 0, .keys = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}};
+static struct zmk_hid_keypad_report kp_report = {.report_id = 1,
+                                                 .body = {.modifiers = 0, .keys = {0}}};
 
 static struct zmk_hid_consumer_report consumer_report = {.report_id = 2,
                                                          .body = {.keys = {0, 0, 0, 0, 0, 0}}};
@@ -35,23 +35,16 @@ int zmk_hid_unregister_mods(zmk_mod_flags modifiers) {
     return 0;
 }
 
-#define KEY_OFFSET 0x02
 #define MAX_KEYS 6
 
-/*
-#define TOGGLE_BOOT_KEY(match, val)                      \
-    for (int idx = 0; idx < MAX_KEYS; idx++)             \
-    {                                                    \
-        if (kp_report.boot.keys[idx + KEY_OFFSET] != match) \
-        {                                                \
-            continue;                                    \
-        }                                                \
-        kp_report.boot.keys[idx + KEY_OFFSET] = val;        \
-        break;                                           \
+#define TOGGLE_KEYPAD(match, val)                                                                  \
+    for (int idx = 0; idx < ZMK_HID_KEYPAD_NKRO_SIZE; idx++) {                                     \
+        if (kp_report.body.keys[idx] != match) {                                                   \
+            continue;                                                                              \
+        }                                                                                          \
+        kp_report.body.keys[idx] = val;                                                            \
+        break;                                                                                     \
     }
-*/
-
-#define TOGGLE_KEY(code, val) WRITE_BIT(kp_report.body.keys[code / 8], code % 8, val)
 
 #define TOGGLE_CONSUMER(match, val)                                                                \
     for (int idx = 0; idx < MAX_KEYS; idx++) {                                                     \
@@ -66,15 +59,7 @@ int zmk_hid_keypad_press(zmk_key code) {
     if (code >= LCTL && code <= RGUI) {
         return zmk_hid_register_mod(code - LCTL);
     }
-
-    if (code > ZMK_HID_MAX_KEYCODE) {
-        return -EINVAL;
-    }
-
-    // TOGGLE_BOOT_KEY(0U, code);
-
-    TOGGLE_KEY(code, true);
-
+    TOGGLE_KEYPAD(0U, code);
     return 0;
 };
 
@@ -82,15 +67,7 @@ int zmk_hid_keypad_release(zmk_key code) {
     if (code >= LCTL && code <= RGUI) {
         return zmk_hid_unregister_mod(code - LCTL);
     }
-
-    if (code > ZMK_HID_MAX_KEYCODE) {
-        return -EINVAL;
-    }
-
-    // TOGGLE_BOOT_KEY(0U, code);
-
-    TOGGLE_KEY(code, false);
-
+    TOGGLE_KEYPAD(code, 0U);
     return 0;
 };
 

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -9,8 +9,8 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include <zmk/hid.h>
 
-static struct zmk_hid_keypad_report kp_report = {.report_id = 1,
-                                                 .body = {.modifiers = 0, .keys = {0}}};
+static struct zmk_hid_keypad_report kp_report = {
+    .report_id = 1, .body = {.modifiers = 0, ._reserved = 0, .keys = {0}}};
 
 static struct zmk_hid_consumer_report consumer_report = {.report_id = 2, .body = {.keys = {0}}};
 

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -12,8 +12,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 static struct zmk_hid_keypad_report kp_report = {.report_id = 1,
                                                  .body = {.modifiers = 0, .keys = {0}}};
 
-static struct zmk_hid_consumer_report consumer_report = {.report_id = 2,
-                                                         .body = {.keys = {0, 0, 0, 0, 0, 0}}};
+static struct zmk_hid_consumer_report consumer_report = {.report_id = 2, .body = {.keys = {0}}};
 
 #define _TOGGLE_MOD(mod, state)                                                                    \
     if (modifier > MOD_RGUI) {                                                                     \
@@ -35,8 +34,6 @@ int zmk_hid_unregister_mods(zmk_mod_flags modifiers) {
     return 0;
 }
 
-#define MAX_KEYS 6
-
 #define TOGGLE_KEYPAD(match, val)                                                                  \
     for (int idx = 0; idx < ZMK_HID_KEYPAD_NKRO_SIZE; idx++) {                                     \
         if (kp_report.body.keys[idx] != match) {                                                   \
@@ -47,7 +44,7 @@ int zmk_hid_unregister_mods(zmk_mod_flags modifiers) {
     }
 
 #define TOGGLE_CONSUMER(match, val)                                                                \
-    for (int idx = 0; idx < MAX_KEYS; idx++) {                                                     \
+    for (int idx = 0; idx < ZMK_HID_CONSUMER_NKRO_SIZE; idx++) {                                   \
         if (consumer_report.body.keys[idx] != match) {                                             \
             continue;                                                                              \
         }                                                                                          \


### PR DESCRIPTION
- Replace keypad report's NKRO bit-array with a configurable integer (DV) array.
- Refactor consumer report to a configurable size.
- Add missing constant into keypad report so that it's boot friendly.

### Testing
- Integration tests run on each commit.
- End-to-end tests after rebasing #236.
- Not yet tested in use (@petejohanson offered to do so).
- Not yet tested varying the configurable sizes.  But my best guess is ...
  - The keypad report should be fine until `ZMK_HID_KEYPAD_NKRO_SIZE` = 13
  - The consumer report should be fine until `ZMK_HID_CONSUMER_NKRO_SIZE` = 7