### PR TITLE
build(west): migrate to zmkfirmware/zephyr fork

### DIFF
--- a/app/west.yml
+++ b/app/west.yml
@@ -2,13 +2,13 @@ manifest:
   remotes:
     - name: zephyrproject-rtos
       url-base: https://github.com/zephyrproject-rtos
-    - name: petejohanson
-      url-base: https://github.com/petejohanson
+    - name: zmkfirmware
+      url-base: https://github.com/zmkfirmware
     - name: microsoft
       url-base: https://github.com/microsoft
   projects:
     - name: zephyr
-      remote: petejohanson
+      remote: zmkfirmware
       revision: zmk-v2.3.0-with-fixes
       clone-depth: 1
       import:


### PR DESCRIPTION
Replaces `petejohanson` with `zmkfirmware` for ZMK's fork of Zephyr (branch `zmk-v2.3.0-with-fixes`).