### PR TITLE
run-test.sh: use the POSIX '-L 1' for xargs

### DIFF
--- a/app/run-test.sh
+++ b/app/run-test.sh
@@ -17,7 +17,7 @@ testcases=$(find $path -name native_posix.keymap -exec dirname \{\} \;)
 num_cases=$(echo "$testcases" | wc -l)
 if [ $num_cases -gt 1 ]; then
 	echo "" > ./build/tests/pass-fail.log
-	echo "$testcases" | xargs -l -P 4 ./run-test.sh
+	echo "$testcases" | xargs -L 1 -P 4 ./run-test.sh
 	err=$?
 	sort -k2 ./build/tests/pass-fail.log
 	exit $err


### PR DESCRIPTION
This allows tests to be run on platforms where '-l'
isn't implemented, such as MacOS.