### PR TITLE
refactor(workflows): align GitHub workflow conventions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+name: Build
+
 on:
   push:
     paths:
@@ -6,12 +8,9 @@ on:
     paths:
       - "app/**"
 
-name: Build
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build Test
     strategy:
       matrix:
         board: [proton_c, nice_nano, bluemicro840_v1, nrfmicro_13]
@@ -45,8 +44,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache west modules
-        timeout-minutes: 2
-        continue-on-error: true
         uses: actions/cache@v2
         env:
           cache-name: cache-zephyr-modules
@@ -61,32 +58,34 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: West Init
+        timeout-minutes: 2
+        continue-on-error: true
+      - name: West init
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-init
         with:
           args: 'init "-l app"'
-      - name: West Update
+      - name: West update
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-update
         with:
           args: "update"
-      - name: West Config Zephyr Base
+      - name: West config Zephyr base
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-config
         with:
           args: 'config "--global zephyr.base-prefer configfile"'
-      - name: West Zephyr Export
+      - name: West Zephyr export
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-zephyr-export
         with:
           args: "zephyr-export"
-      - name: West Build
+      - name: West build
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-build
         with:
           args: 'build "-s app -b ${{ matrix.board }} -- -DSHIELD=${{ matrix.shield }}"'
-      - name: Archive Build
+      - name: Archive build
         uses: actions/upload-artifact@v2
         if: ${{ matrix.board != 'proton_c' }}
         with:

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -1,4 +1,4 @@
-name: clang-format-lint
+name: Clang Format
 
 on:
   push:
@@ -19,8 +19,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: clang-format lint
-
     steps:
       - uses: actions/checkout@v2
       - uses: DoozyX/clang-format-lint-action@v0.9

--- a/.github/workflows/doc-checks.yml
+++ b/.github/workflows/doc-checks.yml
@@ -1,4 +1,4 @@
-name: doc-checks
+name: Docs Checks
 
 on:
   push:
@@ -11,8 +11,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: ESLint
-
     steps:
       - uses: actions/checkout@v2
       - uses: bahmutov/npm-install@v1
@@ -24,12 +22,11 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     name: Prettier
-
     steps:
       - uses: actions/checkout@v2
       - uses: bahmutov/npm-install@v1
         with:
           working-directory: docs
-      - name: Prettier Check
+      - name: Prettier check
         run: npm run prettier:check
         working-directory: docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: Tests
+
 on:
   push:
     paths:
@@ -8,20 +10,15 @@ on:
       - "app/tests/**"
       - "app/src/**"
 
-name: Test
-
 jobs:
   integration_test:
     runs-on: ubuntu-latest
-    name: Integration Tests
     steps:
       # To use this repository's private action,
       # you must check out the repository
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache west modules
-        timeout-minutes: 2
-        continue-on-error: true
         uses: actions/cache@v2
         env:
           cache-name: cache-zephyr-modules
@@ -36,33 +33,35 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: West Init
+        timeout-minutes: 2
+        continue-on-error: true
+      - name: West init
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-init
         with:
           args: 'init "-l app"'
-      - name: West Update
+      - name: West update
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-update
         with:
           args: "update"
-      - name: West Config Zephyr Base
+      - name: West config Zephyr base
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-config
         with:
           args: 'config "--global zephyr.base-prefer configfile"'
-      - name: West Zephyr Export
+      - name: West Zephyr export
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-zephyr-export
         with:
           args: "zephyr-export"
-      - name: Test All
+      - name: Test all
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-build
         with:
           entrypoint: /bin/bash
           args: '-c "west test"'
-      - name: Archive Build
+      - name: Archive build
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Cosmetic pass at aligning the conventions used in ZMK's workflows with GitHub's examples.  Based on examples found at:
https://github.com/actions/starter-workflows

I'm not personally a fan of GitHub's conventions, but aligning to them helps improve consistency.