### PR TITLE
fix(boards): Use unused pins for m2 board UART.

### DIFF
--- a/app/boards/arm/nrf52840_m2/nrf52840_m2.dts
+++ b/app/boards/arm/nrf52840_m2/nrf52840_m2.dts
@@ -55,10 +55,10 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <19>;
-	rx-pin = <21>;
-	rts-pin = <23>;
-	cts-pin = <25>;
+	tx-pin = <42>;
+	rx-pin = <43>;
+	rts-pin = <44>;
+	cts-pin = <45>;
 };
 
 &usbd {


### PR DESCRIPTION
* Current pins conflict w/ m60 shield matrix pins, causing
  odd matrix events when logging/UART is enabled.