### PR TITLE
ci(build): ignore failing upload-artifacts step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,3 +112,4 @@ jobs:
           path: |
             build/zephyr/zmk.hex
             build/zephyr/zmk.uf2
+        continue-on-error: true


### PR DESCRIPTION
Ignore failed "archive artifacts" steps which are making lots of builds fail. This is needed because currently many "archive artifact" steps failing with an "ECONNRESET" error.