### PR TITLE
ci(build): replace board matrix array with list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        board: [proton_c, nice_nano, bluemicro840_v1, nrfmicro_13]
+        board:
+          - proton_c
+          - nice_nano
+          - bluemicro840_v1
+          - nrfmicro_13
         shield:
           - boardsource3x4
           - corne_left


### PR DESCRIPTION
A multi-line list can be more merge friendly than a single-line array.