### PR TITLE
west test command to run testsuite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         id: west-build
         with:
           entrypoint: /bin/bash
-          args: '-c "cd app && ./run-test.sh all"'
+          args: '-c "west test"'
       - name: Archive Build
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /zmk-config
 /build
 *.DS_Store
+__pycache__

--- a/app/scripts/west-commands.yml
+++ b/app/scripts/west-commands.yml
@@ -1,0 +1,9 @@
+# Copyright (c) 2020, ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+west-commands:
+  - file: scripts/west_commands/test.py
+    commands:
+      - name: test
+        class: Test
+        help: run zmk testsuite

--- a/app/scripts/west_commands/test.py
+++ b/app/scripts/west_commands/test.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 The ZMK Contributors
+#
+# SPDX-License-Identifier: MIT
+'''Test runner for ZMK.'''
+
+import os
+from textwrap import dedent            # just for nicer code indentation
+
+from west.commands import WestCommand
+from west import log                   # use this for user output
+
+
+class Test(WestCommand):
+    def __init__(self):
+        super().__init__(
+            'test',  # gets stored as self.name
+            'run zmk testsuite',  # self.help
+            # self.description:
+            dedent('''Run the zmk testsuite.'''))
+
+    def do_add_parser(self, parser_adder):
+        parser = parser_adder.add_parser(self.name,
+                                         help=self.help,
+                                         description=self.description)
+
+        parser.add_argument('test_path', default="all",
+                            help='The path to the test. Defaults to "all".', nargs="?")
+        return parser           # gets stored as self.parser
+
+    def do_run(self, args, unknown_args):
+        # the run-test script assumes the app directory is the current dir.
+        os.chdir(f'{self.topdir}/app')
+        exit(os.system(f'{self.topdir}/app/run-test.sh {args.test_path}'))

--- a/app/west.yml
+++ b/app/west.yml
@@ -37,4 +37,4 @@ manifest:
       remote: microsoft
       path: tools/uf2
   self:
-    path: zmk
+    west-commands: scripts/west-commands.yml

--- a/docs/docs/development/tests.md
+++ b/docs/docs/development/tests.md
@@ -4,7 +4,9 @@ sidebar_label: Tests
 ---
 
 Running tests requires [native posix support](posix-board). Any folder under `/app/tests`
-containing `native_posix.keymap` will be selected when running `./run-test.sh all`.
+containing `native_posix.keymap` will be selected when running `west test`.
+
+Run a single test with `west test <testname>`, like `west test tests/toggle-layer/normal`.
 
 ## Creating a New Test Set
 


### PR DESCRIPTION
This PR adds  West command 'test' that runs our testsuite.

For now it adds little value, but this opens the way to run the testsuite from python instead of a bash script. This may enable us to run the tests on Windows and add nice things like pretty printing.

The command is invoked as `west test` and runs the current test runner.