### PR TITLE
refactor(docs): Remove explicit document ids (part 2)

### DIFF
--- a/docs/docs/dev-guide-new-shield.md
+++ b/docs/docs/dev-guide-new-shield.md
@@ -1,5 +1,4 @@
 ---
-id: dev-guide-new-shield
 title: New Keyboard Shield
 ---
 


### PR DESCRIPTION
This was missed in: 4d42e792c5fe71156ca5618513645a0e825e2fc2

I even searched all files for `id: ` before submitting yesterday.

Must be Gremlins.