### PR TITLE
fix(core): Assert BLE device name is correct length

### DIFF
--- a/app/boards/shields/splitreus62/Kconfig.defconfig
+++ b/app/boards/shields/splitreus62/Kconfig.defconfig
@@ -16,7 +16,7 @@ endif
 if SHIELD_SPLITREUS62_RIGHT
 
 config ZMK_KEYBOARD_NAME
-	default "Splitreus62 Right"
+	default "Splitreus62 Rt"
 
 endif
 

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -63,6 +63,8 @@ static uint8_t active_profile;
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
+BUILD_ASSERT(DEVICE_NAME_LEN <= 16, "ERROR: BLE device name is too long. Max length: 16");
+
 #define IS_HOST_PERIPHERAL                                                                         \
     (!IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_ROLE_CENTRAL))
 #define IS_SPLIT_PERIPHERAL                                                                        \


### PR DESCRIPTION
Closes #613. I found the max length by incrementally adding a character until it broke. 16 seems to be the maximum. While researching I found that the max should be 29 for BLE (31 bytes - 2 bytes for header), so I'm not sure where the limitation is.

Preprocessor `#if` and `#error` cannot be used because you can't compare a `sizeof` output.