### PR TITLE
Initial nullbitsco tidbit bring up

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
           - splitreus62_left
           - splitreus62_right
           - tg4x
+          - tidbit
         include:
           - board: dz60rgb_rev1
           - board: nrf52840_m2

--- a/app/boards/shields/tidbit/Kconfig.defconfig
+++ b/app/boards/shields/tidbit/Kconfig.defconfig
@@ -1,0 +1,45 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_TIDBIT
+
+config ZMK_KEYBOARD_NAME
+	default "tidbit"
+
+endif
+
+if ZMK_DISPLAY
+
+config I2C
+	default y
+
+config SSD1306
+	default y
+
+config SSD1306_REVERSE_MODE
+	default y
+
+endif # ZMK_DISPLAY
+
+if LVGL
+
+config LVGL_HOR_RES_MAX
+	default 128
+
+config LVGL_VER_RES_MAX
+	default 32
+
+config LVGL_VDB_SIZE
+	default 64
+
+config LVGL_DPI
+	default 148
+
+config LVGL_BITS_PER_PIXEL
+	default 1
+
+choice LVGL_COLOR_DEPTH
+	default LVGL_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL

--- a/app/boards/shields/tidbit/Kconfig.shield
+++ b/app/boards/shields/tidbit/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_TIDBIT
+	def_bool $(shields_list_contains,tidbit)

--- a/app/boards/shields/tidbit/README.md
+++ b/app/boards/shields/tidbit/README.md
@@ -1,0 +1,41 @@
+# Building ZMK for the Tidbit
+
+Some general notes/commands for building standard tidbit layouts from the assembly documentation.
+
+## Standard "Non Dense" Build
+
+```
+west build -p -d build/tidbit/default --board nice_nano -- -DSHIELD=tidbit
+```
+
+## Dense "19 keys" Build
+
+```
+west build -p -d build/tidbit/19_key --board nice_nano -- -DSHIELD=tidbit_19key
+```
+
+## LED Notes
+
+If you built your tidbit without the LEDs _and_ are using a nice!nano board, you'll need to change the following in your local tidbit config or add them to the end of the file.
+
+```
+CONFIG_ZMK_RGB_UNDERGLOW=n
+CONFIG_WS2812_STRIP=n
+```
+
+## Encoder Notes
+
+If you built your tidbit without encoders, you'll need to change the following in your local tidbit config or add them to the end of the file.
+
+```
+CONFIG_EC11=n
+CONFIG_EC11_TRIGGER_GLOBAL_THREAD=n
+```
+
+## OLED Builds
+
+If using an OLED screen, you'll need to change the following in your local tidbit config or add them to the end of the file.
+
+```
+CONFIG_ZMK_DISPLAY=y
+```

--- a/app/boards/shields/tidbit/boards/nice_nano.conf
+++ b/app/boards/shields/tidbit/boards/nice_nano.conf
@@ -1,0 +1,4 @@
+# Enable underglow
+CONFIG_ZMK_RGB_UNDERGLOW=y
+# Use the STRIP config specific to the LEDs you're using
+CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/tidbit/boards/nice_nano.overlay
+++ b/app/boards/shields/tidbit/boards/nice_nano.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <9>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <8>; /* number of LEDs */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/tidbit/boards/proton_c.conf
+++ b/app/boards/shields/tidbit/boards/proton_c.conf
@@ -1,0 +1,1 @@
+CONFIG_SENSOR=y

--- a/app/boards/shields/tidbit/tidbit.conf
+++ b/app/boards/shields/tidbit/tidbit.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Enable Encoders
+CONFIG_EC11=y
+CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Enable underglow
+#CONFIG_ZMK_RGB_UNDERGLOW=y
+# Use the STRIP config specific to the LEDs you're using
+#CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/tidbit/tidbit.dtsi
+++ b/app/boards/shields/tidbit/tidbit.dtsi
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix-transform.h>
+
+/ {
+	kscan0: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+		label = "KSCAN";
+
+		diode-direction = "row2col";
+
+		row-gpios
+			= <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_d 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_d 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_d 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_d 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			;
+
+		col-gpios
+			= <&pro_micro_a 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_a 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_a 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_a 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			;
+
+	};
+
+	default_transform: keymap_transform_0 {
+		compatible = "zmk,matrix-transform";
+		columns = <4>;
+		rows = <5>;
+
+		map = <
+			RC(0,1) RC(0,2) RC(0,3)
+			RC(1,0) RC(1,1) RC(1,2) RC(1,3)
+			RC(2,0) RC(2,1) RC(2,2) RC(2,3)
+			RC(3,0) RC(3,1) RC(3,2) RC(3,3)
+			RC(4,0) RC(4,1) RC(4,2) RC(4,3)
+		>;
+	};
+
+	encoder_1_top_row: encoder_1_top_row {
+		compatible = "alps,ec11";
+		label = "Top Row Encoder";
+		a-gpios = <&pro_micro_d 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro_d 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	encoder_1: encoder_1 {
+		compatible = "alps,ec11";
+		label = "Encoder 1";
+		a-gpios = <&pro_micro_d 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro_d 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	encoder_2: encoder_2 {
+		compatible = "alps,ec11";
+		label = "Encoder 2";
+		a-gpios = <&pro_micro_d 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro_d 9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	encoder_3: encoder_3 {
+		compatible = "alps,ec11";
+		label = "Encoder 3";
+		a-gpios = <&pro_micro_d 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro_d 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	encoder_4: encoder_4 {
+		compatible = "alps,ec11";
+		label = "Encoder 4";
+		a-gpios = <&pro_micro_d 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro_d 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	chosen {
+		zmk,kscan = &kscan0;
+		zmk,matrix_transform = &default_transform;
+	};
+};
+
+&pro_micro_i2c {
+	status = "okay";
+
+	oled: ssd1306@3c {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3c>;
+		label = "DISPLAY";
+		width = <128>;
+		height = <32>;
+		segment-offset = <0>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <31>;
+		segment-remap;
+		com-invdir;
+		com-sequential;
+		prechargep = <0x22>;
+	};
+};

--- a/app/boards/shields/tidbit/tidbit.keymap
+++ b/app/boards/shields/tidbit/tidbit.keymap
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/keys.h>
+
+&encoder_1_top_row {
+	status = "okay";
+};
+
+/ {
+	sensors {
+		compatible = "zmk,keymap-sensors";
+		sensors = <&encoder_1_top_row>;
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		
+		default_layer {
+			bindings = <
+								&kp KP_NUMLOCK  &kp KP_ASTERISK &kp KP_MINUS
+				&kp KP_NUMBER_7 &kp KP_NUMBER_8 &kp KP_NUMBER_9 &kp KP_PLUS
+				&kp KP_NUMBER_4 &kp KP_NUMBER_5 &kp KP_NUMBER_6 &kp &none
+				&kp KP_NUMBER_1 &kp KP_NUMBER_2 &kp KP_NUMBER_3 &lt 1 KP_ENTER
+				&none           &kp KP_NUMBER_0 &kp KP_DOT      &none
+			>;
+
+			sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;
+		};
+
+		 func_layer {
+			 bindings = <
+								&none           &reset          &bootloader
+				&out OUT_TOG    &out OUT_USB    &out OUT_BLE    &none
+				&bt BT_SEL 0    &bt BT_PRV      &bt BT_NXT      &bt BT_CLR
+				&bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &tog 0
+				&kp C_MUTE      &none           &none           &none
+			 >;
+
+			 sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;
+		 };
+	};
+};

--- a/app/boards/shields/tidbit/tidbit.overlay
+++ b/app/boards/shields/tidbit/tidbit.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "tidbit.dtsi"

--- a/app/boards/shields/tidbit/tidbit_19key.conf
+++ b/app/boards/shields/tidbit/tidbit_19key.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Enable Encoders
+CONFIG_EC11=y
+CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Enable underglow
+#CONFIG_ZMK_RGB_UNDERGLOW=y
+# Use the STRIP config specific to the LEDs you're using
+#CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/tidbit/tidbit_19key.keymap
+++ b/app/boards/shields/tidbit/tidbit_19key.keymap
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "tidbit.dtsi"
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+&encoder_4 {
+	status = "okay";
+};
+
+/ {
+	sensors {
+		compatible = "zmk,keymap-sensors";
+		sensors = <&encoder_4>;
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		
+		default_layer {
+			bindings = <
+								&tog 1          &kp KP_NUMLOCK  &kp KP_SLASH
+				&kp KP_NUMBER_7 &kp KP_NUMBER_8 &kp KP_NUMBER_9 &kp KP_ASTERISK
+				&kp KP_NUMBER_4 &kp KP_NUMBER_5 &kp KP_NUMBER_6 &kp KP_MINUS
+				&kp KP_NUMBER_1 &kp KP_NUMBER_2 &kp KP_NUMBER_3 &kp KP_PLUS
+				&kp C_MUTE      &kp KP_NUMBER_0 &kp KP_DOT      &kp KP_ENTER
+			>;
+
+			sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;
+		};
+
+		 func_layer {
+			 bindings = <
+								&tog 0          &reset          &bootloader
+				&out OUT_TOG    &out OUT_USB    &out OUT_BLE    &none
+				&bt BT_SEL 0    &bt BT_PRV      &bt BT_NXT      &bt BT_CLR
+				&bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &none
+				&kp C_MUTE      &none           &none           &none
+			 >;
+
+			sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;
+		 };
+	};
+};

--- a/app/boards/shields/tidbit/tidbit_19key.overlay
+++ b/app/boards/shields/tidbit/tidbit_19key.overlay
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "tidbit.dtsi"
+#include "tidbit_19key.keymap"

--- a/docs/docs/hardware.md
+++ b/docs/docs/hardware.md
@@ -35,6 +35,7 @@ That being said, there are currently only a few specific [boards](/docs/faq#what
 - [Boardsource 3x4 Macro](https://boardsource.xyz/store/5ecc2008eee64242946c98c1) (`boardsource3x4`)
 - [QAZ](https://www.cbkbd.com/product/qaz-keyboard-kit) (`qaz`)
 - [CRBN](https://keygem.store/collections/group-buys/products/group-buy-featherlight-40-kit) (`crbn`)
+- [tidbit](https://nullbits.co/tidbit/) (`tidbit`)
 
 ## Other Hardware
 

--- a/docs/static/setup.ps1
+++ b/docs/static/setup.ps1
@@ -91,9 +91,9 @@ Write-Host "Keyboard Shield Selection:"
 $prompt = "Pick a keyboard"
 
 # TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
-$options = "Kyria", "Lily58", "Corne", "Splitreus62", "Sofle", "Iris", "Reviung41", "RoMac", "RoMac+", "makerdiary M60", "Microdox", "TG4X", "QAZ", "NIBBLE", "Jorne", "Jian", "CRBN"
-$names = "kyria", "lily58", "corne", "splitreus62", "sofle", "iris", "reviung41", "romac", "romac_plus", "m60", "microdox", "tg4x", "qaz", "nibble", "jorne", "jian", "crbn"
-$splits = "y", "y", "y", "y", "y", "y", "n", "n", "n", "n", "y", "n", "n", "n", "y", "y", "n"
+$options = "Kyria", "Lily58", "Corne", "Splitreus62", "Sofle", "Iris", "Reviung41", "RoMac", "RoMac+", "makerdiary M60", "Microdox", "TG4X", "QAZ", "NIBBLE", "Jorne", "Jian", "CRBN", "Tidbit"
+$names = "kyria", "lily58", "corne", "splitreus62", "sofle", "iris", "reviung41", "romac", "romac_plus", "m60", "microdox", "tg4x", "qaz", "nibble", "jorne", "jian", "crbn", "tidbit"
+$splits = "y", "y", "y", "y", "y", "y", "n", "n", "n", "n", "y", "n", "n", "n", "y", "y", "n", "n"
 
 $choice = Get-Choice-From-Options -Options $options -Prompt $prompt
 $shield_title = $($options[$choice])

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -92,7 +92,7 @@ echo ""
 echo "Keyboard Shield Selection:"
 
 prompt="Pick an keyboard:"
-options=("Kyria" "Lily58" "Corne" "Splitreus62" "Sofle" "Iris" "Reviung41" "RoMac" "RoMac+" "makerdiary M60" "Microdox" "TG4X" "QAZ" "Jorne" "Jian" "CRBN")
+options=("Kyria" "Lily58" "Corne" "Splitreus62" "Sofle" "Iris" "Reviung41" "RoMac" "RoMac+" "makerdiary M60" "Microdox" "TG4X" "QAZ" "Jorne" "Jian" "CRBN" "Tidbit")
 
 PS3="$prompt "
 # TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
@@ -118,6 +118,7 @@ select opt in "${options[@]}" "Quit"; do
     15 ) shield_title="Jorne" shield="jorne"; split="y"; break;;
     16 ) shield_title="Jian" shield="jian"; split="y"; break;;
     17 ) shield_title="CRBN" shield="crbn"; split="n"; break;;
+    18 ) shield_title="Tidbit" shield="tidbit"; split="n" break;;
 
     # Add link to docs on adding your own custom shield in your ZMK config!
     # $(( ${#options[@]}+1 )) ) echo "Other!"; break;;


### PR DESCRIPTION
Bring up for the nullbits.co tidbit. This bring up includes 2 keymaps that match the assembly documentation

- standard "number pad" build
- "19 keys" build that is more dense