### PR TITLE
Crbn encoder

### DIFF
--- a/app/boards/shields/crbn/crbn.conf
+++ b/app/boards/shields/crbn/crbn.conf
@@ -1,0 +1,3 @@
+# Uncomment lines below to enable encoder
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y

--- a/app/boards/shields/crbn/crbn.keymap
+++ b/app/boards/shields/crbn/crbn.keymap
@@ -26,30 +26,30 @@
 			>;
 		};
 
-    lower {
+		lower {
 			bindings = <
 				&kp LS(GRAVE) &kp LS(N1) &kp LS(N2) &kp LS(N3) &kp LS(N4) &kp LS(N5) &kp LS(N6) &kp LS(N7) &kp LS(N8) &kp LS(N9) &kp LS(N0) &kp DEL
 				&kp DEL &kp F1 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6 &kp UNDER &kp PLUS &kp LT &kp GT &kp PIPE
 				&trans &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12 &kp LS(HASH) &kp LS(BSLH) &kp HOME &kp END &trans
 				&trans &trans &trans &trans &trans &trans &trans &mo 3 &kp C_NEXT &kp C_VOL_DN &kp C_VOL_UP &kp C_PP
 			>;
-    };
+		};
 
-    raise {
+		raise {
 			bindings = <
 				&kp GRAVE &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp N8 &kp N9 &kp N0 &kp BSPC
 				&kp DEL &kp F1 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6 &kp MINUS &kp EQUAL &kp LBKT &kp RBKT &kp BSLH
 				&trans &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12 &kp HASH &kp BSLH &kp PG_UP &kp PG_DN &trans
 				&trans &trans &trans &trans &mo 3 &trans &trans &trans &kp C_NEXT &kp C_VOL_DN &kp C_VOL_UP &kp C_PP
-    	>;
-    };
+			>;
+		};
 		control {
 			bindings = <
 				&reset &bootloader &bt BT_CLR &bt BT_PRV &bt BT_NXT &trans &trans &trans &trans &trans &trans &trans
 				&trans &trans &trans &trans &trans &trans &trans &trans &trans &trans &trans &trans
 				&trans &trans &trans &trans &trans &trans &trans &trans &trans &trans &trans &trans
 				&trans &trans &trans &trans &trans &trans &trans &trans &trans &trans &trans &trans
-    	>;
-    };
-  };
+			>;
+		};
+	};
 };

--- a/app/boards/shields/crbn/crbn.keymap
+++ b/app/boards/shields/crbn/crbn.keymap
@@ -24,6 +24,8 @@
 				&kp LSHFT &kp Z    &kp X &kp C &kp V &kp B  &kp N   &kp M  &kp COMMA &kp DOT &kp BSLH &kp RET
 				&trans   &kp LGUI &kp LALT &kp LCTRL &mo 1 &kp SPACE &trans &mo 2 &kp LEFT &kp DOWN &kp UP &kp RIGHT
 			>;
+
+			sensor-bindings = <&inc_dec_kp PG_UP PG_DN>;
 		};
 
 		lower {
@@ -33,6 +35,8 @@
 				&trans &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12 &kp LS(HASH) &kp LS(BSLH) &kp HOME &kp END &trans
 				&trans &trans &trans &trans &trans &trans &trans &mo 3 &kp C_NEXT &kp C_VOL_DN &kp C_VOL_UP &kp C_PP
 			>;
+
+			sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
 		};
 
 		raise {
@@ -43,6 +47,7 @@
 				&trans &trans &trans &trans &mo 3 &trans &trans &trans &kp C_NEXT &kp C_VOL_DN &kp C_VOL_UP &kp C_PP
 			>;
 		};
+		
 		control {
 			bindings = <
 				&reset &bootloader &bt BT_CLR &bt BT_PRV &bt BT_NXT &trans &trans &trans &trans &trans &trans &trans

--- a/app/boards/shields/crbn/crbn.overlay
+++ b/app/boards/shields/crbn/crbn.overlay
@@ -11,31 +11,31 @@
 		zmk,kscan = &kscan0;
 	};
 
-  kscan0: kscan_0 {
-      compatible = "zmk,kscan-gpio-matrix";
-      label = "KSCAN";
-      diode-direction = "col2row";
+	kscan0: kscan_0 {
+		compatible = "zmk,kscan-gpio-matrix";
+		label = "KSCAN";
+		diode-direction = "col2row";
 
-      col-gpios
-          = <&pro_micro_d 1 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 0 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 2 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 3 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 4 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 7 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 8 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 9 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 10 GPIO_ACTIVE_HIGH>
-          , <&pro_micro_d 16 GPIO_ACTIVE_HIGH>
-          ;
+		col-gpios
+			= <&pro_micro_d 1 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 0 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 2 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 3 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 4 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 5 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 6 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 7 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 8 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 9 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 10 GPIO_ACTIVE_HIGH>
+			, <&pro_micro_d 16 GPIO_ACTIVE_HIGH>
+			;
 
-      row-gpios
-          = <&pro_micro_d 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-          , <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-          , <&pro_micro_a 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-          , <&pro_micro_a 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-          ;
-  };
+		row-gpios
+			= <&pro_micro_d 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_a 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro_a 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			;
+	};
 };

--- a/app/boards/shields/crbn/crbn.overlay
+++ b/app/boards/shields/crbn/crbn.overlay
@@ -38,4 +38,18 @@
 			, <&pro_micro_a 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
 			;
 	};
+
+	encoder: encoder {
+		compatible = "alps,ec11";
+		label = "ENCODER";
+		a-gpios = <&pro_micro_a 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro_a 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		resolution = <2>;
+		status = "okay";
+	};
+
+	sensors {
+		compatible = "zmk,keymap-sensors";
+		sensors = <&encoder>;
+	};
 };


### PR DESCRIPTION
Converted spaces to tabs based on kyria shield examples.
Encoder is disabled by default. Built locally with `west build -p -b nice_nano -- -DSHIELD=crbn` and uf2 flashed successfully. 