### PR TITLE
fix(core): Initialize layer state with base layer activated

### DIFF
--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -19,7 +19,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/events/layer_state_changed.h>
 #include <zmk/events/sensor_event.h>
 
-static zmk_keymap_layers_state_t _zmk_keymap_layer_state = 0;
+static zmk_keymap_layers_state_t _zmk_keymap_layer_state = 1;
 static uint8_t _zmk_keymap_layer_default = 0;
 
 #define DT_DRV_COMPAT zmk_keymap


### PR DESCRIPTION
The first time layer 0 is activated, a 'layer activated' trigger is sent, but the layer can never be deactiated because it's the base layer. This is a bit unexpected.

This PR initializes the layer state to 1, so the base layer is always activated, and no "ghost triggers" for the base layer are sent.