### PR TITLE
add viterbi support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,8 @@ jobs:
           - splitreus62_right
           - tg4x
           - tidbit
+          - viterbi_left
+          - viterbi_right
         cmake-args: [""]
         include:
           - board: bdn9_rev2

--- a/app/boards/shields/viterbi/Kconfig.defconfig
+++ b/app/boards/shields/viterbi/Kconfig.defconfig
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_VITERBI_LEFT
+
+config ZMK_KEYBOARD_NAME
+    default "Viterbi Left"
+
+config ZMK_SPLIT_BLE_ROLE_CENTRAL
+    default y
+
+endif
+
+if SHIELD_VITERBI_RIGHT
+
+config ZMK_KEYBOARD_NAME
+    default "Viterbi Right"
+
+endif
+
+if SHIELD_VITERBI_LEFT || SHIELD_VITERBI_RIGHT
+
+config ZMK_SPLIT
+    default y
+
+endif

--- a/app/boards/shields/viterbi/Kconfig.shield
+++ b/app/boards/shields/viterbi/Kconfig.shield
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_VITERBI_LEFT
+    def_bool $(shields_list_contains,viterbi_left)
+
+config SHIELD_VITERBI_RIGHT
+    def_bool $(shields_list_contains,viterbi_right)

--- a/app/boards/shields/viterbi/README.md
+++ b/app/boards/shields/viterbi/README.md
@@ -1,0 +1,17 @@
+#### Note to user:
+
+- RGB UNDERGLOW
+untested
+If desired, RGB underglow must be manually enabled before building and flashing. Check 'viterbi.conf' to do so.
+
+- Peripheral RGB function is impaired until full support is implemented in the master branch.
+untested
+unavailable
+
+- OLED displays are not currently included in this shield. May be updated after OLED support is live.
+untested
+unavailable
+
+---
+
+TheRealFenrir was here.

--- a/app/boards/shields/viterbi/boards/nice_nano.overlay
+++ b/app/boards/shields/viterbi/boards/nice_nano.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+&spi1 {
+  compatible = "nordic,nrf-spim";
+  status = "okay";
+  mosi-pin = <6>;
+  // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+  sck-pin = <5>;
+  miso-pin = <7>;
+
+  led_strip: ws2812@0 {
+    compatible = "worldsemi,ws2812-spi";
+    label = "WS2812";
+
+    /* SPI */
+    reg = <0>; /* ignored, but necessary for SPI bindings */
+    spi-max-frequency = <4000000>;
+
+    /* WS2812 */
+    chain-length = <32>; /* number of LEDs */
+    spi-one-frame = <0x70>;
+    spi-zero-frame = <0x40>;
+  };
+};
+
+/ {
+  chosen {
+    zmk,underglow = &led_strip;
+  };
+};

--- a/app/boards/shields/viterbi/viterbi.conf
+++ b/app/boards/shields/viterbi/viterbi.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Enables RGB functionality (Uncomment lines below to enable.)
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/viterbi/viterbi.dtsi
+++ b/app/boards/shields/viterbi/viterbi.dtsi
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <14>;
+        rows = <5>;
+// ---------------------------------------------------------   -------------------------------------------------------------
+// | SW1   | SW2   | SW3   | SW4   | SW5   | SW6   | SW7   |   | SW7   | SW6   | SW5   | SW4    | SW3    | SW2    | SW1    |
+// | SW8   | SW9   | SW10  | SW11  | SW12  | SW13  | SW14  |   | SW14  | SW13  | SW12  | SW11   | SW10   | SW9    | SW8    |
+// | SW15  | SW16  | SW17  | SW18  | SW19  | SW20  | SW21  |   | SW21  | SW20  | SW19  | SW18   | SW17   | SW16   | SW15   |
+// | SW22  | SW23  | SW24  | SW25  | SW26  | SW27  | SW28  |   | SW28  | SW27  | SW26  | SW25   | SW24   | SW23   | SW22   |
+// | SW29  | SW30  | SW31  | SW32  | SW33  | SW34  | SW35  |   | SW35  | SW34  | SW33  | SW32   | SW31   | SW30   | SW29   |
+// ---------------------------------------------------------   -------------------------------------------------------------
+        map = <
+    RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6)     RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12) RC(0,13)
+    RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6)     RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12) RC(1,13)
+    RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6)     RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11) RC(2,12) RC(2,13)
+    RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6)     RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11) RC(3,12) RC(3,13)
+    RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(4,6)     RC(4,7) RC(4,8) RC(4,9) RC(4,10) RC(4,11) RC(4,12) RC(4,13)
+        >;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+
+        diode-direction = "col2row";
+        row-gpios
+            = <&pro_micro_d 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+        
+    };
+};

--- a/app/boards/shields/viterbi/viterbi.keymap
+++ b/app/boards/shields/viterbi/viterbi.keymap
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+ #include <behaviors.dtsi>
+ #include <dt-bindings/zmk/keys.h>
+ #include <dt-bindings/zmk/bt.h>
+ #include <dt-bindings/zmk/rgb.h>
+ #include <dt-bindings/zmk/ext_power.h>
+ #include <dt-bindings/zmk/outputs.h>
+
+#define DEFAULT 0
+#define LOWER	1
+#define RAISE	2
+/ {
+       keymap {
+              compatible = "zmk,keymap";
+ 
+              default_layer {
+ // -------------------------------------------------------------------   ------------------------------------------------------------------
+ // | GRAVE    | 1      | 2      | 3       |   4    |   5    | -      |   | =       |   6     |   7    |   8     |   9    |   0    |  BSPC  |
+ // | TAB      | Q      | W      | E       |   R    |   T    | [      |   |         |   Y     |   U    |   I     |   O    |   P    |  '     |
+ // | ESC      | A      | S      | D       |   F    |   G    | \      |   |         |   H     |   J    |   K     |   L    |   ;    |  RET   |
+ // | SHIFT    | Z      | X      | C       |   V    |   B    | PGDN   |   | PGUP    |   N     |   M    |   ,     |   .    |   /    | RAISE  |
+ // | LCTRL    | LGUI   | LALT   | LOWER   | SPACE  -        | HOME   |   | END     | SPACE   -        |  LEFT   |  DOWN  |  UP    |  RIGHT |
+ // -------------------------------------------------------------------   ------------------------------------------------------------------
+                     bindings = <
+     &kp GRAVE  &kp N1   &kp N2   &kp N3    &kp N4    &kp N5  &kp MINUS    &kp EQUAL &kp N6    &kp N7   &kp N8    &kp N9   &kp N0   &kp BSPC
+     &kp TAB    &kp Q    &kp W    &kp E     &kp R     &kp T   &kp LBKT     &kp RBKT  &kp Y     &kp U    &kp I     &kp O    &kp P    &kp SQT
+     &kp ESC    &kp A    &kp S    &kp D     &kp F     &kp G   &kp BSLH     &kp DEL   &kp H     &kp J    &kp K     &kp L    &kp SEMI &kp RET
+     &kp LSHFT  &kp Z    &kp X    &kp C     &kp V     &kp B   &kp PGDN     &kp PGUP  &kp N     &kp M    &kp COMMA &kp DOT  &kp FSLH &mo RAISE
+     &kp LCTRL  &kp LGUI &kp LALT &mo LOWER &kp SPACE &trans  &kp HOME     &kp END   &kp SPACE &trans   &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
+                     >;
+              };
+              lower_layer {
+ // -------------------------------------------------------------------   -----------------------------------------------------------------------
+ // |          | F1     | F2     | F3      | F4     | F5     | F11    |   | F12    | F6      | F7     | F8      | F9       | F10      |         |
+ // |          |        |        |         |        |        |        |   |        |         |        |         |          |          |         |
+ // |          |        |        |         |        |        |        |   |        |         |        |         |          |          |         |
+ // |          |        |        |         |        |        |        |   |        |         |        |         |          |          |         |
+ // |          |        |        |         | RESET  | OUT_TOG|        |   |        |         |        |         |          |          |         |
+ // -------------------------------------------------------------------   -----------------------------------------------------------------------
+                     bindings = <
+     &trans     &kp F1   &kp F2   &kp F3    &kp F4   &kp F5   &kp F11      &kp F12  &kp F6    &kp F7   &kp F8    &kp F9     &kp F10    &trans
+     &trans     &trans   &trans   &trans    &trans   &trans   &trans       &trans   &trans    &trans   &trans    &trans     &trans     &trans
+     &trans     &trans   &trans   &trans    &trans   &trans   &trans       &trans   &trans    &trans   &trans    &trans     &trans     &trans
+     &trans     &trans   &trans   &trans    &trans   &trans   &trans       &trans   &trans    &trans   &trans    &trans     &trans     &trans
+     &trans     &trans   &trans   &trans    &reset   &out OUT_TOG &trans   &trans   &trans    &trans   &trans    &trans     &trans     &trans
+                     >;
+              };
+              raise_layer {
+ // ------------------------------------------------------------------------------------------   -------------------------------------------------------------------------------------
+ // | BT CLR   | BTSEL0      | BTSEL1      | BTSEL2      | BTSEL3      | BTSEL4     |        |   |        |         |            |         |               |               |         |
+ // |          |             |             |             |             |            |        |   |        | RESET   | OUT_TOG    |         |               |               |         |
+ // |          |             |             |             |             |            |        |   |        |         |            |         |               |               | EP TOG  |
+ // |          |             |             |             |             |            |        |   |        |         |            |         |               |               |         |
+ // |          |             |             |             | RESET       | OUT_TOG    |        |   |        |         |            |         | RGB BRI-      | RGB BRI+      | RGB TOG |
+ // ------------------------------------------------------------------------------------------   -------------------------------------------------------------------------------------
+                     bindings = <
+     &bt BT_CLR &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4 &trans       &trans   &trans    &trans       &trans    &trans          &trans          &trans
+     &trans     &trans        &trans        &trans        &trans        &trans       &trans       &trans   &reset    &out OUT_TOG &trans    &trans          &trans          &trans
+     &trans     &trans        &trans        &trans        &trans        &trans       &trans       &trans   &trans    &trans       &trans    &trans          &trans          &ext_power EP_TOG
+     &trans     &trans        &trans        &trans        &trans        &trans       &trans       &trans   &trans    &trans       &trans    &trans          &trans          &trans
+     &trans     &trans        &trans        &trans        &reset        &out OUT_TOG &trans       &trans   &trans    &trans       &trans    &rgb_ug RGB_BRD &rgb_ug RGB_BRI &rgb_ug RGB_TOG
+                     >;
+              };
+       };
+};

--- a/app/boards/shields/viterbi/viterbi_left.overlay
+++ b/app/boards/shields/viterbi/viterbi_left.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+ 
+#include "viterbi.dtsi"
+
+&kscan0 {
+    col-gpios
+        = <&pro_micro_a 3 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_a 2 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_a 1 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_a 0 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 16 GPIO_ACTIVE_HIGH>
+        ;
+};

--- a/app/boards/shields/viterbi/viterbi_right.overlay
+++ b/app/boards/shields/viterbi/viterbi_right.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "viterbi.dtsi"
+
+&default_transform {
+	col-offset = <7>;
+};
+
+&kscan0 {
+    col-gpios
+        = <&pro_micro_d 16 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_a 0 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_a 1 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_a 2 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_a 3 GPIO_ACTIVE_HIGH>
+        ;
+};


### PR DESCRIPTION
Viterbi up and running with ZMK

KNOWN ISSUES:
1. -rgb controls not working for LED backlights (very few worked with QMK firmware, but I was at least able to go on and off, and change brightness. Now I can't do any of that). Probably a shield incompatibility and a me problem. -
2. external power cutoff (nice!nano) only affects master board (is this an issue with all split boards?).

UPON FURTHER INVESTIGATION 
Issue 1: it does appear that ZMK does not support backlights at all, and only underglow, probably due to the horrifying battery usage. So this is expected behavior.
Issue 2: I really need to figure out how external power cutoff works for both boards, so that one board isn't always running out of battery.