### PR TITLE
feat: add retro tapping (disable hold-tap timer)

### DIFF
--- a/app/tests/hold-tap/balanced-disable-timer/1-dn-up/events.patterns
+++ b/app/tests/hold-tap/balanced-disable-timer/1-dn-up/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/balanced-disable-timer/1-dn-up/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced-disable-timer/1-dn-up/keycode_events.snapshot
@@ -1,0 +1,5 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (hold-preferred event 0)
+kp_pressed: usage_page 0x07 keycode 0x09 mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced-disable-timer/1-dn-up/native_posix.keymap
+++ b/app/tests/hold-tap/balanced-disable-timer/1-dn-up/native_posix.keymap
@@ -1,0 +1,11 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10) 
+		ZMK_MOCK_RELEASE(0,0,10) 
+	>;
+};

--- a/app/tests/hold-tap/balanced-disable-timer/3a-moddn-dn-modup-up/events.patterns
+++ b/app/tests/hold-tap/balanced-disable-timer/3a-moddn-dn-modup-up/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/balanced-disable-timer/3a-moddn-dn-modup-up/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced-disable-timer/3a-moddn-dn-modup-up/keycode_events.snapshot
@@ -1,0 +1,7 @@
+kp_pressed: usage_page 0x07 keycode 0xe4 mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (hold-preferred event 0)
+kp_pressed: usage_page 0x07 keycode 0x09 mods 0x00
+kp_released: usage_page 0x07 keycode 0xe4 mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced-disable-timer/3a-moddn-dn-modup-up/native_posix.keymap
+++ b/app/tests/hold-tap/balanced-disable-timer/3a-moddn-dn-modup-up/native_posix.keymap
@@ -1,0 +1,13 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(1,1,10) /*ctrl*/
+		ZMK_MOCK_PRESS(0,0,100)  /*mt f-shift */
+		ZMK_MOCK_RELEASE(1,1,10)
+		ZMK_MOCK_RELEASE(0,0,10) 
+	>;
+};

--- a/app/tests/hold-tap/balanced-disable-timer/3c-kcdn-dn-kcup-up/events.patterns
+++ b/app/tests/hold-tap/balanced-disable-timer/3c-kcdn-dn-kcup-up/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/balanced-disable-timer/3c-kcdn-dn-kcup-up/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced-disable-timer/3c-kcdn-dn-kcup-up/keycode_events.snapshot
@@ -1,0 +1,7 @@
+kp_pressed: usage_page 0x07 keycode 0x07 mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+kp_released: usage_page 0x07 keycode 0x07 mods 0x00
+ht_decide: 0 decided tap (hold-preferred event 0)
+kp_pressed: usage_page 0x07 keycode 0x09 mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced-disable-timer/3c-kcdn-dn-kcup-up/native_posix.keymap
+++ b/app/tests/hold-tap/balanced-disable-timer/3c-kcdn-dn-kcup-up/native_posix.keymap
@@ -1,0 +1,13 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(1,0,10) /*d*/
+		ZMK_MOCK_PRESS(0,0,100)  /*mt f-shift */
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10) 
+	>;
+};

--- a/app/tests/hold-tap/balanced-disable-timer/4c-dn-kcdn-kcup-up/events.patterns
+++ b/app/tests/hold-tap/balanced-disable-timer/4c-dn-kcdn-kcup-up/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/balanced-disable-timer/4c-dn-kcdn-kcup-up/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced-disable-timer/4c-dn-kcdn-kcup-up/keycode_events.snapshot
@@ -1,0 +1,7 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold (hold-preferred event 1)
+kp_pressed: usage_page 0x07 keycode 0xe1 mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 mods 0x00
+kp_released: usage_page 0x07 keycode 0xe1 mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced-disable-timer/4c-dn-kcdn-kcup-up/native_posix.keymap
+++ b/app/tests/hold-tap/balanced-disable-timer/4c-dn-kcdn-kcup-up/native_posix.keymap
@@ -1,0 +1,14 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+		/* timer */ 
+	>;
+};

--- a/app/tests/hold-tap/balanced-disable-timer/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/balanced-disable-timer/behavior_keymap.dtsi
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+
+
+
+/ {
+	behaviors {
+		ht_hold: behavior_hold_hold_tap {
+			compatible = "zmk,behavior-hold-tap";
+			label = "hold_hold_tap";
+			#binding-cells = <2>;
+			flavor = "hold-preferred";
+			tapping_term_ms = <0>;
+			bindings = <&kp>, <&kp>;
+		};
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&ht_hold LEFT_SHIFT F &ht_hold LEFT_CONTROL J
+				&kp D &kp RIGHT_CONTROL>;
+		};
+	};
+};

--- a/app/tests/hold-tap/hold-preferred-disable-timer/1-dn-up/events.patterns
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/1-dn-up/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/hold-preferred-disable-timer/1-dn-up/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/1-dn-up/keycode_events.snapshot
@@ -1,0 +1,5 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (hold-preferred event 0)
+kp_pressed: usage_page 0x07 keycode 0x09 mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred-disable-timer/1-dn-up/native_posix.keymap
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/1-dn-up/native_posix.keymap
@@ -1,0 +1,11 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10) 
+		ZMK_MOCK_RELEASE(0,0,10) 
+	>;
+};

--- a/app/tests/hold-tap/hold-preferred-disable-timer/3a-moddn-dn-modup-up/events.patterns
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/3a-moddn-dn-modup-up/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/hold-preferred-disable-timer/3a-moddn-dn-modup-up/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/3a-moddn-dn-modup-up/keycode_events.snapshot
@@ -1,0 +1,7 @@
+kp_pressed: usage_page 0x07 keycode 0xe4 mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (hold-preferred event 0)
+kp_pressed: usage_page 0x07 keycode 0x09 mods 0x00
+kp_released: usage_page 0x07 keycode 0xe4 mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred-disable-timer/3a-moddn-dn-modup-up/native_posix.keymap
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/3a-moddn-dn-modup-up/native_posix.keymap
@@ -1,0 +1,13 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(1,1,10) /*ctrl*/
+		ZMK_MOCK_PRESS(0,0,100)  /*mt f-shift */
+		ZMK_MOCK_RELEASE(1,1,10)
+		ZMK_MOCK_RELEASE(0,0,10) 
+	>;
+};

--- a/app/tests/hold-tap/hold-preferred-disable-timer/3c-kcdn-dn-kcup-up/events.patterns
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/3c-kcdn-dn-kcup-up/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/hold-preferred-disable-timer/3c-kcdn-dn-kcup-up/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/3c-kcdn-dn-kcup-up/keycode_events.snapshot
@@ -1,0 +1,7 @@
+kp_pressed: usage_page 0x07 keycode 0x07 mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+kp_released: usage_page 0x07 keycode 0x07 mods 0x00
+ht_decide: 0 decided tap (hold-preferred event 0)
+kp_pressed: usage_page 0x07 keycode 0x09 mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred-disable-timer/3c-kcdn-dn-kcup-up/native_posix.keymap
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/3c-kcdn-dn-kcup-up/native_posix.keymap
@@ -1,0 +1,13 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(1,0,10) /*d*/
+		ZMK_MOCK_PRESS(0,0,100)  /*mt f-shift */
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10) 
+	>;
+};

--- a/app/tests/hold-tap/hold-preferred-disable-timer/4c-dn-kcdn-kcup-up/events.patterns
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/4c-dn-kcdn-kcup-up/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/hold-preferred-disable-timer/4c-dn-kcdn-kcup-up/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/4c-dn-kcdn-kcup-up/keycode_events.snapshot
@@ -1,0 +1,7 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold (hold-preferred event 1)
+kp_pressed: usage_page 0x07 keycode 0xe1 mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 mods 0x00
+kp_released: usage_page 0x07 keycode 0xe1 mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred-disable-timer/4c-dn-kcdn-kcup-up/native_posix.keymap
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/4c-dn-kcdn-kcup-up/native_posix.keymap
@@ -1,0 +1,14 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+		/* timer */ 
+	>;
+};

--- a/app/tests/hold-tap/hold-preferred-disable-timer/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/hold-preferred-disable-timer/behavior_keymap.dtsi
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+
+
+
+/ {
+	behaviors {
+		ht_hold: behavior_hold_hold_tap {
+			compatible = "zmk,behavior-hold-tap";
+			label = "hold_hold_tap";
+			#binding-cells = <2>;
+			flavor = "hold-preferred";
+			tapping_term_ms = <0>;
+			bindings = <&kp>, <&kp>;
+		};
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&ht_hold LEFT_SHIFT F &ht_hold LEFT_CONTROL J
+				&kp D &kp RIGHT_CONTROL>;
+		};
+	};
+};

--- a/docs/docs/behavior/hold-tap.md
+++ b/docs/docs/behavior/hold-tap.md
@@ -21,6 +21,14 @@ By default, the hold-tap is configured to also select the 'hold' functionality i
 
 We call this the 'hold-preferred' flavor of hold-taps. While this flavor may work very well for a ctrl/escape key, it's not very well suited for home-row mods or layer-taps. That's why there are two more flavors to choose from: 'tap-preferred' and 'balanced'.
 
+#### Flavors
+
+- The 'hold-preferred' flavor triggers the hold behavior when the tapping_term_ms has expired or another key is pressed.
+- The 'balanced' flavor will trigger the hold behavior when the tapping_term_ms has expired or another key is pressed and released.
+- The 'tap-preferred' flavor triggers the hold behavior when the tapping_term_ms has expired. It triggers the tap behavior when another key is pressed.
+
+When the hold-tap key is released and the hold behavior has not been triggered, the tap behavior will trigger.
+
 ![Hold-tap comparison](../assets/hold-tap/comparison.png)
 
 ### Basic usage
@@ -29,7 +37,7 @@ For basic usage, please see [mod-tap](./mod-tap.md) and [layer-tap](./layers.md)
 
 ### Advanced Configuration
 
-A code example which configures a mod-tap setting that works with homerow mods:
+This example configures a hold-tap setting that works well with homerow mods:
 
 ```
 #include <behaviors.dtsi>
@@ -62,8 +70,16 @@ A code example which configures a mod-tap setting that works with homerow mods:
 
 If this config does not work for you, try the flavor "tap-preferred" and a short tapping_term_ms such as 120ms.
 
-If you want to use a tap-hold with a keycode from a different code page, you have to define another behavior with another "bindings" parameter.For example, if you want to use SHIFT and volume up, define the bindings like `bindings = <&kp>, <&kp>;`. Only single-argument behaviors are supported at the moment.
+#### Disabling the timer
+
+If you set the tapping_term_ms to `0`, the timer is disabled for this hold-tap:
+
+- The 'hold-preferred' flavor with tapping_term_ms `0` triggers the hold behavior when another key is pressed.
+- The 'balanced' flavor with tapping_term_ms `0` triggers the hold behavior when another key is pressed and released.
+- The 'tap-preferred' flavor with tapping_term_ms `0` never triggers the hold behavior (so don't set the tapping_term for these to 0)!
 
 #### Comparison to QMK
 
 The hold-preferred flavor works similar to the `HOLD_ON_OTHER_KEY_PRESS` setting in QMK. The 'balanced' flavor is similar to the `PERMISSIVE_HOLD` setting, and the `tap-preferred` flavor is similar to `IGNORE_MOD_TAP_INTERRUPT`.
+
+Setting the `tapping_term_ms` to `0` is equivalent to `RETRO_TAPPING` in QMK.


### PR DESCRIPTION
closes #339.

If you set the tapping_term_ms to `0`, the timer is disabled for this hold-tap:

- The 'hold-preferred' flavor with tapping_term_ms `0` triggers the hold behavior when another key is pressed.
- The 'balanced' flavor with tapping_term_ms `0` triggers the hold behavior when another key is pressed and released.
- The 'tap-preferred' flavor with tapping_term_ms `0` never triggers the hold behavior (so don't set the tapping_term for these to 0)!