### PR TITLE
refactor(workflows): remove `2-` prefix from cache keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,11 @@ jobs:
             tools/
             zephyr/
             bootloader/
-          key: 2-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('app/west.yml') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('app/west.yml') }}
           restore-keys: |
-            2-${{ runner.os }}-build-${{ env.cache-name }}-
-            2-${{ runner.os }}-build-
-            2-${{ runner.os }}-
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: West Init
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-init

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,11 @@ jobs:
             tools/
             zephyr/
             bootloader/
-          key: 2-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('app/west.yml') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('app/west.yml') }}
           restore-keys: |
-            2-${{ runner.os }}-build-${{ env.cache-name }}-
-            2-${{ runner.os }}-build-
-            2-${{ runner.os }}-
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: West Init
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-init


### PR DESCRIPTION
Removes obsolete cache invalidation hack.

Ref: 064323b667e33b3f68e56165e9add66b7482ed68