### PR TITLE
Added bluetooth disconnect feature

### DIFF
--- a/app/include/dt-bindings/zmk/bt.h
+++ b/app/include/dt-bindings/zmk/bt.h
@@ -9,6 +9,7 @@
 #define BT_PRV_CMD 2
 #define BT_SEL_CMD 3
 // #define BT_FULL_RESET_CMD   4
+#define BT_DIS_CMD 5
 
 /*
 Note: Some future commands will include additional parameters, so we
@@ -18,4 +19,5 @@ defines these aliases up front.
 #define BT_CLR BT_CLR_CMD 0
 #define BT_NXT BT_NXT_CMD 0
 #define BT_PRV BT_PRV_CMD 0
+#define BT_DIS BT_DIS_CMD 0
 #define BT_SEL BT_SEL_CMD

--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -13,6 +13,7 @@ int zmk_ble_clear_bonds();
 int zmk_ble_prof_next();
 int zmk_ble_prof_prev();
 int zmk_ble_prof_select(uint8_t index);
+int zmk_ble_disconnect();
 
 int zmk_ble_active_profile_index();
 bt_addr_le_t *zmk_ble_active_profile_addr();

--- a/app/src/behaviors/behavior_bt.c
+++ b/app/src/behaviors/behavior_bt.c
@@ -28,6 +28,8 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
         return zmk_ble_prof_prev();
     case BT_SEL_CMD:
         return zmk_ble_prof_select(binding->param2);
+    case BT_DIS_CMD:
+        return zmk_ble_disconnect();
     default:
         LOG_ERR("Unknown BT command: %d", binding->param1);
     }

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -594,6 +594,23 @@ static int zmk_ble_init(const struct device *_arg) {
     return 0;
 }
 
+int zmk_ble_disconnect() {
+    LOG_DBG("");
+
+    for (uint8_t profile_index = 0; profile_index < PROFILE_COUNT; profile_index++) {
+        struct zmk_ble_profile *profile = &profiles[profile_index];
+
+        if (bt_addr_le_cmp(&(profile->peer), BT_ADDR_LE_ANY)) {
+            LOG_DBG("Disconnecting profile %d!", profile_index);
+
+            struct bt_conn *conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &(profile->peer));
+            bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+        }
+    }
+
+    return 0;
+}
+
 int zmk_ble_unpair_all() {
     int resp = 0;
     for (int i = BT_ID_DEFAULT; i < CONFIG_BT_ID_MAX; i++) {

--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -32,6 +32,7 @@ Here is a table describing the command for each define:
 | `BT_NXT` | Switch to the next profile, cycling through to the first one when the end is reached.                                                                     |
 | `BT_PRV` | Switch to the previous profile, cycling through to the last one when the beginning is reached.                                                            |
 | `BT_SEL` | Select the 0-indexed profile by number. Please note: this definition must include a number as an argument in the keymap to work correctly. eg. `BT_SEL 0` |
+| `BT_DIS` | Disconnects all bluetooth profiles. This command disables bluetooth advertising until a board reset is issued.                                            |
 
 ## Bluetooth Behavior
 
@@ -67,6 +68,12 @@ The bluetooth behavior completes an bluetooth action given on press.
 
    ```
    &bt BT_SEL 1
+   ```
+
+1. Behavior binding to disconnect bluetooth:
+
+   ```
+   &bt BT_DIS
    ```
 
 ## Bluetooth Pairing and Profiles


### PR DESCRIPTION
This adds the bluetooth keycode `&bt BT_DIS`, which disconnects all profiles.

It can potentially be used for disabling all bluetooth profiles for travel. By resetting the keyboard, the profiles are enabled again.