### PR TITLE
Add support for capacitors on ADC for BVD

### DIFF
--- a/app/drivers/sensor/battery_voltage_divider/battery_voltage_divider.c
+++ b/app/drivers/sensor/battery_voltage_divider/battery_voltage_divider.c
@@ -77,6 +77,9 @@ static int bvd_sample_fetch(const struct device *dev, enum sensor_channel chan) 
             LOG_DBG("Failed to enable ADC power GPIO: %d", rc);
             return rc;
         }
+
+        // wait for any capacitance to charge up
+        k_sleep(K_MSEC(10));
     }
 
     // Read ADC


### PR DESCRIPTION
It is good practice in  hardware to connect a capacitor to any analog input. If anyone is using the `power_gpios`, with the idea of saving power by "enabling" the battery voltage divider with an NMOS, it takes a while for that capacitor to charge. 
This change adds just that, a 10ms delay after turning on the `power_gpios.pin`.