### PR TITLE
 Add Events page to development section

### DIFF
--- a/docs/docs/development/events.md
+++ b/docs/docs/development/events.md
@@ -1,7 +1,9 @@
 ---
 title: Events
 ---
+
 ## Overview
+
 ZMK uses events to decouple behaviours and to allow new functionality to be added to existing events.
 
 ## Subscribing to events
@@ -54,6 +56,9 @@ todo
 
 todo
 
+That's for the state of a specific hid usage (keycode) being pressed/released.
+Those events would be what you would feed into a WPM calculation.
+
 ### `layer_state_changed`
 
 todo
@@ -65,10 +70,17 @@ todo
 ### `position_state_changed`
 
 todo
+A "key position" is a logical identifier for a physical key.
+We transform from row/column to single integer position early on.
+So the position is the 0-indexed value in the array of physical switches, normally if you started counting from top left corner and went left ttomright, top to bottom.
+A keymap is a set of layers, where each layer is an array of bindings for each logical key position.
+So, the "earliest event when a key is pressed" is the position state changed. The state being pressed or released.
+Once that gets processed by the keymap, mostly the behaviors then generate keycode state changes.
 
-## `sensor_event`
+### `sensor_event`
+
 todo
 
 ### `usb_conn_state_changed`
-todo
 
+todo

--- a/docs/docs/development/events.md
+++ b/docs/docs/development/events.md
@@ -1,0 +1,37 @@
+---
+title: Events
+---
+## Overview
+ZMK uses events to decouple behaviours and to allow new functionality to be added to existing events.
+
+## `activity_state_changed`
+Fired by the activity monitor when the state changes. The monitor subscribes to `position_state_changed` and `sensor_event` events to keep track of activity.
+
+* `ZMK_ACTIVITY_ACTIVE` 
+* `ZMK_ACTIVITY_IDLE` - When idle time is greater than `CONFIG_ZMK_IDLE_TIMEOUT `
+* `ZMK_ACTIVITY_SLEEP` - When `CONFIG_ZMK_SLEEP` is enabled and idle time is greater than `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`
+
+## `battery_state_changed`
+todo
+
+## `ble_active_profile_changed`
+todo
+
+## `keycode_state_changed`
+todo
+
+## `layer_state_changed`
+todo
+
+## `modifiers_state_changed`
+todo
+
+## `position_state_changed`
+todo
+
+## `sensor_event`
+todo
+
+## `usb_conn_state_changed`
+todo
+

--- a/docs/docs/development/events.md
+++ b/docs/docs/development/events.md
@@ -52,12 +52,19 @@ todo
 
 todo
 
+### `position_state_changed`
+
+Fired whenever there is a change in state of any key after a matrix scan.
+
+The column/row data coming from the matrix is converted into an integer key `position` representing the 0 based index of the key that was pressed. Positions go from left to right, top to bottom, starting from 0.
+
+That `state` bool represents whether the key is pressed or not.
+
+`keymap` subscribes to these events, processes them against the configured keymap configuration and raises `keycode_state_changed` with the parsed keycodes.
+
 ### `keycode_state_changed`
 
-todo
-
-That's for the state of a specific hid usage (keycode) being pressed/released.
-Those events would be what you would feed into a WPM calculation.
+Fired in response to processing a `position_state_changed` event which is processed against the keymap configuration and raises `keycode_state_changed` events with the parsed keycode and pressed state.
 
 ### `layer_state_changed`
 
@@ -66,16 +73,6 @@ todo
 ### `modifiers_state_changed`
 
 todo
-
-### `position_state_changed`
-
-todo
-A "key position" is a logical identifier for a physical key.
-We transform from row/column to single integer position early on.
-So the position is the 0-indexed value in the array of physical switches, normally if you started counting from top left corner and went left ttomright, top to bottom.
-A keymap is a set of layers, where each layer is an array of bindings for each logical key position.
-So, the "earliest event when a key is pressed" is the position state changed. The state being pressed or released.
-Once that gets processed by the keymap, mostly the behaviors then generate keycode state changes.
 
 ### `sensor_event`
 

--- a/docs/docs/development/events.md
+++ b/docs/docs/development/events.md
@@ -4,34 +4,71 @@ title: Events
 ## Overview
 ZMK uses events to decouple behaviours and to allow new functionality to be added to existing events.
 
-## `activity_state_changed`
+## Subscribing to events
+
+Subscribing to events uses a combination of the `ZMK_SUBSCRIPTION` and `ZMK_LISTENER` macros.
+
+`ZMK_SUBSCRIPTION` tells the event manager that the module wants to subscribe to a particular type of event.
+
+`ZMK_LISTENER` tells the event manager which method of the module to call when an event is raised on a subscription. When subscribing to multiple event types, you can check which event type was raised using the `is_<event_type>` helper methods (See example below).
+
+:::note
+The event manager expects the method to be called `<module>_listener` by convention.
+:::
+
+```
+int behavior_hold_tap_listener(const struct zmk_event_header *eh) {
+    if (is_position_state_changed(eh)) {
+        return position_state_changed_listener(eh);
+    } else if (is_keycode_state_changed(eh)) {
+        return keycode_state_changed_listener(eh);
+    }
+    return 0;
+}
+
+ZMK_LISTENER(behavior_hold_tap, behavior_hold_tap_listener);
+ZMK_SUBSCRIPTION(behavior_hold_tap, keycode_state_changed);
+```
+
+todo: Describe the return values from the listener methods.
+
+## Events
+
+### `activity_state_changed`
+
 Fired by the activity monitor when the state changes. The monitor subscribes to `position_state_changed` and `sensor_event` events to keep track of activity.
 
-* `ZMK_ACTIVITY_ACTIVE` 
-* `ZMK_ACTIVITY_IDLE` - When idle time is greater than `CONFIG_ZMK_IDLE_TIMEOUT `
-* `ZMK_ACTIVITY_SLEEP` - When `CONFIG_ZMK_SLEEP` is enabled and idle time is greater than `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`
+- `ZMK_ACTIVITY_ACTIVE`
+- `ZMK_ACTIVITY_IDLE` - When idle time is greater than `CONFIG_ZMK_IDLE_TIMEOUT `
+- `ZMK_ACTIVITY_SLEEP` - When `CONFIG_ZMK_SLEEP` is enabled and idle time is greater than `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`
 
-## `battery_state_changed`
+### `battery_state_changed`
+
 todo
 
-## `ble_active_profile_changed`
+### `ble_active_profile_changed`
+
 todo
 
-## `keycode_state_changed`
+### `keycode_state_changed`
+
 todo
 
-## `layer_state_changed`
+### `layer_state_changed`
+
 todo
 
-## `modifiers_state_changed`
+### `modifiers_state_changed`
+
 todo
 
-## `position_state_changed`
+### `position_state_changed`
+
 todo
 
 ## `sensor_event`
 todo
 
-## `usb_conn_state_changed`
+### `usb_conn_state_changed`
 todo
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -45,6 +45,7 @@ module.exports = {
       "development/posix-board",
       "development/tests",
       "development/usb-logging",
+      "development/events",
       {
         type: "category",
         label: "Guides",


### PR DESCRIPTION
Add an events page to the developer docs section.

Note: I'm a beginner to C++ so if I've named anything wrong e.g. module/method/macro, please let me know!
Closes: #552 which was on my main branch