### PR TITLE
docs(key-press): Change `codes` to `usages`

### DIFF
--- a/docs/docs/behaviors/key-press.md
+++ b/docs/docs/behaviors/key-press.md
@@ -19,7 +19,7 @@ The categories of supported codes are:
 
 Please visit the [codes](../codes) section for a comprehensive list.
 
-For advanced users, user-defined HID codes are also supported but must be encoded, please see [`dt-bindings/zmk/keys.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/keys.h) for further insight.
+For advanced users, user-defined HID usages are also supported but must be encoded, please see [`dt-bindings/zmk/keys.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/keys.h) for further insight.
 
 ## Keycode Defines
 


### PR DESCRIPTION
`usages` is a more accurate term in this context.