### PR TITLE
Rebound v4 - New shield support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
           - qaz
           - quefrency_left
           - quefrency_right
+          - rebound_v4
           - reviung41
           - romac
           - romac_plus

--- a/app/boards/shields/rebound/Kconfig.defconfig
+++ b/app/boards/shields/rebound/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_REBOUND_V4
+
+config ZMK_KEYBOARD_NAME
+    default "Rebound v4"
+
+endif

--- a/app/boards/shields/rebound/Kconfig.shield
+++ b/app/boards/shields/rebound/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_REBOUND_V4
+    def_bool $(shields_list_contains,rebound_v4)

--- a/app/boards/shields/rebound/README.md
+++ b/app/boards/shields/rebound/README.md
@@ -1,0 +1,64 @@
+# Supported versions
+
+This shield, Rebound_v4 provides support for the Montsinger Rebound v4.x variants only.
+Previous iterations of the Rebound, variants v3.x and earlier are not supported as they use a different matrix to that which is used for the Rebound v4.x variants.
+
+## Building ZMK for the Rebound_v4
+
+Some general notes/commands for building the Montsinger Rebound_v4 from the assembly documentation.
+
+## Layouts using 1u and/or 2u thumb keys
+
+If you built your Rebound_v4 with 2u keys on the bottom row, key-presses of the inside/second column 1u key on the bottom row will be redundant (the switch position labelled as "optional" in the keymap diagram below).
+
+If your Rebound_v4 is built with hotswap support using PCB sockets, you may wish to assign key-press behaviours to all four 1u keys to allow hotswapping between 1u and 2u layouts on both left and right portions of the PCB without having to rebuild and reflash the firmware.
+
+As an example template of each layout, the default keymap shown below envisages a uniform 1u layout on the left portion of the pcb, and a 2u layout on the right portion with the redundant key labelled as "optional" and assigned with key-press "&none".
+
+(Therefore, if you instead choose to implement a 2u layout for the left portion of the PCB whilst using the below default keymap, the key currently mapped as "&kp DEL" on the bottom row will simply become redundant until a 1u layout is implemented)
+
+```
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+// -------------------------------------------------------------------------------------
+// |   Q   |   W   |   E   |    R   |    T   |    1   |                        |   1   |    Y   |    U   |   I   |   O   |   P   |
+// | GUI/A | ALT/S | CTL/D | SHFT/F |    G   |    2   |        | TAB  |        |   2   |    H   | SHFT/J | CTL/K | ALT/L | GUI/' |
+// |   Z   |   X   |   C   |    V   |    B   |    3   |        | RET  |        |   3   |    N   |    M   |   ,   |   .   |   /   |
+// | CTRL  |  ALT  |  GUI  |  SHFT  |   DEL  |  BSPC  |        | CAPS |        |  SPC  |optional|   GUI  |  ALT  |  CTRL |   ;   |
+//
+		bindings = <
+   &kp Q       &kp W      &kp E       &kp R       &kp T   &mo 1               &mo 1     &kp Y     &kp U       &kp I       &kp O      &kp P
+   &hm LGUI A  &hm LALT S &hm LCTRL D &hm LSHFT F &kp G   &mo 2     &kp TAB   &mo 2     &kp H     &hm RSHFT J &hm RCTRL K &hm RALT L &hm RGUI SQT
+   &kp Z       &kp X      &kp C       &kp V       &kp B   &mo 3     &kp RET   &mo 3     &kp N     &kp M       &kp COMMA   &kp DOT    &kp FSLH  
+   &kp LCTRL   &kp LALT   &kp LGUI    &kp LSHFT   &kp DEL &kp BSPC  &kp CAPS  &kp SPACE &none     &kp RGUI    &kp RALT    &kp RCTRL  &kp SEMI                   
+                        >;
+
+			sensor-bindings = <&inc_dec_kp DEL BSPC>;
+                };
+```
+
+## Encoder Notes
+
+If you built your Rebound_v4 with encoders, you will need to amend your Rebound_v4 config file by uncommenting the following two lines:
+
+```
+# Uncomment these two lines to add support for encoders
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+```
+
+To the following:
+```
+# Uncomment these two lines to add support for encoders
+CONFIG_EC11=y
+CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+```
+
+If you built your Rebound_v4 without encoders, you can either leave those two lines in your Rebound_v4 config file as comments, or replace them with:
+
+```
+CONFIG_EC11=n
+CONFIG_EC11_TRIGGER_GLOBAL_THREAD=n
+```

--- a/app/boards/shields/rebound/rebound_v4.conf
+++ b/app/boards/shields/rebound/rebound_v4.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Uncomment these two lines to add support for encoders
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y

--- a/app/boards/shields/rebound/rebound_v4.dtsi
+++ b/app/boards/shields/rebound/rebound_v4.dtsi
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <7>;
+        rows = <8>;
+
+        map = <
+RC(0,0) RC(7,0) RC(0,1) RC(7,1) RC(0,2) RC(7,2)         RC(0,4) RC(7,4) RC(0,5) RC(7,5) RC(0,6) RC(7,6)
+RC(1,0) RC(6,0) RC(1,1) RC(6,1) RC(1,2) RC(6,2) RC(1,3) RC(1,4) RC(6,4) RC(1,5) RC(6,5) RC(1,6) RC(6,6)
+RC(2,0) RC(5,0) RC(2,1) RC(5,1) RC(2,2) RC(5,2) RC(2,3) RC(2,4) RC(5,4) RC(2,5) RC(5,5) RC(2,6) RC(5,6)
+RC(3,0) RC(4,0) RC(3,1) RC(4,1) RC(3,2) RC(4,2) RC(3,3) RC(3,4) RC(4,4) RC(3,5) RC(4,5) RC(3,6) RC(4,6)
+        >;
+    };
+
+    kscan0: kscan_0 {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "row2col";
+
+        col-gpios
+            = <&pro_micro_d 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+	      , <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+
+        row-gpios
+            = <&pro_micro_d 2 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 3 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 4 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_a 0 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_a 1 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_a 2 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_a 3 GPIO_ACTIVE_HIGH>
+            ;
+    };
+
+    encoder: encoder {
+        compatible = "alps,ec11";
+        label = "ENCODER";
+        a-gpios = <&pro_micro_d 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+        b-gpios = <&pro_micro_d 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+        resolution = <2>;
+        status = "okay";
+    };
+
+    sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&encoder>;
+    };
+};

--- a/app/boards/shields/rebound/rebound_v4.keymap
+++ b/app/boards/shields/rebound/rebound_v4.keymap
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/modifiers.h>
+#include <dt-bindings/zmk/outputs.h>
+
+/ {
+    behaviors {
+        hm: homerow_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HOMEROW_MODS";
+            #binding-cells = <2>;
+            tapping_term_ms = <175>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+// -------------------------------------------------------------------------------------
+// |   Q   |   W   |   E   |    R   |  T  |  1   |                |  1  |    Y   |    U   |   I   |   O   |   P   |
+// | GUI/A | ALT/S | CTL/D | SHFT/F |  G  |  2   |    | TAB  |    |  2  |    H   | SHFT/J | CTL/K | ALT/L | GUI/' |
+// |   Z   |   X   |   C   |    V   |  B  |  3   |    | RET  |    |  3  |    N   |    M   |   ,   |   .   |   /   |
+// | CTRL  |  ALT  |  GUI  |  SHFT  | DEL | BSPC |    | CAPS |    | SPC |optional|   GUI  |  ALT  |  CTRL |   ;   |
+//
+		bindings = <
+   &kp Q       &kp W      &kp E       &kp R       &kp T   &mo 1               &mo 1     &kp Y     &kp U       &kp I       &kp O      &kp P
+   &hm LGUI A  &hm LALT S &hm LCTRL D &hm LSHFT F &kp G   &mo 2     &kp TAB   &mo 2     &kp H     &hm RSHFT J &hm RCTRL K &hm RALT L &hm RGUI SQT
+   &kp Z       &kp X      &kp C       &kp V       &kp B   &mo 3     &kp RET   &mo 3     &kp N     &kp M       &kp COMMA   &kp DOT    &kp FSLH
+   &kp LCTRL   &kp LALT   &kp LGUI    &kp LSHFT   &kp DEL &kp BSPC  &kp CAPS  &kp SPACE &none     &kp RGUI    &kp RALT    &kp RCTRL  &kp SEMI
+                        >;
+
+			sensor-bindings = <&inc_dec_kp DEL BSPC>;
+                };
+
+        lower_layer {
+// ----------------------------------------------------------------------------------
+// |  !   |  @  |  #  |  $  |  %  |  `  |                   |     | HOME | PGUP |  UP  | PGDN |      |
+// |  ^   |  &  |  *  |  (  |  )  |  ~  |     |       |     |     | END  | LEFT | DOWN | RGHT |      |
+// |  _   |  +  |  {  |  }  | "|" |     |     |       |     |     |      |      |      |      |      |
+// | ESC  | ALT | GUI | CAPS|  "  |     |     |       |     |     |      |      |      |      |      |
+//
+		bindings = <
+   &kp EXCL  &kp AT   &kp HASH &kp DLLR &kp PRCNT &kp GRAVE                 &trans &kp HOME &kp PG_UP &kp UP   &kp PG_DN &trans
+   &kp CARET &kp AMPS &kp STAR &kp LPAR &kp RPAR  &trans        &trans      &trans &kp END  &kp LEFT  &kp DOWN &kp RIGHT &trans
+   &kp MINUS &kp PLUS &kp PIPE &kp LBKT &kp RBKT  &trans        &trans      &trans &trans   &trans    &trans   &trans    &trans
+   &kp ESC   &kp LALT &kp LGUI &kp CAPS &kp DQT   &trans        &trans      &trans &trans   &trans    &trans   &trans    &trans
+                        >;
+
+			sensor-bindings = <&inc_dec_kp PG_DN PG_UP>;
+                };
+
+        keypad_layer {
+// -----------------------------------------------------------------------------------------
+// |  -  |  9  |  8  |  7  | NUM |     |                   |     | NUM |  7  |  8  |  9  |  -  |
+// |  +  |  6  |  5  |  4  |  /  |     |     |       |     |     |  /  |  4  |  5  |  6  |  +  |
+// |  =  |  3  |  2  |  1  |  *  |     |     |       |     |     |  *  |  1  |  2  |  3  |  =  |
+// | RET |  .  |  0  |  0  | CLR |     |     |       |     |     | CLR |  0  |  0  |  .  | RET |
+//
+		bindings = <
+   &kp KP_MINUS &kp KP_N9  &kp KP_N8 &kp KP_N7 &kp KP_NUM      &trans              &trans &kp KP_NUM      &kp KP_N9 &kp KP_N8 &kp KP_N7  &kp KP_MINUS
+   &kp KP_PLUS  &kp KP_N6  &kp KP_N5 &kp KP_N4 &kp KP_SLASH    &trans    &trans    &trans &kp KP_SLASH    &kp KP_N6 &kp KP_N5 &kp KP_N4  &kp KP_PLUS
+   &kp KP_EQUAL &kp KP_N3  &kp KP_N2 &kp KP_N1 &kp KP_MULTIPLY &trans    &trans    &trans &kp KP_MULTIPLY &kp KP_N3 &kp KP_N2 &kp KP_N1  &kp KP_EQUAL
+   &kp KP_ENTER &kp KP_DOT &kp KP_N0 &kp KP_N0 &kp KP_CLEAR    &trans    &trans    &trans &kp KP_CLEAR    &kp KP_N0 &kp KP_N0 &kp KP_DOT &kp KP_ENTER
+                        >;
+
+			sensor-bindings = <&inc_dec_kp RIGHT LEFT>;
+                };
+
+	raise_layer {
+// -----------------------------------------------------------------------------------------
+// |     |     |     |     |     |  BT1  |                  |  BT4  | F1  | F2  | F3  | F4  | F5  |
+// |  1  |  2  |  3  |  4  |  5  |  BT2  |    | BT CLR |    |  BT5  |  6  |  7  |  8  |  9  |  0  |
+// |  -  |  =  |  [  |  ]  |  \  |  BT3  |    | RESET  |    |       | F6  | F7  | F8  | F9  | F10 |
+// | ESC | ALT | CMD | CAPS|  "  |  USB  |    |        |    |  BLE  |     |     |     | F11 | F12 |
+//
+		bindings = <
+   &trans    &trans    &trans   &trans   &trans   &bt BT_SEL 0                 &bt BT_SEL 3 &kp F1  &kp F2  &kp F3  &kp F4  &kp F5
+   &kp N1    &kp N2    &kp N3   &kp N4   &kp N5   &bt BT_SEL 1    &bt BT_CLR   &bt BT_SEL 4 &kp N6  &kp N7  &kp N8  &kp N9  &kp N0
+   &kp MINUS &kp EQUAL &kp LBKT &kp RBKT &kp BSLH &bt BT_SEL 2    &reset       &trans       &kp F6  &kp F7  &kp F8  &kp F9  &kp F10
+   &kp ESC   &kp LALT  &kp LGUI &kp CAPS &kp DQT  &out OUT_USB    &trans       &out OUT_BLE &kp F11 &kp F12 &kp F13 &kp F14 &kp F15
+                        >;
+
+			sensor-bindings = <&inc_dec_kp DOWN UP>;
+		};
+	};
+};

--- a/app/boards/shields/rebound/rebound_v4.overlay
+++ b/app/boards/shields/rebound/rebound_v4.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "rebound_v4.dtsi"

--- a/docs/docs/hardware.md
+++ b/docs/docs/hardware.md
@@ -31,6 +31,7 @@ That being said, there are currently only a few specific [boards](/docs/faq#what
 - [Splitreus62](https://github.com/Na-Cly/splitreus62) (`splitreus62_left` and `splitreus62_right`)
 - [Jorne](https://github.com/joric/jorne) (`jorne_left` and `jorne_right`)
 - [Jian](https://github.com/KGOH/Jian-Info) (`jian_left` and `jian_right`)
+- [Rebound v4](https://store.montsinger.net/products/rebound) (`rebound_v4`)
 - [Reviung41](https://github.com/gtips/reviung/tree/master/reviung41) (`reviung41`)
 - [RoMac+ v4](https://www.littlekeyboards.com/products/romac) (`romac_plus`)
 - [RoMac v2](https://mechboards.co.uk/shop/kits/romac-macro-pad/) (`romac`)

--- a/docs/static/setup.ps1
+++ b/docs/static/setup.ps1
@@ -58,11 +58,11 @@ catch [System.Management.Automation.CommandNotFoundException] {
 Test-Git-Config -Option "user.name" -ErrMsg "Git username not set!`nRun: git config --global user.name 'My Name'"
 Test-Git-Config -Option "user.email" -ErrMsg "Git email not set!`nRun: git config --global user.email 'example@myemail.com'"
 
-$permission = (Get-Acl $pwd).Access | 
+$permission = (Get-Acl $pwd).Access |
 ?{$_.IdentityReference -match $env:UserName `
 	-and $_.FileSystemRights -match "FullControl" `
-		-or $_.FileSystemRights -match "Write"	} | 
-			
+		-or $_.FileSystemRights -match "Write"	} |
+
 		Select IdentityReference,FileSystemRights
 
 If (-Not $permission){
@@ -90,9 +90,9 @@ Write-Host "Keyboard Shield Selection:"
 $prompt = "Pick a keyboard"
 
 # TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
-$options = "Kyria", "Lily58", "Corne", "Splitreus62", "Sofle", "Iris", "Reviung41", "RoMac", "RoMac+", "makerdiary M60", "Microdox", "TG4X", "QAZ", "NIBBLE", "Jorne", "Jian", "CRBN", "Tidbit", "Eek!", "BFO-9000", "Helix"
-$names = "kyria", "lily58", "corne", "splitreus62", "sofle", "iris", "reviung41", "romac", "romac_plus", "m60", "microdox", "tg4x", "qaz", "nibble", "jorne", "jian", "crbn", "tidbit", "eek", "bfo9000", "helix"
-$splits = "y", "y", "y", "y", "y", "y", "n", "n", "n", "n", "y", "n", "n", "n", "y", "y", "n", "n", "n", "n", "y"
+$options = "Kyria", "Lily58", "Corne", "Splitreus62", "Sofle", "Iris", "Reviung41", "RoMac", "RoMac+", "makerdiary M60", "Microdox", "TG4X", "QAZ", "NIBBLE", "Jorne", "Jian", "CRBN", "Tidbit", "Eek!", "BFO-9000", "Helix", "Rebound v4"
+$names = "kyria", "lily58", "corne", "splitreus62", "sofle", "iris", "reviung41", "romac", "romac_plus", "m60", "microdox", "tg4x", "qaz", "nibble", "jorne", "jian", "crbn", "tidbit", "eek", "bfo9000", "helix", "rebound_v4"
+$splits = "y", "y", "y", "y", "y", "y", "n", "n", "n", "n", "y", "n", "n", "n", "y", "y", "n", "n", "n", "n", "y", "n"
 
 $choice = Get-Choice-From-Options -Options $options -Prompt $prompt
 $shield_title = $($options[$choice])

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -91,7 +91,7 @@ echo ""
 echo "Keyboard Shield Selection:"
 
 prompt="Pick an keyboard:"
-options=("Kyria" "Lily58" "Corne" "Splitreus62" "Sofle" "Iris" "Reviung41" "RoMac" "RoMac+" "makerdiary M60" "Microdox" "TG4X" "QAZ" "NIBBLE" "Jorne" "Jian" "CRBN" "Tidbit" "Eek!" "BFO-9000" "Helix")
+options=("Kyria" "Lily58" "Corne" "Splitreus62" "Sofle" "Iris" "Reviung41" "RoMac" "RoMac+" "makerdiary M60" "Microdox" "TG4X" "QAZ" "NIBBLE" "Jorne" "Jian" "CRBN" "Tidbit" "Eek!" "BFO-9000" "Helix" "Rebound v4")
 
 PS3="$prompt "
 # TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
@@ -121,6 +121,7 @@ select opt in "${options[@]}" "Quit"; do
     19 ) shield_title="Eek!" shield="eek"; split="n" break;;
     20 ) shield_title="BFO-9000" shield="bfo9000"; split="y"; break;;
     21 ) shield_title="Helix" shield="helix"; split="y"; break;;
+    22 ) shield_title="Rebound_v4" shield="rebound v4"; split="n"; break;;
 
     # Add link to docs on adding your own custom shield in your ZMK config!
     # $(( ${#options[@]}+1 )) ) echo "Other!"; break;;


### PR DESCRIPTION
Adds support for a new unibody shield: Rebound 4-3. Default keymap includes 1u thumb clusters on the left "half" and 2u thumb key on the right "half" to provide examples of each layout option.

Testing has been undertaken over USB and BLE using my own rebound 4-3 with n!n and encoder. No issues with build or in use. 