### PR TITLE
ci(build): add support for board-only builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,13 +86,28 @@ jobs:
         id: west-zephyr-export
         with:
           args: "zephyr-export"
+      - name: Prepare variables
+        id: variables
+        run: |
+          SHIELD_ARG=
+          ARTIFACT_NAME="${{ matrix.board }}"
+
+          if [ -n "${{ matrix.shield }}" ]; then
+            SHIELD_ARG="-DSHIELD=${{ matrix.shield }}"
+            ARTIFACT_NAME="${ARTIFACT_NAME}-${{ matrix.shield }}"
+          fi
+
+          ARTIFACT_NAME="${ARTIFACT_NAME}-zmk"
+
+          echo ::set-output name=shield-arg::${SHIELD_ARG}
+          echo ::set-output name=artifact-name::${ARTIFACT_NAME}
       - name: West build
         uses: "docker://zmkfirmware/zephyr-west-action-arm:latest"
         id: west-build
         with:
-          args: 'build "-s app -b ${{ matrix.board }} -- -DSHIELD=${{ matrix.shield }}"'
+          args: 'build "-s app -b ${{ matrix.board }} -- ${{ steps.variables.outputs.shield-arg }}'
       - name: Archive build
         uses: actions/upload-artifact@v2
         with:
-          name: "${{ matrix.board }}-${{ matrix.shield }}-zmk-uf2"
+          name: "${{ steps.variables.outputs.artifact-name }}-uf2"
           path: build/zephyr/zmk.uf2


### PR DESCRIPTION
Lays the groundwork for CI building boards that don't require shields.

Tested using `dz60rgb_rev1` board.  See https://github.com/innovaker/zmk/actions/runs/397136358 for results.