### PR TITLE
ci(docs-checks): remove prettier name

### DIFF
--- a/.github/workflows/doc-checks.yml
+++ b/.github/workflows/doc-checks.yml
@@ -23,7 +23,6 @@ jobs:
         working-directory: docs
   prettier:
     runs-on: ubuntu-latest
-    name: Prettier
     steps:
       - uses: actions/checkout@v2
       - uses: bahmutov/npm-install@v1


### PR DESCRIPTION
Aligns with other jobs/workflows.  It isn't necessary.