### PR TITLE
only send zmk_battery_state_changed on change

### DIFF
--- a/app/include/zmk/battery.h
+++ b/app/include/zmk/battery.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2021 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+uint8_t zmk_battery_state_of_charge();

--- a/app/include/zmk/events/battery_state_changed.h
+++ b/app/include/zmk/events/battery_state_changed.h
@@ -14,4 +14,6 @@ struct zmk_battery_state_changed {
     uint8_t state_of_charge;
 };
 
+int32_t zmk_battery_state_of_charge();
+
 ZMK_EVENT_DECLARE(zmk_battery_state_changed);

--- a/app/include/zmk/events/battery_state_changed.h
+++ b/app/include/zmk/events/battery_state_changed.h
@@ -14,6 +14,4 @@ struct zmk_battery_state_changed {
     uint8_t state_of_charge;
 };
 
-int32_t zmk_battery_state_of_charge();
-
 ZMK_EVENT_DECLARE(zmk_battery_state_changed);

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -41,6 +41,8 @@ static int zmk_battery_update(const struct device *battery) {
     }
 
     if (last_state_of_charge != state_of_charge.val1) {
+        last_state_of_charge = state_of_charge.val1;
+
         LOG_DBG("Setting BAS GATT battery level to %d.", state_of_charge.val1);
 
         rc = bt_bas_set_battery_level(state_of_charge.val1);
@@ -52,8 +54,6 @@ static int zmk_battery_update(const struct device *battery) {
 
         rc = ZMK_EVENT_RAISE(new_zmk_battery_state_changed(
             (struct zmk_battery_state_changed){.state_of_charge = state_of_charge.val1}));
-
-        last_state_of_charge = state_of_charge.val1;
     }
 
     return rc;


### PR DESCRIPTION
Currently the battery polling sends a zmk_battery_state_changed every minute whether or not the charge level changes.  This change will only send zmk_battery_state_changed if the battery level changes.