### PR TITLE
ci(build): remove proton_c guard from uf2 archive step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,6 @@ jobs:
           args: 'build "-s app -b ${{ matrix.board }} -- -DSHIELD=${{ matrix.shield }}"'
       - name: Archive build
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.board != 'proton_c' }}
         with:
           name: "${{ matrix.board }}-${{ matrix.shield }}-zmk-uf2"
           path: build/zephyr/zmk.uf2


### PR DESCRIPTION
Guards conditions aren't strictly required because the build only logs a warning if the file doesn't exist.  It still completes successfully.