### PR TITLE
Update devcontainer config to facilitate working with documentation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,14 +2,22 @@ FROM zmkfirmware/zephyr-west-action-arm
 
 ENV LC_ALL=C
 
-RUN apt-get -y update && \
-    apt-get -y upgrade && \
-    apt-get install --no-install-recommends -y \
+RUN apt-get -y update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
     ssh \
     nano \
     locales \
-    gpg && \
-    rm -rf /var/lib/apt/lists/*
+    ssh \
+    gpg \
+    gpg-agent \
+    curl \
+    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && apt-get -y update \
+    && apt-get install --no-install-recommends -y nodejs \
+    && node --version \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY .bashrc tmp
 RUN mv /tmp/.bashrc ~/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "ZMK Development",
   "dockerFile": "Dockerfile",
   "extensions": ["ms-vscode.cpptools"],
-  "runArgs": ["--security-opt", "label=disable"],
+  "runArgs": ["--security-opt", "label=disable", "--publish", "3000"],
   "containerEnv": {"WORKSPACE_DIR": "${containerWorkspaceFolder}"},
   "settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash"


### PR DESCRIPTION
Updates the devcontainer config to include npm and expose port 3000 via the docker image so local updates to documentation are easier to put together.

This is especially handy for anyone using the docker+vscode dev environment