### PR TITLE
refactor(ble): silence warning `auth_passkey_display` not used

### DIFF
--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -404,6 +404,7 @@ static struct bt_conn_cb conn_callbacks = {
     .security_changed = security_changed,
 };
 
+/*
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey) {
     char addr[BT_ADDR_LE_STR_LEN];
 
@@ -411,6 +412,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey) {
 
     LOG_DBG("Passkey for %s: %06u", log_strdup(addr), passkey);
 }
+*/
 
 #ifdef CONFIG_ZMK_BLE_PASSKEY_ENTRY
 


### PR DESCRIPTION
Silences the following build warning ...

```
../src/ble.c:407:13: warning: 'auth_passkey_display' defined but not used [-Wunused-function]
  407 | static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey) {
```

@petejohanson, is this obsolete code?

Zephyr v2.4.0 (#223) seems to have stricter build rules by default, so this will soon cause an error.