### PR TITLE
docs(shield): Add docs based on #510 changes

### DIFF
--- a/app/boards/shields/bfo9000/Kconfig.defconfig
+++ b/app/boards/shields/bfo9000/Kconfig.defconfig
@@ -3,11 +3,11 @@
 
 if SHIELD_BFO9000_LEFT
 
-config ZMK_SPLIT_BLE_ROLE_CENTRAL
-	default y
-
 config ZMK_KEYBOARD_NAME
 	default "BFO9000 Left"
+
+config ZMK_SPLIT_BLE_ROLE_CENTRAL
+	default y
 
 endif
 
@@ -15,6 +15,9 @@ if SHIELD_BFO9000_RIGHT
 
 config ZMK_KEYBOARD_NAME
 	default "BFO9000 Right"
+
+config USB
+	default y
 
 endif
 

--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -91,6 +91,9 @@ endif
 ```
 
 Similarly to defining the halves of a split board in `Kconfig.shield` it is important to set the `ZMK_KEYBOARD_NAME` for each half of a split keyboard.
+You'll also want to set which half is the central side. Most boards set it to the left.
+Then on the peripheral half, you'll want to turn USB on so that it shows USB status on displays properly.
+Finally, you'll want to turn on the split option for both sides. This can all be seen below.
 
 ```
 if SHIELD_MY_BOARD_LEFT
@@ -98,12 +101,25 @@ if SHIELD_MY_BOARD_LEFT
 config ZMK_KEYBOARD_NAME
 	default "My Awesome Keyboard Left"
 
+config ZMK_SPLIT_BLE_ROLE_CENTRAL
+	default y
+
 endif
 
 if SHIELD_MY_BOARD_RIGHT
 
 config ZMK_KEYBOARD_NAME
 	default "My Awesome Keyboard Right"
+
+config USB
+	default y
+
+endif
+
+if SHIELD_MY_BOARD_LEFT || SHIELD_MY_BOARD_RIGHT
+
+config ZMK_SPLIT
+	default y
 
 endif
 ```
@@ -265,23 +281,7 @@ For example, a split board called `my_awesome_split_board` would have the follow
 - `my_awesome_split_board_left.conf` - Configuration elements only affect left half
 - `my_awesome_split_board_right.conf` - Configuration elements only affect right half
 
-For proper communication between keyboard halves and that between the central half and the computer,
-the **the central and peripheral halves of the keyboard must be defined**. This can be seen below.
-
-```
-// Central Half (Usually the left side: my_awesome_split_board_left.conf)
-
-CONFIG_ZMK_SPLIT=y
-CONFIG_ZMK_SPLIT_BLE_ROLE_CENTRAL=y
-```
-
-```
-// Peripheral Half (Usually the right side: my_awesome_split_board_right.conf)
-
-CONFIG_ZMK_SPLIT=y
-```
-
-Using the .conf file that affects both halves of a split board would be for adding features like deep-sleep or rotary encoders.
+In most case you'll only need to use the .conf file that affects both halves of a split board. It's used for adding features like deep-sleep or rotary encoders.
 
 ```
 // my_awesome_split_board.conf


### PR DESCRIPTION
This updates the docs for split boards to show how split configurations should be done based on the changes in #510.