### PR TITLE
fix(logging): remove unnecessary newline

### DIFF
--- a/app/drivers/sensor/battery_voltage_divider/battery_voltage_divider.c
+++ b/app/drivers/sensor/battery_voltage_divider/battery_voltage_divider.c
@@ -93,7 +93,7 @@ static int bvd_sample_fetch(const struct device *dev, enum sensor_channel chan) 
                               &val);
 
         uint16_t millivolts = val * (uint64_t)drv_cfg->full_ohm / drv_cfg->output_ohm;
-        LOG_DBG("ADC raw %d ~ %d mV => %d mV\n", drv_data->adc_raw, val, millivolts);
+        LOG_DBG("ADC raw %d ~ %d mV => %d mV", drv_data->adc_raw, val, millivolts);
         uint8_t percent = lithium_ion_mv_to_pct(millivolts);
         LOG_DBG("Percent: %d", percent);
 

--- a/app/src/kscan.c
+++ b/app/src/kscan.c
@@ -47,7 +47,7 @@ void zmk_kscan_process_msgq(struct k_work *item) {
     while (k_msgq_get(&zmk_kscan_msgq, &ev, K_NO_WAIT) == 0) {
         bool pressed = (ev.state == ZMK_KSCAN_EVENT_STATE_PRESSED);
         uint32_t position = zmk_matrix_transform_row_column_to_position(ev.row, ev.column);
-        LOG_DBG("Row: %d, col: %d, position: %d, pressed: %s\n", ev.row, ev.column, position,
+        LOG_DBG("Row: %d, col: %d, position: %d, pressed: %s", ev.row, ev.column, position,
                 (pressed ? "true" : "false"));
         ZMK_EVENT_RAISE(new_zmk_position_state_changed((struct zmk_position_state_changed){
             .state = pressed, .position = position, .timestamp = k_uptime_get()}));


### PR DESCRIPTION
Newlines are automatically added to logs. These newlines are very distracting while reading through big logfiles.