### PR TITLE
fix(underglow): Switch from legacy SPI to SPIM

### DIFF
--- a/app/boards/shields/corne/boards/nice_nano.overlay
+++ b/app/boards/shields/corne/boards/nice_nano.overlay
@@ -1,5 +1,5 @@
 &spi1 {
-	compatible = "nordic,nrf-spi";
+	compatible = "nordic,nrf-spim";
 	/* Cannot be used together with i2c0. */
 	status = "okay";
 	mosi-pin = <6>;

--- a/app/boards/shields/kyria/boards/nice_nano.overlay
+++ b/app/boards/shields/kyria/boards/nice_nano.overlay
@@ -1,5 +1,5 @@
 &spi1 {
-	compatible = "nordic,nrf-spi";
+	compatible = "nordic,nrf-spim";
 	status = "okay";
 	mosi-pin = <6>;
 	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.

--- a/app/boards/shields/kyria/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/kyria/boards/nrfmicro_11.overlay
@@ -1,5 +1,5 @@
 &spi1 {
-	compatible = "nordic,nrf-spi";
+	compatible = "nordic,nrf-spim";
 	status = "okay";
 	mosi-pin = <6>;
 	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.

--- a/app/boards/shields/kyria/boards/nrfmicro_11_flipped.overlay
+++ b/app/boards/shields/kyria/boards/nrfmicro_11_flipped.overlay
@@ -1,5 +1,5 @@
 &spi1 {
-	compatible = "nordic,nrf-spi";
+	compatible = "nordic,nrf-spim";
 	status = "okay";
 	mosi-pin = <6>;
 	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.

--- a/app/boards/shields/kyria/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/kyria/boards/nrfmicro_13.overlay
@@ -1,5 +1,5 @@
 &spi1 {
-	compatible = "nordic,nrf-spi";
+	compatible = "nordic,nrf-spim";
 	status = "okay";
 	mosi-pin = <6>;
 	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.

--- a/app/boards/shields/microdox/boards/nice_nano.overlay
+++ b/app/boards/shields/microdox/boards/nice_nano.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 &spi1 {
-	compatible = "nordic,nrf-spi";
+	compatible = "nordic,nrf-spim";
 	/* Cannot be used together with i2c0. */
 	status = "okay";
 	mosi-pin = <6>;

--- a/app/boards/shields/reviung41/boards/nice_nano.overlay
+++ b/app/boards/shields/reviung41/boards/nice_nano.overlay
@@ -1,5 +1,5 @@
 &spi1 {
-	compatible = "nordic,nrf-spi";
+	compatible = "nordic,nrf-spim";
 	status = "okay";
 	mosi-pin = <6>;
 	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.

--- a/app/boards/shields/romac_plus/boards/nice_nano.overlay
+++ b/app/boards/shields/romac_plus/boards/nice_nano.overlay
@@ -1,5 +1,5 @@
 &spi1 {
-	compatible = "nordic,nrf-spi";
+	compatible = "nordic,nrf-spim";
 	status = "okay";
 	mosi-pin = <6>;
 	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.

--- a/docs/docs/feature/underglow.md
+++ b/docs/docs/feature/underglow.md
@@ -61,7 +61,7 @@ Here's an example of an nRF52 SPI definition:
 
 ```
 &spi1 {
-  compatible = "nordic,nrf-spi";
+  compatible = "nordic,nrf-spim";
   status = "okay";
   mosi-pin = <6>;
   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.


### PR DESCRIPTION
This replaces the legacy Nordic SPI master implementation in favor of SPIM. It has been confirmed to fix #305 for those who have tested it. It also reduces power consumption of the underglow part of the firmware from 55µA to 30µA. #312 should note this.

The reason for this fix working is speculated to be because SPIM does not require the CPU to transfer data packets to and from RAM. Because of this it's speculated that the CPU was busy for a few µs, which caused the strip update to get reset in the middle of transfer.