### PR TITLE
fix(tests): fix testrunner for 'all'

### DIFF
--- a/app/run-test.sh
+++ b/app/run-test.sh
@@ -4,15 +4,14 @@
 #
 # SPDX-License-Identifier: MIT
 #
-
 if [ -z "$1" ]; then
 	echo "Usage: ./run-test.sh <path to testcase>"
 	exit 1
 fi
 
 path="$1"
-if [ path = "all" ]; then
-	path = "tests"
+if [ $path = "all" ]; then
+	path="tests"
 fi
 
 testcases=$(find $path -name native_posix.keymap -exec dirname \{\} \;)


### PR DESCRIPTION
fixes bug that was introduced in the latest improvement of the testrunner. "west test" was not running all tests, neither was "west test all" or "./run-test.sh all".