### PR TITLE
refactor(endpoints): rename usage_report parameter to usage_page

### DIFF
--- a/app/include/zmk/endpoints.h
+++ b/app/include/zmk/endpoints.h
@@ -18,4 +18,4 @@ int zmk_endpoints_select(enum zmk_endpoint endpoint);
 int zmk_endpoints_toggle();
 enum zmk_endpoint zmk_endpoints_selected();
 
-int zmk_endpoints_send_report(uint8_t usage_report);
+int zmk_endpoints_send_report(uint8_t usage_page);


### PR DESCRIPTION
Aligns `zmk_endpoints_send_report` function declaration with its definition:

https://github.com/zmkfirmware/zmk/blob/e89aa1cde82e93bcdac7324751af2cbab4d1d44f/app/src/endpoints.c#L133