### PR TITLE
ci(build): remove artifact uf2 suffix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Archive build
         uses: actions/upload-artifact@v2
         with:
-          name: "${{ steps.variables.outputs.artifact-name }}-uf2"
+          name: "${{ steps.variables.outputs.artifact-name }}"
           path: |
             build/zephyr/zmk.hex
             build/zephyr/zmk.uf2


### PR DESCRIPTION
The archive now contains hex and uf2 files so the uf2 suffix is no longer accurate.  It probably should've been removed as part of the earlier hex commit.

See: 97d045e7ef887f8b532838676347e8def0291215