### PR TITLE
Fix offset in NIBBLE transformation and keymap

### DIFF
--- a/app/boards/shields/nibble/nibble.keymap
+++ b/app/boards/shields/nibble/nibble.keymap
@@ -20,7 +20,7 @@
              &kp ESC   &kp N1    &kp N2    &kp N3    &kp N4    &kp N5    &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp MINUS &kp EQUAL &kp BSPC &kp HOME
 &kp C_VOL_UP &kp TAB   &kp Q     &kp W     &kp E     &kp R     &kp T     &kp Y     &kp U     &kp I     &kp O     &kp P     &kp LBKT  &kp RBKT  &kp BSLH &kp DEL
 &kp C_VOL_DN &kp CLCK  &kp A     &kp S     &kp D     &kp F     &kp G     &kp H     &kp J     &kp K     &kp L     &kp SEMI  &kp SQT             &kp RET  &kp PG_UP
-&trans       &kp LSHFT &kp Z     &kp X     &kp C     &kp V     &kp B     &kp N     &kp M     &kp COMMA &kp DOT   &kp FSLH  &kp RSHFT           &kp UP   &kp PG_DN
+&trans       &kp LSHFT &trans    &kp Z     &kp X     &kp C     &kp V     &kp B     &kp N     &kp M     &kp COMMA &kp DOT   &kp FSLH  &kp RSHFT &kp UP   &kp PG_DN
 &trans       &kp LCTRL &kp LGUI  &kp LALT                      &kp SPACE                     &mo FUNC  &kp RALT  &kp RCTRL &kp LEFT            &kp DOWN &kp RIGHT
             >;
         };
@@ -29,7 +29,7 @@
             &kp TILDE   &kp F1    &kp F2    &kp F3    &kp F4    &kp F5    &kp F6    &kp F7    &kp F8    &kp F9    &kp F10   &kp F11   &kp F12 &trans      &kp END
 &bt BT_CLR  &trans      &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans  &trans      &bootloader
 &trans      &trans      &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans            &trans      &trans
-&bt BT_PRV  &trans      &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans            &trans      &trans
+&bt BT_PRV  &trans      &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans  &trans      &trans
 &bt BT_NXT  &trans      &trans    &trans                        &trans                        &trans    &trans    &trans    &kp C_PREV        &kp C_PP    &kp C_NEXT
             >;
         };

--- a/app/boards/shields/nibble/nibble.overlay
+++ b/app/boards/shields/nibble/nibble.overlay
@@ -21,7 +21,7 @@
 			, <&pro_micro_d 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 			, <&pro_micro_d 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 			, <&pro_micro_d 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-			, <&pro_micro_d 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+			, <&pro_micro_d 4  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 			;
 		output-gpios
 			= <&pro_micro_a 3 GPIO_ACTIVE_HIGH>
@@ -39,11 +39,11 @@
 		//TODO: Add a keymap graphic here
 
 		map = <
-		RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9)  RC(0,10) RC(0,11) RC(0,12) RC(0,13) RC(0,14) RC(0,15)
-RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9)  RC(1,10) RC(1,11) RC(1,12) RC(1,13) RC(1,14) RC(1,15)
-RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9)  RC(2,10) RC(2,11) RC(2,12) 	     RC(2,14) RC(2,15)
-RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9)  RC(3,10) RC(3,11) RC(3,12)          RC(3,14) RC(3,15)
-RC(4,0) RC(4,1) RC(4,2) RC(4,3)                 RC(4,6)                 RC(4,9)  RC(4,10) RC(4,11) RC(4,12)          RC(4,14) RC(4,15) 
+		RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12) RC(0,13) RC(0,14) RC(0,15)
+RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12) RC(1,13) RC(1,14) RC(1,15)
+RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11) RC(2,12) 	        RC(2,14) RC(2,15)
+RC(3,0) RC(3,1) RC(0,0) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9)  RC(3,10) RC(3,11) RC(3,12) RC(3,14) RC(3,15)
+RC(4,0) RC(4,1) RC(4,2) RC(4,3)                 RC(4,6)                 RC(4,9) RC(4,10) RC(4,11) RC(4,12)          RC(4,14) RC(4,15) 
 		>;
 	};
 };


### PR DESCRIPTION
The NIBBLE code was written before the unified ANSI + ISO board was released, which added an additional key to support ISO left shift. After the key was added (row 0, column 0), the matrix transformation was missing RC(0,0), which caused some strange behavior in the kscan driver: pressing the 7 key sent an esc/alt.

Adding RC(0,0) and updating the default keymap to match this resolves the issue. &trans is used in the new slot in the keymap and can be replaced with the pipe/backslash key if a user is building with an ISO layout.

Tested locally on my dev NIBBLE and also by @mcrosson.