### PR TITLE
Convert direct KSCAN driver to PORT events for power management improvements.

### DIFF
--- a/app/boards/shields/cradio/Kconfig.defconfig
+++ b/app/boards/shields/cradio/Kconfig.defconfig
@@ -14,10 +14,3 @@ config ZMK_KEYBOARD_NAME
 	default "cradio right"
 
 endif
-
-if SHIELD_CRADIO_RIGHT || SHIELD_CRADIO_LEFT
-
-config ZMK_KSCAN_DIRECT_POLLING
-	default y
-
-endif


### PR DESCRIPTION
* Switch interrupt configuration so nRF52 uses
  PORT events for lower power use, and wake
  from deep sleep.
* Closes #272