### PR TITLE
docs(codes): Windows Support: Language/International Inputs

### DIFF
--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -3378,7 +3378,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3399,7 +3399,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3420,7 +3420,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3441,7 +3441,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3462,7 +3462,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3483,7 +3483,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3567,7 +3567,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: true,
       linux: true,
       android: false,
       macos: null,
@@ -3588,7 +3588,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: true,
       linux: true,
       android: false,
       macos: null,
@@ -3609,7 +3609,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3630,7 +3630,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3651,7 +3651,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,


### PR DESCRIPTION
### Windows version/build?
Windows 10 Version 1909
### What codes did you test?
LANG1
LANG2
LANG3
LANG4
LANG5
INT1
INT2
INT3
INT4
INT5
INT6
### How did you test?
Manual use with my Helix split keyboard using the associated ZMK shield, within both standard QWERTY input and Japanese Microsoft IME.
### Have you any useful information?
I was able to get `LANG1` and `LANG2` to both work without issue on Windows. They function to switch between English and Japanese input. However, the latter three codes (`LANG3-5`) and all `INT_` codes did not produce any results for me. Either they are incompatible, or are used exclusively in other languages, and do not serve dual purposes in this case.
### Has anyone else tested/verified it?
Not as far as I am aware, no.