### PR TITLE
build(west): set `self: path:` to nothing

### DIFF
--- a/app/west.yml
+++ b/app/west.yml
@@ -37,4 +37,4 @@ manifest:
       remote: microsoft
       path: tools/uf2
   self:
-    path: zmk
+    path:


### PR DESCRIPTION
The self path should be `app`.  Setting it to nothing achieves the same result but with more flexibility if it becomes a module.

At time of writing, this change has also been made _implicitly_ in PR #385.