### PR TITLE
fix(ext-power): Initialize as soon as settings are available

### DIFF
--- a/app/dts/bindings/zmk,ext-power-generic.yaml
+++ b/app/dts/bindings/zmk,ext-power-generic.yaml
@@ -15,3 +15,7 @@ properties:
   label:
     type: string
     required: true
+  init-delay-ms:
+    type: int
+    description: Number of milliseconds to delay after initializing driver
+    required: false

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -23,6 +23,7 @@ struct ext_power_generic_config {
     const char *label;
     const uint8_t pin;
     const uint8_t flags;
+    const uint16_t init_delay_ms;
 };
 
 struct ext_power_generic_data {
@@ -171,6 +172,10 @@ static int ext_power_generic_init(const struct device *dev) {
     ext_power_enable(dev);
 #endif
 
+    if (config->init_delay_ms) {
+        k_msleep(config->init_delay_ms);
+    }
+
     return 0;
 }
 
@@ -210,7 +215,8 @@ static int ext_power_generic_pm_control(const struct device *dev, uint32_t ctrl_
 static const struct ext_power_generic_config config = {
     .label = DT_INST_GPIO_LABEL(0, control_gpios),
     .pin = DT_INST_GPIO_PIN(0, control_gpios),
-    .flags = DT_INST_GPIO_FLAGS(0, control_gpios)};
+    .flags = DT_INST_GPIO_FLAGS(0, control_gpios),
+    .init_delay_ms = DT_INST_PROP_OR(0, init_delay_ms, 0)};
 
 static struct ext_power_generic_data data = {
     .status = false,

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -223,13 +223,15 @@ static const struct ext_power_api api = {.enable = ext_power_generic_enable,
                                          .disable = ext_power_generic_disable,
                                          .get = ext_power_generic_get};
 
+#define ZMK_EXT_POWER_INIT_PRIORITY 81
+
 #ifdef CONFIG_DEVICE_POWER_MANAGEMENT
 DEVICE_DEFINE(ext_power_generic, DT_INST_LABEL(0), ext_power_generic_init,
-              &ext_power_generic_pm_control, &data, &config, APPLICATION,
-              CONFIG_APPLICATION_INIT_PRIORITY, &api);
+              &ext_power_generic_pm_control, &data, &config, POST_KERNEL,
+              ZMK_EXT_POWER_INIT_PRIORITY, &api);
 #else
 DEVICE_AND_API_INIT(ext_power_generic, DT_INST_LABEL(0), ext_power_generic_init, &data, &config,
-                    APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY, &api);
+                    POST_KERNEL, ZMK_EXT_POWER_INIT_PRIORITY, &api);
 #endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */


### PR DESCRIPTION
This adjusts the initialization of the `ext_power` driver to be right after the flash systems have been initialized (All flash systems initialize by `POST_KERNEL` priority `80`). This way we know `ext_power` is properly initialized for the rest of the devices that need external power on start.

Currently, this fixes displays not turning on after deep sleep, but this should prevent similar issues in the future.

This is a step towards recovering devices when `ext_power` is in use. The next step is tying more devices to the PM policy so they can re-initialize without the entire system needing to be reset when `ext_power` is used while we keep context (idle, behaviors, etc).

I'm wondering if this init priority should be a Kconfig value.

Some boards' power switch takes some substantial time to actually switch to powered on, so the `init-delay-ms` property has been added, which holds the system for `n` milliseconds after enabling (or disabling) the power switch on initialization. This makes sure that when devices like the OLED are initialized, the power is ready to be used.

~~This is also not fully tested but works in theory. We need to reconfirm this change works and doesn't break the settings integration with `ext_power`~~ Re-init tested by @mcrosson, @tominabox1, and @karnadii. Settings confirmed to hold on start by @mcrosson.