### PR TITLE
docs: Fixed PS Script, Added Wired Split FAQ, and Removed an Outdated Note

### DIFF
--- a/docs/docs/behaviors/key-press.md
+++ b/docs/docs/behaviors/key-press.md
@@ -33,11 +33,6 @@ provided by ZMK near the top:
 
 Doing so makes a set of defines such as `A`, `N1`, etc. available for use with these behaviors
 
-:::note
-There is an [open issue](https://github.com/zmkfirmware/zmk/issues/21) to provide a more comprehensive, and
-complete set of defines for the full keypad and consumer usage pages in the future for ZMK.
-:::
-
 ### Improperly defined keymap - `dtlib.DTError: <board>.dts.pre.tmp:<line number>`
 
 When compiling firmware from a keymap, it may be common to encounter an error in the form of a`dtlib.DTError: <board>.dts.pre.tmp:<line number>`.

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -76,6 +76,10 @@ Therefore in ZMK, [board](#what-is-a-board) and [shield](#what-is-a-shield) are 
 
 Please note, many keyboards only have a single PCB which includes the “brains” (MCU) onboard. In ZMK, these have no [shield](#what-is-a-shield), only a [board](#what-is-a-board).
 
+### Does ZMK support wired split?
+
+Currently, ZMK only supports wireless split, but wired split is possible and we welcome contributions!
+
 ### What bootloader does ZMK use?
 
 ZMK isn’t designed for any particular bootloader, and supports flashing different boards with different flash utilities (e.g. OpenOCD, nrfjprog, etc.). So if you have any difficulties, please let us know on [Discord](https://zmkfirmware.dev/community/discord/invite)!

--- a/docs/docs/user-setup.md
+++ b/docs/docs/user-setup.md
@@ -82,7 +82,7 @@ bash -c "$(wget https://zmkfirmware.dev/setup.sh -O -)" '' --wget
 <TabItem value="PowerShell">
 
 ```
-iex ((New-Object System.Net.WebClient).DownloadString('https://zmkfirmware.dev/setup.ps1'))"
+iex ((New-Object System.Net.WebClient).DownloadString('https://zmkfirmware.dev/setup.ps1'))
 ```
 
 </TabItem>


### PR DESCRIPTION
When I documented the PowerShell Install script (#210), I must have made a typo that added an extra quotation mark at the end, but I fixed it and now copying script straight from the docs works. I also added a FAQ for wired split seeing as it comes up in the discord quite often. Lastly I removed a note in `behavior/keypress` because the open issue it referred to is now closed and in main. 