### PR TITLE
feat(devcontainer): add volume mounts for zephyr, modules and tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,10 @@
   "containerEnv": { "WORKSPACE_DIR": "${containerWorkspaceFolder}" },
   "mounts": [
     "type=volume,source=zmk-root-user,target=/root",
-    "type=volume,source=zmk-config,target=/workspaces/zmk-config"
+    "type=volume,source=zmk-config,target=/workspaces/zmk-config",
+    "type=volume,source=zmk-zephyr,target=${containerWorkspaceFolder}/zephyr",
+    "type=volume,source=zmk-zephyr-modules,target=${containerWorkspaceFolder}/modules",
+    "type=volume,source=zmk-zephyr-tools,target=${containerWorkspaceFolder}/tools"
   ],
   "extensions": ["ms-vscode.cpptools"],
   "settings": {


### PR DESCRIPTION
This effectively caches Zephyr and its dependencies.  It also shares them between containers.