### PR TITLE
build: set zmk_config.cmake cmake_minimum_required to VERSION 3.15

### DIFF
--- a/app/cmake/zmk_config.cmake
+++ b/app/cmake/zmk_config.cmake
@@ -5,6 +5,8 @@
 #    * single overlay,
 #    * or per board/shield.
 
+cmake_minimum_required(VERSION 3.15)
+
 get_property(cached_user_config_value CACHE ZMK_CONFIG PROPERTY VALUE)
 
 set(user_config_cli_argument ${cached_user_config_value}) # Either new or old


### PR DESCRIPTION
3.15 is the minimum version required to facilitate `list(PREPEND)` used within `zmk_config.cmake`.

https://cmake.org/cmake/help/v3.15/command/list.html

Fixes #402