### PR TITLE
Add optional `binding_convert_central_state_dependent_params` callback to the behavior driver API.

### DIFF
--- a/app/include/drivers/behavior.h
+++ b/app/include/drivers/behavior.h
@@ -27,6 +27,7 @@ typedef int (*behavior_sensor_keymap_binding_callback_t)(struct zmk_behavior_bin
                                                          int64_t timestamp);
 
 __subsystem struct behavior_driver_api {
+    behavior_keymap_binding_callback_t binding_convert_central_state_dependent_params;
     behavior_keymap_binding_callback_t binding_pressed;
     behavior_keymap_binding_callback_t binding_released;
     behavior_sensor_keymap_binding_callback_t sensor_binding_triggered;
@@ -34,6 +35,30 @@ __subsystem struct behavior_driver_api {
 /**
  * @endcond
  */
+
+/**
+ * @brief Handle the keymap binding which needs to be converted from relative "toggle" to absolute
+ * "turn on"
+ * @param binding Pointer to the details so of the binding
+ * @param event The event that triggered use of the binding
+ *
+ * @retval 0 If successful.
+ * @retval Negative errno code if failure.
+ */
+__syscall int behavior_keymap_binding_convert_central_state_dependent_params(
+    struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event);
+
+static inline int z_impl_behavior_keymap_binding_convert_central_state_dependent_params(
+    struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event) {
+    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->api;
+
+    if (api->binding_convert_central_state_dependent_params == NULL) {
+        return 0;
+    }
+
+    return api->binding_convert_central_state_dependent_params(binding, event);
+}
 
 /**
  * @brief Handle the keymap binding being pressed

--- a/app/include/dt-bindings/zmk/rgb.h
+++ b/app/include/dt-bindings/zmk/rgb.h
@@ -32,5 +32,6 @@
 #define RGB_SPD RGB_SPD_CMD 0
 #define RGB_EFF RGB_EFF_CMD 0
 #define RGB_EFR RGB_EFR_CMD 0
-#define RGB_COLOR_HSB(h, s, v) RGB_COLOR_HSB_CMD(((h) << 16) + ((s) << 8) + (v))
+#define RGB_COLOR_HSB_VAL(h, s, v) (((h) << 16) + ((s) << 8) + (v))
+#define RGB_COLOR_HSB(h, s, v) RGB_COLOR_HSB_CMD##(RGB_COLOR_HSB_VAL(h, s, v))
 #define RGB_COLOR_HSV RGB_COLOR_HSB

--- a/app/include/dt-bindings/zmk/rgb.h
+++ b/app/include/dt-bindings/zmk/rgb.h
@@ -5,19 +5,23 @@
  */
 
 #define RGB_TOG_CMD 0
-#define RGB_HUI_CMD 1
-#define RGB_HUD_CMD 2
-#define RGB_SAI_CMD 3
-#define RGB_SAD_CMD 4
-#define RGB_BRI_CMD 5
-#define RGB_BRD_CMD 6
-#define RGB_SPI_CMD 7
-#define RGB_SPD_CMD 8
-#define RGB_EFF_CMD 9
-#define RGB_EFR_CMD 10
-#define RGB_COLOR_HSB_CMD 11
+#define RGB_ON_CMD 1
+#define RGB_OFF_CMD 2
+#define RGB_HUI_CMD 3
+#define RGB_HUD_CMD 4
+#define RGB_SAI_CMD 5
+#define RGB_SAD_CMD 6
+#define RGB_BRI_CMD 7
+#define RGB_BRD_CMD 8
+#define RGB_SPI_CMD 9
+#define RGB_SPD_CMD 10
+#define RGB_EFF_CMD 11
+#define RGB_EFR_CMD 12
+#define RGB_COLOR_HSB_CMD 13
 
 #define RGB_TOG RGB_TOG_CMD 0
+#define RGB_ON RGB_ON_CMD 0
+#define RGB_OFF RGB_OFF_CMD 0
 #define RGB_HUI RGB_HUI_CMD 0
 #define RGB_HUD RGB_HUD_CMD 0
 #define RGB_SAI RGB_SAI_CMD 0

--- a/app/include/zmk/rgb_underglow.h
+++ b/app/include/zmk/rgb_underglow.h
@@ -7,6 +7,9 @@
 #pragma once
 
 int zmk_rgb_underglow_toggle();
+int zmk_rgb_underglow_get_state(bool *state);
+int zmk_rgb_underglow_on();
+int zmk_rgb_underglow_off();
 int zmk_rgb_underglow_cycle_effect(int direction);
 int zmk_rgb_underglow_change_hue(int direction);
 int zmk_rgb_underglow_change_sat(int direction);

--- a/app/include/zmk/rgb_underglow.h
+++ b/app/include/zmk/rgb_underglow.h
@@ -6,13 +6,22 @@
 
 #pragma once
 
+struct zmk_led_hsb {
+    uint16_t h;
+    uint8_t s;
+    uint8_t b;
+};
+
 int zmk_rgb_underglow_toggle();
 int zmk_rgb_underglow_get_state(bool *state);
 int zmk_rgb_underglow_on();
 int zmk_rgb_underglow_off();
 int zmk_rgb_underglow_cycle_effect(int direction);
+struct zmk_led_hsb zmk_rgb_underglow_calc_hue(int direction);
+struct zmk_led_hsb zmk_rgb_underglow_calc_sat(int direction);
+struct zmk_led_hsb zmk_rgb_underglow_calc_brt(int direction);
 int zmk_rgb_underglow_change_hue(int direction);
 int zmk_rgb_underglow_change_sat(int direction);
 int zmk_rgb_underglow_change_brt(int direction);
 int zmk_rgb_underglow_change_spd(int direction);
-int zmk_rgb_underglow_set_hsb(uint16_t hue, uint8_t saturation, uint8_t brightness);
+int zmk_rgb_underglow_set_hsb(struct zmk_led_hsb color);

--- a/app/src/behaviors/behavior_ext_power.c
+++ b/app/src/behaviors/behavior_ext_power.c
@@ -18,6 +18,22 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
+static int
+on_keymap_binding_convert_central_state_dependent_params(struct zmk_behavior_binding *binding,
+                                                         struct zmk_behavior_binding_event event) {
+    const struct device *ext_power = device_get_binding("EXT_POWER");
+    if (ext_power == NULL) {
+        LOG_ERR("Unable to retrieve ext_power device: %d", binding->param1);
+        return -EIO;
+    }
+
+    if (binding->param1 == EXT_POWER_TOGGLE_CMD) {
+        binding->param1 = ext_power_get(ext_power) > 0 ? EXT_POWER_OFF_CMD : EXT_POWER_ON_CMD;
+    }
+
+    return 0;
+}
+
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     const struct device *ext_power = device_get_binding("EXT_POWER");
@@ -51,6 +67,8 @@ static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
 static int behavior_ext_power_init(const struct device *dev) { return 0; };
 
 static const struct behavior_driver_api behavior_ext_power_driver_api = {
+    .binding_convert_central_state_dependent_params =
+        on_keymap_binding_convert_central_state_dependent_params,
     .binding_pressed = on_keymap_binding_pressed,
     .binding_released = on_keymap_binding_released,
 };

--- a/app/src/behaviors/behavior_rgb_underglow.c
+++ b/app/src/behaviors/behavior_rgb_underglow.c
@@ -25,6 +25,10 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
     switch (binding->param1) {
     case RGB_TOG_CMD:
         return zmk_rgb_underglow_toggle();
+    case RGB_ON_CMD:
+        return zmk_rgb_underglow_on();
+    case RGB_OFF_CMD:
+        return zmk_rgb_underglow_off();
     case RGB_HUI_CMD:
         return zmk_rgb_underglow_change_hue(1);
     case RGB_HUD_CMD:

--- a/app/src/behaviors/behavior_rgb_underglow.c
+++ b/app/src/behaviors/behavior_rgb_underglow.c
@@ -33,12 +33,57 @@ on_keymap_binding_convert_central_state_dependent_params(struct zmk_behavior_bin
         }
 
         binding->param1 = state ? RGB_OFF_CMD : RGB_ON_CMD;
-        LOG_DBG("RGB relative toggle convert to absolute %s", state ? "OFF" : "ON");
-        return 0;
+        break;
+    }
+    case RGB_BRI_CMD: {
+        struct zmk_led_hsb color = zmk_rgb_underglow_calc_brt(1);
+
+        binding->param1 = RGB_COLOR_HSB_CMD;
+        binding->param2 = RGB_COLOR_HSB_VAL(color.h, color.s, color.b);
+        break;
+    }
+    case RGB_BRD_CMD: {
+        struct zmk_led_hsb color = zmk_rgb_underglow_calc_brt(-1);
+
+        binding->param1 = RGB_COLOR_HSB_CMD;
+        binding->param2 = RGB_COLOR_HSB_VAL(color.h, color.s, color.b);
+        break;
+    }
+    case RGB_HUI_CMD: {
+        struct zmk_led_hsb color = zmk_rgb_underglow_calc_hue(1);
+
+        binding->param1 = RGB_COLOR_HSB_CMD;
+        binding->param2 = RGB_COLOR_HSB_VAL(color.h, color.s, color.b);
+        break;
+    }
+    case RGB_HUD_CMD: {
+        struct zmk_led_hsb color = zmk_rgb_underglow_calc_hue(-1);
+
+        binding->param1 = RGB_COLOR_HSB_CMD;
+        binding->param2 = RGB_COLOR_HSB_VAL(color.h, color.s, color.b);
+        break;
+    }
+    case RGB_SAI_CMD: {
+        struct zmk_led_hsb color = zmk_rgb_underglow_calc_sat(1);
+
+        binding->param1 = RGB_COLOR_HSB_CMD;
+        binding->param2 = RGB_COLOR_HSB_VAL(color.h, color.s, color.b);
+        break;
+    }
+    case RGB_SAD_CMD: {
+        struct zmk_led_hsb color = zmk_rgb_underglow_calc_sat(-1);
+
+        binding->param1 = RGB_COLOR_HSB_CMD;
+        binding->param2 = RGB_COLOR_HSB_VAL(color.h, color.s, color.b);
+        break;
     }
     default:
         return 0;
     }
+
+    LOG_DBG("RGB relative convert to absolute (%d/%d)", binding->param1, binding->param2);
+
+    return 0;
 };
 
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
@@ -71,8 +116,9 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
     case RGB_EFR_CMD:
         return zmk_rgb_underglow_cycle_effect(-1);
     case RGB_COLOR_HSB_CMD:
-        return zmk_rgb_underglow_set_hsb((binding->param2 >> 16) & 0xFFFF,
-                                         (binding->param2 >> 8) & 0xFF, binding->param2 & 0xFF);
+        return zmk_rgb_underglow_set_hsb((struct zmk_led_hsb){.h = (binding->param2 >> 16) & 0xFFFF,
+                                                              .s = (binding->param2 >> 8) & 0xFF,
+                                                              .b = binding->param2 & 0xFF});
     }
 
     return -ENOTSUP;

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -17,10 +17,16 @@
 #include <drivers/led_strip.h>
 #include <drivers/ext_power.h>
 
+#include <zmk/rgb_underglow.h>
+
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #define STRIP_LABEL DT_LABEL(DT_CHOSEN(zmk_underglow))
 #define STRIP_NUM_PIXELS DT_PROP(DT_CHOSEN(zmk_underglow), chain_length)
+
+#define HUE_MAX 360
+#define SAT_MAX 100
+#define BRT_MAX 100
 
 enum rgb_underglow_effect {
     UNDERGLOW_EFFECT_SOLID,
@@ -30,16 +36,8 @@ enum rgb_underglow_effect {
     UNDERGLOW_EFFECT_NUMBER // Used to track number of underglow effects
 };
 
-struct led_hsb {
-    uint16_t h;
-    uint8_t s;
-    uint8_t b;
-};
-
 struct rgb_underglow_state {
-    uint16_t hue;
-    uint8_t saturation;
-    uint8_t brightness;
+    struct zmk_led_hsb color;
     uint8_t animation_speed;
     uint8_t current_effect;
     uint16_t animation_step;
@@ -56,13 +54,13 @@ static struct rgb_underglow_state state;
 static const struct device *ext_power;
 #endif
 
-static struct led_rgb hsb_to_rgb(struct led_hsb hsb) {
+static struct led_rgb hsb_to_rgb(struct zmk_led_hsb hsb) {
     double r, g, b;
 
     uint8_t i = hsb.h / 60;
-    double v = hsb.b / 100.0;
-    double s = hsb.s / 100.0;
-    double f = hsb.h / 360.0 * 6 - i;
+    double v = hsb.b / ((float)BRT_MAX);
+    double s = hsb.s / ((float)SAT_MAX);
+    double f = hsb.h / ((float)HUE_MAX) * 6 - i;
     double p = v * (1 - s);
     double q = v * (1 - f * s);
     double t = v * (1 - (1 - f) * s);
@@ -107,23 +105,14 @@ static struct led_rgb hsb_to_rgb(struct led_hsb hsb) {
 
 static void zmk_rgb_underglow_effect_solid() {
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
-        int hue = state.hue;
-        int sat = state.saturation;
-        int brt = state.brightness;
-
-        struct led_hsb hsb = {hue, sat, brt};
-
-        pixels[i] = hsb_to_rgb(hsb);
+        pixels[i] = hsb_to_rgb(state.color);
     }
 }
 
 static void zmk_rgb_underglow_effect_breathe() {
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
-        int hue = state.hue;
-        int sat = state.saturation;
-        int brt = abs(state.animation_step - 1200) / 12;
-
-        struct led_hsb hsb = {hue, sat, brt};
+        struct zmk_led_hsb hsb = state.color;
+        hsb.b = abs(state.animation_step - 1200) / 12;
 
         pixels[i] = hsb_to_rgb(hsb);
     }
@@ -137,32 +126,26 @@ static void zmk_rgb_underglow_effect_breathe() {
 
 static void zmk_rgb_underglow_effect_spectrum() {
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
-        int hue = state.animation_step;
-        int sat = state.saturation;
-        int brt = state.brightness;
-
-        struct led_hsb hsb = {hue, sat, brt};
+        struct zmk_led_hsb hsb = state.color;
+        hsb.h = state.animation_step;
 
         pixels[i] = hsb_to_rgb(hsb);
     }
 
     state.animation_step += state.animation_speed;
-    state.animation_step = state.animation_step % 360;
+    state.animation_step = state.animation_step % HUE_MAX;
 }
 
 static void zmk_rgb_underglow_effect_swirl() {
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
-        int hue = (360 / STRIP_NUM_PIXELS * i + state.animation_step) % 360;
-        int sat = state.saturation;
-        int brt = state.brightness;
-
-        struct led_hsb hsb = {hue, sat, brt};
+        struct zmk_led_hsb hsb = state.color;
+        hsb.h = (HUE_MAX / STRIP_NUM_PIXELS * i + state.animation_step) % HUE_MAX;
 
         pixels[i] = hsb_to_rgb(hsb);
     }
 
     state.animation_step += state.animation_speed * 2;
-    state.animation_step = state.animation_step % 360;
+    state.animation_step = state.animation_step % HUE_MAX;
 }
 
 static void zmk_rgb_underglow_tick(struct k_work *work) {
@@ -243,9 +226,11 @@ static int zmk_rgb_underglow_init(const struct device *_arg) {
 #endif
 
     state = (struct rgb_underglow_state){
-        hue : CONFIG_ZMK_RGB_UNDERGLOW_HUE_START,
-        saturation : CONFIG_ZMK_RGB_UNDERGLOW_SAT_START,
-        brightness : CONFIG_ZMK_RGB_UNDERGLOW_BRT_START,
+        color : {
+            h : CONFIG_ZMK_RGB_UNDERGLOW_HUE_START,
+            s : CONFIG_ZMK_RGB_UNDERGLOW_SAT_START,
+            b : CONFIG_ZMK_RGB_UNDERGLOW_BRT_START,
+        },
         animation_speed : CONFIG_ZMK_RGB_UNDERGLOW_SPD_START,
         current_effect : CONFIG_ZMK_RGB_UNDERGLOW_EFF_START,
         animation_step : 0,
@@ -337,16 +322,8 @@ int zmk_rgb_underglow_cycle_effect(int direction) {
     if (!led_strip)
         return -ENODEV;
 
-    if (state.current_effect == 0 && direction < 0) {
-        state.current_effect = UNDERGLOW_EFFECT_NUMBER - 1;
-        return 0;
-    }
-
-    state.current_effect += direction;
-
-    if (state.current_effect >= UNDERGLOW_EFFECT_NUMBER) {
-        state.current_effect = 0;
-    }
+    state.current_effect += UNDERGLOW_EFFECT_NUMBER + direction;
+    state.current_effect %= UNDERGLOW_EFFECT_NUMBER;
 
     state.animation_step = 0;
 
@@ -357,30 +334,58 @@ int zmk_rgb_underglow_toggle() {
     return state.on ? zmk_rgb_underglow_off() : zmk_rgb_underglow_on();
 }
 
-int zmk_rgb_underglow_set_hsb(uint16_t hue, uint8_t saturation, uint8_t brightness) {
-    if (hue > 360 || saturation > 100 || brightness > 100) {
+int zmk_rgb_underglow_set_hsb(struct zmk_led_hsb color) {
+    if (color.h > HUE_MAX || color.s > SAT_MAX || color.b > BRT_MAX) {
         return -ENOTSUP;
     }
 
-    state.hue = hue;
-    state.saturation = saturation;
-    state.brightness = brightness;
+    state.color = color;
 
     return 0;
+}
+
+struct zmk_led_hsb zmk_rgb_underglow_calc_hue(int direction) {
+    struct zmk_led_hsb color = state.color;
+
+    color.h += HUE_MAX + (direction * CONFIG_ZMK_RGB_UNDERGLOW_HUE_STEP);
+    color.h %= HUE_MAX;
+
+    return color;
+}
+
+struct zmk_led_hsb zmk_rgb_underglow_calc_sat(int direction) {
+    struct zmk_led_hsb color = state.color;
+
+    int s = color.s + (direction * CONFIG_ZMK_RGB_UNDERGLOW_SAT_STEP);
+    if (s < 0) {
+        s = 0;
+    } else if (s > SAT_MAX) {
+        s = SAT_MAX;
+    }
+    color.s = s;
+
+    return color;
+}
+
+struct zmk_led_hsb zmk_rgb_underglow_calc_brt(int direction) {
+    struct zmk_led_hsb color = state.color;
+
+    int b = color.b + (direction * CONFIG_ZMK_RGB_UNDERGLOW_BRT_STEP);
+    if (b < 0) {
+        b = 0;
+    } else if (b > BRT_MAX) {
+        b = BRT_MAX;
+    }
+    color.b = b;
+
+    return color;
 }
 
 int zmk_rgb_underglow_change_hue(int direction) {
     if (!led_strip)
         return -ENODEV;
 
-    if (state.hue == 0 && direction < 0) {
-        state.hue = 360 - CONFIG_ZMK_RGB_UNDERGLOW_HUE_STEP;
-        return 0;
-    }
-
-    state.hue += direction * CONFIG_ZMK_RGB_UNDERGLOW_HUE_STEP;
-
-    state.hue = state.hue % 360;
+    state.color = zmk_rgb_underglow_calc_hue(direction);
 
     return zmk_rgb_underglow_save_state();
 }
@@ -389,15 +394,7 @@ int zmk_rgb_underglow_change_sat(int direction) {
     if (!led_strip)
         return -ENODEV;
 
-    if (state.saturation == 0 && direction < 0) {
-        return 0;
-    }
-
-    state.saturation += direction * CONFIG_ZMK_RGB_UNDERGLOW_SAT_STEP;
-
-    if (state.saturation > 100) {
-        state.saturation = 100;
-    }
+    state.color = zmk_rgb_underglow_calc_sat(direction);
 
     return zmk_rgb_underglow_save_state();
 }
@@ -406,15 +403,7 @@ int zmk_rgb_underglow_change_brt(int direction) {
     if (!led_strip)
         return -ENODEV;
 
-    if (state.brightness == 0 && direction < 0) {
-        return 0;
-    }
-
-    state.brightness += direction * CONFIG_ZMK_RGB_UNDERGLOW_BRT_STEP;
-
-    if (state.brightness > 100) {
-        state.brightness = 100;
-    }
+    state.color = zmk_rgb_underglow_calc_brt(direction);
 
     return zmk_rgb_underglow_save_state();
 }


### PR DESCRIPTION
Based on [discussions](https://discord.com/channels/719497620560543766/719565084208398406/801454819340189726) in Discord, this adds a new (optional) behavior driver callback, that allows behaviors to convert a relative binding invocation (e.g. "Toggle Power" or "Next Profile", into an *absolute* one.

This is *mostly* important for behaviors that, after #547, won't only be executed locally, but maybe "globally" on central and peripheral, we can ensure all devices converge to the same final state, not be out of sync.

I've only implemented this so far for ext power and RGB, since the "profile select" *only* matters for central side anyways.