### PR TITLE
build: Remove unnecessary SYSCALL_INCLUDE_DIRS for drivers

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -10,7 +10,6 @@ list(APPEND DTS_ROOT ${CMAKE_SOURCE_DIR}/drivers/zephyr)
 list(APPEND ZEPHYR_EXTRA_MODULES
   ${CMAKE_CURRENT_SOURCE_DIR}/drivers
 )
-list(APPEND SYSCALL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/drivers/zephyr)
 
 include(cmake/zmk_config.cmake)
 


### PR DESCRIPTION
This doesn't seem to be required for the current system?