### PR TITLE
Change the board selection part of setup.sh, so that the 4th option ("makerdiary nRF52840 M.2") can be selected

### DIFF
--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -79,7 +79,7 @@ select opt in "${options[@]}" "Quit"; do
     1 ) board="nice_nano"; break;;
     2 ) board="proton_c"; break;;
     3 ) board="bluemicro840_v1"; break;;
-    3 ) board="nrf52840_m2"; break;;
+    4 ) board="nrf52840_m2"; break;;
 
     $(( ${#options[@]}+1 )) ) echo "Goodbye!"; exit 1;;
     *) echo "Invalid option. Try another one."; continue;;


### PR DESCRIPTION
This should fix Issue [#659](https://github.com/zmkfirmware/zmk/issues/659).