### PR TITLE
fix(pre-commit): use prettier mirror and pin version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 fail_fast: false
 repos:
   - repo: https://github.com/pocc/pre-commit-hooks
-    rev: master
+    rev: v1.1.1
     hooks:
       - id: clang-format
         args:
           - -i
-  - repo: https://github.com/prettier/prettier
-    rev: master
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
     hooks:
       - id: prettier


### PR DESCRIPTION
This uses the recommended repository for the prettier pre-commit hook and pins the versions of both hooks to avoid surprises in the future.