### PR TITLE
refactor(core): define usage page as uint16_t

### DIFF
--- a/app/include/zmk/endpoints.h
+++ b/app/include/zmk/endpoints.h
@@ -18,4 +18,4 @@ int zmk_endpoints_select(enum zmk_endpoint endpoint);
 int zmk_endpoints_toggle();
 enum zmk_endpoint zmk_endpoints_selected();
 
-int zmk_endpoints_send_report(uint8_t usage_page);
+int zmk_endpoints_send_report(uint16_t usage_page);

--- a/app/include/zmk/events/keycode_state_changed.h
+++ b/app/include/zmk/events/keycode_state_changed.h
@@ -14,7 +14,7 @@
 
 struct keycode_state_changed {
     struct zmk_event_header header;
-    uint8_t usage_page;
+    uint16_t usage_page;
     uint32_t keycode;
     uint8_t implicit_modifiers;
     bool state;

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -130,7 +130,7 @@ static int send_consumer_report() {
     }
 }
 
-int zmk_endpoints_send_report(uint8_t usage_page) {
+int zmk_endpoints_send_report(uint16_t usage_page) {
 
     LOG_DBG("usage page 0x%02X", usage_page);
     switch (usage_page) {

--- a/app/src/hid_listener.c
+++ b/app/src/hid_listener.c
@@ -16,7 +16,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <dt-bindings/zmk/hid_usage_pages.h>
 #include <zmk/endpoints.h>
 
-static int hid_listener_keycode_pressed(uint8_t usage_page, uint32_t keycode,
+static int hid_listener_keycode_pressed(uint16_t usage_page, uint32_t keycode,
                                         zmk_mod_flags_t implicit_modifiers) {
     int err;
     LOG_DBG("usage_page 0x%02X keycode 0x%02X mods 0x%02X", usage_page, keycode,
@@ -41,7 +41,7 @@ static int hid_listener_keycode_pressed(uint8_t usage_page, uint32_t keycode,
     return zmk_endpoints_send_report(usage_page);
 }
 
-static int hid_listener_keycode_released(uint8_t usage_page, uint32_t keycode,
+static int hid_listener_keycode_released(uint16_t usage_page, uint32_t keycode,
                                          zmk_mod_flags_t implicit_modifiers) {
     int err;
     LOG_DBG("usage_page 0x%02X keycode 0x%02X mods 0x%02X", usage_page, keycode,


### PR DESCRIPTION
Aligns with the HID specification.

Usage page values were sometimes declared as `uint8_t` and sometimes `uint16_t`.  This commit aligns all instances with the HID specification for consistency.