### PR TITLE
docs(codes): Windows Support: Symbols, Operations, and Punctuation

### DIFF
--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -1368,7 +1368,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=84",
     os: {
-      windows: null,
+      windows: true,
       linux: true,
       android: true,
       macos: null,
@@ -1393,7 +1393,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=84",
     os: {
-      windows: null,
+      windows: true,
       linux: true,
       android: true,
       macos: null,
@@ -2706,7 +2706,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,
@@ -3336,7 +3336,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,
@@ -3357,7 +3357,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=86",
     os: {
-      windows: null,
+      windows: false,
       linux: false,
       android: false,
       macos: null,
@@ -4008,7 +4008,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,
@@ -4029,7 +4029,7 @@ export default [
     ],
     documentation: "https://usb.org/sites/default/files/hut1_2.pdf#page=87",
     os: {
-      windows: null,
+      windows: false,
       linux: true,
       android: true,
       macos: null,


### PR DESCRIPTION
### Windows version/build?
Windows 10 Version 1909
### What codes did you test?
KP_EQUAL
KP_COMMA
KP_LPAR
KP_RPAR
KP_EQUAL_AS400
NON_US_HASH
TILDE2
### How did you test?
Manual use with my Helix split keyboard using the associated ZMK shield within an open document file alongside keyboardchecker.com.
### Have you any useful information?
`NON_US_HASH` produced a forward slash. `TILDE2` produced a pipe. I believe the specific results may be dependent on the region of the IME being used. As they did in fact produce characters (which likely differ based on IME), I've decided to mark them as 'true', but if reviewers disagree with this approach, I think it is also acceptable to consider them 'false' and otherwise nonfunctional.
### Has anyone else tested/verified it?
Not as far as I am aware, no.