### PR TITLE
feat(underglow): RGB toggle controls ext_power

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -187,6 +187,10 @@ if ZMK_RGB_UNDERGLOW
 config SPI
 	default y
 
+config ZMK_RGB_UNDERGLOW_EXT_POWER
+	bool "RGB underglow toggling also controls external power"
+	default y
+
 config ZMK_RGB_UNDERGLOW_HUE_STEP
 	int "RGB underglow hue step in degrees of 360"
 	default 10
@@ -220,7 +224,7 @@ config ZMK_RGB_UNDERGLOW_EFF_START
 	default 0
 
 config ZMK_RGB_UNDERGLOW_ON_START
-	bool "Whether RGB underglow starts on by default"
+	bool "RGB underglow starts on by default"
 	default y
 
 #ZMK_RGB_UNDERGLOW

--- a/app/src/behaviors/behavior_rgb_underglow.c
+++ b/app/src/behaviors/behavior_rgb_underglow.c
@@ -48,8 +48,14 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
     return -ENOTSUP;
 }
 
+static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
+    return 0;
+}
+
 static const struct behavior_driver_api behavior_rgb_underglow_driver_api = {
     .binding_pressed = on_keymap_binding_pressed,
+    .binding_released = on_keymap_binding_released,
 };
 
 DEVICE_AND_API_INIT(behavior_rgb_underglow, DT_INST_LABEL(0), behavior_rgb_underglow_init, NULL,

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -15,6 +15,7 @@
 #include <logging/log.h>
 
 #include <drivers/led_strip.h>
+#include <drivers/ext_power.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
@@ -45,34 +46,14 @@ struct rgb_underglow_state {
     bool on;
 };
 
-struct device *led_strip;
+static struct device *led_strip;
 
-struct led_rgb pixels[STRIP_NUM_PIXELS];
+static struct led_rgb pixels[STRIP_NUM_PIXELS];
 
-struct rgb_underglow_state state;
+static struct rgb_underglow_state state;
 
-#if IS_ENABLED(CONFIG_SETTINGS)
-static int rgb_settings_set(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg) {
-    const char *next;
-    int rc;
-
-    if (settings_name_steq(name, "state", &next) && !next) {
-        if (len != sizeof(state)) {
-            return -EINVAL;
-        }
-
-        rc = read_cb(cb_arg, &state, sizeof(state));
-        if (rc >= 0) {
-            return 0;
-        }
-
-        return rc;
-    }
-
-    return -ENOENT;
-}
-
-struct settings_handler rgb_conf = {.name = "rgb/underglow", .h_set = rgb_settings_set};
+#if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
+static struct device *ext_power;
 #endif
 
 static struct led_rgb hsb_to_rgb(struct led_hsb hsb) {
@@ -228,6 +209,29 @@ static void zmk_rgb_underglow_tick_handler(struct k_timer *timer) {
 K_TIMER_DEFINE(underglow_tick, zmk_rgb_underglow_tick_handler, NULL);
 
 #if IS_ENABLED(CONFIG_SETTINGS)
+static int rgb_settings_set(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg) {
+    const char *next;
+    int rc;
+
+    if (settings_name_steq(name, "state", &next) && !next) {
+        if (len != sizeof(state)) {
+            return -EINVAL;
+        }
+
+        rc = read_cb(cb_arg, &state, sizeof(state));
+        if (rc >= 0) {
+            k_timer_start(&underglow_tick, K_NO_WAIT, K_MSEC(50));
+            return 0;
+        }
+
+        return rc;
+    }
+
+    return -ENOENT;
+}
+
+struct settings_handler rgb_conf = {.name = "rgb/underglow", .h_set = rgb_settings_set};
+
 static void zmk_rgb_underglow_save_state_work() {
     settings_save_one("rgb/underglow/state", &state, sizeof(state));
 }
@@ -244,6 +248,13 @@ static int zmk_rgb_underglow_init(struct device *_arg) {
         return -EINVAL;
     }
 
+#if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
+    ext_power = device_get_binding("EXT_POWER");
+    if (ext_power == NULL) {
+        LOG_ERR("Unable to retrieve ext_power device: EXT_POWER");
+    }
+#endif
+
     state = (struct rgb_underglow_state){
         hue : CONFIG_ZMK_RGB_UNDERGLOW_HUE_START,
         saturation : CONFIG_ZMK_RGB_UNDERGLOW_SAT_START,
@@ -257,9 +268,9 @@ static int zmk_rgb_underglow_init(struct device *_arg) {
 #if IS_ENABLED(CONFIG_SETTINGS)
     settings_register(&rgb_conf);
     k_delayed_work_init(&underglow_save_work, zmk_rgb_underglow_save_state_work);
-#endif
-
+#else
     k_timer_start(&underglow_tick, K_NO_WAIT, K_MSEC(50));
+#endif
 
     return 0;
 }
@@ -298,6 +309,22 @@ int zmk_rgb_underglow_toggle() {
         return -ENODEV;
 
     state.on = !state.on;
+
+#if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
+    if (ext_power != NULL) {
+        int rc;
+
+        if (state.on) {
+            rc = ext_power_enable(ext_power);
+        } else {
+            rc = ext_power_disable(ext_power);
+        }
+
+        if (rc != 0) {
+            LOG_ERR("Unable to toggle EXT_POWER: %d", rc);
+        }
+    }
+#endif
 
     if (state.on) {
         state.animation_step = 0;

--- a/docs/docs/features/underglow.md
+++ b/docs/docs/features/underglow.md
@@ -35,17 +35,18 @@ If your board or shield does not have RGB underglow configured, refer to [Adding
 
 There are various Kconfig options used to configure the RGB underglow feature. These can all be set in the `.conf` file.
 
-| Option                               | Description                                    | Default |
-| ------------------------------------ | ---------------------------------------------- | ------- |
-| `CONFIG_ZMK_RGB_UNDERGLOW_HUE_STEP`  | Hue step in degrees of 360 used by RGB actions | 10      |
-| `CONFIG_ZMK_RGB_UNDERGLOW_SAT_STEP`  | Saturation step in percent used by RGB actions | 10      |
-| `CONFIG_ZMK_RGB_UNDERGLOW_BRT_STEP`  | Brightness step in percent used by RGB actions | 10      |
-| `CONFIG_ZMK_RGB_UNDERGLOW_HUE_START` | Default hue 0-359 in degrees                   | 0       |
-| `CONFIG_ZMK_RGB_UNDERGLOW_SAT_START` | Default saturation 0-100 in percent            | 100     |
-| `CONFIG_ZMK_RGB_UNDERGLOW_BRT_START` | Default brightness 0-100 in percent            | 100     |
-| `CONFIG_ZMK_RGB_UNDERGLOW_SPD_START` | Default effect speed 1-5                       | 3       |
-| `CONFIG_ZMK_RGB_UNDERGLOW_EFF_START` | Default effect integer from the effect enum    | 0       |
-| `CONFIG_ZMK_RGB_UNDERGLOW_ON_START`  | Default on state                               | y       |
+| Option                               | Description                                     | Default |
+| ------------------------------------ | ----------------------------------------------- | ------- |
+| `CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER` | Underglow toggling also controls external power | y       |
+| `CONFIG_ZMK_RGB_UNDERGLOW_HUE_STEP`  | Hue step in degrees of 360 used by RGB actions  | 10      |
+| `CONFIG_ZMK_RGB_UNDERGLOW_SAT_STEP`  | Saturation step in percent used by RGB actions  | 10      |
+| `CONFIG_ZMK_RGB_UNDERGLOW_BRT_STEP`  | Brightness step in percent used by RGB actions  | 10      |
+| `CONFIG_ZMK_RGB_UNDERGLOW_HUE_START` | Default hue 0-359 in degrees                    | 0       |
+| `CONFIG_ZMK_RGB_UNDERGLOW_SAT_START` | Default saturation 0-100 in percent             | 100     |
+| `CONFIG_ZMK_RGB_UNDERGLOW_BRT_START` | Default brightness 0-100 in percent             | 100     |
+| `CONFIG_ZMK_RGB_UNDERGLOW_SPD_START` | Default effect speed 1-5                        | 3       |
+| `CONFIG_ZMK_RGB_UNDERGLOW_EFF_START` | Default effect integer from the effect enum     | 0       |
+| `CONFIG_ZMK_RGB_UNDERGLOW_ON_START`  | Default on state                                | y       |
 
 ## Adding RGB Underglow to a Board
 


### PR DESCRIPTION
This adds the ability for RGB underglow toggling to control ext_power to save immensely on battery when RGB is off. It also can be turned off if people want to have more fine tuned control if they have more than RGB on their board for example.

This PR also fixes the error being thrown on release of any underglow behavior and the quick blip of red LED on start when using settings.