### PR TITLE
Include sensor value with sensor_event

### DIFF
--- a/app/include/drivers/behavior.h
+++ b/app/include/drivers/behavior.h
@@ -23,8 +23,7 @@
 typedef int (*behavior_keymap_binding_callback_t)(struct zmk_behavior_binding *binding,
                                                   struct zmk_behavior_binding_event event);
 typedef int (*behavior_sensor_keymap_binding_callback_t)(struct zmk_behavior_binding *binding,
-                                                         const struct device *sensor,
-                                                         int64_t timestamp);
+                                                         int32_t value, int64_t timestamp);
 
 __subsystem struct behavior_driver_api {
     behavior_keymap_binding_callback_t binding_convert_central_state_dependent_params;
@@ -118,12 +117,11 @@ static inline int z_impl_behavior_keymap_binding_released(struct zmk_behavior_bi
  * @retval Negative errno code if failure.
  */
 __syscall int behavior_sensor_keymap_binding_triggered(struct zmk_behavior_binding *binding,
-                                                       const struct device *sensor,
-                                                       int64_t timestamp);
+                                                       int32_t value, int64_t timestamp);
 
 static inline int
-z_impl_behavior_sensor_keymap_binding_triggered(struct zmk_behavior_binding *binding,
-                                                const struct device *sensor, int64_t timestamp) {
+z_impl_behavior_sensor_keymap_binding_triggered(struct zmk_behavior_binding *binding, int32_t value,
+                                                int64_t timestamp) {
     const struct device *dev = device_get_binding(binding->behavior_dev);
     const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->api;
 
@@ -131,7 +129,7 @@ z_impl_behavior_sensor_keymap_binding_triggered(struct zmk_behavior_binding *bin
         return -ENOTSUP;
     }
 
-    return api->sensor_binding_triggered(binding, sensor, timestamp);
+    return api->sensor_binding_triggered(binding, value, timestamp);
 }
 
 /**

--- a/app/include/zmk/events/sensor_event.h
+++ b/app/include/zmk/events/sensor_event.h
@@ -13,6 +13,7 @@ struct zmk_sensor_event {
     uint8_t sensor_number;
     const struct device *sensor;
     int64_t timestamp;
+    int32_t value;
 };
 
 ZMK_EVENT_DECLARE(zmk_sensor_event);

--- a/app/src/behaviors/behavior_sensor_rotate_key_press.c
+++ b/app/src/behaviors/behavior_sensor_rotate_key_press.c
@@ -20,21 +20,13 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 static int behavior_sensor_rotate_key_press_init(const struct device *dev) { return 0; };
 
-static int on_sensor_binding_triggered(struct zmk_behavior_binding *binding,
-                                       const struct device *sensor, int64_t timestamp) {
-    struct sensor_value value;
-    int err;
+static int on_sensor_binding_triggered(struct zmk_behavior_binding *binding, int32_t value,
+                                       int64_t timestamp) {
     uint32_t keycode;
-    LOG_DBG("inc keycode 0x%02X dec keycode 0x%02X", binding->param1, binding->param2);
+    LOG_DBG("inc keycode 0x%02X dec keycode 0x%02X sensor value: %d", binding->param1,
+            binding->param2, value);
 
-    err = sensor_channel_get(sensor, SENSOR_CHAN_ROTATION, &value);
-
-    if (err) {
-        LOG_WRN("Failed to ge sensor rotation value: %d", err);
-        return err;
-    }
-
-    switch (value.val1) {
+    switch (value) {
     case 1:
         keycode = binding->param1;
         break;

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -209,8 +209,7 @@ int zmk_keymap_position_state_changed(uint32_t position, bool pressed, int64_t t
 }
 
 #if ZMK_KEYMAP_HAS_SENSORS
-int zmk_keymap_sensor_triggered(uint8_t sensor_number, const struct device *sensor,
-                                int64_t timestamp) {
+int zmk_keymap_sensor_triggered(uint8_t sensor_number, int32_t value, int64_t timestamp) {
     for (int layer = ZMK_KEYMAP_LAYERS_LEN - 1; layer >= _zmk_keymap_layer_default; layer--) {
         if (zmk_keymap_layer_active(layer) && zmk_sensor_keymap[layer] != NULL) {
             struct zmk_behavior_binding *binding = &zmk_sensor_keymap[layer][sensor_number];
@@ -227,7 +226,7 @@ int zmk_keymap_sensor_triggered(uint8_t sensor_number, const struct device *sens
                 continue;
             }
 
-            ret = behavior_sensor_keymap_binding_triggered(binding, sensor, timestamp);
+            ret = behavior_sensor_keymap_binding_triggered(binding, value, timestamp);
 
             if (ret > 0) {
                 LOG_DBG("behavior processing to continue to next layer");
@@ -256,7 +255,7 @@ int keymap_listener(const zmk_event_t *eh) {
 #if ZMK_KEYMAP_HAS_SENSORS
     const struct zmk_sensor_event *sensor_ev;
     if ((sensor_ev = as_zmk_sensor_event(eh)) != NULL) {
-        return zmk_keymap_sensor_triggered(sensor_ev->sensor_number, sensor_ev->sensor,
+        return zmk_keymap_sensor_triggered(sensor_ev->sensor_number, sensor_ev->value,
                                            sensor_ev->timestamp);
     }
 #endif /* ZMK_KEYMAP_HAS_SENSORS */

--- a/app/src/sensors.c
+++ b/app/src/sensors.c
@@ -51,7 +51,9 @@ static void zmk_sensors_trigger_handler(const struct device *dev, struct sensor_
         LOG_WRN("Failed to get sensor rotation value: %d", err);
         return;
     }
-
+    if (value.val1 == 0) {
+        return;
+    }
     ZMK_EVENT_RAISE(
         new_zmk_sensor_event((struct zmk_sensor_event){.sensor_number = item->sensor_number,
                                                        .sensor = dev,

--- a/app/src/sensors.c
+++ b/app/src/sensors.c
@@ -44,8 +44,19 @@ static void zmk_sensors_trigger_handler(const struct device *dev, struct sensor_
         return;
     }
 
-    ZMK_EVENT_RAISE(new_zmk_sensor_event((struct zmk_sensor_event){
-        .sensor_number = item->sensor_number, .sensor = dev, .timestamp = k_uptime_get()}));
+    struct sensor_value value;
+    err = sensor_channel_get(dev, SENSOR_CHAN_ROTATION, &value);
+
+    if (err) {
+        LOG_WRN("Failed to get sensor rotation value: %d", err);
+        return;
+    }
+
+    ZMK_EVENT_RAISE(
+        new_zmk_sensor_event((struct zmk_sensor_event){.sensor_number = item->sensor_number,
+                                                       .sensor = dev,
+                                                       .value = value.val1,
+                                                       .timestamp = k_uptime_get()}));
 }
 
 static void zmk_sensors_init_item(const char *node, uint8_t i, uint8_t abs_i) {


### PR DESCRIPTION
Add the sensor value to the sensor event and remove the device/sensor struct.

I've tested this works on my sofle as I didn't see any tests for encoders yet.

One thing I did notice while testing is the there are a TON of false-positive events for the sensor where it's just sending zero... I added a check before raising the initial event to reduce them, but I'm not sure if that's desired or not. 