### PR TITLE
Use constants for EV_EV_EVENT_BUBBLE, ZMK_BEHAVIOR_OPAQUE and ZMK_BEHAVIOR_TRANSPARENT

### DIFF
--- a/app/include/zmk/behavior.h
+++ b/app/include/zmk/behavior.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#define ZMK_BEHAVIOR_OPAQUE 0
+#define ZMK_BEHAVIOR_TRANSPARENT 1
+
 struct zmk_behavior_binding {
     char *behavior_dev;
     uint32_t param1;

--- a/app/include/zmk/event_manager.h
+++ b/app/include/zmk/event_manager.h
@@ -19,6 +19,7 @@ struct zmk_event_header {
     uint8_t last_listener_index;
 };
 
+#define ZMK_EV_EVENT_BUBBLE 0
 #define ZMK_EV_EVENT_HANDLED 1
 #define ZMK_EV_EVENT_CAPTURED 2
 

--- a/app/src/behaviors/behavior_bt.c
+++ b/app/src/behaviors/behavior_bt.c
@@ -39,7 +39,7 @@ static int behavior_bt_init(const struct device *dev) { return 0; };
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api behavior_bt_driver_api = {

--- a/app/src/behaviors/behavior_ext_power.c
+++ b/app/src/behaviors/behavior_ext_power.c
@@ -43,7 +43,7 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static int behavior_ext_power_init(const struct device *dev) { return 0; };

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -392,16 +392,16 @@ static int position_state_changed_listener(const struct zmk_event_header *eh) {
 
     if (undecided_hold_tap == NULL) {
         LOG_DBG("%d bubble (no undecided hold_tap active)", ev->position);
-        return 0;
+        return ZMK_EV_EVENT_BUBBLE;
     }
 
     if (undecided_hold_tap->position == ev->position) {
         if (ev->state) { // keydown
             LOG_ERR("hold-tap listener should be called before before most other listeners!");
-            return 0;
+            return ZMK_EV_EVENT_BUBBLE;
         } else { // keyup
             LOG_DBG("%d bubble undecided hold-tap keyrelease event", undecided_hold_tap->position);
-            return 0;
+            return ZMK_EV_EVENT_BUBBLE;
         }
     }
 
@@ -418,7 +418,7 @@ static int position_state_changed_listener(const struct zmk_event_header *eh) {
         // we'll catch modifiers later in modifier_state_changed_listener
         LOG_DBG("%d bubbling %d %s event", undecided_hold_tap->position, ev->position,
                 ev->state ? "down" : "up");
-        return 0;
+        return ZMK_EV_EVENT_BUBBLE;
     }
 
     LOG_DBG("%d capturing %d %s event", undecided_hold_tap->position, ev->position,
@@ -439,12 +439,12 @@ static int keycode_state_changed_listener(const struct zmk_event_header *eh) {
 
     if (undecided_hold_tap == NULL) {
         // LOG_DBG("0x%02X bubble (no undecided hold_tap active)", ev->keycode);
-        return 0;
+        return ZMK_EV_EVENT_BUBBLE;
     }
 
     if (!only_mods(ev)) {
         // LOG_DBG("0x%02X bubble (not a mod)", ev->keycode);
-        return 0;
+        return ZMK_EV_EVENT_BUBBLE;
     }
 
     // only key-up events will bubble through position_state_changed_listener
@@ -461,7 +461,7 @@ int behavior_hold_tap_listener(const struct zmk_event_header *eh) {
     } else if (is_keycode_state_changed(eh)) {
         return keycode_state_changed_listener(eh);
     }
-    return 0;
+    return ZMK_EV_EVENT_BUBBLE;
 }
 
 ZMK_LISTENER(behavior_hold_tap, behavior_hold_tap_listener);

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -310,7 +310,7 @@ static int on_hold_tap_binding_pressed(struct zmk_behavior_binding *binding,
     if (undecided_hold_tap != NULL) {
         LOG_DBG("ERROR another hold-tap behavior is undecided.");
         // if this happens, make sure the behavior events occur AFTER other position events.
-        return 0;
+        return ZMK_BEHAVIOR_OPAQUE;
     }
 
     struct active_hold_tap *hold_tap =
@@ -318,7 +318,7 @@ static int on_hold_tap_binding_pressed(struct zmk_behavior_binding *binding,
     if (hold_tap == NULL) {
         LOG_ERR("unable to store hold-tap info, did you press more than %d hold-taps?",
                 ZMK_BHV_HOLD_TAP_MAX_HELD);
-        return 0;
+        return ZMK_BEHAVIOR_OPAQUE;
     }
 
     LOG_DBG("%d new undecided hold_tap", event.position);
@@ -331,7 +331,7 @@ static int on_hold_tap_binding_pressed(struct zmk_behavior_binding *binding,
         k_delayed_work_submit(&hold_tap->work, K_MSEC(tapping_term_ms_left));
     }
 
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static int on_hold_tap_binding_released(struct zmk_behavior_binding *binding,
@@ -339,7 +339,7 @@ static int on_hold_tap_binding_released(struct zmk_behavior_binding *binding,
     struct active_hold_tap *hold_tap = find_hold_tap(event.position);
     if (hold_tap == NULL) {
         LOG_ERR("ACTIVE_HOLD_TAP_CLEANED_UP_TOO_EARLY");
-        return 0;
+        return ZMK_BEHAVIOR_OPAQUE;
     }
 
     // If these events were queued, the timer event may be queued too late or not at all.
@@ -379,7 +379,7 @@ static int on_hold_tap_binding_released(struct zmk_behavior_binding *binding,
         clear_hold_tap(hold_tap);
     }
 
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api behavior_hold_tap_driver_api = {

--- a/app/src/behaviors/behavior_none.c
+++ b/app/src/behaviors/behavior_none.c
@@ -22,12 +22,12 @@ static int behavior_none_init(const struct device *dev) { return 0; };
 
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api behavior_none_driver_api = {

--- a/app/src/behaviors/behavior_reset.c
+++ b/app/src/behaviors/behavior_reset.c
@@ -30,7 +30,7 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
     // See
     // https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/d6b28e66053eea467166f44875e3c7ec741cb471/src/main.c#L107
     sys_reboot(cfg->type);
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api behavior_reset_driver_api = {

--- a/app/src/behaviors/behavior_rgb_underglow.c
+++ b/app/src/behaviors/behavior_rgb_underglow.c
@@ -50,7 +50,7 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api behavior_rgb_underglow_driver_api = {

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -177,7 +177,7 @@ static const struct behavior_driver_api behavior_sticky_key_driver_api = {
 
 static int sticky_key_keycode_state_changed_listener(const struct zmk_event_header *eh) {
     if (!is_keycode_state_changed(eh)) {
-        return 0;
+        return ZMK_EV_EVENT_BUBBLE;
     }
     struct keycode_state_changed *ev = cast_keycode_state_changed(eh);
     for (int i = 0; i < ZMK_BHV_STICKY_KEY_MAX_HELD; i++) {
@@ -222,7 +222,7 @@ static int sticky_key_keycode_state_changed_listener(const struct zmk_event_head
             }
         }
     }
-    return 0;
+    return ZMK_EV_EVENT_BUBBLE;
 }
 
 ZMK_LISTENER(behavior_sticky_key, sticky_key_keycode_state_changed_listener);

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -138,12 +138,12 @@ static int on_sticky_key_binding_pressed(struct zmk_behavior_binding *binding,
     if (sticky_key == NULL) {
         LOG_ERR("unable to store sticky key, did you press more than %d sticky_key?",
                 ZMK_BHV_STICKY_KEY_MAX_HELD);
-        return 0;
+        return ZMK_BEHAVIOR_OPAQUE;
     }
 
     press_sticky_key_behavior(sticky_key, event.timestamp);
     LOG_DBG("%d new sticky_key", event.position);
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static int on_sticky_key_binding_released(struct zmk_behavior_binding *binding,
@@ -151,7 +151,7 @@ static int on_sticky_key_binding_released(struct zmk_behavior_binding *binding,
     struct active_sticky_key *sticky_key = find_sticky_key(event.position);
     if (sticky_key == NULL) {
         LOG_ERR("ACTIVE STICKY KEY CLEARED TOO EARLY");
-        return 0;
+        return ZMK_BEHAVIOR_OPAQUE;
     }
 
     if (sticky_key->modified_key_usage_page != 0 && sticky_key->modified_key_keycode != 0) {
@@ -167,7 +167,7 @@ static int on_sticky_key_binding_released(struct zmk_behavior_binding *binding,
     if (ms_left > 0) {
         k_delayed_work_submit(&sticky_key->release_timer, K_MSEC(ms_left));
     }
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api behavior_sticky_key_driver_api = {

--- a/app/src/behaviors/behavior_toggle_layer.c
+++ b/app/src/behaviors/behavior_toggle_layer.c
@@ -29,7 +29,7 @@ static int tog_keymap_binding_pressed(struct zmk_behavior_binding *binding,
 static int tog_keymap_binding_released(struct zmk_behavior_binding *binding,
                                        struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d layer %d", event.position, binding->param1);
-    return 0;
+    return ZMK_BEHAVIOR_OPAQUE;
 }
 
 static const struct behavior_driver_api behavior_tog_driver_api = {

--- a/app/src/behaviors/behavior_transparent.c
+++ b/app/src/behaviors/behavior_transparent.c
@@ -22,12 +22,12 @@ static int behavior_transparent_init(const struct device *dev) { return 0; };
 
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
-    return 1;
+    return ZMK_BEHAVIOR_TRANSPARENT;
 }
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
-    return 1;
+    return ZMK_BEHAVIOR_TRANSPARENT;
 }
 
 static const struct behavior_driver_api behavior_transparent_driver_api = {

--- a/app/src/display/widgets/battery_status.c
+++ b/app/src/display/widgets/battery_status.c
@@ -78,7 +78,7 @@ lv_obj_t *zmk_widget_battery_status_obj(struct zmk_widget_battery_status *widget
 int battery_status_listener(const struct zmk_event_header *eh) {
     struct zmk_widget_battery_status *widget;
     SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { set_battery_symbol(widget->obj); }
-    return 0;
+    return ZMK_EV_EVENT_BUBBLE;
 }
 
 ZMK_LISTENER(widget_battery_status, battery_status_listener)

--- a/app/src/display/widgets/output_status.c
+++ b/app/src/display/widgets/output_status.c
@@ -82,7 +82,7 @@ lv_obj_t *zmk_widget_output_status_obj(struct zmk_widget_output_status *widget) 
 int output_status_listener(const struct zmk_event_header *eh) {
     struct zmk_widget_output_status *widget;
     SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { set_status_symbol(widget->obj); }
-    return 0;
+    return ZMK_EV_EVENT_BUBBLE;
 }
 
 ZMK_LISTENER(widget_output_status, output_status_listener)

--- a/app/src/split_listener.c
+++ b/app/src/split_listener.c
@@ -29,7 +29,7 @@ int split_listener(const struct zmk_event_header *eh) {
             return zmk_split_bt_position_released(ev->position);
         }
     }
-    return 0;
+    return ZMK_EV_EVENT_BUBBLE;
 }
 
 ZMK_LISTENER(split_listener, split_listener);


### PR DESCRIPTION
This PR defines constants for  EV_EV_EVENT_BUBBLE, ZMK_BEHAVIOR_OPAQUE and ZMK_BEHAVIOR_TRANSPARENT so we don't have to use magic numbers in the `behavior_driver_api` return values.