### PR TITLE
fix(behaviors): Add missing hold-tap trigger

### DIFF
--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -451,6 +451,8 @@ static int on_hold_tap_binding_pressed(struct zmk_behavior_binding *binding,
     int32_t tapping_term_ms_left = (hold_tap->timestamp + cfg->tapping_term_ms) - k_uptime_get();
     if (tapping_term_ms_left > 0) {
         k_delayed_work_submit(&hold_tap->work, K_MSEC(tapping_term_ms_left));
+    } else {
+        decide_hold_tap(hold_tap, HT_TIMER_EVENT);
     }
 
     return ZMK_BEHAVIOR_OPAQUE;


### PR DESCRIPTION
A hold-tap trigger was missing in the scenario where a hold-tap behavior
was queued for a while and it's timer should've run out.