### PR TITLE
Tweak/cleanup bluetooth documentation so codes are more clear

### DIFF
--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -18,26 +18,16 @@ which is added at the top of the keymap file:
 #include <dt-bindings/zmk/bt.h>
 ```
 
-This will allow you to reference the actions defined in this header such as `BT_CLR_CMD`.
+This will allow you to reference the actions defined in this header such as `BT_CLR`.
 
 Here is a table describing the command for each define:
 
-| Define       | Action                                                                                         |
-| ------------ | ---------------------------------------------------------------------------------------------- |
-| `BT_CLR_CMD` | Clear bond information between the keyboard and host for the selected profile.                 |
-| `BT_NXT_CMD` | Switch to the next profile, cycling through to the first one when the end is reached.          |
-| `BT_PRV_CMD` | Switch to the previous profile, cycling through to the last one when the beginning is reached. |
-| `BT_SEL_CMD` | Select the 0-indexed profile by number.                                                        |
-
-Because at least one bluetooth commands takes an additional parameter, it is recommended to use
-the following aliases in your keymap to avoid having to specify an ignored second parameter:
-
-| Define   | Action                                                                           |
-| -------- | -------------------------------------------------------------------------------- |
-| `BT_CLR` | Alias for `BT_CLR_CMD 0` to clear the current profile's bond to the current host |
-| `BT_NXT` | Alias for `BT_NXT_CMD 0` to select the next profile                              |
-| `BT_PRV` | Alias for `BT_PRV_CMD 0` to select the previous profile                          |
-| `BT_SEL` | Alias for `BT_SEL_CMD` to select the given profile, e.g. `&bt BT_SEL 1`          |
+| Define   | Action                                                                                                                                                    |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BT_CLR` | Clear bond information between the keyboard and host for the selected profile.                                                                            |
+| `BT_NXT` | Switch to the next profile, cycling through to the first one when the end is reached.                                                                     |
+| `BT_PRV` | Switch to the previous profile, cycling through to the last one when the beginning is reached.                                                            |
+| `BT_SEL` | Select the 0-indexed profile by number. Please note: this definition must include a number as an argument in the keymap to work correctly. eg. `BT_SEL 0` |
 
 ## Bluetooth Behavior
 
@@ -46,8 +36,8 @@ The bluetooth behavior completes an bluetooth action given on press.
 ### Behavior Binding
 
 - Reference: `&bt`
-- Parameter #1: The bluetooth command define, e.g. `BT_CLR_CMD`
-- Parameter #2: (Reserved for future bluetooth command types)
+- Parameter #1: The bluetooth command define, e.g. `BT_CLR`
+- Parameter #2: Only applies to `BT_SEL` and is the 0-indexed profile by number
 
 ### Examples
 

--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -9,6 +9,10 @@ The bluetooth behavior allows management of various settings and states related 
 between the keyboard and the host. By default, ZMK supports five "profiles" for selecting which bonded host
 computer/laptop/keyboard should receive the keyboard input; many of the commands here operation on those profiles.
 
+:::note Number of Profiles
+Please note there are only five available Bluetooth profiles by default. If you need to increase the number of available profiles you can set `CONFIG_BT_MAX_CONN` in your `zmk-config` `.conf` file.
+:::
+
 ## Bluetooth Command Defines
 
 Bluetooth command defines are provided through the [`dt-bindings/zmk/bt.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/bt.h) header,


### PR DESCRIPTION
This update mainly removes the `BT_*_CMD` codes which shouldn't be used in practice and better calls attention to `BT_SEL` needing a parameter passed to function correctly