### PR TITLE
build(west): add clone-depth = 1 to zephyr and uf2

### DIFF
--- a/app/west.yml
+++ b/app/west.yml
@@ -10,6 +10,7 @@ manifest:
     - name: zephyr
       remote: petejohanson
       revision: zmk-v2.3.0-with-fixes
+      clone-depth: 1
       import:
         # TODO: Rename once upstream offers option like `exclude` or `denylist`
         name-blacklist:
@@ -36,5 +37,6 @@ manifest:
     - name: uf2
       remote: microsoft
       path: tools/uf2
+      clone-depth: 1
   self:
     west-commands: scripts/west-commands.yml


### PR DESCRIPTION
This reduces zephyr's footprint to 33% and dramatically reduces the cloning times (`west update`).

What do you think @petejohanson?  Please check it locally just in case there's any environmental factors.

If this PR is merged, then I'll reset the CI build cache with a follow-up PR.  I suspect we'll see improvements.