### PR TITLE
Core event struct/data refactor

### DIFF
--- a/app/include/zmk/event_manager.h
+++ b/app/include/zmk/event_manager.h
@@ -39,8 +39,7 @@ struct zmk_event_subscription {
         struct event_type data;                                                                    \
     };                                                                                             \
     struct event_type##_event *new_##event_type(struct event_type);                                \
-    bool is_##event_type(const zmk_event_t *eh);                                                   \
-    struct event_type *cast_##event_type(const zmk_event_t *eh);                                   \
+    struct event_type *as_##event_type(const zmk_event_t *eh);                                     \
     extern const struct zmk_event_type zmk_event_##event_type;
 
 #define ZMK_EVENT_IMPL(event_type)                                                                 \
@@ -54,9 +53,9 @@ struct zmk_event_subscription {
         ev->data = data;                                                                           \
         return ev;                                                                                 \
     };                                                                                             \
-    bool is_##event_type(const zmk_event_t *eh) { return eh->event == &zmk_event_##event_type; };  \
-    struct event_type *cast_##event_type(const zmk_event_t *eh) {                                  \
-        return &((struct event_type##_event *)eh)->data;                                           \
+    struct event_type *as_##event_type(const zmk_event_t *eh) {                                    \
+        return (eh->event == &zmk_event_##event_type) ? &((struct event_type##_event *)eh)->data   \
+                                                      : NULL;                                      \
     };
 
 #define ZMK_LISTENER(mod, cb) const struct zmk_listener zmk_listener_##mod = {.callback = cb};

--- a/app/include/zmk/event_manager.h
+++ b/app/include/zmk/event_manager.h
@@ -14,16 +14,16 @@ struct zmk_event_type {
     const char *name;
 };
 
-struct zmk_event_header {
+typedef struct {
     const struct zmk_event_type *event;
     uint8_t last_listener_index;
-};
+} zmk_event_t;
 
 #define ZMK_EV_EVENT_BUBBLE 0
 #define ZMK_EV_EVENT_HANDLED 1
 #define ZMK_EV_EVENT_CAPTURED 2
 
-typedef int (*zmk_listener_callback_t)(const struct zmk_event_header *eh);
+typedef int (*zmk_listener_callback_t)(const zmk_event_t *eh);
 struct zmk_listener {
     zmk_listener_callback_t callback;
 };
@@ -34,25 +34,29 @@ struct zmk_event_subscription {
 };
 
 #define ZMK_EVENT_DECLARE(event_type)                                                              \
-    struct event_type *new_##event_type();                                                         \
-    bool is_##event_type(const struct zmk_event_header *eh);                                       \
-    struct event_type *cast_##event_type(const struct zmk_event_header *eh);                       \
+    struct event_type##_event {                                                                    \
+        zmk_event_t header;                                                                        \
+        struct event_type data;                                                                    \
+    };                                                                                             \
+    struct event_type##_event *new_##event_type(struct event_type);                                \
+    bool is_##event_type(const zmk_event_t *eh);                                                   \
+    struct event_type *cast_##event_type(const zmk_event_t *eh);                                   \
     extern const struct zmk_event_type zmk_event_##event_type;
 
 #define ZMK_EVENT_IMPL(event_type)                                                                 \
     const struct zmk_event_type zmk_event_##event_type = {.name = STRINGIFY(event_type)};          \
     const struct zmk_event_type *zmk_event_ref_##event_type __used                                 \
         __attribute__((__section__(".event_type"))) = &zmk_event_##event_type;                     \
-    struct event_type *new_##event_type() {                                                        \
-        struct event_type *ev = (struct event_type *)k_malloc(sizeof(struct event_type));          \
+    struct event_type##_event *new_##event_type(struct event_type data) {                          \
+        struct event_type##_event *ev =                                                            \
+            (struct event_type##_event *)k_malloc(sizeof(struct event_type##_event));              \
         ev->header.event = &zmk_event_##event_type;                                                \
+        ev->data = data;                                                                           \
         return ev;                                                                                 \
     };                                                                                             \
-    bool is_##event_type(const struct zmk_event_header *eh) {                                      \
-        return eh->event == &zmk_event_##event_type;                                               \
-    };                                                                                             \
-    struct event_type *cast_##event_type(const struct zmk_event_header *eh) {                      \
-        return (struct event_type *)eh;                                                            \
+    bool is_##event_type(const zmk_event_t *eh) { return eh->event == &zmk_event_##event_type; };  \
+    struct event_type *cast_##event_type(const zmk_event_t *eh) {                                  \
+        return &((struct event_type##_event *)eh)->data;                                           \
     };
 
 #define ZMK_LISTENER(mod, cb) const struct zmk_listener zmk_listener_##mod = {.callback = cb};
@@ -65,18 +69,19 @@ struct zmk_event_subscription {
             .listener = &zmk_listener_##mod,                                                       \
     };
 
-#define ZMK_EVENT_RAISE(ev) zmk_event_manager_raise((struct zmk_event_header *)ev);
+#define ZMK_EVENT_RAISE(ev) zmk_event_manager_raise((zmk_event_t *)ev);
 
 #define ZMK_EVENT_RAISE_AFTER(ev, mod)                                                             \
-    zmk_event_manager_raise_after((struct zmk_event_header *)ev, &zmk_listener_##mod);
+    zmk_event_manager_raise_after((zmk_event_t *)ev, &zmk_listener_##mod);
 
 #define ZMK_EVENT_RAISE_AT(ev, mod)                                                                \
-    zmk_event_manager_raise_at((struct zmk_event_header *)ev, &zmk_listener_##mod);
+    zmk_event_manager_raise_at((zmk_event_t *)ev, &zmk_listener_##mod);
 
-#define ZMK_EVENT_RELEASE(ev) zmk_event_manager_release((struct zmk_event_header *)ev);
+#define ZMK_EVENT_RELEASE(ev) zmk_event_manager_release((zmk_event_t *)ev);
 
-int zmk_event_manager_raise(struct zmk_event_header *event);
-int zmk_event_manager_raise_after(struct zmk_event_header *event,
-                                  const struct zmk_listener *listener);
-int zmk_event_manager_raise_at(struct zmk_event_header *event, const struct zmk_listener *listener);
-int zmk_event_manager_release(struct zmk_event_header *event);
+#define ZMK_EVENT_FREE(ev) k_free((void *)ev);
+
+int zmk_event_manager_raise(zmk_event_t *event);
+int zmk_event_manager_raise_after(zmk_event_t *event, const struct zmk_listener *listener);
+int zmk_event_manager_raise_at(zmk_event_t *event, const struct zmk_listener *listener);
+int zmk_event_manager_release(zmk_event_t *event);

--- a/app/include/zmk/events/activity_state_changed.h
+++ b/app/include/zmk/events/activity_state_changed.h
@@ -10,17 +10,8 @@
 #include <zmk/event_manager.h>
 #include <zmk/activity.h>
 
-struct activity_state_changed {
-    struct zmk_event_header header;
+struct zmk_activity_state_changed {
     enum zmk_activity_state state;
 };
 
-ZMK_EVENT_DECLARE(activity_state_changed);
-
-static inline struct activity_state_changed *
-create_activity_state_changed(enum zmk_activity_state state) {
-    struct activity_state_changed *ev = new_activity_state_changed();
-    ev->state = state;
-
-    return ev;
-}
+ZMK_EVENT_DECLARE(zmk_activity_state_changed);

--- a/app/include/zmk/events/battery_state_changed.h
+++ b/app/include/zmk/events/battery_state_changed.h
@@ -9,10 +9,9 @@
 #include <zephyr.h>
 #include <zmk/event_manager.h>
 
-struct battery_state_changed {
-    struct zmk_event_header header;
+struct zmk_battery_state_changed {
     // TODO: Other battery channels
     uint8_t state_of_charge;
 };
 
-ZMK_EVENT_DECLARE(battery_state_changed);
+ZMK_EVENT_DECLARE(zmk_battery_state_changed);

--- a/app/include/zmk/events/ble_active_profile_changed.h
+++ b/app/include/zmk/events/ble_active_profile_changed.h
@@ -12,10 +12,9 @@
 
 #include <zmk/ble/profile.h>
 
-struct ble_active_profile_changed {
-    struct zmk_event_header header;
+struct zmk_ble_active_profile_changed {
     uint8_t index;
     struct zmk_ble_profile *profile;
 };
 
-ZMK_EVENT_DECLARE(ble_active_profile_changed);
+ZMK_EVENT_DECLARE(zmk_ble_active_profile_changed);

--- a/app/include/zmk/events/keycode_state_changed.h
+++ b/app/include/zmk/events/keycode_state_changed.h
@@ -12,8 +12,7 @@
 #include <zmk/event_manager.h>
 #include <zmk/keys.h>
 
-struct keycode_state_changed {
-    struct zmk_event_header header;
+struct zmk_keycode_state_changed {
     uint16_t usage_page;
     uint32_t keycode;
     uint8_t implicit_modifiers;
@@ -21,10 +20,10 @@ struct keycode_state_changed {
     int64_t timestamp;
 };
 
-ZMK_EVENT_DECLARE(keycode_state_changed);
+ZMK_EVENT_DECLARE(zmk_keycode_state_changed);
 
-static inline struct keycode_state_changed *
-keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t timestamp) {
+static inline struct zmk_keycode_state_changed_event *
+zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t timestamp) {
     uint16_t page = HID_USAGE_PAGE(encoded) & 0xFF;
     uint16_t id = HID_USAGE_ID(encoded);
     zmk_mod_flags_t implicit_mods = SELECT_MODS(encoded);
@@ -33,11 +32,10 @@ keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t times
         page = HID_USAGE_KEY;
     }
 
-    struct keycode_state_changed *ev = new_keycode_state_changed();
-    ev->usage_page = page;
-    ev->keycode = id;
-    ev->implicit_modifiers = implicit_mods;
-    ev->state = pressed;
-    ev->timestamp = timestamp;
-    return ev;
+    return new_zmk_keycode_state_changed(
+        (struct zmk_keycode_state_changed){.usage_page = page,
+                                           .keycode = id,
+                                           .implicit_modifiers = implicit_mods,
+                                           .state = pressed,
+                                           .timestamp = timestamp});
 }

--- a/app/include/zmk/events/layer_state_changed.h
+++ b/app/include/zmk/events/layer_state_changed.h
@@ -9,20 +9,16 @@
 #include <zephyr.h>
 #include <zmk/event_manager.h>
 
-struct layer_state_changed {
-    struct zmk_event_header header;
+struct zmk_layer_state_changed {
     uint8_t layer;
     bool state;
     int64_t timestamp;
 };
 
-ZMK_EVENT_DECLARE(layer_state_changed);
+ZMK_EVENT_DECLARE(zmk_layer_state_changed);
 
-static inline struct layer_state_changed *create_layer_state_changed(uint8_t layer, bool state) {
-    struct layer_state_changed *ev = new_layer_state_changed();
-    ev->layer = layer;
-    ev->state = state;
-    ev->timestamp = k_uptime_get();
-
-    return ev;
+static inline struct zmk_layer_state_changed_event *create_layer_state_changed(uint8_t layer,
+                                                                               bool state) {
+    return new_zmk_layer_state_changed((struct zmk_layer_state_changed){
+        .layer = layer, .state = state, .timestamp = k_uptime_get()});
 }

--- a/app/include/zmk/events/modifiers_state_changed.h
+++ b/app/include/zmk/events/modifiers_state_changed.h
@@ -10,19 +10,9 @@
 #include <zmk/keys.h>
 #include <zmk/event_manager.h>
 
-struct modifiers_state_changed {
-    struct zmk_event_header header;
+struct zmk_modifiers_state_changed {
     zmk_mod_flags_t modifiers;
     bool state;
 };
 
-ZMK_EVENT_DECLARE(modifiers_state_changed);
-
-inline struct modifiers_state_changed *create_modifiers_state_changed(zmk_mod_flags_t modifiers,
-                                                                      bool state) {
-    struct modifiers_state_changed *ev = new_modifiers_state_changed();
-    ev->modifiers = modifiers;
-    ev->state = state;
-
-    return ev;
-}
+ZMK_EVENT_DECLARE(zmk_modifiers_state_changed);

--- a/app/include/zmk/events/position_state_changed.h
+++ b/app/include/zmk/events/position_state_changed.h
@@ -8,16 +8,10 @@
 
 #include <zephyr.h>
 #include <zmk/event_manager.h>
-
-struct zmk_position_state_changed_data {
+struct zmk_position_state_changed {
     uint32_t position;
     bool state;
     int64_t timestamp;
 };
 
-struct position_state_changed {
-    struct zmk_event_header header;
-    struct zmk_position_state_changed_data data;
-};
-
-ZMK_EVENT_DECLARE(position_state_changed);
+ZMK_EVENT_DECLARE(zmk_position_state_changed);

--- a/app/include/zmk/events/position_state_changed.h
+++ b/app/include/zmk/events/position_state_changed.h
@@ -9,11 +9,15 @@
 #include <zephyr.h>
 #include <zmk/event_manager.h>
 
-struct position_state_changed {
-    struct zmk_event_header header;
+struct zmk_position_state_changed_data {
     uint32_t position;
     bool state;
     int64_t timestamp;
+};
+
+struct position_state_changed {
+    struct zmk_event_header header;
+    struct zmk_position_state_changed_data data;
 };
 
 ZMK_EVENT_DECLARE(position_state_changed);

--- a/app/include/zmk/events/sensor_event.h
+++ b/app/include/zmk/events/sensor_event.h
@@ -9,12 +9,10 @@
 #include <zephyr.h>
 #include <zmk/event_manager.h>
 #include <device.h>
-
-struct sensor_event {
-    struct zmk_event_header header;
+struct zmk_sensor_event {
     uint8_t sensor_number;
     const struct device *sensor;
     int64_t timestamp;
 };
 
-ZMK_EVENT_DECLARE(sensor_event);
+ZMK_EVENT_DECLARE(zmk_sensor_event);

--- a/app/include/zmk/events/usb_conn_state_changed.h
+++ b/app/include/zmk/events/usb_conn_state_changed.h
@@ -12,9 +12,8 @@
 #include <zmk/event_manager.h>
 #include <zmk/usb.h>
 
-struct usb_conn_state_changed {
-    struct zmk_event_header header;
+struct zmk_usb_conn_state_changed {
     enum zmk_usb_conn_state conn_state;
 };
 
-ZMK_EVENT_DECLARE(usb_conn_state_changed);
+ZMK_EVENT_DECLARE(zmk_usb_conn_state_changed);

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -29,7 +29,10 @@ static uint32_t activity_last_uptime;
 #define MAX_SLEEP_MS CONFIG_ZMK_IDLE_SLEEP_TIMEOUT
 #endif
 
-int raise_event() { return ZMK_EVENT_RAISE(create_activity_state_changed(activity_state)); }
+int raise_event() {
+    return ZMK_EVENT_RAISE(new_zmk_activity_state_changed(
+        (struct zmk_activity_state_changed){.state = activity_state}));
+}
 
 int set_state(enum zmk_activity_state state) {
     if (activity_state == state)
@@ -41,7 +44,7 @@ int set_state(enum zmk_activity_state state) {
 
 enum zmk_activity_state zmk_activity_get_state() { return activity_state; }
 
-int activity_event_listener(const struct zmk_event_header *eh) {
+int activity_event_listener(const zmk_event_t *eh) {
     activity_last_uptime = k_uptime_get();
 
     return set_state(ZMK_ACTIVITY_ACTIVE);
@@ -74,7 +77,7 @@ int activity_init() {
 }
 
 ZMK_LISTENER(activity, activity_event_listener);
-ZMK_SUBSCRIPTION(activity, position_state_changed);
-ZMK_SUBSCRIPTION(activity, sensor_event);
+ZMK_SUBSCRIPTION(activity, zmk_position_state_changed);
+ZMK_SUBSCRIPTION(activity, zmk_sensor_event);
 
 SYS_INIT(activity_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -45,9 +45,8 @@ static int zmk_battery_update(const struct device *battery) {
         return rc;
     }
 
-    struct battery_state_changed *ev = new_battery_state_changed();
-    ev->state_of_charge = state_of_charge.val1;
-    return ZMK_EVENT_RAISE(ev);
+    return ZMK_EVENT_RAISE(new_zmk_battery_state_changed(
+        (struct zmk_battery_state_changed){.state_of_charge = state_of_charge.val1}));
 }
 
 static void zmk_battery_work(struct k_work *work) {

--- a/app/src/behaviors/behavior_key_press.c
+++ b/app/src/behaviors/behavior_key_press.c
@@ -22,14 +22,14 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
     return ZMK_EVENT_RAISE(
-        keycode_state_changed_from_encoded(binding->param1, true, event.timestamp));
+        zmk_keycode_state_changed_from_encoded(binding->param1, true, event.timestamp));
 }
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
     return ZMK_EVENT_RAISE(
-        keycode_state_changed_from_encoded(binding->param1, false, event.timestamp));
+        zmk_keycode_state_changed_from_encoded(binding->param1, false, event.timestamp));
 }
 
 static const struct behavior_driver_api behavior_key_press_driver_api = {

--- a/app/src/behaviors/behavior_sensor_rotate_key_press.c
+++ b/app/src/behaviors/behavior_sensor_rotate_key_press.c
@@ -45,12 +45,12 @@ static int on_sensor_binding_triggered(struct zmk_behavior_binding *binding,
 
     LOG_DBG("SEND %d", keycode);
 
-    ZMK_EVENT_RAISE(keycode_state_changed_from_encoded(keycode, true, timestamp));
+    ZMK_EVENT_RAISE(zmk_keycode_state_changed_from_encoded(keycode, true, timestamp));
 
     // TODO: Better way to do this?
     k_msleep(5);
 
-    return ZMK_EVENT_RAISE(keycode_state_changed_from_encoded(keycode, false, timestamp));
+    return ZMK_EVENT_RAISE(zmk_keycode_state_changed_from_encoded(keycode, false, timestamp));
 }
 
 static const struct behavior_driver_api behavior_sensor_rotate_key_press_driver_api = {

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -176,10 +176,10 @@ static const struct behavior_driver_api behavior_sticky_key_driver_api = {
 };
 
 static int sticky_key_keycode_state_changed_listener(const zmk_event_t *eh) {
-    if (!is_zmk_keycode_state_changed(eh)) {
+    struct zmk_keycode_state_changed *ev = as_zmk_keycode_state_changed(eh);
+    if (ev == NULL) {
         return ZMK_EV_EVENT_BUBBLE;
     }
-    struct zmk_keycode_state_changed *ev = cast_zmk_keycode_state_changed(eh);
     for (int i = 0; i < ZMK_BHV_STICKY_KEY_MAX_HELD; i++) {
         struct active_sticky_key *sticky_key = &active_sticky_keys[i];
         if (sticky_key->position == ZMK_BHV_STICKY_KEY_POSITION_FREE) {

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -175,11 +175,11 @@ static const struct behavior_driver_api behavior_sticky_key_driver_api = {
     .binding_released = on_sticky_key_binding_released,
 };
 
-static int sticky_key_keycode_state_changed_listener(const struct zmk_event_header *eh) {
-    if (!is_keycode_state_changed(eh)) {
+static int sticky_key_keycode_state_changed_listener(const zmk_event_t *eh) {
+    if (!is_zmk_keycode_state_changed(eh)) {
         return ZMK_EV_EVENT_BUBBLE;
     }
-    struct keycode_state_changed *ev = cast_keycode_state_changed(eh);
+    struct zmk_keycode_state_changed *ev = cast_zmk_keycode_state_changed(eh);
     for (int i = 0; i < ZMK_BHV_STICKY_KEY_MAX_HELD; i++) {
         struct active_sticky_key *sticky_key = &active_sticky_keys[i];
         if (sticky_key->position == ZMK_BHV_STICKY_KEY_POSITION_FREE) {
@@ -226,7 +226,7 @@ static int sticky_key_keycode_state_changed_listener(const struct zmk_event_head
 }
 
 ZMK_LISTENER(behavior_sticky_key, sticky_key_keycode_state_changed_listener);
-ZMK_SUBSCRIPTION(behavior_sticky_key, keycode_state_changed);
+ZMK_SUBSCRIPTION(behavior_sticky_key, zmk_keycode_state_changed);
 
 void behavior_sticky_key_timer_handler(struct k_work *item) {
     struct active_sticky_key *sticky_key =

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -92,11 +92,8 @@ static bt_addr_le_t peripheral_addr;
 #endif /* IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_ROLE_CENTRAL) */
 
 static void raise_profile_changed_event() {
-    struct ble_active_profile_changed *ev = new_ble_active_profile_changed();
-    ev->index = active_profile;
-    ev->profile = &profiles[active_profile];
-
-    ZMK_EVENT_RAISE(ev);
+    ZMK_EVENT_RAISE(new_zmk_ble_active_profile_changed((struct zmk_ble_active_profile_changed){
+        .index = active_profile, .profile = &profiles[active_profile]}));
 }
 
 static void raise_profile_changed_event_callback(struct k_work *work) {

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -291,7 +291,7 @@ static void activate_combo(struct combo_cfg *combo) {
     }
     move_pressed_keys_to_active_combo(active_combo);
     press_combo_behavior(
-        combo, cast_zmk_position_state_changed(active_combo->key_positions_pressed[0])->timestamp);
+        combo, as_zmk_position_state_changed(active_combo->key_positions_pressed[0])->timestamp);
 }
 
 static void deactivate_combo(int active_combo_index) {
@@ -315,7 +315,7 @@ static bool release_combo_key(int32_t position, int64_t timestamp) {
         for (int i = 0; i < active_combo->combo->key_position_len; i++) {
             if (active_combo->key_positions_pressed[i] == NULL) {
                 all_keys_pressed = false;
-            } else if (cast_zmk_position_state_changed(active_combo->key_positions_pressed[i])
+            } else if (as_zmk_position_state_changed(active_combo->key_positions_pressed[i])
                            ->position != position) {
                 all_keys_released = false;
             } else { // not null and position matches
@@ -418,11 +418,11 @@ static void combo_timeout_handler(struct k_work *item) {
 }
 
 static int position_state_changed_listener(const zmk_event_t *ev) {
-    if (!is_zmk_position_state_changed(ev)) {
+    struct zmk_position_state_changed *data = as_zmk_position_state_changed(ev);
+    if (data == NULL) {
         return 0;
     }
 
-    struct zmk_position_state_changed *data = cast_zmk_position_state_changed(ev);
     if (data->state) { // keydown
         return position_state_down(ev, data);
     } else { // keyup

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -40,7 +40,7 @@ struct active_combo {
     // key_positions_pressed is filled with key_positions when the combo is pressed.
     // The keys are removed from this array when they are released.
     // Once this array is empty, the behavior is released.
-    struct position_state_changed *key_positions_pressed[CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO];
+    const zmk_event_t *key_positions_pressed[CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO];
 };
 
 struct combo_candidate {
@@ -52,7 +52,7 @@ struct combo_candidate {
 };
 
 // set of keys pressed
-struct position_state_changed *pressed_keys[CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO] = {NULL};
+const zmk_event_t *pressed_keys[CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO] = {NULL};
 // the set of candidate combos based on the currently pressed_keys
 struct combo_candidate candidates[CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY];
 // the last candidate that was completely pressed
@@ -202,7 +202,7 @@ static int clear_candidates() {
     return CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY;
 }
 
-static int capture_pressed_key(struct position_state_changed *ev) {
+static int capture_pressed_key(const zmk_event_t *ev) {
     for (int i = 0; i < CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY; i++) {
         if (pressed_keys[i] != NULL) {
             continue;
@@ -228,7 +228,7 @@ static void release_pressed_keys() {
         if (pressed_keys[i] == NULL) {
             return;
         }
-        struct position_state_changed *captured_event = pressed_keys[i];
+        const zmk_event_t *captured_event = pressed_keys[i];
         pressed_keys[i] = NULL;
         ZMK_EVENT_RAISE(captured_event);
     }
@@ -290,7 +290,8 @@ static void activate_combo(struct combo_cfg *combo) {
         return;
     }
     move_pressed_keys_to_active_combo(active_combo);
-    press_combo_behavior(combo, active_combo->key_positions_pressed[0]->timestamp);
+    press_combo_behavior(
+        combo, cast_zmk_position_state_changed(active_combo->key_positions_pressed[0])->timestamp);
 }
 
 static void deactivate_combo(int active_combo_index) {
@@ -314,10 +315,11 @@ static bool release_combo_key(int32_t position, int64_t timestamp) {
         for (int i = 0; i < active_combo->combo->key_position_len; i++) {
             if (active_combo->key_positions_pressed[i] == NULL) {
                 all_keys_pressed = false;
-            } else if (active_combo->key_positions_pressed[i]->position != position) {
+            } else if (cast_zmk_position_state_changed(active_combo->key_positions_pressed[i])
+                           ->position != position) {
                 all_keys_released = false;
             } else { // not null and position matches
-                k_free(active_combo->key_positions_pressed[i]);
+                ZMK_EVENT_FREE(active_combo->key_positions_pressed[i]);
                 active_combo->key_positions_pressed[i] = NULL;
                 key_released = true;
             }
@@ -362,16 +364,16 @@ static void update_timeout_task() {
     }
 }
 
-static int position_state_down(struct position_state_changed *ev) {
+static int position_state_down(const zmk_event_t *ev, struct zmk_position_state_changed *data) {
     int num_candidates;
     if (candidates[0].combo == NULL) {
-        num_candidates = setup_candidates_for_first_keypress(ev->position, ev->timestamp);
+        num_candidates = setup_candidates_for_first_keypress(data->position, data->timestamp);
         if (num_candidates == 0) {
             return 0;
         }
     } else {
-        filter_timed_out_candidates(ev->timestamp);
-        num_candidates = filter_candidates(ev->position);
+        filter_timed_out_candidates(data->timestamp);
+        num_candidates = filter_candidates(data->position);
     }
     update_timeout_task();
 
@@ -395,7 +397,7 @@ static int position_state_down(struct position_state_changed *ev) {
     }
 }
 
-static int position_state_up(struct position_state_changed *ev) {
+static int position_state_up(struct zmk_position_state_changed *ev) {
     cleanup();
     if (release_combo_key(ev->position, ev->timestamp)) {
         return ZMK_EV_EVENT_HANDLED;
@@ -415,21 +417,21 @@ static void combo_timeout_handler(struct k_work *item) {
     update_timeout_task();
 }
 
-static int position_state_changed_listener(const struct zmk_event_header *eh) {
-    if (!is_position_state_changed(eh)) {
+static int position_state_changed_listener(const zmk_event_t *ev) {
+    if (!is_zmk_position_state_changed(ev)) {
         return 0;
     }
 
-    struct position_state_changed *ev = cast_position_state_changed(eh);
-    if (ev->state) { // keydown
-        return position_state_down(ev);
+    struct zmk_position_state_changed *data = cast_zmk_position_state_changed(ev);
+    if (data->state) { // keydown
+        return position_state_down(ev, data);
     } else { // keyup
-        return position_state_up(ev);
+        return position_state_up(data);
     }
 }
 
 ZMK_LISTENER(combo, position_state_changed_listener);
-ZMK_SUBSCRIPTION(combo, position_state_changed);
+ZMK_SUBSCRIPTION(combo, zmk_position_state_changed);
 
 // todo: remove this once #506 is merged and #include <zmk/keymap.h>
 #define KEY_BINDING_TO_STRUCT(idx, drv_inst)                                                       \

--- a/app/src/display/main.c
+++ b/app/src/display/main.c
@@ -76,7 +76,11 @@ int zmk_display_init() {
 }
 
 int display_event_handler(const zmk_event_t *eh) {
-    struct zmk_activity_state_changed *ev = cast_zmk_activity_state_changed(eh);
+    struct zmk_activity_state_changed *ev = as_zmk_activity_state_changed(eh);
+    if (ev == NULL) {
+        return -ENOTSUP;
+    }
+
     switch (ev->state) {
     case ZMK_ACTIVITY_ACTIVE:
         start_display_updates();

--- a/app/src/display/main.c
+++ b/app/src/display/main.c
@@ -75,8 +75,8 @@ int zmk_display_init() {
     return 0;
 }
 
-int display_event_handler(const struct zmk_event_header *eh) {
-    struct activity_state_changed *ev = cast_activity_state_changed(eh);
+int display_event_handler(const zmk_event_t *eh) {
+    struct zmk_activity_state_changed *ev = cast_zmk_activity_state_changed(eh);
     switch (ev->state) {
     case ZMK_ACTIVITY_ACTIVE:
         start_display_updates();
@@ -93,4 +93,4 @@ int display_event_handler(const struct zmk_event_header *eh) {
 }
 
 ZMK_LISTENER(display, display_event_handler);
-ZMK_SUBSCRIPTION(display, activity_state_changed);
+ZMK_SUBSCRIPTION(display, zmk_activity_state_changed);

--- a/app/src/display/widgets/battery_status.c
+++ b/app/src/display/widgets/battery_status.c
@@ -75,14 +75,14 @@ lv_obj_t *zmk_widget_battery_status_obj(struct zmk_widget_battery_status *widget
     return widget->obj;
 }
 
-int battery_status_listener(const struct zmk_event_header *eh) {
+int battery_status_listener(const zmk_event_t *eh) {
     struct zmk_widget_battery_status *widget;
     SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { set_battery_symbol(widget->obj); }
     return ZMK_EV_EVENT_BUBBLE;
 }
 
 ZMK_LISTENER(widget_battery_status, battery_status_listener)
-ZMK_SUBSCRIPTION(widget_battery_status, battery_state_changed);
+ZMK_SUBSCRIPTION(widget_battery_status, zmk_battery_state_changed);
 #if IS_ENABLED(CONFIG_USB)
-ZMK_SUBSCRIPTION(widget_battery_status, usb_conn_state_changed);
+ZMK_SUBSCRIPTION(widget_battery_status, zmk_usb_conn_state_changed);
 #endif /* IS_ENABLED(CONFIG_USB) */

--- a/app/src/display/widgets/layer_status.c
+++ b/app/src/display/widgets/layer_status.c
@@ -69,11 +69,11 @@ lv_obj_t *zmk_widget_layer_status_obj(struct zmk_widget_layer_status *widget) {
     return widget->obj;
 }
 
-int layer_status_listener(const struct zmk_event_header *eh) {
+int layer_status_listener(const zmk_event_t *eh) {
     struct zmk_widget_layer_status *widget;
     SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { set_layer_symbol(widget->obj); }
     return 0;
 }
 
 ZMK_LISTENER(widget_layer_status, layer_status_listener)
-ZMK_SUBSCRIPTION(widget_layer_status, layer_state_changed);
+ZMK_SUBSCRIPTION(widget_layer_status, zmk_layer_state_changed);

--- a/app/src/display/widgets/output_status.c
+++ b/app/src/display/widgets/output_status.c
@@ -79,7 +79,7 @@ lv_obj_t *zmk_widget_output_status_obj(struct zmk_widget_output_status *widget) 
     return widget->obj;
 }
 
-int output_status_listener(const struct zmk_event_header *eh) {
+int output_status_listener(const zmk_event_t *eh) {
     struct zmk_widget_output_status *widget;
     SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { set_status_symbol(widget->obj); }
     return ZMK_EV_EVENT_BUBBLE;
@@ -87,8 +87,8 @@ int output_status_listener(const struct zmk_event_header *eh) {
 
 ZMK_LISTENER(widget_output_status, output_status_listener)
 #if defined(CONFIG_USB)
-ZMK_SUBSCRIPTION(widget_output_status, usb_conn_state_changed);
+ZMK_SUBSCRIPTION(widget_output_status, zmk_usb_conn_state_changed);
 #endif
 #if defined(CONFIG_ZMK_BLE)
-ZMK_SUBSCRIPTION(widget_output_status, ble_active_profile_changed);
+ZMK_SUBSCRIPTION(widget_output_status, zmk_ble_active_profile_changed);
 #endif

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -245,17 +245,17 @@ static void update_current_endpoint() {
     }
 }
 
-static int endpoint_listener(const struct zmk_event_header *eh) {
+static int endpoint_listener(const zmk_event_t *eh) {
     update_current_endpoint();
     return 0;
 }
 
 ZMK_LISTENER(endpoint_listener, endpoint_listener);
 #if IS_ENABLED(CONFIG_ZMK_USB)
-ZMK_SUBSCRIPTION(endpoint_listener, usb_conn_state_changed);
+ZMK_SUBSCRIPTION(endpoint_listener, zmk_usb_conn_state_changed);
 #endif
 #if IS_ENABLED(CONFIG_ZMK_BLE)
-ZMK_SUBSCRIPTION(endpoint_listener, ble_active_profile_changed);
+ZMK_SUBSCRIPTION(endpoint_listener, zmk_ble_active_profile_changed);
 #endif
 
 SYS_INIT(zmk_endpoints_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/app/src/event_manager.c
+++ b/app/src/event_manager.c
@@ -17,7 +17,7 @@ extern struct zmk_event_type *__event_type_end[];
 extern struct zmk_event_subscription __event_subscriptions_start[];
 extern struct zmk_event_subscription __event_subscriptions_end[];
 
-int zmk_event_manager_handle_from(struct zmk_event_header *event, uint8_t start_index) {
+int zmk_event_manager_handle_from(zmk_event_t *event, uint8_t start_index) {
     int ret = 0;
     uint8_t len = __event_subscriptions_end - __event_subscriptions_start;
     for (int i = start_index; i < len; i++) {
@@ -48,12 +48,9 @@ release:
     return ret;
 }
 
-int zmk_event_manager_raise(struct zmk_event_header *event) {
-    return zmk_event_manager_handle_from(event, 0);
-}
+int zmk_event_manager_raise(zmk_event_t *event) { return zmk_event_manager_handle_from(event, 0); }
 
-int zmk_event_manager_raise_after(struct zmk_event_header *event,
-                                  const struct zmk_listener *listener) {
+int zmk_event_manager_raise_after(zmk_event_t *event, const struct zmk_listener *listener) {
     uint8_t len = __event_subscriptions_end - __event_subscriptions_start;
     for (int i = 0; i < len; i++) {
         struct zmk_event_subscription *ev_sub = __event_subscriptions_start + i;
@@ -68,8 +65,7 @@ int zmk_event_manager_raise_after(struct zmk_event_header *event,
     return -EINVAL;
 }
 
-int zmk_event_manager_raise_at(struct zmk_event_header *event,
-                               const struct zmk_listener *listener) {
+int zmk_event_manager_raise_at(zmk_event_t *event, const struct zmk_listener *listener) {
     uint8_t len = __event_subscriptions_end - __event_subscriptions_start;
     for (int i = 0; i < len; i++) {
         struct zmk_event_subscription *ev_sub = __event_subscriptions_start + i;
@@ -84,6 +80,6 @@ int zmk_event_manager_raise_at(struct zmk_event_header *event,
     return -EINVAL;
 }
 
-int zmk_event_manager_release(struct zmk_event_header *event) {
+int zmk_event_manager_release(zmk_event_t *event) {
     return zmk_event_manager_handle_from(event, event->last_listener_index + 1);
 }

--- a/app/src/events/activity_state_changed.c
+++ b/app/src/events/activity_state_changed.c
@@ -7,4 +7,4 @@
 #include <kernel.h>
 #include <zmk/events/activity_state_changed.h>
 
-ZMK_EVENT_IMPL(activity_state_changed);
+ZMK_EVENT_IMPL(zmk_activity_state_changed);

--- a/app/src/events/battery_state_changed.c
+++ b/app/src/events/battery_state_changed.c
@@ -7,4 +7,4 @@
 #include <kernel.h>
 #include <zmk/events/battery_state_changed.h>
 
-ZMK_EVENT_IMPL(battery_state_changed);
+ZMK_EVENT_IMPL(zmk_battery_state_changed);

--- a/app/src/events/ble_active_profile_changed.c
+++ b/app/src/events/ble_active_profile_changed.c
@@ -7,4 +7,4 @@
 #include <kernel.h>
 #include <zmk/events/ble_active_profile_changed.h>
 
-ZMK_EVENT_IMPL(ble_active_profile_changed);
+ZMK_EVENT_IMPL(zmk_ble_active_profile_changed);

--- a/app/src/events/keycode_state_changed.c
+++ b/app/src/events/keycode_state_changed.c
@@ -7,4 +7,4 @@
 #include <kernel.h>
 #include <zmk/events/keycode_state_changed.h>
 
-ZMK_EVENT_IMPL(keycode_state_changed);
+ZMK_EVENT_IMPL(zmk_keycode_state_changed);

--- a/app/src/events/layer_state_changed.c
+++ b/app/src/events/layer_state_changed.c
@@ -7,4 +7,4 @@
 #include <kernel.h>
 #include <zmk/events/layer_state_changed.h>
 
-ZMK_EVENT_IMPL(layer_state_changed);
+ZMK_EVENT_IMPL(zmk_layer_state_changed);

--- a/app/src/events/modifiers_state_changed.c
+++ b/app/src/events/modifiers_state_changed.c
@@ -7,4 +7,4 @@
 #include <kernel.h>
 #include <zmk/events/modifiers_state_changed.h>
 
-ZMK_EVENT_IMPL(modifiers_state_changed);
+ZMK_EVENT_IMPL(zmk_modifiers_state_changed);

--- a/app/src/events/position_state_changed.c
+++ b/app/src/events/position_state_changed.c
@@ -7,4 +7,4 @@
 #include <kernel.h>
 #include <zmk/events/position_state_changed.h>
 
-ZMK_EVENT_IMPL(position_state_changed);
+ZMK_EVENT_IMPL(zmk_position_state_changed);

--- a/app/src/events/sensor_event.c
+++ b/app/src/events/sensor_event.c
@@ -7,4 +7,4 @@
 #include <kernel.h>
 #include <zmk/events/sensor_event.h>
 
-ZMK_EVENT_IMPL(sensor_event);
+ZMK_EVENT_IMPL(zmk_sensor_event);

--- a/app/src/events/usb_conn_state_changed.c
+++ b/app/src/events/usb_conn_state_changed.c
@@ -7,4 +7,4 @@
 #include <kernel.h>
 #include <zmk/events/usb_conn_state_changed.h>
 
-ZMK_EVENT_IMPL(usb_conn_state_changed);
+ZMK_EVENT_IMPL(zmk_usb_conn_state_changed);

--- a/app/src/hid_listener.c
+++ b/app/src/hid_listener.c
@@ -71,8 +71,8 @@ static int hid_listener_keycode_released(uint16_t usage_page, uint32_t keycode,
 }
 
 int hid_listener(const zmk_event_t *eh) {
-    if (is_zmk_keycode_state_changed(eh)) {
-        const struct zmk_keycode_state_changed *ev = cast_zmk_keycode_state_changed(eh);
+    const struct zmk_keycode_state_changed *ev = as_zmk_keycode_state_changed(eh);
+    if (ev) {
         if (ev->state) {
             hid_listener_keycode_pressed(ev->usage_page, ev->keycode, ev->implicit_modifiers);
         } else {

--- a/app/src/hid_listener.c
+++ b/app/src/hid_listener.c
@@ -70,9 +70,9 @@ static int hid_listener_keycode_released(uint16_t usage_page, uint32_t keycode,
     return zmk_endpoints_send_report(usage_page);
 }
 
-int hid_listener(const struct zmk_event_header *eh) {
-    if (is_keycode_state_changed(eh)) {
-        const struct keycode_state_changed *ev = cast_keycode_state_changed(eh);
+int hid_listener(const zmk_event_t *eh) {
+    if (is_zmk_keycode_state_changed(eh)) {
+        const struct zmk_keycode_state_changed *ev = cast_zmk_keycode_state_changed(eh);
         if (ev->state) {
             hid_listener_keycode_pressed(ev->usage_page, ev->keycode, ev->implicit_modifiers);
         } else {
@@ -83,4 +83,4 @@ int hid_listener(const struct zmk_event_header *eh) {
 }
 
 ZMK_LISTENER(hid_listener, hid_listener);
-ZMK_SUBSCRIPTION(hid_listener, keycode_state_changed);
+ZMK_SUBSCRIPTION(hid_listener, zmk_keycode_state_changed);

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -246,14 +246,13 @@ int zmk_keymap_sensor_triggered(uint8_t sensor_number, const struct device *sens
 
 #endif /* ZMK_KEYMAP_HAS_SENSORS */
 
-int keymap_listener(const struct zmk_event_header *eh) {
-    if (is_position_state_changed(eh)) {
-        const struct position_state_changed *ev = cast_position_state_changed(eh);
-        return zmk_keymap_position_state_changed(ev->data.position, ev->data.state,
-                                                 ev->data.timestamp);
+int keymap_listener(const zmk_event_t *eh) {
+    if (is_zmk_position_state_changed(eh)) {
+        const struct zmk_position_state_changed *ev = cast_zmk_position_state_changed(eh);
+        return zmk_keymap_position_state_changed(ev->position, ev->state, ev->timestamp);
 #if ZMK_KEYMAP_HAS_SENSORS
-    } else if (is_sensor_event(eh)) {
-        const struct sensor_event *ev = cast_sensor_event(eh);
+    } else if (is_zmk_sensor_event(eh)) {
+        const struct zmk_sensor_event *ev = cast_zmk_sensor_event(eh);
         return zmk_keymap_sensor_triggered(ev->sensor_number, ev->sensor, ev->timestamp);
 #endif /* ZMK_KEYMAP_HAS_SENSORS */
     }
@@ -262,8 +261,8 @@ int keymap_listener(const struct zmk_event_header *eh) {
 }
 
 ZMK_LISTENER(keymap, keymap_listener);
-ZMK_SUBSCRIPTION(keymap, position_state_changed);
+ZMK_SUBSCRIPTION(keymap, zmk_position_state_changed);
 
 #if ZMK_KEYMAP_HAS_SENSORS
-ZMK_SUBSCRIPTION(keymap, sensor_event);
+ZMK_SUBSCRIPTION(keymap, zmk_sensor_event);
 #endif /* ZMK_KEYMAP_HAS_SENSORS */

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -249,7 +249,8 @@ int zmk_keymap_sensor_triggered(uint8_t sensor_number, const struct device *sens
 int keymap_listener(const struct zmk_event_header *eh) {
     if (is_position_state_changed(eh)) {
         const struct position_state_changed *ev = cast_position_state_changed(eh);
-        return zmk_keymap_position_state_changed(ev->position, ev->state, ev->timestamp);
+        return zmk_keymap_position_state_changed(ev->data.position, ev->data.state,
+                                                 ev->data.timestamp);
 #if ZMK_KEYMAP_HAS_SENSORS
     } else if (is_sensor_event(eh)) {
         const struct sensor_event *ev = cast_sensor_event(eh);

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -247,15 +247,19 @@ int zmk_keymap_sensor_triggered(uint8_t sensor_number, const struct device *sens
 #endif /* ZMK_KEYMAP_HAS_SENSORS */
 
 int keymap_listener(const zmk_event_t *eh) {
-    if (is_zmk_position_state_changed(eh)) {
-        const struct zmk_position_state_changed *ev = cast_zmk_position_state_changed(eh);
-        return zmk_keymap_position_state_changed(ev->position, ev->state, ev->timestamp);
-#if ZMK_KEYMAP_HAS_SENSORS
-    } else if (is_zmk_sensor_event(eh)) {
-        const struct zmk_sensor_event *ev = cast_zmk_sensor_event(eh);
-        return zmk_keymap_sensor_triggered(ev->sensor_number, ev->sensor, ev->timestamp);
-#endif /* ZMK_KEYMAP_HAS_SENSORS */
+    const struct zmk_position_state_changed *pos_ev;
+    if ((pos_ev = as_zmk_position_state_changed(eh)) != NULL) {
+        return zmk_keymap_position_state_changed(pos_ev->position, pos_ev->state,
+                                                 pos_ev->timestamp);
     }
+
+#if ZMK_KEYMAP_HAS_SENSORS
+    const struct zmk_sensor_event *sensor_ev;
+    if ((sensor_ev = as_zmk_sensor_event(eh)) != NULL) {
+        return zmk_keymap_sensor_triggered(sensor_ev->sensor_number, sensor_ev->sensor,
+                                           sensor_ev->timestamp);
+    }
+#endif /* ZMK_KEYMAP_HAS_SENSORS */
 
     return -ENOTSUP;
 }

--- a/app/src/kscan.c
+++ b/app/src/kscan.c
@@ -47,13 +47,10 @@ void zmk_kscan_process_msgq(struct k_work *item) {
     while (k_msgq_get(&zmk_kscan_msgq, &ev, K_NO_WAIT) == 0) {
         bool pressed = (ev.state == ZMK_KSCAN_EVENT_STATE_PRESSED);
         uint32_t position = zmk_matrix_transform_row_column_to_position(ev.row, ev.column);
-        struct position_state_changed *pos_ev;
         LOG_DBG("Row: %d, col: %d, position: %d, pressed: %s\n", ev.row, ev.column, position,
                 (pressed ? "true" : "false"));
-        pos_ev = new_position_state_changed();
-        pos_ev->data = (struct zmk_position_state_changed_data){
-            .state = pressed, .position = position, .timestamp = k_uptime_get()};
-        ZMK_EVENT_RAISE(pos_ev);
+        ZMK_EVENT_RAISE(new_zmk_position_state_changed((struct zmk_position_state_changed){
+            .state = pressed, .position = position, .timestamp = k_uptime_get()}));
     }
 }
 

--- a/app/src/kscan.c
+++ b/app/src/kscan.c
@@ -51,9 +51,8 @@ void zmk_kscan_process_msgq(struct k_work *item) {
         LOG_DBG("Row: %d, col: %d, position: %d, pressed: %s\n", ev.row, ev.column, position,
                 (pressed ? "true" : "false"));
         pos_ev = new_position_state_changed();
-        pos_ev->state = pressed;
-        pos_ev->position = position;
-        pos_ev->timestamp = k_uptime_get();
+        pos_ev->data = (struct zmk_position_state_changed_data){
+            .state = pressed, .position = position, .timestamp = k_uptime_get()};
         ZMK_EVENT_RAISE(pos_ev);
     }
 }

--- a/app/src/sensors.c
+++ b/app/src/sensors.c
@@ -35,7 +35,6 @@ static struct sensors_data_item sensors[] = {UTIL_LISTIFY(ZMK_KEYMAP_SENSORS_LEN
 static void zmk_sensors_trigger_handler(const struct device *dev, struct sensor_trigger *trigger) {
     int err;
     struct sensors_data_item *item = CONTAINER_OF(trigger, struct sensors_data_item, trigger);
-    struct sensor_event *event;
 
     LOG_DBG("sensor %d", item->sensor_number);
 
@@ -45,12 +44,8 @@ static void zmk_sensors_trigger_handler(const struct device *dev, struct sensor_
         return;
     }
 
-    event = new_sensor_event();
-    event->sensor_number = item->sensor_number;
-    event->sensor = dev;
-    event->timestamp = k_uptime_get();
-
-    ZMK_EVENT_RAISE(event);
+    ZMK_EVENT_RAISE(new_zmk_sensor_event((struct zmk_sensor_event){
+        .sensor_number = item->sensor_number, .sensor = dev, .timestamp = k_uptime_get()}));
 }
 
 static void zmk_sensors_init_item(const char *node, uint8_t i, uint8_t abs_i) {

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -33,22 +33,14 @@ static struct bt_uuid_128 uuid = BT_UUID_INIT_128(ZMK_SPLIT_BT_SERVICE_UUID);
 static struct bt_gatt_discover_params discover_params;
 static struct bt_gatt_subscribe_params subscribe_params;
 
-struct zmk_split_peripheral_event {
-    uint32_t position;
-    uint32_t state;
-    int32_t timestamp;
-};
-
-K_MSGQ_DEFINE(peripheral_event_msgq, sizeof(struct zmk_split_peripheral_event),
+K_MSGQ_DEFINE(peripheral_event_msgq, sizeof(struct zmk_position_state_changed_data),
               CONFIG_ZMK_SPLIT_BLE_CENTRAL_POSITION_QUEUE_SIZE, 4);
 
 void peripheral_event_work_callback(struct k_work *work) {
-    struct zmk_split_peripheral_event ev;
+    struct zmk_position_state_changed_data ev;
     while (k_msgq_get(&peripheral_event_msgq, &ev, K_NO_WAIT) == 0) {
         struct position_state_changed *pos_ev = new_position_state_changed();
-        pos_ev->position = ev.position;
-        pos_ev->state = ev.state;
-        pos_ev->timestamp = ev.timestamp;
+        pos_ev->data = ev;
 
         LOG_DBG("Trigger key position state change for %d", ev.position);
         ZMK_EVENT_RAISE(pos_ev);
@@ -82,7 +74,7 @@ static uint8_t split_central_notify_func(struct bt_conn *conn,
             if (changed_positions[i] & BIT(j)) {
                 uint32_t position = (i * 8) + j;
                 bool pressed = position_state[i] & BIT(j);
-                struct zmk_split_peripheral_event ev = {
+                struct zmk_position_state_changed_data ev = {
                     .position = position, .state = pressed, .timestamp = k_uptime_get()};
 
                 k_msgq_put(&peripheral_event_msgq, &ev, K_NO_WAIT);

--- a/app/src/split_listener.c
+++ b/app/src/split_listener.c
@@ -23,10 +23,10 @@ int split_listener(const struct zmk_event_header *eh) {
     LOG_DBG("");
     if (is_position_state_changed(eh)) {
         const struct position_state_changed *ev = cast_position_state_changed(eh);
-        if (ev->state) {
-            return zmk_split_bt_position_pressed(ev->position);
+        if (ev->data.state) {
+            return zmk_split_bt_position_pressed(ev->data.position);
         } else {
-            return zmk_split_bt_position_released(ev->position);
+            return zmk_split_bt_position_released(ev->data.position);
         }
     }
     return ZMK_EV_EVENT_BUBBLE;

--- a/app/src/split_listener.c
+++ b/app/src/split_listener.c
@@ -19,18 +19,18 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/hid.h>
 #include <zmk/endpoints.h>
 
-int split_listener(const struct zmk_event_header *eh) {
+int split_listener(const zmk_event_t *eh) {
     LOG_DBG("");
-    if (is_position_state_changed(eh)) {
-        const struct position_state_changed *ev = cast_position_state_changed(eh);
-        if (ev->data.state) {
-            return zmk_split_bt_position_pressed(ev->data.position);
+    if (is_zmk_position_state_changed(eh)) {
+        const struct zmk_position_state_changed *ev = cast_zmk_position_state_changed(eh);
+        if (ev->state) {
+            return zmk_split_bt_position_pressed(ev->position);
         } else {
-            return zmk_split_bt_position_released(ev->data.position);
+            return zmk_split_bt_position_released(ev->position);
         }
     }
     return ZMK_EV_EVENT_BUBBLE;
 }
 
 ZMK_LISTENER(split_listener, split_listener);
-ZMK_SUBSCRIPTION(split_listener, position_state_changed);
+ZMK_SUBSCRIPTION(split_listener, zmk_position_state_changed);

--- a/app/src/split_listener.c
+++ b/app/src/split_listener.c
@@ -21,8 +21,8 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 int split_listener(const zmk_event_t *eh) {
     LOG_DBG("");
-    if (is_zmk_position_state_changed(eh)) {
-        const struct zmk_position_state_changed *ev = cast_zmk_position_state_changed(eh);
+    const struct zmk_position_state_changed *ev = as_zmk_position_state_changed(eh);
+    if (ev != NULL) {
         if (ev->state) {
             return zmk_split_bt_position_pressed(ev->position);
         } else {

--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -55,10 +55,8 @@ int zmk_usb_hid_send_report(const uint8_t *report, size_t len) {
 #endif /* CONFIG_ZMK_USB */
 
 static void raise_usb_status_changed_event() {
-    struct usb_conn_state_changed *ev = new_usb_conn_state_changed();
-    ev->conn_state = zmk_usb_get_conn_state();
-
-    ZMK_EVENT_RAISE(ev);
+    ZMK_EVENT_RAISE(new_zmk_usb_conn_state_changed(
+        (struct zmk_usb_conn_state_changed){.conn_state = zmk_usb_get_conn_state()}));
 }
 
 enum usb_dc_status_code zmk_usb_get_status() { return usb_status; }


### PR DESCRIPTION
This came up from freedback on #547, where @joelspadin had noted it would be nice to be able to copy data from event to type used locally.

A big part of the *issue* with doing that was the way event manager required that event types mix their data and the first "header" field.

This refactor removes that need, by having the event manager code generate a wrapper/containing type for each event type, leaving the data payload "pure data".

`is_` and `cast_` prefixes updated appropriately, and we've also made a typedef `zmk_event_t` to be passed to subscription callbacks.

Once we're happy, I'll rebase #547 