### PR TITLE
refactor(Kconfig): Set USB default based on hardware capabilities

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -317,6 +317,9 @@ config KERNEL_BIN_NAME
 config REBOOT
 	default y
 
+config USB
+	default y if HAS_HW_NRF_USBD
+
 module = ZMK
 module-str = zmk
 source "subsys/logging/Kconfig.template.log_config"

--- a/app/boards/shields/bfo9000/Kconfig.defconfig
+++ b/app/boards/shields/bfo9000/Kconfig.defconfig
@@ -16,9 +16,6 @@ if SHIELD_BFO9000_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "BFO9000 Right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_BFO9000_LEFT || SHIELD_BFO9000_RIGHT

--- a/app/boards/shields/corne/Kconfig.defconfig
+++ b/app/boards/shields/corne/Kconfig.defconfig
@@ -12,9 +12,6 @@ if SHIELD_CORNE_RIGHT
 
 config ZMK_KEYBOARD_NAME
 	default "Corne Right"
-
-config USB
-	default y
 	
 endif
 

--- a/app/boards/shields/cradio/Kconfig.defconfig
+++ b/app/boards/shields/cradio/Kconfig.defconfig
@@ -16,9 +16,6 @@ if SHIELD_CRADIO_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "cradio right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_CRADIO_LEFT || SHIELD_CRADIO_RIGHT

--- a/app/boards/shields/helix/Kconfig.defconfig
+++ b/app/boards/shields/helix/Kconfig.defconfig
@@ -16,9 +16,6 @@ if SHIELD_HELIX_RIGHT
 config ZMK_KEYBOARD_NAME
     default "Helix Right"
 
-config USB
-    default y
-
 endif
 
 if SHIELD_HELIX_LEFT || SHIELD_HELIX_RIGHT

--- a/app/boards/shields/iris/Kconfig.defconfig
+++ b/app/boards/shields/iris/Kconfig.defconfig
@@ -16,9 +16,6 @@ if SHIELD_IRIS_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "Iris Right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_IRIS_LEFT || SHIELD_IRIS_RIGHT

--- a/app/boards/shields/jian/Kconfig.defconfig
+++ b/app/boards/shields/jian/Kconfig.defconfig
@@ -14,9 +14,6 @@ if SHIELD_JIAN_RIGHT
 
 config ZMK_KEYBOARD_NAME
 	default "Jian Right"
-
-config USB
-	default y
 	
 endif
 

--- a/app/boards/shields/jorne/Kconfig.defconfig
+++ b/app/boards/shields/jorne/Kconfig.defconfig
@@ -14,9 +14,6 @@ if SHIELD_JORNE_RIGHT
 
 config ZMK_KEYBOARD_NAME
 	default "Jorne Right"
-
-config USB
-	default y
 	
 endif
 

--- a/app/boards/shields/kyria/Kconfig.defconfig
+++ b/app/boards/shields/kyria/Kconfig.defconfig
@@ -15,9 +15,6 @@ if SHIELD_KYRIA_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "Kyria Right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_KYRIA_LEFT || SHIELD_KYRIA_RIGHT

--- a/app/boards/shields/lily58/Kconfig.defconfig
+++ b/app/boards/shields/lily58/Kconfig.defconfig
@@ -14,9 +14,6 @@ if SHIELD_LILY58_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "Lily58 Right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_LILY58_LEFT || SHIELD_LILY58_RIGHT

--- a/app/boards/shields/microdox/Kconfig.defconfig
+++ b/app/boards/shields/microdox/Kconfig.defconfig
@@ -17,9 +17,6 @@ if SHIELD_MICRODOX_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "Microdox Right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_MICRODOX_LEFT || SHIELD_MICRODOX_RIGHT

--- a/app/boards/shields/quefrency/Kconfig.defconfig
+++ b/app/boards/shields/quefrency/Kconfig.defconfig
@@ -17,9 +17,6 @@ if SHIELD_QUEFRENCY_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "Quefrency Right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_QUEFRENCY_LEFT || SHIELD_QUEFRENCY_RIGHT

--- a/app/boards/shields/sofle/Kconfig.defconfig
+++ b/app/boards/shields/sofle/Kconfig.defconfig
@@ -16,9 +16,6 @@ if SHIELD_SOFLE_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "Sofle Right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_SOFLE_LEFT || SHIELD_SOFLE_RIGHT

--- a/app/boards/shields/splitreus62/Kconfig.defconfig
+++ b/app/boards/shields/splitreus62/Kconfig.defconfig
@@ -18,9 +18,6 @@ if SHIELD_SPLITREUS62_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "Splitreus62 Right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_SPLITREUS62_LEFT || SHIELD_SPLITREUS62_RIGHT

--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -111,9 +111,6 @@ if SHIELD_MY_BOARD_RIGHT
 config ZMK_KEYBOARD_NAME
 	default "My Awesome Keyboard Right"
 
-config USB
-	default y
-
 endif
 
 if SHIELD_MY_BOARD_LEFT || SHIELD_MY_BOARD_RIGHT


### PR DESCRIPTION
Removes the USB default under every split right half in favor of a default based on hardware capabilities in the main app Kconfig.
