### PR TITLE
boards: Cleanup and standardize features

### DIFF
--- a/app/boards/arm/bluemicro840/bluemicro840_v1.dts
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1.dts
@@ -14,9 +14,6 @@
 
 	chosen {
 		zephyr,code-partition = &code_partition;
-		// zephyr,console = &uart0;
-		//zephyr,bt-mon-uart = &uart0;
-		//zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};
@@ -27,6 +24,12 @@
 			gpios = <&gpio0 42 GPIO_ACTIVE_HIGH>;
 			label = "Blue LED";
 		};
+	};
+
+	ext-power {
+		compatible = "zmk,ext-power-generic";
+		label = "EXT_POWER";
+		control-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 	};
 
 	vbatt {
@@ -40,6 +43,10 @@
 };
 
 &adc {
+	status = "okay";
+};
+
+&gpiote {
 	status = "okay";
 };
 
@@ -61,10 +68,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <39>;
-	rx-pin = <34>;
-	rts-pin = <33>;
-	cts-pin = <12>;
+	tx-pin = <19>;
+	rx-pin = <21>;
+	rts-pin = <23>;
+	cts-pin = <25>;
 };
 
 &usbd {

--- a/app/boards/arm/nice_nano/nice_nano.dts
+++ b/app/boards/arm/nice_nano/nice_nano.dts
@@ -14,9 +14,6 @@
 
 	chosen {
 		zephyr,code-partition = &code_partition;
-		// zephyr,console = &uart0;
-		//zephyr,bt-mon-uart = &uart0;
-		//zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};
@@ -70,10 +67,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <39>;
-	rx-pin = <34>;
-	rts-pin = <33>;
-	cts-pin = <12>;
+	tx-pin = <19>;
+	rx-pin = <21>;
+	rts-pin = <23>;
+	cts-pin = <25>;
 };
 
 &usbd {

--- a/app/boards/arm/nrf52840_m2/nrf52840_m2.dts
+++ b/app/boards/arm/nrf52840_m2/nrf52840_m2.dts
@@ -12,9 +12,6 @@
 
 	chosen {
 		zephyr,code-partition = &code_partition;
-		//zephyr,console = &uart0;
-		//zephyr,bt-mon-uart = &uart0;
-		//zephyr,bt-c2h-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};
@@ -37,6 +34,14 @@
 
 };
 
+&adc {
+	status = "okay";
+};
+
+&gpiote {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -46,13 +51,13 @@
 };
 
 &uart0 {
-	compatible = "nordic,nrf-uart";
+	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <16>;
-	rx-pin = <15>;
-	rts-pin = <14>;
-	cts-pin = <13>;
+	tx-pin = <19>;
+	rx-pin = <21>;
+	rts-pin = <23>;
+	cts-pin = <25>;
 };
 
 &usbd {

--- a/app/boards/arm/nrfmicro/nrfmicro_11.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11.dts
@@ -33,6 +33,10 @@
 	};
 };
 
+&gpiote {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -51,10 +55,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <39>;
-	rx-pin = <34>;
-	rts-pin = <33>;
-	cts-pin = <12>;
+	tx-pin = <19>;
+	rx-pin = <21>;
+	rts-pin = <23>;
+	cts-pin = <25>;
 };
 
 &usbd {

--- a/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
@@ -33,6 +33,10 @@
 	};
 };
 
+&gpiote {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -51,10 +55,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <39>;
-	rx-pin = <34>;
-	rts-pin = <33>;
-	cts-pin = <12>;
+	tx-pin = <19>;
+	rx-pin = <21>;
+	rts-pin = <23>;
+	cts-pin = <25>;
 };
 
 &usbd {

--- a/app/boards/arm/nrfmicro/nrfmicro_13.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13.dts
@@ -45,6 +45,10 @@
 	status = "okay";
 };
 
+&gpiote {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };
@@ -63,10 +67,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <39>;
-	rx-pin = <34>;
-	rts-pin = <33>;
-	cts-pin = <12>;
+	tx-pin = <19>;
+	rx-pin = <21>;
+	rts-pin = <23>;
+	cts-pin = <25>;
 };
 
 &usbd {


### PR DESCRIPTION
This cleans up some extra commented-out items, standardizes the UART to unexposed pins, closes #294, and closes #295.