### PR TITLE
(feat) Allow setting underglow color by key press

### DIFF
--- a/app/dts/behaviors/rgb_underglow.dtsi
+++ b/app/dts/behaviors/rgb_underglow.dtsi
@@ -9,7 +9,7 @@
 		rgb_ug: behavior_rgb_underglow {
 			compatible = "zmk,behavior-rgb-underglow";
 			label = "RGB_UNDERGLOW";
-			#binding-cells = <1>;
+			#binding-cells = <2>;
 		};
 	};
 };

--- a/app/dts/bindings/behaviors/zmk,behavior-rgb-underglow.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-rgb-underglow.yaml
@@ -5,4 +5,4 @@ description: RGB Underglow Action
 
 compatible: "zmk,behavior-rgb-underglow"
 
-include: one_param.yaml
+include: two_param.yaml

--- a/app/include/dt-bindings/zmk/rgb.h
+++ b/app/include/dt-bindings/zmk/rgb.h
@@ -4,14 +4,29 @@
  * SPDX-License-Identifier: MIT
  */
 
-#define RGB_TOG 0
-#define RGB_HUI 1
-#define RGB_HUD 2
-#define RGB_SAI 3
-#define RGB_SAD 4
-#define RGB_BRI 5
-#define RGB_BRD 6
-#define RGB_SPI 7
-#define RGB_SPD 8
-#define RGB_EFF 9
-#define RGB_EFR 10
+#define RGB_TOG_CMD 0
+#define RGB_HUI_CMD 1
+#define RGB_HUD_CMD 2
+#define RGB_SAI_CMD 3
+#define RGB_SAD_CMD 4
+#define RGB_BRI_CMD 5
+#define RGB_BRD_CMD 6
+#define RGB_SPI_CMD 7
+#define RGB_SPD_CMD 8
+#define RGB_EFF_CMD 9
+#define RGB_EFR_CMD 10
+#define RGB_COLOR_HSB_CMD 11
+
+#define RGB_TOG RGB_TOG_CMD 0
+#define RGB_HUI RGB_HUI_CMD 0
+#define RGB_HUD RGB_HUD_CMD 0
+#define RGB_SAI RGB_SAI_CMD 0
+#define RGB_SAD RGB_SAD_CMD 0
+#define RGB_BRI RGB_BRI_CMD 0
+#define RGB_BRD RGB_BRD_CMD 0
+#define RGB_SPI RGB_SPI_CMD 0
+#define RGB_SPD RGB_SPD_CMD 0
+#define RGB_EFF RGB_EFF_CMD 0
+#define RGB_EFR RGB_EFR_CMD 0
+#define RGB_COLOR_HSB(h, s, v) RGB_COLOR_HSB_CMD(((h) << 16) + ((s) << 8) + (v))
+#define RGB_COLOR_HSV RGB_COLOR_HSB

--- a/app/include/zmk/rgb_underglow.h
+++ b/app/include/zmk/rgb_underglow.h
@@ -12,3 +12,4 @@ int zmk_rgb_underglow_change_hue(int direction);
 int zmk_rgb_underglow_change_sat(int direction);
 int zmk_rgb_underglow_change_brt(int direction);
 int zmk_rgb_underglow_change_spd(int direction);
+int zmk_rgb_underglow_set_hsb(uint16_t hue, uint8_t saturation, uint8_t brightness);

--- a/app/src/behaviors/behavior_rgb_underglow.c
+++ b/app/src/behaviors/behavior_rgb_underglow.c
@@ -21,28 +21,31 @@ static int behavior_rgb_underglow_init(const struct device *dev) { return 0; }
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     switch (binding->param1) {
-    case RGB_TOG:
+    case RGB_TOG_CMD:
         return zmk_rgb_underglow_toggle();
-    case RGB_HUI:
+    case RGB_HUI_CMD:
         return zmk_rgb_underglow_change_hue(1);
-    case RGB_HUD:
+    case RGB_HUD_CMD:
         return zmk_rgb_underglow_change_hue(-1);
-    case RGB_SAI:
+    case RGB_SAI_CMD:
         return zmk_rgb_underglow_change_sat(1);
-    case RGB_SAD:
+    case RGB_SAD_CMD:
         return zmk_rgb_underglow_change_sat(-1);
-    case RGB_BRI:
+    case RGB_BRI_CMD:
         return zmk_rgb_underglow_change_brt(1);
-    case RGB_BRD:
+    case RGB_BRD_CMD:
         return zmk_rgb_underglow_change_brt(-1);
-    case RGB_SPI:
+    case RGB_SPI_CMD:
         return zmk_rgb_underglow_change_spd(1);
-    case RGB_SPD:
+    case RGB_SPD_CMD:
         return zmk_rgb_underglow_change_spd(-1);
-    case RGB_EFF:
+    case RGB_EFF_CMD:
         return zmk_rgb_underglow_cycle_effect(1);
-    case RGB_EFR:
+    case RGB_EFR_CMD:
         return zmk_rgb_underglow_cycle_effect(-1);
+    case RGB_COLOR_HSB_CMD:
+        return zmk_rgb_underglow_set_hsb((binding->param2 >> 16) & 0xFFFF,
+                                         (binding->param2 >> 8) & 0xFF, binding->param2 & 0xFF);
     }
 
     return -ENOTSUP;

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -346,6 +346,19 @@ int zmk_rgb_underglow_toggle() {
     return zmk_rgb_underglow_save_state();
 }
 
+int zmk_rgb_underglow_set_hsb(uint16_t hue, uint8_t saturation, uint8_t brightness) {
+    if (hue > 360 || saturation > 100 || brightness > 100) {
+        return -ENOTSUP;
+    }
+
+    state.hue = hue;
+    state.saturation = saturation;
+    state.brightness = brightness;
+    state.current_effect = UNDERGLOW_EFFECT_SOLID;
+
+    return 0;
+}
+
 int zmk_rgb_underglow_change_hue(int direction) {
     if (!led_strip)
         return -ENODEV;

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -354,7 +354,6 @@ int zmk_rgb_underglow_set_hsb(uint16_t hue, uint8_t saturation, uint8_t brightne
     state.hue = hue;
     state.saturation = saturation;
     state.brightness = brightness;
-    state.current_effect = UNDERGLOW_EFFECT_SOLID;
 
     return 0;
 }

--- a/docs/docs/behaviors/lighting.md
+++ b/docs/docs/behaviors/lighting.md
@@ -44,7 +44,7 @@ The "RGB underglow" behavior completes an RGB action given on press.
 
 - Reference: `&rgb_ug`
 - Parameter #1: The RGB action define, e.g. `RGB_TOG` or `RGB_BRI`
-- Parameter #1: Only applies to `RGB_COLOR_HSB` and is the HSB values of the color to set within parenthesis and separated by a common (see below for an example)
+- Parameter #2: Only applies to `RGB_COLOR_HSB` and is the HSB values of the color to set within parenthesis and separated by a common (see below for an example)
 
 :::note HSB Values
 

--- a/docs/docs/behaviors/lighting.md
+++ b/docs/docs/behaviors/lighting.md
@@ -21,19 +21,20 @@ This will allow you to reference the actions defined in this header such as `RGB
 
 Here is a table describing the action for each define:
 
-| Define    | Action                                                    |
-| --------- | --------------------------------------------------------- |
-| `RGB_TOG` | Toggles the RGB feature on and off                        |
-| `RGB_HUI` | Increases the hue of the RGB feature                      |
-| `RGB_HUD` | Decreases the hue of the RGB feature                      |
-| `RGB_SAI` | Increases the saturation of the RGB feature               |
-| `RGB_SAD` | Decreases the saturation of the RGB feature               |
-| `RGB_BRI` | Increases the brightness of the RGB feature               |
-| `RGB_BRD` | Decreases the brightness of the RGB feature               |
-| `RGB_SPI` | Increases the speed of the RGB feature effect's animation |
-| `RGB_SPD` | Decreases the speed of the RGB feature effect's animation |
-| `RGB_EFF` | Cycles the RGB feature's effect forwards                  |
-| `RGB_EFR` | Cycles the RGB feature's effect reverse                   |
+| Define          | Action                                                                                         |
+| --------------- | ---------------------------------------------------------------------------------------------- |
+| `RGB_TOG`       | Toggles the RGB feature on and off                                                             |
+| `RGB_HUI`       | Increases the hue of the RGB feature                                                           |
+| `RGB_HUD`       | Decreases the hue of the RGB feature                                                           |
+| `RGB_SAI`       | Increases the saturation of the RGB feature                                                    |
+| `RGB_SAD`       | Decreases the saturation of the RGB feature                                                    |
+| `RGB_BRI`       | Increases the brightness of the RGB feature                                                    |
+| `RGB_BRD`       | Decreases the brightness of the RGB feature                                                    |
+| `RGB_SPI`       | Increases the speed of the RGB feature effect's animation                                      |
+| `RGB_SPD`       | Decreases the speed of the RGB feature effect's animation                                      |
+| `RGB_EFF`       | Cycles the RGB feature's effect forwards                                                       |
+| `RGB_EFR`       | Cycles the RGB feature's effect reverse                                                        |
+| `RGB_COLOR_HSB` | Sets a specific [HSB (HSV)](https://en.wikipedia.org/wiki/HSL_and_HSV) value for the underglow |
 
 ## RGB Underglow
 
@@ -42,10 +43,31 @@ The "RGB underglow" behavior completes an RGB action given on press.
 ### Behavior Binding
 
 - Reference: `&rgb_ug`
-- Parameter: The RGB action define, e.g. `RGB_TOG` or `RGB_BRI`
+- Parameter #1: The RGB action define, e.g. `RGB_TOG` or `RGB_BRI`
+- Parameter #1: Only applies to `RGB_COLOR_HSB` and is the HSB values of the color to set within parenthesis and separated by a common (see below for an example)
 
-Example:
+:::note HSB Values
 
-```
-&rgb_ug RGB_TOG
-```
+When specifying HSB values you'll need to use `RGB_COLOR_HSB(h, s, b)` in your keymap file. See below for an example.
+
+Value Limits:
+
+- Hue values can _not_ exceed 360 (degrees)
+- Saturation values can _not_ exceed 100 (percent)
+- Brightness values can _not_ exceed 100 (percent)
+
+:::
+
+### Examples
+
+1. Toggle underglow on/off
+
+   ```
+   &rgb_ug RGB_TOG
+   ```
+
+1. Set a specific HSB color (green)
+
+   ```
+   &rgb_ug RGB_COLOR_HSB(128,100,100)
+   ```


### PR DESCRIPTION
This PR implements a behavior to allow setting the HSV of the underglow via a keymap binding.