### PR TITLE
ci(build): add zmk.hex to archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,4 +121,5 @@ jobs:
         with:
           name: "${{ steps.variables.outputs.artifact-name }}-uf2"
           path: |
+            build/zephyr/zmk.hex
             build/zephyr/zmk.uf2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,4 +120,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: "${{ steps.variables.outputs.artifact-name }}-uf2"
-          path: build/zephyr/zmk.uf2
+          path: |
+            build/zephyr/zmk.uf2


### PR DESCRIPTION
This facilitates users who can't utilize the uf2 artifact.