### PR TITLE
Update new keyboard shield testing documentation.

### DIFF
--- a/docs/docs/development/build-flash.md
+++ b/docs/docs/development/build-flash.md
@@ -118,11 +118,17 @@ Now start VSCode and rebuild the container after being prompted. You should be a
 
 ## Flashing
 
-Once built, the previously supplied parameters will be remembered so you can run the following to flash your
-board with it in bootloader mode:
+The above build commands generate a UF2 file in `build/zephyr` (or
+`build/left|right/zephyr` if you followed the instructions for splits) and is by
+default named `zmk.uf2`. If your board supports USB Flashing Format (UF2), copy
+that file onto the root of the USB mass storage device for your board. The
+controller should flash your built firmware and automatically restart once
+flashing is complete.
+
+Alternatively, if your board supports flashing and you're not developing from
+within a Dockerized environment, enable Device Firmware Upgrade (DFU) mode on
+your board and run the following command to flash:
 
 ```
 west flash
 ```
-
-For boards that have drag and drop .uf2 flashing capability, the .uf2 file to flash can be found in `build/zephyr` (or `build/left|right/zephyr` if you followed the instructions for splits) and is by default named `zmk.uf2`.

--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -463,11 +463,20 @@ you should be able to test with a build command like:
 west build --pristine -b proton_c -- -DSHIELD=my_board
 ```
 
-and then flash with:
+The above build command generates `build/zephyr/zmk.uf2`.  If your board
+supports USB Flashing Format (UF2), copy that file onto the root of the USB mass
+storage device for your board.  The controller should flash your built firmware
+and automatically restart once flashing is complete.
+
+Alternatively, if your board supports flashing and you're not developing from
+within a Dockerized environment, then you can test your build with:  
 
 ```
 west flash
 ```
+
+Please have a look at documentation specific to
+[building and flashing](build-flash) for additional information.
 
 :::note
 Further testing your keyboard shield without altering the root keymap file can be done with the use of `-DZMK_CONFIG` in your `west build` command,

--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -463,13 +463,13 @@ you should be able to test with a build command like:
 west build --pristine -b proton_c -- -DSHIELD=my_board
 ```
 
-The above build command generates `build/zephyr/zmk.uf2`.  If your board
+The above build command generates `build/zephyr/zmk.uf2`. If your board
 supports USB Flashing Format (UF2), copy that file onto the root of the USB mass
-storage device for your board.  The controller should flash your built firmware
+storage device for your board. The controller should flash your built firmware
 and automatically restart once flashing is complete.
 
 Alternatively, if your board supports flashing and you're not developing from
-within a Dockerized environment, then you can test your build with:  
+within a Dockerized environment, then you can test your build with:
 
 ```
 west flash

--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -469,7 +469,8 @@ storage device for your board. The controller should flash your built firmware
 and automatically restart once flashing is complete.
 
 Alternatively, if your board supports flashing and you're not developing from
-within a Dockerized environment, then you can test your build with:
+within a Dockerized environment, enable Device Firmware Upgrade (DFU) mode on
+your board and run the following command to test your build:
 
 ```
 west flash


### PR DESCRIPTION
Clarifying the need for `west flash` in a dockerized environment and providing a high-level overview of testing a board with UF2 support.  As a first-time developer in this environment, it wasn't entirely clear to me that `west flash` shouldn't work from within a Docker container and it seemed like a good opportunity to clarify the documentation.