### PR TITLE
style(hold-tap)!: write hold-tap params with dashes

### DIFF
--- a/app/boards/shields/qaz/qaz.keymap
+++ b/app/boards/shields/qaz/qaz.keymap
@@ -18,7 +18,7 @@
             compatible = "zmk,behavior-hold-tap";
             label = "homerow mods";
             #binding-cells = <2>;
-            tapping_term_ms = <225>;
+            tapping-term-ms = <225>;
             flavor = "tap-preferred";
             bindings = <&kp>, <&kp>;
         };

--- a/app/boards/shields/tg4x/tg4x.keymap
+++ b/app/boards/shields/tg4x/tg4x.keymap
@@ -14,7 +14,7 @@
 			compatible = "zmk,behavior-hold-tap";
 			label = "Hold Tap";
 			#binding-cells = <2>;
-			tapping_term_ms = <200>;
+			tapping-term-ms = <200>;
 			flavor = "tap-preferred";
 			bindings = <&kp>, <&kp>;
 		};

--- a/app/dts/behaviors/layer_tap.dtsi
+++ b/app/dts/behaviors/layer_tap.dtsi
@@ -11,7 +11,7 @@
 			label = "LAYER_TAP";
 			#binding-cells = <2>;
 			flavor = "tap-preferred";
-			tapping_term_ms = <200>;
+			tapping-term-ms = <200>;
 			bindings = <&mo>, <&kp>;
 		};
 	};

--- a/app/dts/behaviors/mod_tap.dtsi
+++ b/app/dts/behaviors/mod_tap.dtsi
@@ -11,7 +11,7 @@
 			label = "MOD_TAP";
 			#binding-cells = <2>;
 			flavor = "hold-preferred";
-			tapping_term_ms = <200>;
+			tapping-term-ms = <200>;
 			bindings = <&kp>, <&kp>;
 		};
 	};

--- a/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
@@ -11,11 +11,15 @@ properties:
   bindings:
     type: phandles
     required: true
-  tapping_term_ms:
+  tapping-term-ms:
     type: int
-  quick_tap_ms:
+  tapping_term_ms: # deprecated
+    type: int
+  quick-tap-ms:
     type: int
     default: -1
+  quick_tap_ms: # deprecated
+    type: int
   flavor:
     type: string
     required: false

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -47,7 +47,6 @@ struct behavior_hold_tap_config {
 // this data is specific for each hold-tap
 struct active_hold_tap {
     int32_t position;
-    // todo: move these params into the config->behaviors->tap and
     uint32_t param_hold;
     uint32_t param_tap;
     int64_t timestamp;

--- a/app/tests/hold-tap/balanced/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/balanced/behavior_keymap.dtsi
@@ -9,8 +9,8 @@
 			label = "HOLD_TAP_BALANCED";
 			#binding-cells = <2>;
 			flavor = "balanced";
-			tapping_term_ms = <300>;
-			quick_tap_ms = <200>;
+			tapping-term-ms = <300>;
+			quick-tap-ms = <200>;
 			bindings = <&kp>, <&kp>;
 		};
 	};

--- a/app/tests/hold-tap/balanced/many-nested/native_posix.keymap
+++ b/app/tests/hold-tap/balanced/many-nested/native_posix.keymap
@@ -9,7 +9,7 @@
 			label = "HOLD_TAP_BALANCED";
 			#binding-cells = <2>;
 			flavor = "balanced";
-			tapping_term_ms = <300>;
+			tapping-term-ms = <300>;
 			bindings = <&kp>, <&kp>;
 		};
 	};

--- a/app/tests/hold-tap/hold-preferred/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/hold-preferred/behavior_keymap.dtsi
@@ -11,8 +11,8 @@
 			label = "hold_hold_tap";
 			#binding-cells = <2>;
 			flavor = "hold-preferred";
-			tapping_term_ms = <300>;
-			quick_tap_ms = <200>;
+			tapping-term-ms = <300>;
+			quick-tap-ms = <200>;
 			bindings = <&kp>, <&kp>;
 		};
 	};

--- a/app/tests/hold-tap/tap-preferred/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-preferred/behavior_keymap.dtsi
@@ -9,8 +9,8 @@
 			label = "MOD_TAP";
 			#binding-cells = <2>;
 			flavor = "tap-preferred";
-			tapping_term_ms = <300>;
-			quick_tap_ms = <200>;
+			tapping-term-ms = <300>;
+			quick-tap-ms = <200>;
 			bindings = <&kp>, <&kp>;
 		};
 	};

--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -23,9 +23,9 @@ We call this the 'hold-preferred' flavor of hold-taps. While this flavor may wor
 
 #### Flavors
 
-- The 'hold-preferred' flavor triggers the hold behavior when the `tapping_term_ms` has expired or another key is pressed.
-- The 'balanced' flavor will trigger the hold behavior when the `tapping_term_ms` has expired or another key is pressed and released.
-- The 'tap-preferred' flavor triggers the hold behavior when the `tapping_term_ms` has expired. It triggers the tap behavior when another key is pressed.
+- The 'hold-preferred' flavor triggers the hold behavior when the `tapping-term-ms` has expired or another key is pressed.
+- The 'balanced' flavor will trigger the hold behavior when the `tapping-term-ms` has expired or another key is pressed and released.
+- The 'tap-preferred' flavor triggers the hold behavior when the `tapping-term-ms` has expired. It triggers the tap behavior when another key is pressed.
 
 When the hold-tap key is released and the hold behavior has not been triggered, the tap behavior will trigger.
 
@@ -37,7 +37,7 @@ For basic usage, please see [mod-tap](./mod-tap.md) and [layer-tap](./layers.md)
 
 ### Advanced Configuration
 
-#### `tapping_term_ms`
+#### `tapping-term-ms`
 
 Defines how long a key must be pressed to trigger Hold behavior.
 
@@ -61,7 +61,7 @@ This example configures a hold-tap that works well for homerow mods:
 			compatible = "zmk,behavior-hold-tap";
 			label = "HOMEROW_MODS";
 			#binding-cells = <2>;
-			tapping_term_ms = <150>;
+			tapping-term-ms = <150>;
 			quick_tap_ms = <0>;
 			flavor = "tap-preferred";
 			bindings = <&kp>, <&kp>;
@@ -81,7 +81,7 @@ This example configures a hold-tap that works well for homerow mods:
 
 ```
 
-If this config does not work for you, try the flavor "balanced" with a medium `tapping_term_ms` such as 200ms.
+If this config does not work for you, try the flavor "balanced" with a medium `tapping-term-ms` such as 200ms.
 
 #### Comparison to QMK
 

--- a/docs/docs/behaviors/mod-tap.md
+++ b/docs/docs/behaviors/mod-tap.md
@@ -34,7 +34,7 @@ You can configure a different tapping term in your keymap:
 
 ```
 &mt {
-    tapping_term_ms = <400>;
+    tapping-term-ms = <400>;
 };
 
 / {
@@ -46,4 +46,4 @@ You can configure a different tapping term in your keymap:
 
 ### Additional information
 
-The mod-tap is a [hold-tap](./hold-tap.md) under the hood with the "balanced" flavor and tapping_term_ms 200.
+The mod-tap is a [hold-tap](./hold-tap.md) under the hood with the "balanced" flavor and tapping-term-ms 200.


### PR DESCRIPTION
tapping_term_ms -> tapping-term-ms
quick_tap_ms -> quick-tap-ms


Unfortunately I have not found a way to make this backwards compatible, so I don't know if you want to make this change. Thoughts?