### PR TITLE
Updated function calls with missing reference. GPIO missing.

### DIFF
--- a/app/drivers/zephyr/battery_voltage_divider.c
+++ b/app/drivers/zephyr/battery_voltage_divider.c
@@ -205,8 +205,8 @@ static const struct bvd_config bvd_cfg = {
     .power_gpios =
         {
             DT_INST_GPIO_LABEL(0, power_gpios),
-            DT_INST_PIN(0, power_gpios),
-            DT_INST_FLAGS(0, power_gpios),
+            DT_INST_GPIO_PIN(0, power_gpios),
+            DT_INST_GPIO_FLAGS(0, power_gpios),
         },
 #endif
     .output_ohm = DT_INST_PROP(0, output_ohms),


### PR DESCRIPTION
Updated function calls with missing reference. GPIO missing.

To my understanding:
DT_INST_GPIO_PIN() should be called instead of DT_INST_PIN()
DT_INST_GPIO_FLAGS() should be called instead of DT_INST_FLAGS()

Current implementation does not compile when using control pin.