### PR TITLE
refactor: make constant #binding-cells definitions optional

### DIFF
--- a/app/tests/hold-tap/balanced/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/balanced/behavior_keymap.dtsi
@@ -7,7 +7,6 @@
 		ht_bal: behavior_hold_tap_balanced {
 			compatible = "zmk,behavior-hold-tap";
 			label = "HOLD_TAP_BALANCED";
-			#binding-cells = <2>;
 			flavor = "balanced";
 			tapping_term_ms = <300>;
 			bindings = <&kp>, <&kp>;

--- a/app/tests/hold-tap/balanced/many-nested/native_posix.keymap
+++ b/app/tests/hold-tap/balanced/many-nested/native_posix.keymap
@@ -7,7 +7,6 @@
 		ht_bal: behavior_hold_tap_balanced {
 			compatible = "zmk,behavior-hold-tap";
 			label = "HOLD_TAP_BALANCED";
-			#binding-cells = <2>;
 			flavor = "balanced";
 			tapping_term_ms = <300>;
 			bindings = <&kp>, <&kp>;

--- a/app/tests/hold-tap/hold-preferred/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/hold-preferred/behavior_keymap.dtsi
@@ -9,7 +9,6 @@
 		ht_hold: behavior_hold_hold_tap {
 			compatible = "zmk,behavior-hold-tap";
 			label = "hold_hold_tap";
-			#binding-cells = <2>;
 			flavor = "hold-preferred";
 			tapping_term_ms = <300>;
 			bindings = <&kp>, <&kp>;

--- a/app/tests/hold-tap/tap-preferred/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-preferred/behavior_keymap.dtsi
@@ -7,7 +7,6 @@
 		tp: behavior_tap_preferred {
 			compatible = "zmk,behavior-hold-tap";
 			label = "MOD_TAP";
-			#binding-cells = <2>;
 			flavor = "tap-preferred";
 			tapping_term_ms = <300>;
 			bindings = <&kp>, <&kp>;

--- a/docs/docs/behavior/hold-tap.md
+++ b/docs/docs/behavior/hold-tap.md
@@ -40,7 +40,6 @@ A code example which configures a mod-tap setting that works with homerow mods:
 		hm: homerow_mods {
 			compatible = "zmk,behavior-hold-tap";
 			label = "HOMEROW_MODS";
-			#binding-cells = <2>;
 			tapping_term_ms = <175>;
 			flavor = "balanced";
 			bindings = <&kp>, <&kp>;


### PR DESCRIPTION
Each behavior is required to specify a #binding-cells value, which seems redundant. This PR makes it unnecessary to repeat this  constant value in each behavior.