### PR TITLE
Initial simple CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+* @zmkfirmware/core
+
+/app/boards @zmkfirmware/boards-shields
+
+/docs @zmkfirmware/docs


### PR DESCRIPTION
I've created two new GH teams for this, instead of listing individuals in `CODEOWNERS`. Once this is in, we can tweak the @zmkfirmware/boards-shields-team  and @zmkfirmware/docs-team teams as needed, etc.