### PR TITLE
feat(devcontainer): persist bash history

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,10 @@
   "name": "ZMK Development",
   "dockerFile": "Dockerfile",
   "runArgs": ["--security-opt", "label=disable"],
-  "containerEnv": { "WORKSPACE_DIR": "${containerWorkspaceFolder}" },
+  "containerEnv": {
+    "WORKSPACE_DIR": "${containerWorkspaceFolder}",
+    "PROMPT_COMMAND": "history -a"
+  },
   "mounts": [
     "type=volume,source=zmk-root-user,target=/root",
     "type=volume,source=zmk-config,target=/workspaces/zmk-config"


### PR DESCRIPTION
When combined with the root user volume, this commit instructs bash to save each command to the bash history after execution, thereby sharing the bash history between any containers that use the volume.

Based on the advice of KemoNine.