### PR TITLE
docs(codes): Windows Support: Workflow Commands and Locks

### DIFF
--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -3084,7 +3084,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3105,7 +3105,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3126,7 +3126,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3147,7 +3147,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3168,7 +3168,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -3273,7 +3273,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: false,
       android: false,
       macos: null,
@@ -3315,7 +3315,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: true,
       linux: false,
       android: false,
       macos: null,
@@ -3861,7 +3861,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: false,
       linux: false,
       android: false,
       macos: null,
@@ -7135,7 +7135,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=150",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -7156,7 +7156,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=150",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -7177,7 +7177,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=150",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -7198,7 +7198,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=150",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,
@@ -7618,7 +7618,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=152",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: false,
       macos: null,


### PR DESCRIPTION
### Windows version/build?
Windows 10 Version 1909
### What codes did you test?
C_AC_CUT
C_AC_COPY
C_AC_PASTE
K_CUT
K_COPY
K_PASTE
C_AC_UNDO
C_AC_REDO
K_UNDO
K_REDO
RET2
LCAPS
LSLCK
### How did you test?
Manual use with my Helix split keyboard using the associated ZMK shield in an open document file alongside keyboardchecker.com within Firefox.
### Have you any useful information?
`LSLCK` worked for me in several windows such as document files, browser tabs, and more. Nothing else appeared to function whatsoever.
### Has anyone else tested/verified it?
Not as far as I am aware, no.