### PR TITLE
docs(codes): Windows Support: Display Adjustment Commands

### DIFF
--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -5035,7 +5035,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=134",
     os: {
-      windows: null,
+      windows: false,
       linux: false,
       android: true,
       macos: null,
@@ -5140,7 +5140,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=134",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: null,
       macos: null,
@@ -5161,7 +5161,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=134",
     os: {
-      windows: null,
+      windows: true,
       linux: true,
       android: null,
       macos: null,
@@ -5182,7 +5182,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=134",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: null,
       macos: null,
@@ -5203,7 +5203,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=134",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: null,
       macos: null,
@@ -5224,7 +5224,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=134",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: null,
       macos: null,
@@ -5245,7 +5245,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=134",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: null,
       macos: null,
@@ -5266,7 +5266,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=134",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: null,
       macos: null,

--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -5182,7 +5182,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=134",
     os: {
-      windows: false,
+      windows: true,
       linux: true,
       android: null,
       macos: null,


### PR DESCRIPTION
### Windows version/build?
Windows 10 Version 1909
### What codes did you test?
C_BRI_UP
C_BRI_DN
C_BRI_MIN
C_BRI_MAX
C_BRI_AUTO
C_BKLT_TOG
C_ASPECT
C_PIP
### How did you test?
Manual use with my Helix split keyboard using the associated ZMK shield on the desktop and in video windows.
### Have you any useful information?
Nothing but `C_BRI_UP` worked whatsoever to change the brightness or perspective settings of my display.
### Has anyone else tested/verified it?
Not as far as I am aware, no.