### PR TITLE
refactor(docs): Remove explicit document ids

### DIFF
--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -1,5 +1,4 @@
 ---
-id: customization
 title: Customizing ZMK/`zmk-config` folders
 sidebar_label: Customizing ZMK
 ---

--- a/docs/docs/dev-boards-shields-keymaps.md
+++ b/docs/docs/dev-boards-shields-keymaps.md
@@ -1,5 +1,4 @@
 ---
-id: dev-boards-shields-keymaps
 title: Boards, Shields, and Keymaps
 ---
 

--- a/docs/docs/dev-build-flash.md
+++ b/docs/docs/dev-build-flash.md
@@ -1,5 +1,4 @@
 ---
-id: dev-build-flash
 title: Building and Flashing
 sidebar_label: Building and Flashing
 ---

--- a/docs/docs/dev-clean-room.md
+++ b/docs/docs/dev-clean-room.md
@@ -1,5 +1,4 @@
 ---
-id: dev-clean-room
 title: Clean Room Implementation
 sidebar_label: Clean Room
 ---

--- a/docs/docs/dev-guide-usb-logging.md
+++ b/docs/docs/dev-guide-usb-logging.md
@@ -1,5 +1,4 @@
 ---
-id: dev-guide-usb-logging
 title: USB Logging
 ---
 

--- a/docs/docs/dev-posix-board.md
+++ b/docs/docs/dev-posix-board.md
@@ -1,5 +1,4 @@
 ---
-id: dev-posix-board
 title: Native Posix board target
 ---
 

--- a/docs/docs/dev-setup.md
+++ b/docs/docs/dev-setup.md
@@ -1,5 +1,4 @@
 ---
-id: dev-setup
 title: Basic Setup
 sidebar_label: Basic Setup
 ---
@@ -450,7 +449,7 @@ This step pulls down quite a bit of tooling. Go grab a cup of coffee, it can tak
 :::info
 If you're using Docker, you're done with setup! You must restart the container at this point. The easiest way to do so is to close the VS Code window, verify that the container has stopped in Docker Dashboard, and reopen the container with VS Code.
 
-Once your container is restarted, proceed to [Building and Flashing](./dev-build.md).
+Once your container is restarted, proceed to [Building and Flashing](./dev-build-flash.md).
 :::
 
 #### Export Zephyr™ Core

--- a/docs/docs/dev-tests.md
+++ b/docs/docs/dev-tests.md
@@ -1,5 +1,4 @@
 ---
-id: dev-tests
 title: Tests
 sidebar_label: Tests
 ---

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -1,5 +1,4 @@
 ---
-id: faq
 title: FAQs
 sidebar_label: FAQs
 ---

--- a/docs/docs/feature/keymaps.md
+++ b/docs/docs/feature/keymaps.md
@@ -1,5 +1,4 @@
 ---
-id: keymaps
 title: Keymaps & Behaviors
 sidebar_label: Keymaps
 ---

--- a/docs/docs/hardware.md
+++ b/docs/docs/hardware.md
@@ -1,5 +1,4 @@
 ---
-id: hardware
 title: Supported Hardware
 sidebar_label: Supported Hardware
 ---

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,5 +1,4 @@
 ---
-id: intro
 title: Introduction to ZMK
 sidebar_label: Introduction
 slug: /

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1,5 +1,4 @@
 ---
-id: troubleshooting
 title: Troubleshooting
 sidebar_title: Troubleshooting
 ---

--- a/docs/docs/user-setup.md
+++ b/docs/docs/user-setup.md
@@ -1,5 +1,4 @@
 ---
-id: user-setup
 title: Installing ZMK
 sidebar_label: Installing ZMK
 ---


### PR DESCRIPTION
Aligns older documents with newer file-based ids.  Lays the groundwork for upcoming organizational refactors.

@petejohanson, the newer documents haven't been setting explicit ids and have instead relied on implicit ids from the filenames and directory layouts.  We should probably align everything to one convention.  Please reject the PR if you feel explicit ids are the better path.