### PR TITLE
refactor: change `keypad` to `keyboard`

### DIFF
--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -15,7 +15,7 @@
 
 #define COLLECTION_REPORT 0x03
 
-#define ZMK_HID_KEYPAD_NKRO_SIZE 6
+#define ZMK_HID_KEYBOARD_NKRO_SIZE 6
 
 #define ZMK_HID_CONSUMER_NKRO_SIZE 6
 
@@ -89,9 +89,9 @@ static const u8_t zmk_hid_report_desc[] = {
     /* REPORT_SIZE (1) */
     HID_GI_REPORT_SIZE,
     0x08,
-    /* REPORT_COUNT (ZMK_HID_KEYPAD_NKRO_SIZE) */
+    /* REPORT_COUNT (ZMK_HID_KEYBOARD_NKRO_SIZE) */
     HID_GI_REPORT_COUNT,
-    ZMK_HID_KEYPAD_NKRO_SIZE,
+    ZMK_HID_KEYBOARD_NKRO_SIZE,
     /* INPUT (Data,Ary,Abs) */
     HID_MI_INPUT,
     0x00,
@@ -146,15 +146,15 @@ static const u8_t zmk_hid_report_desc[] = {
 //     u8_t keys[6];
 // } __packed;
 
-struct zmk_hid_keypad_report_body {
+struct zmk_hid_keyboard_report_body {
     zmk_mod_flags modifiers;
     u8_t _reserved;
-    u8_t keys[ZMK_HID_KEYPAD_NKRO_SIZE];
+    u8_t keys[ZMK_HID_KEYBOARD_NKRO_SIZE];
 } __packed;
 
-struct zmk_hid_keypad_report {
+struct zmk_hid_keyboard_report {
     u8_t report_id;
-    struct zmk_hid_keypad_report_body body;
+    struct zmk_hid_keyboard_report_body body;
 } __packed;
 
 struct zmk_hid_consumer_report_body {
@@ -170,13 +170,13 @@ int zmk_hid_register_mod(zmk_mod modifier);
 int zmk_hid_unregister_mod(zmk_mod modifier);
 int zmk_hid_implicit_modifiers_press(zmk_mod_flags implicit_modifiers);
 int zmk_hid_implicit_modifiers_release();
-int zmk_hid_keypad_press(zmk_key key);
-int zmk_hid_keypad_release(zmk_key key);
-void zmk_hid_keypad_clear();
+int zmk_hid_keyboard_press(zmk_key key);
+int zmk_hid_keyboard_release(zmk_key key);
+void zmk_hid_keyboard_clear();
 
 int zmk_hid_consumer_press(zmk_key key);
 int zmk_hid_consumer_release(zmk_key key);
 void zmk_hid_consumer_clear();
 
-struct zmk_hid_keypad_report *zmk_hid_get_keypad_report();
+struct zmk_hid_keyboard_report *zmk_hid_get_keyboard_report();
 struct zmk_hid_consumer_report *zmk_hid_get_consumer_report();

--- a/app/include/zmk/hog.h
+++ b/app/include/zmk/hog.h
@@ -11,5 +11,5 @@
 
 int zmk_hog_init();
 
-int zmk_hog_send_keypad_report(struct zmk_hid_keypad_report_body *body);
+int zmk_hog_send_keyboard_report(struct zmk_hid_keyboard_report_body *body);
 int zmk_hog_send_consumer_report(struct zmk_hid_consumer_report_body *body);

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -53,13 +53,13 @@ int zmk_endpoints_toggle() {
     return zmk_endpoints_select(new_endpoint);
 }
 
-static int send_keypad_report() {
-    struct zmk_hid_keypad_report *keypad_report = zmk_hid_get_keypad_report();
+static int send_keyboard_report() {
+    struct zmk_hid_keyboard_report *keyboard_report = zmk_hid_get_keyboard_report();
 
     switch (current_endpoint) {
 #if IS_ENABLED(CONFIG_ZMK_USB)
     case ZMK_ENDPOINT_USB: {
-        int err = zmk_usb_hid_send_report((u8_t *)keypad_report, sizeof(*keypad_report));
+        int err = zmk_usb_hid_send_report((u8_t *)keyboard_report, sizeof(*keyboard_report));
         if (err) {
             LOG_ERR("FAILED TO SEND OVER USB: %d", err);
         }
@@ -69,7 +69,7 @@ static int send_keypad_report() {
 
 #if IS_ENABLED(CONFIG_ZMK_BLE)
     case ZMK_ENDPOINT_BLE: {
-        int err = zmk_hog_send_keypad_report(&keypad_report->body);
+        int err = zmk_hog_send_keyboard_report(&keyboard_report->body);
         if (err) {
             LOG_ERR("FAILED TO SEND OVER HOG: %d", err);
         }
@@ -118,7 +118,7 @@ int zmk_endpoints_send_report(u8_t usage_page) {
     LOG_DBG("usage page 0x%02X", usage_page);
     switch (usage_page) {
     case HID_USAGE_KEY:
-        return send_keypad_report();
+        return send_keyboard_report();
     case HID_USAGE_CONSUMER:
         return send_consumer_report();
     default:
@@ -207,7 +207,7 @@ static enum zmk_endpoint get_selected_endpoint() {
 }
 
 static void disconnect_current_endpoint() {
-    zmk_hid_keypad_clear();
+    zmk_hid_keyboard_clear();
     zmk_hid_consumer_clear();
 
     zmk_endpoints_send_report(HID_USAGE_KEY);

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -10,7 +10,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/hid.h>
 #include <dt-bindings/zmk/modifiers.h>
 
-static struct zmk_hid_keypad_report kp_report = {
+static struct zmk_hid_keyboard_report kp_report = {
     .report_id = 1, .body = {.modifiers = 0, ._reserved = 0, .keys = {0}}};
 
 static struct zmk_hid_consumer_report consumer_report = {.report_id = 2, .body = {.keys = {0}}};
@@ -49,8 +49,8 @@ int zmk_hid_unregister_mod(zmk_mod modifier) {
     return 0;
 }
 
-#define TOGGLE_KEYPAD(match, val)                                                                  \
-    for (int idx = 0; idx < ZMK_HID_KEYPAD_NKRO_SIZE; idx++) {                                     \
+#define TOGGLE_KEYBOARD(match, val)                                                                \
+    for (int idx = 0; idx < ZMK_HID_KEYBOARD_NKRO_SIZE; idx++) {                                   \
         if (kp_report.body.keys[idx] != match) {                                                   \
             continue;                                                                              \
         }                                                                                          \
@@ -77,23 +77,23 @@ int zmk_hid_implicit_modifiers_release() {
     return 0;
 }
 
-int zmk_hid_keypad_press(zmk_key code) {
+int zmk_hid_keyboard_press(zmk_key code) {
     if (code >= HID_USAGE_KEY_KEYBOARD_LEFTCONTROL && code <= HID_USAGE_KEY_KEYBOARD_RIGHT_GUI) {
         return zmk_hid_register_mod(code - HID_USAGE_KEY_KEYBOARD_LEFTCONTROL);
     }
-    TOGGLE_KEYPAD(0U, code);
+    TOGGLE_KEYBOARD(0U, code);
     return 0;
 };
 
-int zmk_hid_keypad_release(zmk_key code) {
+int zmk_hid_keyboard_release(zmk_key code) {
     if (code >= HID_USAGE_KEY_KEYBOARD_LEFTCONTROL && code <= HID_USAGE_KEY_KEYBOARD_RIGHT_GUI) {
         return zmk_hid_unregister_mod(code - HID_USAGE_KEY_KEYBOARD_LEFTCONTROL);
     }
-    TOGGLE_KEYPAD(code, 0U);
+    TOGGLE_KEYBOARD(code, 0U);
     return 0;
 };
 
-void zmk_hid_keypad_clear() { memset(&kp_report.body, 0, sizeof(kp_report.body)); }
+void zmk_hid_keyboard_clear() { memset(&kp_report.body, 0, sizeof(kp_report.body)); }
 
 int zmk_hid_consumer_press(zmk_key code) {
     TOGGLE_CONSUMER(0U, code);
@@ -107,7 +107,7 @@ int zmk_hid_consumer_release(zmk_key code) {
 
 void zmk_hid_consumer_clear() { memset(&consumer_report.body, 0, sizeof(consumer_report.body)); }
 
-struct zmk_hid_keypad_report *zmk_hid_get_keypad_report() {
+struct zmk_hid_keyboard_report *zmk_hid_get_keyboard_report() {
     return &kp_report;
 }
 

--- a/app/src/hid_listener.c
+++ b/app/src/hid_listener.c
@@ -23,7 +23,7 @@ static int hid_listener_keycode_pressed(u8_t usage_page, u32_t keycode,
             implicit_modifiers);
     switch (usage_page) {
     case HID_USAGE_KEY:
-        err = zmk_hid_keypad_press(keycode);
+        err = zmk_hid_keyboard_press(keycode);
         if (err) {
             LOG_ERR("Unable to press keycode");
             return err;
@@ -48,7 +48,7 @@ static int hid_listener_keycode_released(u8_t usage_page, u32_t keycode,
             implicit_modifiers);
     switch (usage_page) {
     case HID_USAGE_KEY:
-        err = zmk_hid_keypad_release(keycode);
+        err = zmk_hid_keyboard_release(keycode);
         if (err) {
             LOG_ERR("Unable to release keycode");
             return err;

--- a/app/src/hog.c
+++ b/app/src/hog.c
@@ -79,9 +79,9 @@ static ssize_t read_hids_report_map(struct bt_conn *conn, const struct bt_gatt_a
 
 static ssize_t read_hids_input_report(struct bt_conn *conn, const struct bt_gatt_attr *attr,
                                       void *buf, u16_t len, u16_t offset) {
-    struct zmk_hid_keypad_report_body *report_body = &zmk_hid_get_keypad_report()->body;
+    struct zmk_hid_keyboard_report_body *report_body = &zmk_hid_get_keyboard_report()->body;
     return bt_gatt_attr_read(conn, attr, buf, len, offset, report_body,
-                             sizeof(struct zmk_hid_keypad_report_body));
+                             sizeof(struct zmk_hid_keyboard_report_body));
 }
 
 static ssize_t read_hids_consumer_input_report(struct bt_conn *conn,
@@ -156,7 +156,7 @@ struct bt_conn *destination_connection() {
     return conn;
 }
 
-int zmk_hog_send_keypad_report(struct zmk_hid_keypad_report_body *report) {
+int zmk_hog_send_keyboard_report(struct zmk_hid_keyboard_report_body *report) {
     struct bt_conn *conn = destination_connection();
     if (conn == NULL) {
         return -ENOTCONN;
@@ -164,8 +164,8 @@ int zmk_hog_send_keypad_report(struct zmk_hid_keypad_report_body *report) {
 
     LOG_DBG("Sending to NULL? %s", conn == NULL ? "yes" : "no");
 
-    int err =
-        bt_gatt_notify(conn, &hog_svc.attrs[5], report, sizeof(struct zmk_hid_keypad_report_body));
+    int err = bt_gatt_notify(conn, &hog_svc.attrs[5], report,
+                             sizeof(struct zmk_hid_keyboard_report_body));
     bt_conn_unref(conn);
     return err;
 };


### PR DESCRIPTION
The application usage used by report 1 is `HID_USAGE_GD_KEYBOARD`.  Moreover, the `keys` usage page (0x07) that primarily feeds into this report is predominantly keyboard codes.  The rest of the system should align with this naming convention.

Note: an alternative is to use `key` or `keys`, instead of `keyboard` / `keypad`.  I'm still not sure on that.  This PR is a step in the right direction however.

end-2-end test logs:
- [e2e-2020-11-13T14-04-25-ble.log](https://github.com/zmkfirmware/zmk/files/5537275/e2e-2020-11-13T14-04-25-ble.log)
- [e2e-2020-11-13T14-04-25-usb.log](https://github.com/zmkfirmware/zmk/files/5537276/e2e-2020-11-13T14-04-25-usb.log)