### PR TITLE
docs(codes): Windows Support: Audio Controls

### DIFF
--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -3210,7 +3210,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,
@@ -3231,7 +3231,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,
@@ -3252,7 +3252,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,
@@ -4370,7 +4370,7 @@ export default [
     documentation:
       "https://source.android.com/devices/input/keyboard-devices#hid-keyboard-and-keypad-page-0x07",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,
@@ -4392,7 +4392,7 @@ export default [
     documentation:
       "https://source.android.com/devices/input/keyboard-devices#hid-keyboard-and-keypad-page-0x07",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,
@@ -4414,7 +4414,7 @@ export default [
     documentation:
       "https://source.android.com/devices/input/keyboard-devices#hid-keyboard-and-keypad-page-0x07",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,
@@ -6085,7 +6085,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=139",
     os: {
-      windows: null,
+      windows: true,
       linux: true,
       android: true,
       macos: null,
@@ -6106,7 +6106,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=139",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -6127,7 +6127,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=139",
     os: {
-      windows: null,
+      windows: true,
       linux: true,
       android: true,
       macos: null,
@@ -6148,7 +6148,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=139",
     os: {
-      windows: null,
+      windows: true,
       linux: true,
       android: true,
       macos: null,


### PR DESCRIPTION
### Windows version/build?
Windows 10 Version 1909
### What codes did you test?
C_VOL_UP
C_VOL_DN
C_MUTE
C_BASS_BOOST
K_VOL_UP
K_VOL_UP2
K_VOL_DN
K_VOL_DN2
K_MUTE
K_MUTE2
### How did you test?
Manual use with my Helix split keyboard using the associated ZMK shield. Tested within Foobar2k, MPC-HC, and YouTube.
### Have you any useful information?
Consumer commands (prefix `C_`) were the only kind that functioned. Keyboard commands (prefix `K_`) did not work whatsoever.
### Has anyone else tested/verified it?
Not as far as I am aware, no.