### PR TITLE
Update Dev Container Fixing Small Bugs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,13 @@
 FROM zmkfirmware/zephyr-west-action-arm
 
+ENV LC_ALL=C
+
 RUN apt-get -y update && \
     apt-get -y upgrade && \
     apt-get install --no-install-recommends -y \
     ssh \
+    nano \
+    locales \
     gpg && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This updates the dev container to address the following bugs

- Add nano so git has a default editor to use in case the user runs git and it needs a default editor
- Setup locales, including a generic default, so make menuconfig can be run