### PR TITLE
Refactor _TRANSFORM_ENTRY

### DIFF
--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -20,7 +20,7 @@ const char *zmk_keymap_layer_label(uint8_t layer);
 
 int zmk_keymap_position_state_changed(uint32_t position, bool pressed, int64_t timestamp);
 
-#define ZMK_KEYMAP_EXTRACT_BINDING(idx, drv_inst)                                                       \
+#define ZMK_KEYMAP_EXTRACT_BINDING(idx, drv_inst)                                                  \
     {                                                                                              \
         .behavior_dev = DT_LABEL(DT_PHANDLE_BY_IDX(drv_inst, bindings, idx)),                      \
         .param1 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(drv_inst, bindings, idx, param1), (0),        \

--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -19,3 +19,12 @@ int zmk_keymap_layer_to(uint8_t layer);
 const char *zmk_keymap_layer_label(uint8_t layer);
 
 int zmk_keymap_position_state_changed(uint32_t position, bool pressed, int64_t timestamp);
+
+#define ZMK_KEYMAP_EXTRACT_BINDING(idx, drv_inst)                                                       \
+    {                                                                                              \
+        .behavior_dev = DT_LABEL(DT_PHANDLE_BY_IDX(drv_inst, bindings, idx)),                      \
+        .param1 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(drv_inst, bindings, idx, param1), (0),        \
+                              (DT_PHA_BY_IDX(drv_inst, bindings, idx, param1))),                   \
+        .param2 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(drv_inst, bindings, idx, param2), (0),        \
+                              (DT_PHA_BY_IDX(drv_inst, bindings, idx, param2))),                   \
+    }

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -18,6 +18,7 @@
 #include <zmk/events/keycode_state_changed.h>
 #include <zmk/events/modifiers_state_changed.h>
 #include <zmk/hid.h>
+#include <zmk/keymap.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
@@ -260,18 +261,10 @@ static int behavior_sticky_key_init(const struct device *dev) {
 struct behavior_sticky_key_data {};
 static struct behavior_sticky_key_data behavior_sticky_key_data;
 
-#define _TRANSFORM_ENTRY(idx, node)                                                                \
-    {                                                                                              \
-        .behavior_dev = DT_LABEL(DT_INST_PHANDLE_BY_IDX(node, bindings, idx)),                     \
-        .param1 = COND_CODE_0(DT_INST_PHA_HAS_CELL_AT_IDX(node, bindings, idx, param1), (0),       \
-                              (DT_INST_PHA_BY_IDX(node, bindings, idx, param1))),                  \
-        .param2 = COND_CODE_0(DT_INST_PHA_HAS_CELL_AT_IDX(node, bindings, idx, param2), (0),       \
-                              (DT_INST_PHA_BY_IDX(node, bindings, idx, param2))),                  \
-    },
-
 #define KP_INST(n)                                                                                 \
     static struct behavior_sticky_key_config behavior_sticky_key_config_##n = {                    \
-        .behavior = _TRANSFORM_ENTRY(0, n).release_after_ms = DT_INST_PROP(n, release_after_ms),   \
+        .behavior = ZMK_KEYMAP_EXTRACT_BINDING(0, DT_DRV_INST(n)),                                 \
+        .release_after_ms = DT_INST_PROP(n, release_after_ms),                                     \
         .quick_release = DT_INST_PROP(n, quick_release),                                           \
     };                                                                                             \
     DEVICE_AND_API_INIT(behavior_sticky_key_##n, DT_INST_LABEL(n), behavior_sticky_key_init,       \

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -28,18 +28,10 @@ static uint8_t _zmk_keymap_layer_default = 0;
 #define ZMK_KEYMAP_NODE DT_DRV_INST(0)
 #define ZMK_KEYMAP_LAYERS_LEN (DT_INST_FOREACH_CHILD(0, LAYER_CHILD_LEN) 0)
 
-#define LAYER_NODE(l) DT_PHANDLE_BY_IDX(ZMK_KEYMAP_NODE, layers, l)
+#define BINDING_WITH_COMMA(idx, drv_inst) ZMK_KEYMAP_EXTRACT_BINDING(idx, drv_inst),
 
-#define _TRANSFORM_ENTRY(idx, layer)                                                               \
-    {                                                                                              \
-        .behavior_dev = DT_LABEL(DT_PHANDLE_BY_IDX(layer, bindings, idx)),                         \
-        .param1 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(layer, bindings, idx, param1), (0),           \
-                              (DT_PHA_BY_IDX(layer, bindings, idx, param1))),                      \
-        .param2 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(layer, bindings, idx, param2), (0),           \
-                              (DT_PHA_BY_IDX(layer, bindings, idx, param2))),                      \
-    },
-
-#define TRANSFORMED_LAYER(node) {UTIL_LISTIFY(DT_PROP_LEN(node, bindings), _TRANSFORM_ENTRY, node)},
+#define TRANSFORMED_LAYER(node)                                                                    \
+    {UTIL_LISTIFY(DT_PROP_LEN(node, bindings), BINDING_WITH_COMMA, node)},
 
 #if ZMK_KEYMAP_HAS_SENSORS
 #define _TRANSFORM_SENSOR_ENTRY(idx, layer)                                                        \


### PR DESCRIPTION
This was suggested in the PR for https://github.com/zmkfirmware/zmk/pull/284 and tracked in https://github.com/zmkfirmware/zmk/issues/447

There are multiple places in the codebase using some variant on `_TRANSFORM_ENTRY`. This PR unifies all of those uses and renames `_TRANSFORM_ENTRY` to the more descriptive `KEY_BINDING_TO_STRUCT`

```
#define _TRANSFORM_ENTRY(idx, drv_inst)                                                       \
    {                                                                                              \
        .behavior_dev = DT_LABEL(DT_PHANDLE_BY_IDX(drv_inst, bindings, idx)),                      \
        .param1 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(drv_inst, bindings, idx, param1), (0),        \
                              (DT_PHA_BY_IDX(drv_inst, bindings, idx, param1))),                   \
        .param2 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(drv_inst, bindings, idx, param2), (0),        \
                              (DT_PHA_BY_IDX(drv_inst, bindings, idx, param2))),                   \
    }
 ```

The second commit in this PR removes the use of the macro in behavior-hold-taps, as param1 and param2 are not used there.