### PR TITLE
docs(key press): Replace deprecated `NUM_1` with `N1`

### DIFF
--- a/docs/docs/behavior/key-press.md
+++ b/docs/docs/behavior/key-press.md
@@ -20,7 +20,7 @@ provided by ZMK near the top:
 #include <dt-bindings/zmk/keys.h>
 ```
 
-Doing so makes a set of defines such as `A`, `NUM_1`, etc. available for use with these behaviors
+Doing so makes a set of defines such as `A`, `N1`, etc. available for use with these behaviors
 
 :::note
 There is an [open issue](https://github.com/zmkfirmware/zmk/issues/21) to provide a more comprehensive, and


### PR DESCRIPTION
This should've been changed in: b8f6d52ae521993c736bdbeaa9cbf63a4de37a5e