### PR TITLE
refactor(workflows): add `3-` prefix to cache keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,11 @@ jobs:
             tools/
             zephyr/
             bootloader/
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('app/west.yml') }}
+          key: 3-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('app/west.yml') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            3-${{ runner.os }}-build-${{ env.cache-name }}-
+            3-${{ runner.os }}-build-
+            3-${{ runner.os }}-
         timeout-minutes: 2
         continue-on-error: true
       - name: West init

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,11 @@ jobs:
             tools/
             zephyr/
             bootloader/
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('app/west.yml') }}
+          key: 3-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('app/west.yml') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            3-${{ runner.os }}-build-${{ env.cache-name }}-
+            3-${{ runner.os }}-build-
+            3-${{ runner.os }}-
         timeout-minutes: 2
         continue-on-error: true
       - name: West init


### PR DESCRIPTION
A hack to invalidate GitHub actions/cache in CI builds/tests.

Activates benefits of 90123caa4ca413f9c9e96d37e9b627ebf0407b66.

Should be reverted after 2 weeks.