### PR TITLE
refactor(docs): Move combos under Features.

### DIFF
--- a/docs/docs/features/combos.md
+++ b/docs/docs/features/combos.md
@@ -1,6 +1,5 @@
 ---
-title: Combo Behavior
-sidebar_label: Combos
+title: Combos
 ---
 
 ## Summary
@@ -9,7 +8,7 @@ Combo keys are a way to combine multiple keypresses to output a different key. F
 
 ### Configuration
 
-Combos are specified like this:
+Combos configured in your `.keymap` file, but are separate from the `keymap` node found there, since they are processed before the normal keymap. They are specified like this:
 
 ```
 / {

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -26,7 +26,7 @@ ZMK is currently missing some features found in other popular firmware. This tab
 | [Display Support](features/displays)[^2]                                                                                  | 🚧  |    🚧     | ✅  |
 | [RGB Underglow](features/underglow)                                                                                       | ✅  |    ✅     | ✅  |
 | One Shot Keys                                                                                                             | ✅  |    ✅     | ✅  |
-| [Combo Keys](behaviors/combos)                                                                                            | ✅  |           | ✅  |
+| [Combo Keys](features/combos)                                                                                             | ✅  |           | ✅  |
 | Macros                                                                                                                    | 🚧  |    ✅     | ✅  |
 | Mouse Keys                                                                                                                | 💡  |    ✅     | ✅  |
 | Low Active Power Usage                                                                                                    | ✅  |           |     |

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -10,6 +10,7 @@ module.exports = {
     ],
     Features: [
       "features/keymaps",
+      "features/combos",
       "features/displays",
       "features/encoders",
       "features/underglow",
@@ -20,7 +21,6 @@ module.exports = {
       "behaviors/misc",
       "behaviors/hold-tap",
       "behaviors/mod-tap",
-      "behaviors/combos",
       "behaviors/reset",
       "behaviors/bluetooth",
       "behaviors/outputs",


### PR DESCRIPTION
* Since combos aren't a behavior, but a new high level keymap
  feature, move under Features section.