### PR TITLE
docs(key-press): remove references to `key press`

### DIFF
--- a/docs/docs/behaviors/key-press.md
+++ b/docs/docs/behaviors/key-press.md
@@ -38,14 +38,14 @@ Doing so makes a set of defines such as `A`, `N1`, etc. available for use with t
 When compiling firmware from a keymap, it may be common to encounter an error in the form of a`dtlib.DTError: <board>.dts.pre.tmp:<line number>`.
 For instructions to resolve such an error, click [here](../troubleshooting###Improperly-defined-keymap)
 
-## Keypad Key Press
+## Key Press
 
-The "keypad key press" behavior sends standard keypad keycodes on press/release.
+The "key press" behavior sends standard keycodes on press/release.
 
 ### Behavior Binding
 
 - Reference: `&kp`
-- Parameter: The keycode usage ID from the keypad usage page, e.g. `4` or `A`
+- Parameter: The keycode usage ID from the usage page, e.g. `4` or `A`
 
 Example:
 


### PR DESCRIPTION
This was obsoleted by eff1b8223b5010d526914530c5d1d469eff356df