### PR TITLE
ci(workflows): remove zephyr.base-prefer configfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,6 @@ jobs:
         run: west init -l app
       - name: West update
         run: west update
-      - name: West config Zephyr base
-        run: west config --global zephyr.base-prefer configfile
       - name: West Zephyr export
         run: west zephyr-export
       - name: Prepare variables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,6 @@ jobs:
         run: west init -l app
       - name: West update
         run: west update
-      - name: West config Zephyr base
-        run: west config --global zephyr.base-prefer configfile
       - name: West Zephyr export
         run: west zephyr-export
       - name: Test all


### PR DESCRIPTION
CI builds successfully without this step.