### PR TITLE
Handle events from peripherals on the main work thread, avoid concurrent GATT notifications to avoid locking up central side..

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -102,7 +102,7 @@ config ZMK_SPLIT
 
 if ZMK_SPLIT
 
-config ZMK_SPLIT_BLE
+menuconfig ZMK_SPLIT_BLE
 	bool "Split keyboard support via BLE transport"
 	depends on ZMK_BLE
 	default y
@@ -124,6 +124,18 @@ config ZMK_SPLIT_BLE_CENTRAL_POSITION_QUEUE_SIZE
 endif
 
 if !ZMK_SPLIT_BLE_ROLE_CENTRAL
+
+config ZMK_SPLIT_BLE_PERIPHERAL_STACK_SIZE
+	int "BLE split peripheral notify thread stack size"
+	default 512
+
+config ZMK_SPLIT_BLE_PERIPHERAL_PRIORITY
+	int "BLE split peripheral notify thread priority"
+	default 5
+
+config ZMK_SPLIT_BLE_PERIPHERAL_POSITION_QUEUE_SIZE
+	int "Max number of key position state events to queue to send to the central"
+	default 10
 
 config ZMK_USB
 	default n

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -41,7 +41,7 @@ config USB_NUMOF_EP_WRITE_RETRIES
 #ZMK_USB
 endif
 
-config ZMK_BLE
+menuconfig ZMK_BLE
 	bool "BLE (HID over GATT)"
 	select BT
 	select BT_SMP
@@ -57,6 +57,22 @@ if ZMK_BLE
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	default 2048
+
+config ZMK_BLE_THREAD_STACK_SIZE
+	int "BLE notify thread stack size"
+	default 512
+
+config ZMK_BLE_THREAD_PRIORITY
+	int "BLE notify thread priority"
+	default 5
+
+config ZMK_BLE_KEYBOARD_REPORT_QUEUE_SIZE
+	int "Max number of keyboard HID reports to queue for sending over BLE"
+	default 20
+
+config ZMK_BLE_CONSUMER_REPORT_QUEUE_SIZE
+	int "Max number of consumer HID reports to queue for sending over BLE"
+	default 5
 
 config ZMK_BLE_CLEAR_BONDS_ON_START
 	bool "Configuration that clears all bond information from the keyboard on startup."

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -94,10 +94,18 @@ config ZMK_SPLIT_BLE
 
 if ZMK_SPLIT_BLE
 
-config ZMK_SPLIT_BLE_ROLE_CENTRAL
+menuconfig ZMK_SPLIT_BLE_ROLE_CENTRAL
 	bool "Central"
 	select BT_CENTRAL
 	select BT_GATT_CLIENT
+
+if ZMK_SPLIT_BLE_ROLE_CENTRAL
+
+config ZMK_SPLIT_BLE_CENTRAL_POSITION_QUEUE_SIZE
+	int "Max number of key position state events to queue when received from peripherals"
+	default 5
+
+endif
 
 if !ZMK_SPLIT_BLE_ROLE_CENTRAL
 

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -376,7 +376,10 @@ static void connected(struct bt_conn *conn, uint8_t err) {
 
     LOG_DBG("Connected %s", log_strdup(addr));
 
-    bt_conn_le_param_update(conn, BT_LE_CONN_PARAM(0x0006, 0x000c, 30, 400));
+    err = bt_conn_le_param_update(conn, BT_LE_CONN_PARAM(0x0006, 0x000c, 30, 400));
+    if (err) {
+        LOG_WRN("Failed to update LE parameters (err %d)", err);
+    }
 
 #if IS_SPLIT_PERIPHERAL
     bt_conn_le_phy_update(conn, BT_CONN_LE_PHY_PARAM_2M);
@@ -423,10 +426,20 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
     }
 }
 
+static void le_param_updated(struct bt_conn *conn, uint16_t interval, uint16_t latency,
+                             uint16_t timeout) {
+    char addr[BT_ADDR_LE_STR_LEN];
+
+    bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+    LOG_DBG("%s: interval %d latency %d timeout %d", addr, interval, latency, timeout);
+}
+
 static struct bt_conn_cb conn_callbacks = {
     .connected = connected,
     .disconnected = disconnected,
     .security_changed = security_changed,
+    .le_param_updated = le_param_updated,
 };
 
 /*

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -55,7 +55,9 @@ int zmk_hid_unregister_mod(zmk_mod_t modifier) {
             continue;                                                                              \
         }                                                                                          \
         keyboard_report.body.keys[idx] = val;                                                      \
-        break;                                                                                     \
+        if (val) {                                                                                 \
+            break;                                                                                 \
+        }                                                                                          \
     }
 
 #define TOGGLE_CONSUMER(match, val)                                                                \
@@ -64,7 +66,9 @@ int zmk_hid_unregister_mod(zmk_mod_t modifier) {
             continue;                                                                              \
         }                                                                                          \
         consumer_report.body.keys[idx] = val;                                                      \
-        break;                                                                                     \
+        if (val) {                                                                                 \
+            break;                                                                                 \
+        }                                                                                          \
     }
 
 int zmk_hid_implicit_modifiers_press(zmk_mod_flags_t implicit_modifiers) {

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -57,8 +57,9 @@ void peripheral_event_work_callback(struct k_work *work) {
 
 K_WORK_DEFINE(peripheral_event_work, peripheral_event_work_callback);
 
-static uint8_t split_central_notify_func(struct bt_conn *conn, struct bt_gatt_subscribe_params *params,
-                                      const void *data, uint16_t length) {
+static uint8_t split_central_notify_func(struct bt_conn *conn,
+                                         struct bt_gatt_subscribe_params *params, const void *data,
+                                         uint16_t length) {
     static uint8_t position_state[POSITION_STATE_DATA_LEN];
 
     uint8_t changed_positions[POSITION_STATE_DATA_LEN];

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -33,9 +33,32 @@ static struct bt_uuid_128 uuid = BT_UUID_INIT_128(ZMK_SPLIT_BT_SERVICE_UUID);
 static struct bt_gatt_discover_params discover_params;
 static struct bt_gatt_subscribe_params subscribe_params;
 
-static uint8_t split_central_notify_func(struct bt_conn *conn,
-                                         struct bt_gatt_subscribe_params *params, const void *data,
-                                         uint16_t length) {
+struct zmk_split_peripheral_event {
+    uint32_t position;
+    uint32_t state;
+    int32_t timestamp;
+};
+
+K_MSGQ_DEFINE(peripheral_event_msgq, sizeof(struct zmk_split_peripheral_event),
+              CONFIG_ZMK_SPLIT_BLE_CENTRAL_POSITION_QUEUE_SIZE, 4);
+
+void peripheral_event_work_callback(struct k_work *work) {
+    struct zmk_split_peripheral_event ev;
+    while (k_msgq_get(&peripheral_event_msgq, &ev, K_NO_WAIT) == 0) {
+        struct position_state_changed *pos_ev = new_position_state_changed();
+        pos_ev->position = ev.position;
+        pos_ev->state = ev.state;
+        pos_ev->timestamp = ev.timestamp;
+
+        LOG_DBG("Trigger key position state change for %d", ev.position);
+        ZMK_EVENT_RAISE(pos_ev);
+    }
+}
+
+K_WORK_DEFINE(peripheral_event_work, peripheral_event_work_callback);
+
+static uint8_t split_central_notify_func(struct bt_conn *conn, struct bt_gatt_subscribe_params *params,
+                                      const void *data, uint16_t length) {
     static uint8_t position_state[POSITION_STATE_DATA_LEN];
 
     uint8_t changed_positions[POSITION_STATE_DATA_LEN];
@@ -58,13 +81,11 @@ static uint8_t split_central_notify_func(struct bt_conn *conn,
             if (changed_positions[i] & BIT(j)) {
                 uint32_t position = (i * 8) + j;
                 bool pressed = position_state[i] & BIT(j);
-                struct position_state_changed *pos_ev = new_position_state_changed();
-                pos_ev->position = position;
-                pos_ev->state = pressed;
-                pos_ev->timestamp = k_uptime_get();
+                struct zmk_split_peripheral_event ev = {
+                    .position = position, .state = pressed, .timestamp = k_uptime_get()};
 
-                LOG_DBG("Trigger key position state change for %d", position);
-                ZMK_EVENT_RAISE(pos_ev);
+                k_msgq_put(&peripheral_event_msgq, &ev, K_NO_WAIT);
+                k_work_submit(&peripheral_event_work);
             }
         }
     }

--- a/app/src/split/bluetooth/service.c
+++ b/app/src/split/bluetooth/service.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/types.h>
 #include <sys/util.h>
+#include <init.h>
 
 #include <logging/log.h>
 
@@ -18,8 +19,10 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/split/bluetooth/uuid.h>
 #include <zmk/split/bluetooth/service.h>
 
+#define POS_STATE_LEN 16
+
 static uint8_t num_of_positions = ZMK_KEYMAP_LEN;
-static uint8_t position_state[16];
+static uint8_t position_state[POS_STATE_LEN];
 
 static ssize_t split_svc_pos_state(struct bt_conn *conn, const struct bt_gatt_attr *attrs,
                                    void *buf, uint16_t len, uint16_t offset) {
@@ -45,12 +48,62 @@ BT_GATT_SERVICE_DEFINE(
     BT_GATT_DESCRIPTOR(BT_UUID_NUM_OF_DIGITALS, BT_GATT_PERM_READ, split_svc_num_of_positions, NULL,
                        &num_of_positions), );
 
+K_THREAD_STACK_DEFINE(service_q_stack, CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_STACK_SIZE);
+
+struct k_work_q service_work_q;
+
+K_MSGQ_DEFINE(position_state_msgq, sizeof(char[POS_STATE_LEN]),
+              CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_POSITION_QUEUE_SIZE, 4);
+
+void send_position_state_callback(struct k_work *work) {
+    uint8_t state[POS_STATE_LEN];
+
+    while (k_msgq_get(&position_state_msgq, &state, K_NO_WAIT) == 0) {
+        int err = bt_gatt_notify(NULL, &split_svc.attrs[1], &state, sizeof(state));
+        if (err) {
+            LOG_DBG("Error notifying %d", err);
+        }
+    }
+};
+
+K_WORK_DEFINE(service_position_notify_work, send_position_state_callback);
+
+int send_position_state() {
+    int err = k_msgq_put(&position_state_msgq, position_state, K_MSEC(100));
+    if (err) {
+        switch (err) {
+        case -EAGAIN: {
+            LOG_WRN("Position state message queue full, popping first message and queueing again");
+            uint8_t discarded_state[POS_STATE_LEN];
+            k_msgq_get(&position_state_msgq, &discarded_state, K_NO_WAIT);
+            return send_position_state();
+        }
+        default:
+            LOG_WRN("Failed to queue position state to send (%d)", err);
+            return err;
+        }
+    }
+
+    k_work_submit_to_queue(&service_work_q, &service_position_notify_work);
+
+    return 0;
+}
+
 int zmk_split_bt_position_pressed(uint8_t position) {
     WRITE_BIT(position_state[position / 8], position % 8, true);
-    return bt_gatt_notify(NULL, &split_svc.attrs[1], &position_state, sizeof(position_state));
+    return send_position_state();
 }
 
 int zmk_split_bt_position_released(uint8_t position) {
     WRITE_BIT(position_state[position / 8], position % 8, false);
-    return bt_gatt_notify(NULL, &split_svc.attrs[1], &position_state, sizeof(position_state));
+    return send_position_state();
 }
+
+int service_init(const struct device *_arg) {
+    k_work_q_start(&service_work_q, service_q_stack, K_THREAD_STACK_SIZEOF(service_q_stack),
+                   CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_PRIORITY);
+
+    return 0;
+}
+
+SYS_INIT(service_init, APPLICATION, CONFIG_ZMK_BLE_INIT_PRIORITY);


### PR DESCRIPTION
Resurrecting this change, since we're still having occasional failures w/ crashes on splits, which I believe could be related (but not fully fixed) to this.

Previously on #466 it was noted that this caused failures to sleep, but I cannot reproduce that here. Setting a low sleep timeout, and my Kyria properly sleeps and awakes from deep sleep.

This now has fixes for splits, and for non-splits, that have encountered spam/crash issues.