### PR TITLE
refactor(settings): Debounce settings with high churn and other small fixes

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -63,7 +63,6 @@ target_sources_ifdef(CONFIG_ZMK_BLE app PRIVATE src/hog.c)
 target_sources_ifdef(CONFIG_ZMK_RGB_UNDERGLOW app PRIVATE src/rgb_underglow.c)
 target_sources(app PRIVATE src/endpoints.c)
 target_sources(app PRIVATE src/hid_listener.c)
-target_sources_ifdef(CONFIG_SETTINGS app PRIVATE src/settings.c)
 target_sources(app PRIVATE src/main.c)
 
 add_subdirectory(src/display/)

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -526,7 +526,8 @@ static int zmk_ble_init(const struct device *_arg) {
         return err;
     }
 
-    settings_load();
+    settings_load_subtree("ble");
+    settings_load_subtree("bt");
 
 #endif
 

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -166,7 +166,7 @@ static int zmk_endpoints_init(const struct device *_arg) {
         return err;
     }
 
-    settings_load();
+    settings_load_subtree("endpoints");
 #endif
 
     return 0;

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -29,6 +29,23 @@ static enum zmk_endpoint preferred_endpoint =
 
 static void update_current_endpoint();
 
+#if IS_ENABLED(CONFIG_SETTINGS)
+static void endpoints_save_preferred_work(struct k_work *work) {
+    settings_save_one("endpoints/preferred", &preferred_endpoint, sizeof(preferred_endpoint));
+}
+
+static struct k_delayed_work endpoints_save_work;
+#endif
+
+static int endpoints_save_preferred() {
+#if IS_ENABLED(CONFIG_SETTINGS)
+    k_delayed_work_cancel(&endpoints_save_work);
+    return k_delayed_work_submit(&endpoints_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
+#else
+    return 0;
+#endif
+}
+
 int zmk_endpoints_select(enum zmk_endpoint endpoint) {
     LOG_DBG("Selected endpoint %d", endpoint);
 
@@ -38,9 +55,7 @@ int zmk_endpoints_select(enum zmk_endpoint endpoint) {
 
     preferred_endpoint = endpoint;
 
-#if IS_ENABLED(CONFIG_SETTINGS)
-    settings_save_one("endpoints/preferred", &preferred_endpoint, sizeof(preferred_endpoint));
-#endif
+    endpoints_save_preferred();
 
     update_current_endpoint();
 
@@ -165,6 +180,8 @@ static int zmk_endpoints_init(const struct device *_arg) {
         LOG_ERR("Failed to register the endpoints settings handler (err %d)", err);
         return err;
     }
+
+    k_delayed_work_init(&endpoints_save_work, endpoints_save_preferred_work);
 
     settings_load_subtree("endpoints");
 #endif

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -142,7 +142,12 @@ static int ext_power_generic_init(const struct device *dev) {
 #if IS_ENABLED(CONFIG_SETTINGS)
     settings_subsys_init();
 
-    settings_register(&ext_power_conf);
+    int err = settings_register(&ext_power_conf);
+    if (err) {
+        LOG_ERR("Failed to register the ext_power settings handler (err %d)", err);
+        return err;
+    }
+
     k_delayed_work_init(&ext_power_save_work, ext_power_save_state_work);
 
     // Set default value (on) if settings isn't set

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -140,6 +140,8 @@ static int ext_power_generic_init(const struct device *dev) {
     }
 
 #if IS_ENABLED(CONFIG_SETTINGS)
+    settings_subsys_init();
+
     settings_register(&ext_power_conf);
     k_delayed_work_init(&ext_power_save_work, ext_power_save_state_work);
 

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -267,7 +267,12 @@ static int zmk_rgb_underglow_init(const struct device *_arg) {
 #if IS_ENABLED(CONFIG_SETTINGS)
     settings_subsys_init();
 
-    settings_register(&rgb_conf);
+    int err = settings_register(&rgb_conf);
+    if (err) {
+        LOG_ERR("Failed to register the ext_power settings handler (err %d)", err);
+        return err;
+    }
+
     k_delayed_work_init(&underglow_save_work, zmk_rgb_underglow_save_state_work);
 
     settings_load_subtree("rgb/underglow");

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -265,6 +265,8 @@ static int zmk_rgb_underglow_init(const struct device *_arg) {
     };
 
 #if IS_ENABLED(CONFIG_SETTINGS)
+    settings_subsys_init();
+
     settings_register(&rgb_conf);
     k_delayed_work_init(&underglow_save_work, zmk_rgb_underglow_save_state_work);
 

--- a/app/src/settings.c
+++ b/app/src/settings.c
@@ -1,8 +1,0 @@
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <settings/settings.h>
-
-static int zmk_settings_init(const struct device *_arg) { return settings_load(); }
-
-SYS_INIT(zmk_settings_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);


### PR DESCRIPTION
This closes #379 as well as removes the unnecessary `settings.c` file by using `settings_load_subtree` in all areas that use settings.