### PR TITLE
docs: Add documentation for config options

### DIFF
--- a/docs/docs/behaviors/caps-word.md
+++ b/docs/docs/behaviors/caps-word.md
@@ -5,7 +5,7 @@ sidebar_label: Caps Word
 
 ## Summary
 
-The caps word behavior behaves similar to a caps lock, but will automatically deactivate when one of the configured "break keycodes" is pressed, or if the caps word key is pressed again. For smaller keyboards, using [mod-taps](/docs/behaviors/mod-tap), this can help avoid repeated alternating holds when typing words in all caps.
+The caps word behavior behaves similar to a caps lock, but will automatically deactivate when any key not in a continue list is pressed, or if the caps word key is pressed again. For smaller keyboards using [mod-taps](/docs/behaviors/mod-tap), this can help avoid repeated alternating holds when typing words in all caps.
 
 The modifiers are applied only to to the alphabetic (`A` to `Z`) keycodes, to avoid automatically appliying them to numeric values, etc.
 

--- a/docs/docs/config/backlight.md
+++ b/docs/docs/config/backlight.md
@@ -3,9 +3,9 @@ title: Backlight Configuration
 sidebar_label: Backlight
 ---
 
-See the [backlight feature page](/docs/features/backlight) for more details, including instructions for adding backlight support to a board.
+See the [backlight feature page](../features/backlight.md) for more details, including instructions for adding backlight support to a board.
 
-See [Configuration Overview](/docs/config) for instructions on how to change these settings.
+See [Configuration Overview](index.md) for instructions on how to change these settings.
 
 ## Kconfig
 
@@ -33,4 +33,4 @@ See the Zephyr devicetree bindings for LED drivers:
 - [gpio-leds](https://docs.zephyrproject.org/latest/build/dts/api/bindings/gpio/gpio-leds.html)
 - [pwm-leds](https://docs.zephyrproject.org/latest/build/dts/api/bindings/led/pwm-leds.html)
 
-See the [backlight feature page](/docs/features/backlight) for examples of the properties that must be set to enable backlighting.
+See the [backlight feature page](../features/backlight.md) for examples of the properties that must be set to enable backlighting.

--- a/docs/docs/config/backlight.md
+++ b/docs/docs/config/backlight.md
@@ -1,0 +1,36 @@
+---
+title: Backlight Configuration
+sidebar_label: Backlight
+---
+
+See the [backlight feature page](/docs/features/backlight) for more details, including instructions for adding backlight support to a board.
+
+See [Configuration Overview](/docs/config) for instructions on how to change these settings.
+
+## Kconfig
+
+Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+
+| Option                               | Type | Description                                           | Default |
+| ------------------------------------ | ---- | ----------------------------------------------------- | ------- |
+| `CONFIG_ZMK_BACKLIGHT`               | bool | Enables LED backlight                                 | n       |
+| `CONFIG_ZMK_BACKLIGHT_BRT_STEP`      | int  | Brightness step in percent                            | 20      |
+| `CONFIG_ZMK_BACKLIGHT_BRT_START`     | int  | Default brightness in percent                         | 40      |
+| `CONFIG_ZMK_BACKLIGHT_ON_START`      | bool | Default backlight state                               | y       |
+| `CONFIG_ZMK_BACKLIGHT_AUTO_OFF_IDLE` | bool | Turn off backlight when keyboard goes into idle state | n       |
+| `CONFIG_ZMK_BACKLIGHT_AUTO_OFF_USB`  | bool | Turn off backlight when USB is disconnected           | n       |
+
+## Devicetree
+
+Applies to: [`/chosen` node](https://docs.zephyrproject.org/latest/build/dts/intro.html#aliases-and-chosen-nodes)
+
+| Property        | Type | Description                                  |
+| --------------- | ---- | -------------------------------------------- |
+| `zmk,backlight` | path | The node for the backlight LED driver to use |
+
+See the Zephyr devicetree bindings for LED drivers:
+
+- [gpio-leds](https://docs.zephyrproject.org/latest/build/dts/api/bindings/gpio/gpio-leds.html)
+- [pwm-leds](https://docs.zephyrproject.org/latest/build/dts/api/bindings/led/pwm-leds.html)
+
+See the [backlight feature page](/docs/features/backlight) for examples of the properties that must be set to enable backlighting.

--- a/docs/docs/config/backlight.md
+++ b/docs/docs/config/backlight.md
@@ -20,6 +20,10 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 | `CONFIG_ZMK_BACKLIGHT_AUTO_OFF_IDLE` | bool | Turn off backlight when keyboard goes into idle state | n       |
 | `CONFIG_ZMK_BACKLIGHT_AUTO_OFF_USB`  | bool | Turn off backlight when USB is disconnected           | n       |
 
+:::note
+The `*_START` settings only determine the initial backlight state. Any changes you make with the [backlight behavior](../behaviors/backlight.md) are saved to flash after a one minute delay and will be used after that.
+:::
+
 ## Devicetree
 
 Applies to: [`/chosen` node](https://docs.zephyrproject.org/latest/build/dts/intro.html#aliases-and-chosen-nodes)

--- a/docs/docs/config/battery.md
+++ b/docs/docs/config/battery.md
@@ -1,0 +1,40 @@
+---
+title: Battery Level
+sidebar_label: Battery Level
+---
+
+See the [battery level feature page](../features/battery.md) for more details on configuring a battery sensor.
+
+See [Configuration Overview](index.md) for instructions on how to change these settings.
+
+### Devicetree
+
+Applies to: [`/chosen` node](https://docs.zephyrproject.org/latest/guides/dts/intro.html#aliases-and-chosen-nodes)
+
+| Property      | Type | Description                                   |
+| ------------- | ---- | --------------------------------------------- |
+| `zmk,battery` | path | The node for the battery sensor driver to use |
+
+## Battery Voltage Divider Sensor
+
+Driver for reading the voltage of a battery using an ADC connected to a voltage divider.
+
+### Devicetree
+
+Applies to: `compatible = "zmk,battery-voltage-divider"`
+
+See [Zephyr's voltage divider documentation](https://docs.zephyrproject.org/latest/build/dts/api/bindings/adc/voltage-divider.html).
+
+## nRF VDDH Battery Sensor
+
+Driver for reading the voltage of a battery using a Nordic nRF52's VDDH pin. This driver has no configuration except for the required `label` property.
+
+### Devicetree
+
+Applies to: `compatible = "zmk,battery-nrf-vddh"`
+
+Definition file: [zmk/app/drivers/zephyr/dts/bindings/sensor/zmk,battery-nrf-vddh.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/sensor/zmk%2Cbattery-nrf-vddh.yaml)
+
+| Property | Type   | Description               |
+| -------- | ------ | ------------------------- |
+| `label`  | string | Unique label for the node |

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -1,0 +1,91 @@
+---
+title: Behavior Configuration
+sidebar_label: Behaviors
+---
+
+Some behaviors have properties to adjust how they behave. These can also be used as templates to create custom behaviors when none of the built-in behaviors do what you want.
+
+See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+
+See the [zmk/app/dts/behaviors/](https://github.com/zmkfirmware/zmk/tree/main/app/dts/behaviors) folder for all default behaviors.
+
+## Hold-Tap
+
+Creates a custom behavior that triggers one behavior when a key is held or a different one when the key is tapped.
+
+See the [hold-tap behavior documentation](/docs/behaviors/hold-tap) for more details and examples.
+
+### Devicetree
+
+Applies to: `compatible = "zmk,behavior-hold-tap"`
+
+| Property          | Type          | Description                                                                    | Default            |
+| ----------------- | ------------- | ------------------------------------------------------------------------------ | ------------------ |
+| `label`           | string        | Unique label for the node                                                      |                    |
+| `#binding-cells`  | int           | Must be `<2>`                                                                  |                    |
+| `bindings`        | phandle array | A list of two behaviors: one for hold and one for tap                          |                    |
+| `tapping-term-ms` | int           | How long in milliseconds the key must be held to trigger a hold                |                    |
+| `quick-tap-ms`    | int           | Tap twice within this period in milliseconds to trigger a tap, even when held  | -1                 |
+| `flavor`          | string        | Adjusts how the behavior chooses between hold and tap                          | `"hold-preferred"` |
+| `retro-tap`       | bool          | Triggers the tap behavior on release if no other key was pressed during a hold | false              |
+
+The `flavor` property may be one of:
+
+- `"hold-preferred"`
+- `"balanced"`
+- `"tap-preferred"`
+
+See the [hold-tap behavior documentation](/docs/behaviors/hold-tap) for an explanation of each flavor.
+
+| Node  | Behavior                                      |
+| ----- | --------------------------------------------- |
+| `&lt` | [Layer-tap](/docs/behaviors/layers#layer-tap) |
+| `&mt` | [Mod-tap](/docs/behaviors/mod-tap)            |
+
+## Mod-Morph
+
+Creates a custom behavior that triggers one behavior when a key is pressed without certain modifiers held or a different one if certain modifiers are held.
+
+### Devicetree
+
+Applies to: `compatible = "zmk,behavior-mod-morph"`
+
+| Property         | Type          | Description                                                                         |
+| ---------------- | ------------- | ----------------------------------------------------------------------------------- |
+| `label`          | string        | Unique label for the node                                                           |
+| `#binding-cells` | int           | Must be `<0>`                                                                       |
+| `bindings`       | phandle array | A list of two behaviors: one for normal press and one for mod morphed press         |
+| `mods`           | int           | A bit field of modifiers which will switch to the morph behavior if any are pressed |
+
+See [dt-bindings/zmk/modifiers.h](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/modifiers.h) for a list of modifiers.
+
+You can use the following nodes to tweak the default behaviors:
+
+| Node     | Behavior     |
+| -------- | ------------ |
+| `&gresc` | Grave escape |
+
+## Sticky Key
+
+Creates a custom behavior that triggers a behavior and keeps it pressed it until another key is pressed and released.
+
+See the [sticky key behavior](/docs/behaviors/sticky-key) and [sticky layer behavior](/docs/behaviors/sticky-layer) documentation for more details and examples.
+
+### Devicetree
+
+Applies to: `compatible = "zmk,behavior-sticky-key"`
+
+| Property           | Type          | Description                                                              | Default |
+| ------------------ | ------------- | ------------------------------------------------------------------------ | ------- |
+| `label`            | string        | Unique label for the node                                                |         |
+| `#binding-cells`   | int           | Must match the number of parameters the `bindings` behavior uses         |         |
+| `bindings`         | phandle array | A behavior (without parameters) to trigger                               |         |
+| `release-after-ms` | int           | Releases the key after this many milliseconds if no other key is pressed | 1000    |
+| `quick-release`    | bool          | Release the sticky key on the next key press instead of release          | false   |
+
+You can use the following nodes to tweak the default behaviors:
+
+| Node  | Behavior                                     |
+| ----- | -------------------------------------------- |
+| `&sk` | [Sticky key](/docs/behaviors/sticky-key)     |
+| `&sl` | [Sticky layer](/docs/behaviors/sticky-layer) |

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -9,6 +9,35 @@ See [Configuration Overview](/docs/config/index) for instructions on how to chan
 
 See the [zmk/app/dts/behaviors/](https://github.com/zmkfirmware/zmk/tree/main/app/dts/behaviors) folder for all default behaviors.
 
+## Caps Word
+
+Creates a custom behavior that behaves similar to a caps lock but deactivates when any key not in a continue list is pressed.
+
+See the [caps word behavior](/docs/behaviors/caps-word) documentation for more details and examples.
+
+### Devicetree
+
+Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-caps-word.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-caps-word.yaml)
+
+Applies to: `compatible = "zmk,behavior-caps-word"`
+
+| Property         | Type   | Description                                                        | Default        |
+| ---------------- | ------ | ------------------------------------------------------------------ | -------------- |
+| `label`          | string | Unique label for the node                                          |                |
+| `#binding-cells` | int    | Must be `<0>`                                                      |                |
+| `continue-list`  | array  | List of [key codes](/docs/codes) which do not deactivate caps lock | `<UNDERSCORE>` |
+| `mods`           | int    | A bit field of modifiers to apply                                  | `<MOD_LSFT>`   |
+
+`continue-list` is treated as if it always includes alphanumeric characters (A-Z, 0-9).
+
+See [dt-bindings/zmk/modifiers.h](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/modifiers.h) for a list of modifiers.
+
+You can use the following nodes to tweak the default behaviors:
+
+| Node         | Behavior                               |
+| ------------ | -------------------------------------- |
+| `&caps_word` | [Caps Word](/docs/behaviors/caps-word) |
+
 ## Hold-Tap
 
 Creates a custom behavior that triggers one behavior when a key is held or a different one when the key is tapped.
@@ -17,45 +46,113 @@ See the [hold-tap behavior documentation](/docs/behaviors/hold-tap) for more det
 
 ### Devicetree
 
+Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-hold-tap.yaml)
+
 Applies to: `compatible = "zmk,behavior-hold-tap"`
 
-| Property          | Type          | Description                                                                    | Default            |
-| ----------------- | ------------- | ------------------------------------------------------------------------------ | ------------------ |
-| `label`           | string        | Unique label for the node                                                      |                    |
-| `#binding-cells`  | int           | Must be `<2>`                                                                  |                    |
-| `bindings`        | phandle array | A list of two behaviors: one for hold and one for tap                          |                    |
-| `tapping-term-ms` | int           | How long in milliseconds the key must be held to trigger a hold                |                    |
-| `quick-tap-ms`    | int           | Tap twice within this period in milliseconds to trigger a tap, even when held  | -1                 |
-| `flavor`          | string        | Adjusts how the behavior chooses between hold and tap                          | `"hold-preferred"` |
-| `retro-tap`       | bool          | Triggers the tap behavior on release if no other key was pressed during a hold | false              |
+| Property                     | Type          | Description                                                                               | Default            |
+| ---------------------------- | ------------- | ----------------------------------------------------------------------------------------- | ------------------ |
+| `label`                      | string        | Unique label for the node                                                                 |                    |
+| `#binding-cells`             | int           | Must be `<2>`                                                                             |                    |
+| `bindings`                   | phandle array | A list of two behaviors (without parameters): one for hold and one for tap                |                    |
+| `flavor`                     | string        | Adjusts how the behavior chooses between hold and tap                                     | `"hold-preferred"` |
+| `tapping-term-ms`            | int           | How long in milliseconds the key must be held to trigger a hold                           |                    |
+| `quick-tap-ms`               | int           | Tap twice within this period (in milliseconds) to trigger a tap, even when held           | -1 (disabled)      |
+| `global-quick-tap`           | bool          | If enabled, `quick-tap-ms` also applies when tapping another key and then this one.       | false              |
+| `retro-tap`                  | bool          | Triggers the tap behavior on release if no other key was pressed during a hold            | false              |
+| `hold-trigger-key-positions` | array         | If set, pressing the hold-tap and then any key position _not_ in the list triggers a tap. |                    |
 
 The `flavor` property may be one of:
 
 - `"hold-preferred"`
 - `"balanced"`
 - `"tap-preferred"`
+- `"tap-unless-interrupted"`
 
 See the [hold-tap behavior documentation](/docs/behaviors/hold-tap) for an explanation of each flavor.
+
+`hold-trigger-key-positions` is an array of zero-based key position indices.
+
+You can use the following nodes to tweak the default behaviors:
 
 | Node  | Behavior                                      |
 | ----- | --------------------------------------------- |
 | `&lt` | [Layer-tap](/docs/behaviors/layers#layer-tap) |
 | `&mt` | [Mod-tap](/docs/behaviors/mod-tap)            |
 
-## Mod-Morph
+## Key Repeat
 
-Creates a custom behavior that triggers one behavior when a key is pressed without certain modifiers held or a different one if certain modifiers are held.
+Creates a custom behavior that repeats the whatever key code was last sent.
+
+See the [key repeat behavior](/docs/behaviors/key-repeat) documentation for more details and examples.
 
 ### Devicetree
 
+Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-key-repeat.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-key-repeat.yaml)
+
+Applies to: `compatible = "zmk,behavior-key-repeat"`
+
+| Property         | Type   | Description                      | Default           |
+| ---------------- | ------ | -------------------------------- | ----------------- |
+| `label`          | string | Unique label for the node        |                   |
+| `#binding-cells` | int    | Must be `<0>`                    |                   |
+| `usage-pages`    | array  | List of HID usage pages to track | `<HID_USAGE_KEY>` |
+
+For the `usage-pages` property, use the `HID_USAGE_*` defines from [dt-bindings/zmk/hid_usage_pages.h](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/hid_usage_pages.h).
+
+You can use the following nodes to tweak the default behaviors:
+
+| Node          | Behavior                                 |
+| ------------- | ---------------------------------------- |
+| `&key_repeat` | [Key repeat](/docs/behaviors/key-repeat) |
+
+## Macro
+
+Creates a custom behavior which triggers a sequence of other behaviors.
+
+See the [macro behavior](/docs/behaviors/macros) documentation for more details and examples.
+
+### Devicetree
+
+Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-macro.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-macro.yaml)
+
+Applies to: `compatible = "zmk,behavior-macro"`
+
+| Property         | Type          | Description                                                                                           | Default |
+| ---------------- | ------------- | ----------------------------------------------------------------------------------------------------- | ------- |
+| `label`          | string        | Unique label for the node                                                                             |         |
+| `#binding-cells` | int           | Must be `<0>`                                                                                         |         |
+| `bindings`       | phandle array | List of behaviors to trigger                                                                          |         |
+| `wait-ms`        | int           | The default time to wait (in milliseconds) before triggering the next behavior.                       | 100     |
+| `tap-ms`         | int           | The default time to wait (in milliseconds) between the press and release events of a tapped behavior. | 100     |
+
+The following macro-specific behaviors can be added at any point in the `bindings` list to change how the macro triggers subsequent behaviors.
+
+| Behavior                   | Description                                                                                           |
+| -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `&macro_tap`               | Switches to tap mode                                                                                  |
+| `&macro_press`             | Switches to press mode                                                                                |
+| `&macro_release`           | Switches to release mode                                                                              |
+| `&macro_pause_for_release` | Pauses the macro until the macro key itself is released                                               |
+| `&macro_wait_time TIME`    | Changes the time to wait (in milliseconds) before triggering the next behavior.                       |
+| `&macro_tap_time TIME`     | Changes the time to wait (in milliseconds) between the press and release events of a tapped behavior. |
+
+## Mod-Morph
+
+Creates a custom behavior that triggers one of two behaviors depending on whether certain modifiers are held.
+
+### Devicetree
+
+Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-mod-morph.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-mod-morph.yaml)
+
 Applies to: `compatible = "zmk,behavior-mod-morph"`
 
-| Property         | Type          | Description                                                                         |
-| ---------------- | ------------- | ----------------------------------------------------------------------------------- |
-| `label`          | string        | Unique label for the node                                                           |
-| `#binding-cells` | int           | Must be `<0>`                                                                       |
-| `bindings`       | phandle array | A list of two behaviors: one for normal press and one for mod morphed press         |
-| `mods`           | int           | A bit field of modifiers which will switch to the morph behavior if any are pressed |
+| Property         | Type          | Description                                                                       |
+| ---------------- | ------------- | --------------------------------------------------------------------------------- |
+| `label`          | string        | Unique label for the node                                                         |
+| `#binding-cells` | int           | Must be `<0>`                                                                     |
+| `bindings`       | phandle array | A list of two behaviors: one for normal press and one for mod morphed press       |
+| `mods`           | int           | A bit field of modifiers. The morph behavior is used if any of these are pressed. |
 
 See [dt-bindings/zmk/modifiers.h](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/modifiers.h) for a list of modifiers.
 
@@ -73,6 +170,8 @@ See the [sticky key behavior](/docs/behaviors/sticky-key) and [sticky layer beha
 
 ### Devicetree
 
+Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-sticky-key.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-sticky-key.yaml)
+
 Applies to: `compatible = "zmk,behavior-sticky-key"`
 
 | Property           | Type          | Description                                                              | Default |
@@ -82,6 +181,7 @@ Applies to: `compatible = "zmk,behavior-sticky-key"`
 | `bindings`         | phandle array | A behavior (without parameters) to trigger                               |         |
 | `release-after-ms` | int           | Releases the key after this many milliseconds if no other key is pressed | 1000    |
 | `quick-release`    | bool          | Release the sticky key on the next key press instead of release          | false   |
+| `ignore-modifiers` | bool          | If enabled, pressing a modifier key does not cancel the sticky key       | true    |
 
 You can use the following nodes to tweak the default behaviors:
 
@@ -89,3 +189,20 @@ You can use the following nodes to tweak the default behaviors:
 | ----- | -------------------------------------------- |
 | `&sk` | [Sticky key](/docs/behaviors/sticky-key)     |
 | `&sl` | [Sticky layer](/docs/behaviors/sticky-layer) |
+
+## Tap Dance
+
+Creates a custom behavior that triggers a different behavior corresponding to the number of times the key is tapped.
+
+### Devicetree
+
+Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-tap-dance.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-tap-dance.yaml)
+
+Applies to: `compatible = "zmk,behavior-tap-dance"`
+
+| Property          | Type          | Description                                                                                  | Default |
+| ----------------- | ------------- | -------------------------------------------------------------------------------------------- | ------- |
+| `label`           | string        | Unique label for the node                                                                    |         |
+| `#binding-cells`  | int           | Must be `<0>`                                                                                |         |
+| `bindings`        | phandle array | A list of behaviors from which to select                                                     |         |
+| `tapping-term-ms` | int           | The maximum time (in milliseconds) between taps before an item from `bindings` is triggered. | 200     |

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -5,7 +5,7 @@ sidebar_label: Behaviors
 
 Some behaviors have properties to adjust how they behave. These can also be used as templates to create custom behaviors when none of the built-in behaviors do what you want.
 
-See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+See [Configuration Overview](index.md) for instructions on how to change these settings.
 
 See the [zmk/app/dts/behaviors/](https://github.com/zmkfirmware/zmk/tree/main/app/dts/behaviors) folder for all default behaviors.
 
@@ -13,7 +13,7 @@ See the [zmk/app/dts/behaviors/](https://github.com/zmkfirmware/zmk/tree/main/ap
 
 Creates a custom behavior that behaves similar to a caps lock but deactivates when any key not in a continue list is pressed.
 
-See the [caps word behavior](/docs/behaviors/caps-word) documentation for more details and examples.
+See the [caps word behavior](../behaviors/caps-word.md) documentation for more details and examples.
 
 ### Devicetree
 
@@ -36,13 +36,13 @@ You can use the following nodes to tweak the default behaviors:
 
 | Node         | Behavior                               |
 | ------------ | -------------------------------------- |
-| `&caps_word` | [Caps Word](/docs/behaviors/caps-word) |
+| `&caps_word` | [Caps Word](../behaviors/caps-word.md) |
 
 ## Hold-Tap
 
 Creates a custom behavior that triggers one behavior when a key is held or a different one when the key is tapped.
 
-See the [hold-tap behavior documentation](/docs/behaviors/hold-tap) for more details and examples.
+See the [hold-tap behavior documentation](../behaviors/hold-tap.md) for more details and examples.
 
 ### Devicetree
 
@@ -69,7 +69,7 @@ The `flavor` property may be one of:
 - `"tap-preferred"`
 - `"tap-unless-interrupted"`
 
-See the [hold-tap behavior documentation](/docs/behaviors/hold-tap) for an explanation of each flavor.
+See the [hold-tap behavior documentation](../behaviors/hold-tap.md) for an explanation of each flavor.
 
 `hold-trigger-key-positions` is an array of zero-based key position indices.
 
@@ -77,14 +77,14 @@ You can use the following nodes to tweak the default behaviors:
 
 | Node  | Behavior                                      |
 | ----- | --------------------------------------------- |
-| `&lt` | [Layer-tap](/docs/behaviors/layers#layer-tap) |
-| `&mt` | [Mod-tap](/docs/behaviors/mod-tap)            |
+| `&lt` | [Layer-tap](../behaviors/layers.md#layer-tap) |
+| `&mt` | [Mod-tap](../behaviors/mod-tap.md)            |
 
 ## Key Repeat
 
 Creates a custom behavior that repeats the whatever key code was last sent.
 
-See the [key repeat behavior](/docs/behaviors/key-repeat) documentation for more details and examples.
+See the [key repeat behavior](../behaviors/key-repeat.md) documentation for more details and examples.
 
 ### Devicetree
 
@@ -104,13 +104,13 @@ You can use the following nodes to tweak the default behaviors:
 
 | Node          | Behavior                                 |
 | ------------- | ---------------------------------------- |
-| `&key_repeat` | [Key repeat](/docs/behaviors/key-repeat) |
+| `&key_repeat` | [Key repeat](../behaviors/key-repeat.md) |
 
 ## Macro
 
 Creates a custom behavior which triggers a sequence of other behaviors.
 
-See the [macro behavior](/docs/behaviors/macros) documentation for more details and examples.
+See the [macro behavior](../behaviors/macros.md) documentation for more details and examples.
 
 ### Devicetree
 
@@ -166,7 +166,7 @@ You can use the following nodes to tweak the default behaviors:
 
 Creates a custom behavior that triggers a behavior and keeps it pressed it until another key is pressed and released.
 
-See the [sticky key behavior](/docs/behaviors/sticky-key) and [sticky layer behavior](/docs/behaviors/sticky-layer) documentation for more details and examples.
+See the [sticky key behavior](../behaviors/sticky-key.md) and [sticky layer behavior](../behaviors/sticky-layer.md) documentation for more details and examples.
 
 ### Devicetree
 
@@ -187,8 +187,8 @@ You can use the following nodes to tweak the default behaviors:
 
 | Node  | Behavior                                     |
 | ----- | -------------------------------------------- |
-| `&sk` | [Sticky key](/docs/behaviors/sticky-key)     |
-| `&sl` | [Sticky layer](/docs/behaviors/sticky-layer) |
+| `&sk` | [Sticky key](../behaviors/sticky-key.md)     |
+| `&sl` | [Sticky layer](../behaviors/sticky-layer.md) |
 
 ## Tap Dance
 

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -158,9 +158,9 @@ See [dt-bindings/zmk/modifiers.h](https://github.com/zmkfirmware/zmk/blob/main/a
 
 You can use the following nodes to tweak the default behaviors:
 
-| Node     | Behavior     |
-| -------- | ------------ |
-| `&gresc` | Grave escape |
+| Node     | Behavior                                  |
+| -------- | ----------------------------------------- |
+| `&gresc` | [Grave escape](../behaviors/mod-morph.md) |
 
 ## Sticky Key
 

--- a/docs/docs/config/combos.md
+++ b/docs/docs/config/combos.md
@@ -1,0 +1,42 @@
+---
+title: Combo Configuration
+sidebar_label: Combos
+---
+
+See the [Combos feature page](/docs/features/combos) for more details and examples.
+
+See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+
+## Kconfig
+
+Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+
+| Config                                | Type | Description                                                    | Default |
+| ------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS` | int  | Maximum number of combos that can be active at the same time   | 4       |
+| `CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY` | int  | Maximum number of active combos that use the same key position | 5       |
+| `CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO` | int  | Maximum number of keys to press to activate a combo            | 4       |
+
+If `CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY` is 5, you can have 5 separate combos that use position `0`, 5 combos that use position `1`, and so on.
+
+If you want a combo that triggers when pressing 5 keys, you must set `CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO` to 5.
+
+## Devicetree
+
+Applies to: `compatible = "zmk,combo"`
+
+Definition file: [zmk/app/dts/bindings/zmk,combos.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk%2Ccombos.yaml)
+
+The `zmk,combos` node itself has no properties. It should have one child node per combo.
+
+Each child node can have the following properties:
+
+| Property        | Type          | Description                                                                        | Default |
+| --------------- | ------------- | ---------------------------------------------------------------------------------- | ------- |
+| `bindings`      | phandle-array | A [behavior](/docs/features/keymaps#behaviors) to run when the combo is triggered  |         |
+| `key-positions` | array         | A list of key position indices for the keys which should trigger the combo         |         |
+| `timeout-ms`    | int           | All the keys must be pressed within this time in milliseconds to trigger the combo | 50      |
+| `slow-release`  | bool          | Releases the combo when all keys are released instead of when any key is released  | false   |
+| `layers`        | array         | A list of layers on which the combo may be triggered. `-1` allows all layers.      | `<-1>`  |
+
+The `key-positions` array must not be longer than the `CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO` setting, which defaults to 4. If you want a combo that triggers when pressing 5 keys, then you must change the setting to 5.

--- a/docs/docs/config/combos.md
+++ b/docs/docs/config/combos.md
@@ -23,7 +23,7 @@ If you want a combo that triggers when pressing 5 keys, you must set `CONFIG_ZMK
 
 ## Devicetree
 
-Applies to: `compatible = "zmk,combo"`
+Applies to: `compatible = "zmk,combos"`
 
 Definition file: [zmk/app/dts/bindings/zmk,combos.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk%2Ccombos.yaml)
 
@@ -31,12 +31,12 @@ The `zmk,combos` node itself has no properties. It should have one child node pe
 
 Each child node can have the following properties:
 
-| Property        | Type          | Description                                                                        | Default |
-| --------------- | ------------- | ---------------------------------------------------------------------------------- | ------- |
-| `bindings`      | phandle-array | A [behavior](../features/keymaps.md#behaviors) to run when the combo is triggered  |         |
-| `key-positions` | array         | A list of key position indices for the keys which should trigger the combo         |         |
-| `timeout-ms`    | int           | All the keys must be pressed within this time in milliseconds to trigger the combo | 50      |
-| `slow-release`  | bool          | Releases the combo when all keys are released instead of when any key is released  | false   |
-| `layers`        | array         | A list of layers on which the combo may be triggered. `-1` allows all layers.      | `<-1>`  |
+| Property        | Type          | Description                                                                                           | Default |
+| --------------- | ------------- | ----------------------------------------------------------------------------------------------------- | ------- |
+| `bindings`      | phandle-array | A [behavior](../features/keymaps.md#behaviors) to run when the combo is triggered                     |         |
+| `key-positions` | array         | A list of key position indices for the keys which should trigger the combo                            |         |
+| `timeout-ms`    | int           | All the keys in `key-positions` must be pressed within this time in milliseconds to trigger the combo | 50      |
+| `slow-release`  | bool          | Releases the combo when all keys are released instead of when any key is released                     | false   |
+| `layers`        | array         | A list of layers on which the combo may be triggered. `-1` allows all layers.                         | `<-1>`  |
 
 The `key-positions` array must not be longer than the `CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO` setting, which defaults to 4. If you want a combo that triggers when pressing 5 keys, then you must change the setting to 5.

--- a/docs/docs/config/combos.md
+++ b/docs/docs/config/combos.md
@@ -3,9 +3,9 @@ title: Combo Configuration
 sidebar_label: Combos
 ---
 
-See the [Combos feature page](/docs/features/combos) for more details and examples.
+See the [Combos feature page](../features/combos.md) for more details and examples.
 
-See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+See [Configuration Overview](index.md) for instructions on how to change these settings.
 
 ## Kconfig
 
@@ -33,7 +33,7 @@ Each child node can have the following properties:
 
 | Property        | Type          | Description                                                                        | Default |
 | --------------- | ------------- | ---------------------------------------------------------------------------------- | ------- |
-| `bindings`      | phandle-array | A [behavior](/docs/features/keymaps#behaviors) to run when the combo is triggered  |         |
+| `bindings`      | phandle-array | A [behavior](../features/keymaps.md#behaviors) to run when the combo is triggered  |         |
 | `key-positions` | array         | A list of key position indices for the keys which should trigger the combo         |         |
 | `timeout-ms`    | int           | All the keys must be pressed within this time in milliseconds to trigger the combo | 50      |
 | `slow-release`  | bool          | Releases the combo when all keys are released instead of when any key is released  | false   |

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -22,22 +22,39 @@ Definition files:
 | `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`  | bool | Enable a widget to show the current output (USB/BLE) | y       |
 | `CONFIG_ZMK_WIDGET_WPM_STATUS`     | bool | Enable a widget to show words per minute             | n       |
 
-If `CONFIG_ZMK_DISPLAY` is enabled, exactly one of the following options must be set to `y`:
+If `CONFIG_ZMK_DISPLAY` is enabled, exactly zero or one of the following options must be set to `y`. The first option is used if none are set.
 
-| Config                                      | Type | Description                    | Default |
-| ------------------------------------------- | ---- | ------------------------------ | ------- |
-| `CONFIG_ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN` | bool | Use the built-in status screen | y       |
-| `CONFIG_ZMK_DISPLAY_STATUS_SCREEN_CUSTOM`   | bool | Use a custom status screen     | n       |
+| Config                                      | Description                    |
+| ------------------------------------------- | ------------------------------ |
+| `CONFIG_ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN` | Use the built-in status screen |
+| `CONFIG_ZMK_DISPLAY_STATUS_SCREEN_CUSTOM`   | Use a custom status screen     |
 
-You must also configure the Zephyr driver for your display. Here are the Kconfig options for common displays.
+If `CONFIG_ZMK_DISPLAY` is enabled, exactly zero or one of the following options must be set to `y`. The first option is used if none are set.
 
-- [SSD1306](https://docs.zephyrproject.org/latest/reference/kconfig/CONFIG_SSD1306.html)
+| Config                                    | Description                               |
+| ----------------------------------------- | ----------------------------------------- |
+| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_SYSTEM`    | Use the system main thread for UI updates |
+| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED` | Use a dedicated thread for UI updates     |
+
+Using a dedicated thread requires more memory but prevents displays with slow updates (e.g. E-paper) from delaying key scanning and other processes. If enabled, the following options configure the thread:
+
+| Config                                           | Type | Description                  | Default |
+| ------------------------------------------------ | ---- | ---------------------------- | ------- |
+| `CONFIG_ZMK_DISPLAY_DEDICATED_THREAD_STACK_SIZE` | int  | Stack size for the UI thread | 2048    |
+| `CONFIG_ZMK_DISPLAY_DEDICATED_THREAD_PRIORITY`   | int  | Priority for the UI thread   | 5       |
+
+You must also configure the driver for your display. ZMK provides the following display drivers:
+
+- [IL0323](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/display/Kconfig.il0323)
+
+Zephyr provides several display drivers as well. Search for the name of your display in [Zephyr's Kconfig options](https://docs.zephyrproject.org/latest/kconfig.html) documentation.
 
 ## Devicetree
 
-See the Zephyr Devicetree bindings for your display. Here are the bindings for common displays:
+See the Devicetree bindings for your display. Here are the bindings for common displays:
 
-- [SSD1306 (i2c)](https://docs.zephyrproject.org/latest/reference/devicetree/bindings/solomon,ssd1306fb-i2c.html)
-- [SSD1306 (spi)](https://docs.zephyrproject.org/latest/reference/devicetree/bindings/solomon,ssd1306fb-spi.html)
+- [IL0323](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/display/gooddisplay%2Cil0323.yaml)
+- [SSD1306 (i2c)](https://docs.zephyrproject.org/latest/build/dts/api/bindings/display/solomon,ssd1306fb-i2c.html)
+- [SSD1306 (spi)](https://docs.zephyrproject.org/latest/build/dts/api/bindings/display/solomon,ssd1306fb-spi.html)
 
-A full list of supported drivers can be found in [Zephyr's Devicetree bindings index](https://docs.zephyrproject.org/latest/reference/devicetree/bindings.html).
+A full list of drivers provided by Zephyr can be found in [Zephyr's Devicetree bindings index](https://docs.zephyrproject.org/latest/build/dts/api/bindings.html).

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -1,0 +1,43 @@
+---
+title: Display Configuration
+sidebar_label: Displays
+---
+
+See the [displays feature page](/docs/features/displays) for more details.
+
+See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+
+## Kconfig
+
+Definition files:
+
+- [zmk/app/src/display/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/Kconfig)
+- [zmk/app/src/display/widgets/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/widgets/Kconfig)
+
+| Config                             | Type | Description                                          | Default |
+| ---------------------------------- | ---- | ---------------------------------------------------- | ------- |
+| `CONFIG_ZMK_DISPLAY`               | bool | Enable support for displays                          | n       |
+| `CONFIG_ZMK_WIDGET_LAYER_STATUS`   | bool | Enable a widget to show the highest, active layer    | y       |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS` | bool | Enable a widget to show battery charge information   | y       |
+| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`  | bool | Enable a widget to show the current output (USB/BLE) | y       |
+| `CONFIG_ZMK_WIDGET_WPM_STATUS`     | bool | Enable a widget to show words per minute             | n       |
+
+If `CONFIG_ZMK_DISPLAY` is enabled, exactly one of the following options must be set to `y`:
+
+| Config                                      | Type | Description                    | Default |
+| ------------------------------------------- | ---- | ------------------------------ | ------- |
+| `CONFIG_ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN` | bool | Use the built-in status screen | y       |
+| `CONFIG_ZMK_DISPLAY_STATUS_SCREEN_CUSTOM`   | bool | Use a custom status screen     | n       |
+
+You must also configure the Zephyr driver for your display. Here are the Kconfig options for common displays.
+
+- [SSD1306](https://docs.zephyrproject.org/latest/reference/kconfig/CONFIG_SSD1306.html)
+
+## Devicetree
+
+See the Zephyr Devicetree bindings for your display. Here are the bindings for common displays:
+
+- [SSD1306 (i2c)](https://docs.zephyrproject.org/latest/reference/devicetree/bindings/solomon,ssd1306fb-i2c.html)
+- [SSD1306 (spi)](https://docs.zephyrproject.org/latest/reference/devicetree/bindings/solomon,ssd1306fb-spi.html)
+
+A full list of supported drivers can be found in [Zephyr's Devicetree bindings index](https://docs.zephyrproject.org/latest/reference/devicetree/bindings.html).

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -3,9 +3,9 @@ title: Display Configuration
 sidebar_label: Displays
 ---
 
-See the [displays feature page](/docs/features/displays) for more details.
+See the [displays feature page](../features/displays.md) for more details.
 
-See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+See [Configuration Overview](index.md) for instructions on how to change these settings.
 
 ## Kconfig
 

--- a/docs/docs/config/encoders.md
+++ b/docs/docs/config/encoders.md
@@ -1,0 +1,41 @@
+---
+title: Encoder Configuration
+sidebar_label: Encoders
+---
+
+See the [Encoders feature page](/docs/features/encoders) for more details, including instructions for adding encoder support to a board.
+
+See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+
+## EC11 Encoders
+
+### Kconfig
+
+Definition file: [zmk/app/drivers/sensor/ec11/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/sensor/ec11/Kconfig)
+
+| Config                          | Type | Description                      | Default |
+| ------------------------------- | ---- | -------------------------------- | ------- |
+| `CONFIG_EC11`                   | bool | Enable EC11 encoders             | n       |
+| `CONFIG_EC11_THREAD_PRIORITY`   | int  | Priority of the encoder thread   | 10      |
+| `CONFIG_EC11_THREAD_STACK_SIZE` | int  | Stack size of the encoder thread | 1024    |
+
+If `CONFIG_EC11` is enabled, exactly one of the following options must be set to `y`:
+
+| Config                              | Type | Description                                     |
+| ----------------------------------- | ---- | ----------------------------------------------- |
+| `CONFIG_EC11_TRIGGER_NONE`          | bool | No trigger (encoders are disabled)              |
+| `CONFIG_EC11_TRIGGER_GLOBAL_THREAD` | bool | Process encoder interrupts on the global thread |
+| `CONFIG_EC11_TRIGGER_OWN_THREAD`    | bool | Process encoder interrupts on their own thread  |
+
+### Devicetree
+
+Applies to: `compatible = "alps,ec11"`
+
+Definition file: [zmk/app/drivers/zephyr/dts/bindings/sensor/alps,ec11.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/sensor/alps%2Cec11.yaml)
+
+| Property     | Type       | Description                           | Default |
+| ------------ | ---------- | ------------------------------------- | ------- |
+| `label`      | string     | Unique label for the node             |         |
+| `a-gpios`    | GPIO array | GPIO connected to the encoder's A pin |         |
+| `b-gpios`    | GPIO array | GPIO connected to the encoder's B pin |         |
+| `resolution` | int        | Number of encoder pulses per tick     | 1       |

--- a/docs/docs/config/encoders.md
+++ b/docs/docs/config/encoders.md
@@ -3,9 +3,9 @@ title: Encoder Configuration
 sidebar_label: Encoders
 ---
 
-See the [Encoders feature page](/docs/features/encoders) for more details, including instructions for adding encoder support to a board.
+See the [Encoders feature page](../features/encoders.md) for more details, including instructions for adding encoder support to a board.
 
-See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+See [Configuration Overview](index.md) for instructions on how to change these settings.
 
 ## EC11 Encoders
 

--- a/docs/docs/config/index.md
+++ b/docs/docs/config/index.md
@@ -58,7 +58,7 @@ ZMK will search the shield folder for the following config files:
 - `<shield>.overlay` (Devicetree)
 - `<shield>.keymap` (Devicetree)
 
-For more documentation on creating and configuring a new shield, see [Zephyr's shield documentation](https://docs.zephyrproject.org/latest/guides/porting/shields.html) and [ZMK's new keyboard shield](/docs/development/new-shield) guide.
+For more documentation on creating and configuring a new shield, see [Zephyr's shield documentation](https://docs.zephyrproject.org/latest/hardware/porting/shields.html) and [ZMK's new keyboard shield](../development/new-shield.md) guide.
 
 ## Kconfig Files
 

--- a/docs/docs/config/index.md
+++ b/docs/docs/config/index.md
@@ -1,0 +1,237 @@
+---
+title: Configuration Overview
+sidebar_label: Overview
+---
+
+ZMK has several configuration settings that can be changed to change the behavior of your keyboard. They are set in either Kconfig or Devicetree files.
+
+This page describes the Kconfig and Devicetree file formats and how to change settings in them. See the other pages in the configuration section for a list of settings you can change.
+
+:::note
+All configuration is currently set at compile time. After changing any settings, you must build new firmware and flash it for the changes to apply.
+:::
+
+## Config File Locations
+
+ZMK will search multiple folders for the config files described below. There are three primary locations it will search:
+
+### User Config Folder
+
+When building with a `zmk-config` folder, ZMK will search the `zmk-config/config` folder for the following config files, where `<name>` is the name of the shield if using a shield, or the name of the board otherwise:
+
+- `<name>.conf` (Kconfig)
+- `<name>.keymap` (Devicetree)
+
+These files hold your personal settings for the keyboard. They override any configuration set in the board or shield folders.
+
+When using a split keyboard, you can use a single file without the `_left` or `_right` suffix to configure both sides. For example, `corne.conf` and `corne.keymap` will apply to both `corne_left` and `corne_right`.
+
+### Board Folder
+
+ZMK will search for config files in either of:
+
+- [`zmk/app/boards/arm/<board>`](https://github.com/zmkfirmware/zmk/tree/main/app/boards/arm)
+- `zmk-config/config/boards/arm/<board>`
+
+...where `<board>` is the name of the board. These files describe the hardware of the board.
+
+ZMK will search the board folder for the following config files:
+
+- `<board>_defconfig` (Kconfig)
+- `<board>.dts` (Devicetree)
+- `<board>.keymap` (Devictree, standalone boards only)
+
+For more documentation on creating and configuring a new board, see [Zephyr's board porting guide](https://docs.zephyrproject.org/latest/guides/porting/board_porting.html#write-kconfig-files).
+
+### Shield Folder
+
+When building with a shield, ZMK will search for config files in either of:
+
+- [`zmk/app/boards/shields/<shield>`](https://github.com/zmkfirmware/zmk/tree/main/app/boards/shields)
+- `zmk-config/config/boards/shields/<shield>`
+
+...where `<shield>` is the name of the shield. These files describe the hardware of the shield that the board is plugged into.
+
+ZMK will search the shield folder for the following config files:
+
+- `<shield>.conf` (Kconfig)
+- `<shield>.overlay` (Devicetree)
+- `<shield>.keymap` (Devicetree)
+
+For more documentation on creating and configuring a new shield, see [Zephyr's shield documentation](https://docs.zephyrproject.org/latest/guides/porting/shields.html) and [ZMK's new keyboard shield](/docs/development/new-shield) guide.
+
+## Kconfig Files
+
+Kconfig is used to configure global settings such as the keyboard name and enabling certain hardware devices. These typically have a `.conf` file extension and are text files containing `CONFIG_XYZ=value` assignments, with one setting per line.
+
+Kconfig files look like this:
+
+```
+CONFIG_ZMK_SLEEP=y
+CONFIG_EC11=y
+CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+```
+
+The list of available settings is determined by various files in ZMK whose names start with `Kconfig`.
+
+See [Zephyr's Kconfig documentation](https://docs.zephyrproject.org/latest/guides/kconfig/index.html) for more details on Kconfig files.
+
+### KConfig Value Types
+
+#### bool
+
+Either `y` for yes or `n` for no.
+
+Example: `CONFIG_FOO=y`
+
+#### int
+
+An integer.
+
+Example: `CONFIG_FOO=42`
+
+#### string
+
+Text surrounded by double quotes.
+
+Example: `CONFIG_FOO="foo"`
+
+## Devicetree Files
+
+Various Devicetree files are combined to build a tree that describes the hardware for a keyboard. They are also used to define keymaps. Common file extensions for Devicetree files are `.dts`, `.dtsi`, `.overlay`, and `.keymap`.
+
+Devicetree files look like this:
+
+```devicetree
+/ {
+	chosen {
+		zmk,kscan = &kscan0;
+	};
+
+	kscan0: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+		label = "KSCAN";
+	};
+};
+```
+
+Devicetree properties apply to specific nodes in the tree instead of globally. The properties that can be set for each node are determined by `.yaml` files in ZMK in the various `dts/bindings` folders.
+
+See [Zephyr's Devicetree guide](https://docs.zephyrproject.org/latest/guides/dts/index.html) for more details on Devicetree files.
+
+### Changing Devicetree Properties
+
+Since Devicetree properties are set for specific nodes in the tree, you will first need to find the node you want to configure. You will typically need to
+search through the `.dts` file for you board, `.overlay` file for your shield, or a `.dtsi` file included in by of those files using an `#include` statement.
+
+A Devicetree node looks like this:
+
+```devicetree
+kscan0: kscan {
+    compatible = "zmk,kscan-gpio-matrix";
+    // more properties and/or nodes...
+};
+```
+
+The part before the colon, `kscan0`, is a label. This is optional, and it provides a shortcut to allow changing the properties of the node. The part after the colon, `kscan`, is the node's name. The values inside the curly braces are the node's properties.
+
+The `compatible` property indicates what type of node it is. Search this documentation for the text inside the quotes to see which properties the node
+supports. You can also search ZMK for a file whose name is the value of the `compatible` property with a `.yaml` file extension.
+
+To set a property, see below for examples for common property types, or see [Zephyr's Devicetree documentation](https://docs.zephyrproject.org/latest/guides/dts/intro.html#writing-property-values) for more details on the syntax for properties.
+
+To change a property for an existing node, first find the node you want to change and find its label. Next, outside of any other node, write an ampersand (`&`)
+followed by the node's label, an opening curly brace (`{`), one or more new property values, a closing curly brace (`}`), and a semicolon (`;`).
+
+For example, to adjust the debouncing of the `zmk,kscan-gpio-matrix` node shown above, you could add this to your keymap:
+
+```devicetree
+&kscan0 {
+    debounce-period = <7>;
+};
+```
+
+### Devicetree Property Types
+
+These are some of the property types you will see most often when working with ZMK. [Zephyr's Devicetree bindings documentation](https://docs.zephyrproject.org/latest/guides/dts/bindings.html) provides more detailed information and a full list of types.
+
+#### bool
+
+True or false. To set the property to true, list it with no value. To set it to false, do not list it.
+
+Example: `property;`
+
+If a property has already been set to true and you need to override it to false, use the following command to delete the existing property:
+
+```devicetree
+/delete-property/ the-property-name;
+```
+
+#### int
+
+A single integer surrounded by angle brackets. Also supports mathematical expressions.
+
+Example: `property = <42>;`
+
+#### string
+
+Text surrounded by double quotes.
+
+Example: `property = "foo";`
+
+#### array
+
+A list of integers surrounded by angle brackets and separated with spaces. Mathematical expressions can be used but must be surrounded by parenthesis.
+
+Example: `property = <1 2 3 4>;`
+
+Values can also be split into multiple blocks, e.g. `property = <1 2>, <3 4>;`
+
+#### phandle
+
+A single node reference surrounded by angle brackets.
+
+Example: `property = <&label>`
+
+#### phandles
+
+A list of node references surrounded by angle brackets.
+
+Example: `property = <&label1 &label2 &label3>`
+
+#### phandle array
+
+A list of node references and possibly numbers to associate with the node. Mathematical expressions can be used but must be surrounded by parenthesis.
+
+Example: `property = <&none &mo 1>;`
+
+Values can also be split into multiple blocks, e.g. `property = <&none>, <&mo 1>;`
+
+See the documentation for "phandle-array" in [Zephyr's Devicetree bindings documentation](https://docs.zephyrproject.org/latest/guides/dts/bindings.html)
+for more details on how parameters are associated with nodes.
+
+#### GPIO array
+
+This is just a phandle array. The documentation lists this as a different type to make it clear which properties expect an array of GPIOs.
+
+Each item in the array should be a label for a GPIO node (the names of which differ between hardware platforms) followed by an index and configuration flags. See [Zephyr's GPIO documentation](https://docs.zephyrproject.org/latest/reference/peripherals/gpio.html) for a full list of flags.
+
+Example:
+
+```devicetree
+some-gpios =
+    <&gpio0 0 GPIO_ACTIVE_HIGH>,
+    <&gpio0 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	;
+```
+
+#### path
+
+A path to a node, either as a node reference or as a string.
+
+Examples:
+
+```
+property = &label;
+property = "/path/to/some/node";
+```

--- a/docs/docs/config/index.md
+++ b/docs/docs/config/index.md
@@ -22,9 +22,9 @@ When building with a `zmk-config` folder, ZMK will search the `zmk-config/config
 - `<name>.conf` (Kconfig)
 - `<name>.keymap` (Devicetree)
 
-These files hold your personal settings for the keyboard. They override any configuration set in the board or shield folders.
+These files hold your personal settings for the keyboard. All files are optional. If present, they override any configuration set in the board or shield folders. Otherwise, the default configuration and/or keymap is used.
 
-When using a split keyboard, you can use a single file without the `_left` or `_right` suffix to configure both sides. For example, `corne.conf` and `corne.keymap` will apply to both `corne_left` and `corne_right`.
+When using a split keyboard, you can use a single file without the `_left` or `_right` suffix to configure both sides. For example, `corne.conf` and `corne.keymap` will apply to both `corne_left` and `corne_right`. If a shared config file exists, any left or right files will be ignored.
 
 ### Board Folder
 
@@ -38,8 +38,11 @@ ZMK will search for config files in either of:
 ZMK will search the board folder for the following config files:
 
 - `<board>_defconfig` (Kconfig)
+- `<board>.conf` (Kconfig)
 - `<board>.dts` (Devicetree)
-- `<board>.keymap` (Devictree, standalone boards only)
+- `<board>.keymap` (Devicetree, keyboards with onboard controllers only)
+
+Shared config files (excluding any `_left` or `_right` suffix) are not currently supported in board folders.
 
 For more documentation on creating and configuring a new board, see [Zephyr's board porting guide](https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html#write-kconfig-files).
 
@@ -58,6 +61,8 @@ ZMK will search the shield folder for the following config files:
 - `<shield>.overlay` (Devicetree)
 - `<shield>.keymap` (Devicetree)
 
+Shared config files (excluding any `_left` or `_right` suffix) are not currently supported in shield folders.
+
 For more documentation on creating and configuring a new shield, see [Zephyr's shield documentation](https://docs.zephyrproject.org/latest/hardware/porting/shields.html) and [ZMK's new keyboard shield](../development/new-shield.md) guide.
 
 ## Kconfig Files
@@ -72,7 +77,7 @@ CONFIG_EC11=y
 CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
 ```
 
-The list of available settings is determined by various files in ZMK whose names start with `Kconfig`. Note that options are _not_ prefixed with `CONFIG_` in these files.
+The list of available settings is determined by various files in ZMK whose names start with `Kconfig`. Files ending with `_defconfig` use the same syntax, but are intended for setting configuration specific to the hardware which users typically won't need to change. Note that options are _not_ prefixed with `CONFIG_` in these files.
 
 See [Zephyr's Kconfig documentation](https://docs.zephyrproject.org/latest/build/kconfig/index.html) for more details on Kconfig files.
 
@@ -98,7 +103,14 @@ Example: `CONFIG_FOO="foo"`
 
 ## Devicetree Files
 
-Various Devicetree files are combined to build a tree that describes the hardware for a keyboard. They are also used to define keymaps. Common file extensions for Devicetree files are `.dts`, `.dtsi`, `.overlay`, and `.keymap`.
+Various Devicetree files are combined to build a tree that describes the hardware for a keyboard. They are also used to define keymaps.
+
+Devicetree files use various file extensions. These indicate the purpose of the file, but they have no effect on how the file is processed. Common file extensions for Devicetree files include:
+
+- `.dts`: The base hardware definition.
+- `.overlay`: Adds to and/or overrides definitions in a `.dts` file.
+- `.keymap`: Holds a keymap and user-specific hardware configuration.
+- `.dtsi`: A file which is only intended to be `#include`d from another file.
 
 Devicetree files look like this:
 

--- a/docs/docs/config/index.md
+++ b/docs/docs/config/index.md
@@ -3,7 +3,7 @@ title: Configuration Overview
 sidebar_label: Overview
 ---
 
-ZMK has several configuration settings that can be changed to change the behavior of your keyboard. They are set in either Kconfig or Devicetree files.
+ZMK has many configuration settings that can be changed to change the behavior of your keyboard. They are set in either Kconfig or Devicetree files.
 
 This page describes the Kconfig and Devicetree file formats and how to change settings in them. See the other pages in the configuration section for a list of settings you can change.
 
@@ -41,7 +41,7 @@ ZMK will search the board folder for the following config files:
 - `<board>.dts` (Devicetree)
 - `<board>.keymap` (Devictree, standalone boards only)
 
-For more documentation on creating and configuring a new board, see [Zephyr's board porting guide](https://docs.zephyrproject.org/latest/guides/porting/board_porting.html#write-kconfig-files).
+For more documentation on creating and configuring a new board, see [Zephyr's board porting guide](https://docs.zephyrproject.org/latest/hardware/porting/board_porting.html#write-kconfig-files).
 
 ### Shield Folder
 
@@ -74,7 +74,7 @@ CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
 
 The list of available settings is determined by various files in ZMK whose names start with `Kconfig`. Note that options are _not_ prefixed with `CONFIG_` in these files.
 
-See [Zephyr's Kconfig documentation](https://docs.zephyrproject.org/latest/guides/kconfig/index.html) for more details on Kconfig files.
+See [Zephyr's Kconfig documentation](https://docs.zephyrproject.org/latest/build/kconfig/index.html) for more details on Kconfig files.
 
 ### KConfig Value Types
 
@@ -117,7 +117,7 @@ Devicetree files look like this:
 
 Devicetree properties apply to specific nodes in the tree instead of globally. The properties that can be set for each node are determined by `.yaml` files in ZMK in the various `dts/bindings` folders.
 
-See [Zephyr's Devicetree guide](https://docs.zephyrproject.org/latest/guides/dts/index.html) for more details on Devicetree files.
+See [Zephyr's Devicetree guide](https://docs.zephyrproject.org/latest/build/dts/index.html) for more details on Devicetree files.
 
 ### Changing Devicetree Properties
 
@@ -138,7 +138,7 @@ The part before the colon, `kscan0`, is a label. This is optional, and it provid
 The `compatible` property indicates what type of node it is. Search this documentation for the text inside the quotes to see which properties the node
 supports. You can also search ZMK for a file whose name is the value of the `compatible` property with a `.yaml` file extension.
 
-To set a property, see below for examples for common property types, or see [Zephyr's Devicetree documentation](https://docs.zephyrproject.org/latest/guides/dts/intro.html#writing-property-values) for more details on the syntax for properties.
+To set a property, see below for examples for common property types, or see [Zephyr's Devicetree documentation](https://docs.zephyrproject.org/latest/build/dts/intro.html#writing-property-values) for more details on the syntax for properties.
 
 To change a property for an existing node, first find the node you want to change and find its label. Next, outside of any other node, write an ampersand (`&`)
 followed by the node's label, an opening curly brace (`{`), one or more new property values, a closing curly brace (`}`), and a semicolon (`;`).
@@ -147,13 +147,23 @@ For example, to adjust the debouncing of the `zmk,kscan-gpio-matrix` node shown 
 
 ```devicetree
 &kscan0 {
-    debounce-period = <7>;
+    debounce-press-ms = <0>;
+};
+```
+
+If the node you want to edit doesn't have a label, you can also write a new tree and it will be merged with the existing tree, overriding any properties. Adding this to your keymap would be equivalent to the previous example.
+
+```devicetree
+/ {
+	kscan {
+		debounce-press-ms = <0>;
+	};
 };
 ```
 
 ### Devicetree Property Types
 
-These are some of the property types you will see most often when working with ZMK. [Zephyr's Devicetree bindings documentation](https://docs.zephyrproject.org/latest/guides/dts/bindings.html) provides more detailed information and a full list of types.
+These are some of the property types you will see most often when working with ZMK. [Zephyr's Devicetree bindings documentation](https://docs.zephyrproject.org/latest/build/dts/bindings.html) provides more detailed information and a full list of types.
 
 #### bool
 
@@ -207,14 +217,14 @@ Example: `property = <&none &mo 1>;`
 
 Values can also be split into multiple blocks, e.g. `property = <&none>, <&mo 1>;`
 
-See the documentation for "phandle-array" in [Zephyr's Devicetree bindings documentation](https://docs.zephyrproject.org/latest/guides/dts/bindings.html)
+See the documentation for "phandle-array" in [Zephyr's Devicetree bindings documentation](https://docs.zephyrproject.org/latest/build/dts/bindings.html)
 for more details on how parameters are associated with nodes.
 
 #### GPIO array
 
 This is just a phandle array. The documentation lists this as a different type to make it clear which properties expect an array of GPIOs.
 
-Each item in the array should be a label for a GPIO node (the names of which differ between hardware platforms) followed by an index and configuration flags. See [Zephyr's GPIO documentation](https://docs.zephyrproject.org/latest/reference/peripherals/gpio.html) for a full list of flags.
+Each item in the array should be a label for a GPIO node (the names of which differ between hardware platforms) followed by an index and configuration flags. See [Zephyr's GPIO documentation](https://docs.zephyrproject.org/latest/hardware/peripherals/gpio.html) for a full list of flags.
 
 Example:
 

--- a/docs/docs/config/index.md
+++ b/docs/docs/config/index.md
@@ -72,7 +72,7 @@ CONFIG_EC11=y
 CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
 ```
 
-The list of available settings is determined by various files in ZMK whose names start with `Kconfig`.
+The list of available settings is determined by various files in ZMK whose names start with `Kconfig`. Note that options are _not_ prefixed with `CONFIG_` in these files.
 
 See [Zephyr's Kconfig documentation](https://docs.zephyrproject.org/latest/guides/kconfig/index.html) for more details on Kconfig files.
 

--- a/docs/docs/config/keymap.md
+++ b/docs/docs/config/keymap.md
@@ -3,7 +3,7 @@ title: Keymap Configuration
 sidebar_label: Keymap
 ---
 
-See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+See [Configuration Overview](index.md) for instructions on how to change these settings.
 
 ## Keymap
 
@@ -20,10 +20,10 @@ Each child node can have the following properties:
 | Property          | Type          | Description                                                            |
 | ----------------- | ------------- | ---------------------------------------------------------------------- |
 | `label`           | string        | Unique label for the node                                              |
-| `bindings`        | phandle-array | List of [key behaviors](/docs/features/keymaps#behaviors), one per key |
+| `bindings`        | phandle-array | List of [key behaviors](../features/keymaps.md#behaviors), one per key |
 | `sensor-bindings` | phandle-array | List of sensor behaviors, one per sensor                               |
 
-Items for `bindings` must be listed in the order the keys are defined in the [keyboard scan configuration](/docs/config/kscan).
+Items for `bindings` must be listed in the order the keys are defined in the [keyboard scan configuration](kscan.md).
 
 Items for `sensor-bindings` must be listed in the order the [sensors](#keymap-sensors) are defined.
 
@@ -39,4 +39,4 @@ Applies to: `compatible = "zmk,keymap-sensors"`
 
 The following types of nodes can be used as a sensor:
 
-- [`alps,ec11`](/docs/config/encoders#ec11-encoders)
+- [`alps,ec11`](encoders.md#ec11-encoders)

--- a/docs/docs/config/keymap.md
+++ b/docs/docs/config/keymap.md
@@ -1,0 +1,42 @@
+---
+title: Keymap Configuration
+sidebar_label: Keymap
+---
+
+See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+
+## Keymap
+
+### Devicetree
+
+Applies to: `compatible = "zmk,keymap"`
+
+Definition file: [zmk/app/dts/bindings/zmk,keymap.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk%2Ckeymap.yaml)
+
+The `zmk,keymap` node itself has no properties. It should have one child node per layer of the keymap, starting with the default layer (layer 0).
+
+Each child node can have the following properties:
+
+| Property          | Type          | Description                                                            |
+| ----------------- | ------------- | ---------------------------------------------------------------------- |
+| `label`           | string        | Unique label for the node                                              |
+| `bindings`        | phandle-array | List of [key behaviors](/docs/features/keymaps#behaviors), one per key |
+| `sensor-bindings` | phandle-array | List of sensor behaviors, one per sensor                               |
+
+Items for `bindings` must be listed in the order the keys are defined in the [keyboard scan configuration](/docs/config/kscan).
+
+Items for `sensor-bindings` must be listed in the order the [sensors](#keymap-sensors) are defined.
+
+## Keymap Sensors
+
+### Devicetree
+
+Applies to: `compatible = "zmk,keymap-sensors"`
+
+| Property  | Type     | Description          |
+| --------- | -------- | -------------------- |
+| `sensors` | phandles | List of sensor nodes |
+
+The following types of nodes can be used as a sensor:
+
+- [`alps,ec11`](/docs/config/encoders#ec11-encoders)

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -281,7 +281,70 @@ Definition file: [zmk/app/dts/bindings/zmk,matrix-transform.yaml](https://github
 
 The `map` array should be defined using the `RC()` macro from [dt-bindings/zmk/matrix_transform.h](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/matrix_transform.h). It should have one item per logical position in the keymap. Each item should list the physical row and column that should trigger the key in that position.
 
-### Example Configuration
+### Example: Skipping Unused Positions
+
+Any keyboard which is not a grid of 1 unit keys will likely have some unused positions in the matrix. A matrix transform can be used to skip the unused positions so users don't have to set them to `&none` in keymaps.
+
+```devicetree
+// numpad.overlay
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        rows = <5>;
+        columns = <4>;
+        // define the matrix...
+    };
+
+    default_transform: matrix_transform {
+        compatible = "zmk,matrix-transform";
+        rows = <5>;
+        columns = <4>;
+        // ┌───┬───┬───┬───┐
+        // │NUM│ / │ * │ - │
+        // ├───┼───┼───┼───┤
+        // │ 7 │ 8 │ 9 │ + │
+        // ├───┼───┼───┤   │
+        // │ 4 │ 5 │ 6 │   │
+        // ├───┼───┼───┼───┤
+        // │ 1 │ 2 │ 3 │RET│
+        // ├───┴───┼───┤   │
+        // │ 0     │ . │   │
+        // └───────┴───┴───┘
+        map = <
+            RC(0,0) RC(0,1) RC(0,2) RC(0,3)
+            RC(1,0) RC(1,1) RC(1,2) RC(1,3)
+            RC(2,0) RC(2,1) RC(2,2)
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3)
+            RC(4,0)         RC(4,1)
+        >;
+    };
+};
+```
+
+```devicetree
+// numpad.keymap
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+        default {
+            bindings = <
+                &kp KP_NUM &kp KP_DIV &kp KP_MULT &kp KP_MINUS
+                &kp KP_N7  &kp KP_N8  &kp KP_N9   &kp KP_PLUS
+                &kp KP_N4  &kp KP_N5  &kp KP_N6
+                &kp KP_N1  &kp KP_N2  &kp KP_N3   &kp KP_ENTER
+                &kp KP_N0             &kp KP_DOT
+            >;
+        };
+    }
+};
+```
+
+### Example: Non-standard Matrix
 
 Consider a keyboard with a [duplex matrix](https://wiki.ai03.com/books/pcb-design/page/matrices-and-duplex-matrix), where the matrix has twice as many rows and half as many columns as the keyboard has keys. A matrix transform can be used to correct for this so that keymaps can match the layout of the keys, not the layout of the matrix.
 

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -3,7 +3,7 @@ title: Keyboard Scan Configuration
 sidebar_label: Keyboard Scan
 ---
 
-See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+See [Configuration Overview](index.md) for instructions on how to change these settings.
 
 ## Common
 
@@ -250,7 +250,7 @@ Transforms should be used any time the physical layout of a keyboard's keys does
 
 Transforms can also be used for keyboards with multiple layouts. You can define multiple matrix transform nodes, one for each layout, and users can select which one they want from the `/chosen` node in their keymaps.
 
-See the [new shield guide](/docs/development/new-shield/#optional-matrix-transform) for more documentation on how to define a matrix transform.
+See the [new shield guide](../development/new-shield.md#optional-matrix-transform) for more documentation on how to define a matrix transform.
 
 ### Devicetree
 

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -14,11 +14,14 @@ Definition files:
 - [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
 - [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/kscan/Kconfig)
 
-| Config                              | Type | Description                                            | Default |
-| ----------------------------------- | ---- | ------------------------------------------------------ | ------- |
-| `CONFIG_ZMK_KSCAN_GPIO_DRIVER`      | bool | Enable GPIO keyboard scan driver to detect key presses | y       |
-| `CONFIG_ZMK_KSCAN_EVENT_QUEUE_SIZE` | int  | Size of the event queue for kscan events               | 4       |
-| `CONFIG_ZMK_KSCAN_INIT_PRIORITY`    | int  | Keyboard scan device driver initialization priority    | 40      |
+| Config                                 | Type | Description                                          | Default |
+| -------------------------------------- | ---- | ---------------------------------------------------- | ------- |
+| `CONFIG_ZMK_KSCAN_EVENT_QUEUE_SIZE`    | int  | Size of the event queue for kscan events             | 4       |
+| `CONFIG_ZMK_KSCAN_INIT_PRIORITY`       | int  | Keyboard scan device driver initialization priority  | 40      |
+| `CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS`   | int  | Global debounce time for key press in milliseconds   | -1      |
+| `CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS` | int  | Global debounce time for key release in milliseconds | -1      |
+
+If the debounce press/release values are set to any value other than `-1`, they override the `debounce-press-ms` and `debounce-release-ms` devicetree properties for all keyboard scan drivers which support them.
 
 ### Devicetree
 
@@ -87,13 +90,16 @@ Applies to: `compatible = "zmk,kscan-gpio-matrix"`
 
 Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-matrix.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/kscan/zmk%2Ckscan-gpio-matrix.yaml)
 
-| Property          | Type       | Description                                                  | Default     |
-| ----------------- | ---------- | ------------------------------------------------------------ | ----------- |
-| `label`           | string     | Unique label for the node                                    |             |
-| `row-gpios`       | GPIO array | Matrix row GPIOs in order, starting from the top row         |             |
-| `col-gpios`       | GPIO array | Matrix column GPIOs in order, starting from the leftmost row |             |
-| `debounce-period` | int        | Debounce period in milliseconds                              | 5           |
-| `diode-direction` | string     | The direction of the matrix diodes                           | `"row2col"` |
+| Property                  | Type       | Description                                                                                        | Default     |
+| ------------------------- | ---------- | -------------------------------------------------------------------------------------------------- | ----------- |
+| `label`                   | string     | Unique label for the node                                                                          |             |
+| `row-gpios`               | GPIO array | Matrix row GPIOs in order, starting from the top row                                               |             |
+| `col-gpios`               | GPIO array | Matrix column GPIOs in order, starting from the leftmost row                                       |             |
+| `debounce-press-ms`       | int        | Debounce time for key press in milliseconds. Use 0 for eager debouncing.                           | 5           |
+| `debounce-release-ms`     | int        | Debounce time for key release in milliseconds.                                                     | 5           |
+| `debounce-scan-period-ms` | int        | Time between reads in milliseconds when any key is pressed.                                        | 1           |
+| `diode-direction`         | string     | The direction of the matrix diodes                                                                 | `"row2col"` |
+| `poll-period-ms`          | int        | Time between reads in milliseconds when no key is pressed and ZMK_KSCAN_MATRIX_POLLING is enabled. | 10          |
 
 The `diode-direction` property must be one of:
 
@@ -105,14 +111,6 @@ The `diode-direction` property must be one of:
 ## Composite Driver
 
 Keyboard scan driver which combines multiple other keyboard scan drivers.
-
-### Kconfig
-
-Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
-
-| Config                              | Type | Description                   | Default |
-| ----------------------------------- | ---- | ----------------------------- | ------- |
-| `CONFIG_ZMK_KSCAN_COMPOSITE_DRIVER` | bool | Enable composite kscan driver | n       |
 
 ### Devicetree
 
@@ -226,14 +224,6 @@ One possible way to do this is a 3x4 matrix where the direct GPIO keys are shift
 ## Mock Driver
 
 Mock keyboard scan driver that simulates key events.
-
-### Kconfig
-
-Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
-
-| Config                         | Type | Description              | Default |
-| ------------------------------ | ---- | ------------------------ | ------- |
-| `CONFIG_ZMK_KSCAN_MOCK_DRIVER` | bool | Enable mock kscan driver | n       |
 
 ### Devicetree
 

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -58,10 +58,6 @@ Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-demux
 
 Keyboard scan driver where each key has a dedicated GPIO.
 
-:::note
-Currently this driver does not honor the `CONFIG_ZMK_KSCAN_DEBOUNCE_*` settings.
-:::
-
 ### Kconfig
 
 Definition file: [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/kscan/Kconfig)
@@ -76,11 +72,20 @@ Applies to: `compatible = "zmk,kscan-gpio-direct"`
 
 Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-direct.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/kscan/zmk%2Ckscan-gpio-direct.yaml)
 
-| Property          | Type       | Description                     | Default |
-| ----------------- | ---------- | ------------------------------- | ------- |
-| `label`           | string     | Unique label for the node       |         |
-| `input-gpios`     | GPIO array | Input GPIOs (one per key)       |         |
-| `debounce-period` | int        | Debounce period in milliseconds | 5       |
+| Property                  | Type       | Description                                                                                                 | Default     |
+| ------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- | ----------- |
+| `label`                   | string     | Unique label for the node                                                                                   |             |
+| `input-gpios`             | GPIO array | Input GPIOs (one per key)                                                                                   |             |
+| `debounce-press-ms`       | int        | Debounce time for key press in milliseconds. Use 0 for eager debouncing.                                    | 5           |
+| `debounce-release-ms`     | int        | Debounce time for key release in milliseconds.                                                              | 5           |
+| `debounce-scan-period-ms` | int        | Time between reads in milliseconds when any key is pressed.                                                 | 1           |
+| `diode-direction`         | string     | The direction of the matrix diodes                                                                          | `"row2col"` |
+| `poll-period-ms`          | int        | Time between reads in milliseconds when no key is pressed and `CONFIG_ZMK_KSCAN_DIRECT_POLLING` is enabled. | 10          |
+| `toggle-mode`             | bool       | Use toggle switch mode.                                                                                     | n           |
+
+By default, a switch will drain current through the internal pull up/down resistor whenever it is pressed. This is not ideal for a toggle switch, where the switch may be left in the "pressed" state for a long time. Enabling `toggle-mode` will make the driver flip between pull up and down as the switch is toggled to optimize for power.
+
+`toggle-mode` applies to all switches handled by the instance of the driver. To use a toggle switch with other, non-toggle, direct GPIO switches, create two instances of the direct GPIO driver, one with `toggle-mode` and the other without. Then, use a [composite driver](#composite-driver) to combine them.
 
 ## Matrix Driver
 
@@ -98,16 +103,16 @@ Applies to: `compatible = "zmk,kscan-gpio-matrix"`
 
 Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-matrix.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/kscan/zmk%2Ckscan-gpio-matrix.yaml)
 
-| Property                  | Type       | Description                                                                                        | Default     |
-| ------------------------- | ---------- | -------------------------------------------------------------------------------------------------- | ----------- |
-| `label`                   | string     | Unique label for the node                                                                          |             |
-| `row-gpios`               | GPIO array | Matrix row GPIOs in order, starting from the top row                                               |             |
-| `col-gpios`               | GPIO array | Matrix column GPIOs in order, starting from the leftmost row                                       |             |
-| `debounce-press-ms`       | int        | Debounce time for key press in milliseconds. Use 0 for eager debouncing.                           | 5           |
-| `debounce-release-ms`     | int        | Debounce time for key release in milliseconds.                                                     | 5           |
-| `debounce-scan-period-ms` | int        | Time between reads in milliseconds when any key is pressed.                                        | 1           |
-| `diode-direction`         | string     | The direction of the matrix diodes                                                                 | `"row2col"` |
-| `poll-period-ms`          | int        | Time between reads in milliseconds when no key is pressed and ZMK_KSCAN_MATRIX_POLLING is enabled. | 10          |
+| Property                  | Type       | Description                                                                                                 | Default     |
+| ------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- | ----------- |
+| `label`                   | string     | Unique label for the node                                                                                   |             |
+| `row-gpios`               | GPIO array | Matrix row GPIOs in order, starting from the top row                                                        |             |
+| `col-gpios`               | GPIO array | Matrix column GPIOs in order, starting from the leftmost row                                                |             |
+| `debounce-press-ms`       | int        | Debounce time for key press in milliseconds. Use 0 for eager debouncing.                                    | 5           |
+| `debounce-release-ms`     | int        | Debounce time for key release in milliseconds.                                                              | 5           |
+| `debounce-scan-period-ms` | int        | Time between reads in milliseconds when any key is pressed.                                                 | 1           |
+| `diode-direction`         | string     | The direction of the matrix diodes                                                                          | `"row2col"` |
+| `poll-period-ms`          | int        | Time between reads in milliseconds when no key is pressed and `CONFIG_ZMK_KSCAN_MATRIX_POLLING` is enabled. | 10          |
 
 The `diode-direction` property must be one of:
 
@@ -213,7 +218,7 @@ One possible way to do this is a 3x4 matrix where the direct GPIO keys are shift
         // Include the direct GPIO driver...
         direct {
             kscan = <&kscan2>;
-            row-offset = <3>; // ..and shift it to not overlap
+            row-offset = <3>; // ...and shift it to not overlap
         };
     };
 

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -21,7 +21,7 @@ Definition files:
 | `CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS`   | int  | Global debounce time for key press in milliseconds   | -1      |
 | `CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS` | int  | Global debounce time for key release in milliseconds | -1      |
 
-If the debounce press/release values are set to any value other than `-1`, they override the `debounce-press-ms` and `debounce-release-ms` devicetree properties for all keyboard scan drivers which support them.
+If the debounce press/release values are set to any value other than `-1`, they override the `debounce-press-ms` and `debounce-release-ms` devicetree properties for all keyboard scan drivers which support them. See the [debouncing documentation](../features/debouncing.md) for more details.
 
 ### Devicetree
 
@@ -35,6 +35,10 @@ Applies to: [`/chosen` node](https://docs.zephyrproject.org/latest/guides/dts/in
 ## Demux Driver
 
 Keyboard scan driver which works like a regular matrix but uses a demultiplexer to drive the rows or columns. This allows N GPIOs to drive N<sup>2</sup> rows or columns instead of just N like with a regular matrix.
+
+:::note
+Currently this driver does not honor the `CONFIG_ZMK_KSCAN_DEBOUNCE_*` settings.
+:::
 
 ### Devicetree
 
@@ -53,6 +57,10 @@ Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-demux
 ## Direct GPIO Driver
 
 Keyboard scan driver where each key has a dedicated GPIO.
+
+:::note
+Currently this driver does not honor the `CONFIG_ZMK_KSCAN_DEBOUNCE_*` settings.
+:::
 
 ### Kconfig
 

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -1,0 +1,319 @@
+---
+title: Keyboard Scan Configuration
+sidebar_label: Keyboard Scan
+---
+
+See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+
+## Common
+
+### Kconfig
+
+Definition files:
+
+- [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+- [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/kscan/Kconfig)
+
+| Config                              | Type | Description                                            | Default |
+| ----------------------------------- | ---- | ------------------------------------------------------ | ------- |
+| `CONFIG_ZMK_KSCAN_GPIO_DRIVER`      | bool | Enable GPIO keyboard scan driver to detect key presses | y       |
+| `CONFIG_ZMK_KSCAN_EVENT_QUEUE_SIZE` | int  | Size of the event queue for kscan events               | 4       |
+| `CONFIG_ZMK_KSCAN_INIT_PRIORITY`    | int  | Keyboard scan device driver initialization priority    | 40      |
+
+### Devicetree
+
+Applies to: [`/chosen` node](https://docs.zephyrproject.org/latest/guides/dts/intro.html#aliases-and-chosen-nodes)
+
+| Property               | Type | Description                                                   |
+| ---------------------- | ---- | ------------------------------------------------------------- |
+| `zmk,kscan`            | path | The node for the keyboard scan driver to use                  |
+| `zmk,matrix_transform` | path | The node for the [matrix transform](#matrix-transform) to use |
+
+## Demux Driver
+
+Keyboard scan driver which works like a regular matrix but uses a demultiplexer to drive the rows or columns. This allows N GPIOs to drive N<sup>2</sup> rows or columns instead of just N like with a regular matrix.
+
+### Devicetree
+
+Applies to: `compatible = "zmk,kscan-gpio-demux"`
+
+Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-demux.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/kscan/zmk%2Ckscan-gpio-demux.yaml)
+
+| Property                | Type       | Description                      | Default |
+| ----------------------- | ---------- | -------------------------------- | ------- |
+| `label`                 | string     | Unique label for the node        |         |
+| `input-gpios`           | GPIO array | Input GPIOs                      |         |
+| `output-gpios`          | GPIO array | Demultiplexer address GPIOs      |         |
+| `debounce-period`       | int        | Debounce period in milliseconds  | 5       |
+| `polling-interval-msec` | int        | Polling interval in milliseconds | 25      |
+
+## Direct GPIO Driver
+
+Keyboard scan driver where each key has a dedicated GPIO.
+
+### Kconfig
+
+Definition file: [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/kscan/Kconfig)
+
+| Config                            | Type | Description                                      | Default |
+| --------------------------------- | ---- | ------------------------------------------------ | ------- |
+| `CONFIG_ZMK_KSCAN_DIRECT_POLLING` | bool | Poll for key presses instead of using interrupts | n       |
+
+### Devicetree
+
+Applies to: `compatible = "zmk,kscan-gpio-direct"`
+
+Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-direct.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/kscan/zmk%2Ckscan-gpio-direct.yaml)
+
+| Property          | Type       | Description                     | Default |
+| ----------------- | ---------- | ------------------------------- | ------- |
+| `label`           | string     | Unique label for the node       |         |
+| `input-gpios`     | GPIO array | Input GPIOs (one per key)       |         |
+| `debounce-period` | int        | Debounce period in milliseconds | 5       |
+
+## Matrix Driver
+
+Keyboard scan driver where keys are arranged on a matrix with one GPIO per row and column.
+
+Definition file: [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/kscan/Kconfig)
+
+| Config                            | Type | Description                                      | Default |
+| --------------------------------- | ---- | ------------------------------------------------ | ------- |
+| `CONFIG_ZMK_KSCAN_MATRIX_POLLING` | bool | Poll for key presses instead of using interrupts | n       |
+
+### Devicetree
+
+Applies to: `compatible = "zmk,kscan-gpio-matrix"`
+
+Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-matrix.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/kscan/zmk%2Ckscan-gpio-matrix.yaml)
+
+| Property          | Type       | Description                                                  | Default     |
+| ----------------- | ---------- | ------------------------------------------------------------ | ----------- |
+| `label`           | string     | Unique label for the node                                    |             |
+| `row-gpios`       | GPIO array | Matrix row GPIOs in order, starting from the top row         |             |
+| `col-gpios`       | GPIO array | Matrix column GPIOs in order, starting from the leftmost row |             |
+| `debounce-period` | int        | Debounce period in milliseconds                              | 5           |
+| `diode-direction` | string     | The direction of the matrix diodes                           | `"row2col"` |
+
+The `diode-direction` property must be one of:
+
+| Value       | Description                                                           |
+| ----------- | --------------------------------------------------------------------- |
+| `"row2col"` | Diodes point from rows to columns (cathodes are connected to columns) |
+| `"col2row"` | Diodes point from columns to rows (cathodes are connected to rows)    |
+
+## Composite Driver
+
+Keyboard scan driver which combines multiple other keyboard scan drivers.
+
+### Kconfig
+
+Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+
+| Config                              | Type | Description                   | Default |
+| ----------------------------------- | ---- | ----------------------------- | ------- |
+| `CONFIG_ZMK_KSCAN_COMPOSITE_DRIVER` | bool | Enable composite kscan driver | n       |
+
+### Devicetree
+
+Applies to : `compatible = "zmk,kscan-composite"`
+
+Definition file: [zmk/app/dts/bindings/zmk,kscan-composite.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk,kscan-composite.yaml)
+
+| Property | Type   | Description                                   | Default |
+| -------- | ------ | --------------------------------------------- | ------- |
+| `label`  | string | Unique label for the node                     |         |
+| `rows`   | int    | The number rows of in the composite matrix    |         |
+| `cols`   | int    | The number columns of in the composite matrix |         |
+
+The `zmk,kscan-composite` node should have one child node per keyboard scan driver that should be composited. Each child node can have the following properties:
+
+| Property        | Type    | Description                                                                    | Default |
+| --------------- | ------- | ------------------------------------------------------------------------------ | ------- |
+| `label`         | string  | Unique label for the node                                                      |         |
+| `kscan`         | phandle | Label of the kscan driver to include                                           |         |
+| `row-offset`    | int     | Shifts row 0 of the included driver to a new row in the composite matrix       | 0       |
+| `column-offset` | int     | Shifts column 0 of the included driver to a new column in the composite matrix | 0       |
+
+### Example Configuration
+
+For example, consider a macropad with a 3x3 matrix and two direct GPIO keys:
+
+<div style={{columns: 2, marginBottom: '1em'}}>
+<div style={{breakInside: 'avoid'}}>
+Matrix:
+
+<table>
+    <thead>
+        <tr><th></th><th>Col 0</th><th>Col 1</th><th>Col 2</th></tr>
+    </thead>
+    <tbody>
+        <tr><th>Row 0</th><td>A0</td><td>A1</td><td>A2</td></tr>
+        <tr><th>Row 1</th><td>A3</td><td>A4</td><td>A5</td></tr>
+        <tr><th>Row 2</th><td>A6</td><td>A7</td><td>A8</td></tr>
+    </tbody>
+</table>
+</div>
+
+<div style={{breakInside: 'avoid'}}>
+Direct GPIO:
+
+<table>
+    <thead>
+        <tr><th></th><th>Col 0</th><th>Col 1</th></tr>
+    </thead>
+    <tbody>
+        <tr><th>Row 0</th><td>B0</td><td>B1</td></tr>
+    </tbody>
+</table>
+</div>
+</div>
+
+To combine them, we need to create a composite matrix with enough rows and columns to fit both sets of keys without overlapping, then set row and/or columns offsets to shift them so they do not overlap.
+
+One possible way to do this is a 3x4 matrix where the direct GPIO keys are shifted to below the matrix keys...
+
+<table>
+    <thead>
+        <tr><th></th><th>Col 0</th><th>Col 1</th><th>Col 2</th></tr>
+    </thead>
+    <tbody>
+        <tr><th>Row 0</th><td>A0</td><td>A1</td><td>A2</td></tr>
+        <tr><th>Row 1</th><td>A3</td><td>A4</td><td>A5</td></tr>
+        <tr><th>Row 2</th><td>A6</td><td>A7</td><td>A8</td></tr>
+        <tr><th>Row 3</th><td>B0</td><td>B1</td><td>(none)</td></tr>
+    </tbody>
+</table>
+
+...which can be configured with the following Devicetree code:
+
+```devicetree
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+    };
+
+    kscan0: kscan_composite {
+        compatible = "zmk,kscan-composite";
+        label = "KSCAN0";
+        rows = <3>;
+        columns = <4>;
+
+        // Include the matrix driver
+        matrix {
+            kscan = <&kscan1>;
+        };
+
+        // Include the direct GPIO driver...
+        direct {
+            kscan = <&kscan2>;
+            row-offset = <3>; // ..and shift it to not overlap
+        };
+    };
+
+    kscan1: kscan_matrix {
+        compatible = "zmk,kscan-gpio-matrix";
+        // define 3x3 matrix here...
+    };
+
+    kscan2: kscan_direct {
+        compatible = "zmk,kscan-gpio-direct";
+        // define 2 direct GPIOs here...
+    };
+}
+```
+
+## Mock Driver
+
+Mock keyboard scan driver that simulates key events.
+
+### Kconfig
+
+Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+
+| Config                         | Type | Description              | Default |
+| ------------------------------ | ---- | ------------------------ | ------- |
+| `CONFIG_ZMK_KSCAN_MOCK_DRIVER` | bool | Enable mock kscan driver | n       |
+
+### Devicetree
+
+Applies to: `compatible = "zmk,kscan-mock"`
+
+Definition file: [zmk/app/dts/bindings/zmk,kscan-mock.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk%2Ckscan-mock.yaml)
+
+| Property       | Type   | Description                                   | Default |
+| -------------- | ------ | --------------------------------------------- | ------- |
+| `label`        | string | Unique label for the node                     |         |
+| `event-period` | int    | Milliseconds between each generated event     |         |
+| `events`       | array  | List of key events to simulate                |         |
+| `rows`         | int    | The number rows of in the composite matrix    |         |
+| `cols`         | int    | The number columns of in the composite matrix |         |
+| `exit-after`   | bool   | Exit the program after running all events     | false   |
+
+The `events` array should be defined using the macros from [dt-bindings/zmk/kscan_mock.h](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/kscan_mock.h).
+
+## Matrix Transform
+
+Defines a mapping from keymap logical positions to physical matrix positions.
+
+Transforms should be used any time the physical layout of a keyboard's keys does not match the layout of its electrical matrix and/or when not all positions in the matrix are used. This applies to most non-ortholinear boards.
+
+Transforms can also be used for keyboards with multiple layouts. You can define multiple matrix transform nodes, one for each layout, and users can select which one they want from the `/chosen` node in their keymaps.
+
+See the [new shield guide](/docs/development/new-shield/#optional-matrix-transform) for more documentation on how to define a matrix transform.
+
+### Devicetree
+
+Applies to: `compatible = "zmk,matrix-transform"`
+
+Definition file: [zmk/app/dts/bindings/zmk,matrix-transform.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk%2Cmatrix-transform.yaml)
+
+| Property     | Type  | Description                                                           | Default |
+| ------------ | ----- | --------------------------------------------------------------------- | ------- |
+| `rows`       | int   | Number of rows in the transformed matrix                              |         |
+| `columns`    | int   | Number of columns in the transformed matrix                           |         |
+| `row-offset` | int   | Adds an offset to all rows before looking them up in the transform    | 0       |
+| `col-offset` | int   | Adds an offset to all columns before looking them up in the transform | 0       |
+| `map`        | array | A list of position transforms                                         |         |
+
+The `map` array should be defined using the `RC()` macro from [dt-bindings/zmk/matrix_transform.h](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/matrix_transform.h). It should have one item per logical position in the keymap. Each item should list the physical row and column that should trigger the key in that position.
+
+### Example Configuration
+
+Consider a keyboard with a [duplex matrix](https://wiki.ai03.com/books/pcb-design/page/matrices-and-duplex-matrix), where the matrix has twice as many rows and half as many columns as the keyboard has keys. A matrix transform can be used to correct for this so that keymaps can match the layout of the keys, not the layout of the matrix.
+
+```devicetree
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        rows = <12>;
+        columns = <8>;
+        // define the matrix...
+    };
+
+    default_transform: matrix_transform {
+        compatible = "zmk,matrix-transform";
+        rows = <6>;
+        columns = <16>;
+        // ESC F1 F2 F3   ...
+        // `   1  2  3    ...
+        // Tab  Q  W  E   ...
+        // Caps  A  S  D  ...
+        // Shift  Z  X  C ...
+        // Ctrl Alt       ...
+        map = <
+            RC(0,0) RC(1,0) RC(0,1) RC(1,1)      // ...
+            RC(2,0) RC(3,0) RC(2,1) RC(3,1)      // ...
+            RC(4,0)   RC(5,0) RC(4,1) RC(5,1)    // ...
+            RC(6,0)      RC(7,0) RC(6,1) RC(7,1) // ...
+            RC(8,0)         RC(8,1) RC(9,1)      // ...
+            RC(10,0) RC(11,0)                    // ...
+        >;
+    };
+};
+```

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -3,7 +3,7 @@ title: Power Management Configuration
 sidebar_label: Power Management
 ---
 
-See [Configuration Overview](/docs/config/index) for instructions on how to
+See [Configuration Overview](index.md) for instructions on how to
 change these settings.
 
 ## Idle/Sleep
@@ -26,7 +26,7 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 
 ## External Power Control
 
-Driver for enabling or disabling power to peripherals such as displays and lighting. This driver must be configured to use [power management behaviors](/docs/behaviors/power).
+Driver for enabling or disabling power to peripherals such as displays and lighting. This driver must be configured to use [power management behaviors](../behaviors/power.md).
 
 ### Kconfig
 

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -1,0 +1,65 @@
+---
+title: Power Management Configuration
+sidebar_label: Power Management
+---
+
+See [Configuration Overview](/docs/config/index) for instructions on how to
+change these settings.
+
+## Idle/Sleep
+
+Configuration for entering low power modes when the keyboard is idle.
+
+In the idle state, peripherals such as displays and lighting are disabled, but the keyboard remains connected to Bluetooth so it can immediately respond when you press a key.
+
+In the deep sleep state, the keyboard additionally disconnects from Bluetooth. This state uses very little power, but it may take a few seconds to reconnect after waking.
+
+### Kconfig
+
+Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+
+| Config                          | Type | Description                                           | Default |
+| ------------------------------- | ---- | ----------------------------------------------------- | ------- |
+| `CONFIG_ZMK_IDLE_TIMEOUT`       | int  | Milliseconds of inactivity before entering idle state | 30000   |
+| `CONFIG_ZMK_SLEEP`              | bool | Enable deep sleep support                             | n       |
+| `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT` | int  | Milliseconds of inactivity before entering deep sleep | 900000  |
+
+## External Power Control
+
+Driver for enabling or disabling power to peripherals such as displays and lighting. This driver must be configured to use [power management behaviors](/docs/behaviors/power).
+
+### Kconfig
+
+Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+
+| Config                 | Type | Description                                     | Default |
+| ---------------------- | ---- | ----------------------------------------------- | ------- |
+| `CONFIG_ZMK_EXT_POWER` | bool | Enable support to control external power output | y       |
+
+### Devicetree
+
+Applies to: `compatible = "zmk,ext-power-generic"`
+
+| Property        | Type       | Description                                                   |
+| --------------- | ---------- | ------------------------------------------------------------- |
+| `label`         | string     | Unique label for the node                                     |
+| `control-gpios` | GPIO array | List of GPIOs which should be active to enable external power |
+| `init-delay-ms` | int        | number of milliseconds to delay after initializing the driver |
+
+## Battery Voltage Divider
+
+Driver for reading the voltage of a battery using an ADC connected to a voltage divider.
+
+### Kconfig
+
+Definition file: [zmk/app/drivers/sensor/battery_voltage_divider/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/sensor/battery_voltage_divider/Kconfig)
+
+| Config                               | Type | Description                                                  | Default |
+| ------------------------------------ | ---- | ------------------------------------------------------------ | ------- |
+| `CONFIG_ZMK_BATTERY_VOLTAGE_DIVIDER` | bool | Enable battery voltage divider driver for battery monitoring | n       |
+
+### Devicetree
+
+Applies to: `compatible = "zmk,battery-voltage-divider"`
+
+See [Zephyr's voltage divider documentation](https://docs.zephyrproject.org/latest/reference/devicetree/bindings/voltage-divider.html).

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -50,16 +50,8 @@ Applies to: `compatible = "zmk,ext-power-generic"`
 
 Driver for reading the voltage of a battery using an ADC connected to a voltage divider.
 
-### Kconfig
-
-Definition file: [zmk/app/drivers/sensor/battery_voltage_divider/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/sensor/battery_voltage_divider/Kconfig)
-
-| Config                               | Type | Description                                                  | Default |
-| ------------------------------------ | ---- | ------------------------------------------------------------ | ------- |
-| `CONFIG_ZMK_BATTERY_VOLTAGE_DIVIDER` | bool | Enable battery voltage divider driver for battery monitoring | n       |
-
 ### Devicetree
 
 Applies to: `compatible = "zmk,battery-voltage-divider"`
 
-See [Zephyr's voltage divider documentation](https://docs.zephyrproject.org/latest/reference/devicetree/bindings/voltage-divider.html).
+See [Zephyr's voltage divider documentation](https://docs.zephyrproject.org/latest/build/dts/api/bindings/adc/voltage-divider.html).

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -12,7 +12,7 @@ Configuration for entering low power modes when the keyboard is idle.
 
 In the idle state, peripherals such as displays and lighting are disabled, but the keyboard remains connected to Bluetooth so it can immediately respond when you press a key.
 
-In the deep sleep state, the keyboard additionally disconnects from Bluetooth. This state uses very little power, but it may take a few seconds to reconnect after waking.
+In the deep sleep state, the keyboard additionally disconnects from Bluetooth and any external power output is disabled. This state uses very little power, but it may take a few seconds to reconnect after waking.
 
 ### Kconfig
 
@@ -45,13 +45,3 @@ Applies to: `compatible = "zmk,ext-power-generic"`
 | `label`         | string     | Unique label for the node                                     |
 | `control-gpios` | GPIO array | List of GPIOs which should be active to enable external power |
 | `init-delay-ms` | int        | number of milliseconds to delay after initializing the driver |
-
-## Battery Voltage Divider
-
-Driver for reading the voltage of a battery using an ADC connected to a voltage divider.
-
-### Devicetree
-
-Applies to: `compatible = "zmk,battery-voltage-divider"`
-
-See [Zephyr's voltage divider documentation](https://docs.zephyrproject.org/latest/build/dts/api/bindings/adc/voltage-divider.html).

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -1,0 +1,66 @@
+---
+title: System Configuration
+sidebar_label: System
+---
+
+These are general settings that control how the keyboard behaves and which features it supports. Several of these settings come from Zephyr and are not specific to ZMK, but they are listed here because they are relevant to how a keyboard functions.
+
+See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+
+## Kconfig
+
+Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+
+### General
+
+| Config                              | Type   | Description                                                                   | Default |
+| ----------------------------------- | ------ | ----------------------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_KEYBOARD_NAME`          | string | The name of the keyboard                                                      |         |
+| `CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE` | int    | Milliseconds to wait after a setting change before writing it to flash memory | 60000   |
+| `CONFIG_ZMK_WPM`                    | bool   | Enable calculating words per minute                                           | n       |
+| `CONFIG_HEAP_MEM_POOL_SIZE`         | int    | Size of the heap memory pool                                                  | 8192    |
+
+### USB
+
+| Config                            | Type   | Description                             | Default         |
+| --------------------------------- | ------ | --------------------------------------- | --------------- |
+| `CONFIG_USB`                      | bool   | Enable USB drivers                      |                 |
+| `CONFIG_USB_DEVICE_VID`           | int    | The vendor ID advertised to USB         | `0x1D50`        |
+| `CONFIG_USB_DEVICE_PID`           | int    | The product ID advertised to USB        | `0x615E`        |
+| `CONFIG_USB_DEVICE_MANUFACTURER`  | string | The manufacturer name advertised to USB | `"ZMK Project"` |
+| `CONFIG_USB_HID_POLL_INTERVAL_MS` | int    | USB polling interval in milliseconds    | 9               |
+| `CONFIG_ZMK_USB`                  | bool   | Enable ZMK as a USB keyboard            |                 |
+| `CONFIG_ZMK_USB_INIT_PRIORITY`    | int    | USB init priority                       | 50              |
+
+### Bluetooth
+
+See [Zephyr's Bluetooth stack architecture documentation](https://docs.zephyrproject.org/latest/guides/bluetooth/bluetooth-arch.html)
+for more information on configuring Bluetooth.
+
+| Config                                                | Type | Description                                                            | Default |
+| ----------------------------------------------------- | ---- | ---------------------------------------------------------------------- | ------- |
+| `CONFIG_BT`                                           | bool | Enable Bluetooth support                                               |         |
+| `CONFIG_BT_MAX_CONN`                                  | int  | Maximum number of simultaneous Bluetooth connections                   | 5       |
+| `CONFIG_BT_MAX_PAIRED`                                | int  | Maximum number of paired Bluetooth devices                             | 5       |
+| `CONFIG_ZMK_BLE`                                      | bool | Enable ZMK as a Bluetooth keyboard                                     |         |
+| `CONFIG_ZMK_BLE_INIT_PRIORITY`                        | int  | BLE init priority                                                      | 50      |
+| `CONFIG_ZMK_BLE_THREAD_STACK_SIZE`                    | int  | Stack size of the BLE notify thread                                    | 512     |
+| `CONFIG_ZMK_BLE_THREAD_PRIORITY`                      | int  | Priority of the BLE notify thread                                      | 5       |
+| `CONFIG_ZMK_BLE_KEYBOARD_REPORT_QUEUE_SIZE`           | int  | Max number of keyboard HID reports to queue for sending over BLE       | 20      |
+| `CONFIG_ZMK_BLE_CONSUMER__REPORT_QUEUE_SIZE`          | int  | Max number of consumer HID reports to queue for sending over BLE       | 5       |
+| `CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START`                 | bool | Clears all bond information from the keyboard on startup               | n       |
+| `CONFIG_ZMK_BLE_PASSKEY_ENTRY`                        | bool | Experimental: require typing passkey from host to pair BLE connection  | n       |
+| `CONFIG_ZMK_SPLIT`                                    | bool | Enable split keyboard support                                          | n       |
+| `CONFIG_ZMK_SPLIT_BLE`                                | bool | Use BLE to communicate between split keyboard halves                   | y       |
+| `CONFIG_ZMK_SPLIT_BLE_ROLE_CENTRAL`                   | bool | `y` for central device, `n` for peripheral                             |         |
+| `CONFIG_ZMK_SPLIT_BLE_CENTRAL_POSITION_QUEUE_SIZE`    | int  | Max number of key state events to queue when received from peripherals | 5       |
+| `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_STACK_SIZE`          | int  | Stack size of the split peripheral BLE notify thread                   | 512     |
+| `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_PRIORITY`            | int  | Priority of the split peripheral BLE notify thread                     | 5       |
+| `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_POSITION_QUEUE_SIZE` | int  | Max number of key state events to queue to send to the central         | 10      |
+
+### Logging
+
+| Config                   | Type | Description                              | Default |
+| ------------------------ | ---- | ---------------------------------------- | ------- |
+| `CONFIG_ZMK_USB_LOGGING` | bool | Enable USB CDC ACM logging for debugging | n       |
+| `CONFIG_ZMK_LOG_LEVEL`   | int  | Log level for ZMK debug messages         | 4       |

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -5,7 +5,7 @@ sidebar_label: System
 
 These are general settings that control how the keyboard behaves and which features it supports. Several of these settings come from Zephyr and are not specific to ZMK, but they are listed here because they are relevant to how a keyboard functions.
 
-See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+See [Configuration Overview](index.md) for instructions on how to change these settings.
 
 ## Kconfig
 

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -20,6 +20,32 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 | `CONFIG_ZMK_WPM`                    | bool   | Enable calculating words per minute                                           | n       |
 | `CONFIG_HEAP_MEM_POOL_SIZE`         | int    | Size of the heap memory pool                                                  | 8192    |
 
+### HID
+
+| Config                                | Type | Description                                       | Default |
+| ------------------------------------- | ---- | ------------------------------------------------- | ------- |
+| `CONFIG_ZMK_HID_CONSUMER_REPORT_SIZE` | int  | Number of consumer keys simultaneously reportable | 6       |
+
+Exactly zero or one of the following options may be set to `y`. The first is used if none are set.
+
+| Config                            | Description                                                                                           |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `CONFIG_ZMK_HID_REPORT_TYPE_HKRO` | Enable `CONFIG_ZMK_HID_KEYBOARD_REPORT_SIZE` key roll over.                                           |
+| `CONFIG_ZMK_HID_REPORT_TYPE_NKRO` | Enable full N-key roll over. This may prevent the keyboard from working with some BIOS/UEFI versions. |
+
+If `CONFIG_ZMK_HID_REPORT_TYPE_HKRO` is enabled, it may be configured with the following options:
+
+| Config                                | Type | Description                                       | Default |
+| ------------------------------------- | ---- | ------------------------------------------------- | ------- |
+| `CONFIG_ZMK_HID_KEYBOARD_REPORT_SIZE` | int  | Number of keyboard keys simultaneously reportable | 6       |
+
+Exactly zero or one of the following options may be set to `y`. The first is used if none are set.
+
+| Config                                        | Description                                                                          |
+| --------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `CONFIG_ZMK_HID_CONSUMER_REPORT_USAGES_FULL`  | Enable all consumer key codes, but may have compatibility issues with some host OSes |
+| `CONFIG_ZMK_HID_CONSUMER_REPORT_USAGES_BASIC` | Prevents using some consumer key codes, but allows compatibility with more host OSes |
+
 ### USB
 
 | Config                            | Type   | Description                             | Default         |
@@ -28,7 +54,7 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 | `CONFIG_USB_DEVICE_VID`           | int    | The vendor ID advertised to USB         | `0x1D50`        |
 | `CONFIG_USB_DEVICE_PID`           | int    | The product ID advertised to USB        | `0x615E`        |
 | `CONFIG_USB_DEVICE_MANUFACTURER`  | string | The manufacturer name advertised to USB | `"ZMK Project"` |
-| `CONFIG_USB_HID_POLL_INTERVAL_MS` | int    | USB polling interval in milliseconds    | 9               |
+| `CONFIG_USB_HID_POLL_INTERVAL_MS` | int    | USB polling interval in milliseconds    | 1               |
 | `CONFIG_ZMK_USB`                  | bool   | Enable ZMK as a USB keyboard            |                 |
 | `CONFIG_ZMK_USB_INIT_PRIORITY`    | int    | USB init priority                       | 50              |
 
@@ -37,26 +63,30 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 See [Zephyr's Bluetooth stack architecture documentation](https://docs.zephyrproject.org/latest/guides/bluetooth/bluetooth-arch.html)
 for more information on configuring Bluetooth.
 
-| Config                                                | Type | Description                                                            | Default |
-| ----------------------------------------------------- | ---- | ---------------------------------------------------------------------- | ------- |
-| `CONFIG_BT`                                           | bool | Enable Bluetooth support                                               |         |
-| `CONFIG_BT_MAX_CONN`                                  | int  | Maximum number of simultaneous Bluetooth connections                   | 5       |
-| `CONFIG_BT_MAX_PAIRED`                                | int  | Maximum number of paired Bluetooth devices                             | 5       |
-| `CONFIG_ZMK_BLE`                                      | bool | Enable ZMK as a Bluetooth keyboard                                     |         |
-| `CONFIG_ZMK_BLE_INIT_PRIORITY`                        | int  | BLE init priority                                                      | 50      |
-| `CONFIG_ZMK_BLE_THREAD_STACK_SIZE`                    | int  | Stack size of the BLE notify thread                                    | 512     |
-| `CONFIG_ZMK_BLE_THREAD_PRIORITY`                      | int  | Priority of the BLE notify thread                                      | 5       |
-| `CONFIG_ZMK_BLE_KEYBOARD_REPORT_QUEUE_SIZE`           | int  | Max number of keyboard HID reports to queue for sending over BLE       | 20      |
-| `CONFIG_ZMK_BLE_CONSUMER__REPORT_QUEUE_SIZE`          | int  | Max number of consumer HID reports to queue for sending over BLE       | 5       |
-| `CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START`                 | bool | Clears all bond information from the keyboard on startup               | n       |
-| `CONFIG_ZMK_BLE_PASSKEY_ENTRY`                        | bool | Experimental: require typing passkey from host to pair BLE connection  | n       |
-| `CONFIG_ZMK_SPLIT`                                    | bool | Enable split keyboard support                                          | n       |
-| `CONFIG_ZMK_SPLIT_BLE`                                | bool | Use BLE to communicate between split keyboard halves                   | y       |
-| `CONFIG_ZMK_SPLIT_BLE_ROLE_CENTRAL`                   | bool | `y` for central device, `n` for peripheral                             |         |
-| `CONFIG_ZMK_SPLIT_BLE_CENTRAL_POSITION_QUEUE_SIZE`    | int  | Max number of key state events to queue when received from peripherals | 5       |
-| `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_STACK_SIZE`          | int  | Stack size of the split peripheral BLE notify thread                   | 512     |
-| `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_PRIORITY`            | int  | Priority of the split peripheral BLE notify thread                     | 5       |
-| `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_POSITION_QUEUE_SIZE` | int  | Max number of key state events to queue to send to the central         | 10      |
+| Config                                                | Type | Description                                                             | Default |
+| ----------------------------------------------------- | ---- | ----------------------------------------------------------------------- | ------- |
+| `CONFIG_BT`                                           | bool | Enable Bluetooth support                                                |         |
+| `CONFIG_BT_MAX_CONN`                                  | int  | Maximum number of simultaneous Bluetooth connections                    | 5       |
+| `CONFIG_BT_MAX_PAIRED`                                | int  | Maximum number of paired Bluetooth devices                              | 5       |
+| `CONFIG_ZMK_BLE`                                      | bool | Enable ZMK as a Bluetooth keyboard                                      |         |
+| `CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START`                 | bool | Clears all bond information from the keyboard on startup                | n       |
+| `CONFIG_ZMK_BLE_CONSUMER_REPORT_QUEUE_SIZE`           | int  | Max number of consumer HID reports to queue for sending over BLE        | 5       |
+| `CONFIG_ZMK_BLE_KEYBOARD_REPORT_QUEUE_SIZE`           | int  | Max number of keyboard HID reports to queue for sending over BLE        | 20      |
+| `CONFIG_ZMK_BLE_INIT_PRIORITY`                        | int  | BLE init priority                                                       | 50      |
+| `CONFIG_ZMK_BLE_THREAD_PRIORITY`                      | int  | Priority of the BLE notify thread                                       | 5       |
+| `CONFIG_ZMK_BLE_THREAD_STACK_SIZE`                    | int  | Stack size of the BLE notify thread                                     | 512     |
+| `CONFIG_ZMK_BLE_PASSKEY_ENTRY`                        | bool | Experimental: require typing passkey from host to pair BLE connection   | n       |
+| `CONFIG_ZMK_SPLIT`                                    | bool | Enable split keyboard support                                           | n       |
+| `CONFIG_ZMK_SPLIT_BLE`                                | bool | Use BLE to communicate between split keyboard halves                    | y       |
+| `CONFIG_ZMK_SPLIT_BLE_ROLE_CENTRAL`                   | bool | `y` for central device, `n` for peripheral                              |         |
+| `CONFIG_ZMK_SPLIT_BLE_CENTRAL_POSITION_QUEUE_SIZE`    | int  | Max number of key state events to queue when received from peripherals  | 5       |
+| `CONFIG_ZMK_BLE_SPLIT_CENTRAL_SPLIT_RUN_STACK_SIZE`   | int  | Stack size of the BLE split central write thread                        | 512     |
+| `CONFIG_ZMK_BLE_SPLIT_CENTRAL_SPLIT_RUN_QUEUE_SIZE`   | int  | Max number of behavior run events to queue to send to the peripheral(s) | 5       |
+| `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_STACK_SIZE`          | int  | Stack size of the BLE split peripheral notify thread                    | 650     |
+| `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_PRIORITY`            | int  | Priority of the BLE split peripheral notify thread                      | 5       |
+| `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_POSITION_QUEUE_SIZE` | int  | Max number of key state events to queue to send to the central          | 10      |
+
+Note that `CONFIG_BT_MAX_CONN` and `CONFIG_BT_MAX_PAIRED` should be set to the same value. On a split keyboard they should only be set for the central and must be set to one greater than the desired number of bluetooth profiles.
 
 ### Logging
 

--- a/docs/docs/config/underglow.md
+++ b/docs/docs/config/underglow.md
@@ -5,11 +5,11 @@ sidebar_label: RGB Underglow
 
 See the [RGB Underglow feature page](/docs/features/underglow) for more details, including instructions for adding underglow support to a board.
 
-See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+See [Configuration Overview](/docs/config) for instructions on how to change these settings.
 
 ## Kconfig
 
-RGB underglow depends on [Zephyr's LED strip driver](https://github.com/zephyrproject-rtos/zephyr/tree/master/drivers/led_strip), which provides additional Kconfig options.
+RGB underglow depends on [Zephyr's LED strip driver](https://github.com/zephyrproject-rtos/zephyr/tree/main/drivers/led_strip), which provides additional Kconfig options.
 
 Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
 
@@ -38,6 +38,6 @@ Values for `CONFIG_ZMK_RGB_UNDERGLOW_EFF_START`:
 
 ## Devicetree
 
-ZMK does not have any Devicetree properties of its own. See the Devicetree bindings for [Zephyr's LED strip driver](https://github.com/zephyrproject-rtos/zephyr/tree/master/dts/bindings/led_strip).
+ZMK does not have any Devicetree properties of its own. See the Devicetree bindings for [Zephyr's LED strip drivers](https://github.com/zephyrproject-rtos/zephyr/tree/main/dts/bindings/led_strip).
 
 See the [RGB underglow feature page](/docs/features/underglow) for examples of the properties that must be set to enable underglow.

--- a/docs/docs/config/underglow.md
+++ b/docs/docs/config/underglow.md
@@ -3,9 +3,9 @@ title: RGB Underglow Configuration
 sidebar_label: RGB Underglow
 ---
 
-See the [RGB Underglow feature page](/docs/features/underglow) for more details, including instructions for adding underglow support to a board.
+See the [RGB Underglow feature page](../features/underglow.md) for more details, including instructions for adding underglow support to a board.
 
-See [Configuration Overview](/docs/config) for instructions on how to change these settings.
+See [Configuration Overview](index.md) for instructions on how to change these settings.
 
 ## Kconfig
 
@@ -40,4 +40,4 @@ Values for `CONFIG_ZMK_RGB_UNDERGLOW_EFF_START`:
 
 ZMK does not have any Devicetree properties of its own. See the Devicetree bindings for [Zephyr's LED strip drivers](https://github.com/zephyrproject-rtos/zephyr/tree/main/dts/bindings/led_strip).
 
-See the [RGB underglow feature page](/docs/features/underglow) for examples of the properties that must be set to enable underglow.
+See the [RGB underglow feature page](../features/underglow.md) for examples of the properties that must be set to enable underglow.

--- a/docs/docs/config/underglow.md
+++ b/docs/docs/config/underglow.md
@@ -1,0 +1,43 @@
+---
+title: RGB Underglow Configuration
+sidebar_label: RGB Underglow
+---
+
+See the [RGB Underglow feature page](/docs/features/underglow) for more details, including instructions for adding underglow support to a board.
+
+See [Configuration Overview](/docs/config/index) for instructions on how to change these settings.
+
+## Kconfig
+
+RGB underglow depends on [Zephyr's LED strip driver](https://github.com/zephyrproject-rtos/zephyr/tree/master/drivers/led_strip), which provides additional Kconfig options.
+
+Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+
+| Config                               | Type | Description                                           | Default |
+| ------------------------------------ | ---- | ----------------------------------------------------- | ------- |
+| `CONFIG_ZMK_RGB_UNDERGLOW`           | bool | Enable RGB underglow                                  | n       |
+| `CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER` | bool | Underglow toggling also controls external power       | y       |
+| `CONFIG_ZMK_RGB_UNDERGLOW_HUE_STEP`  | int  | Hue step in degrees (0-359) used by RGB actions       | 10      |
+| `CONFIG_ZMK_RGB_UNDERGLOW_SAT_STEP`  | int  | Saturation step in percent used by RGB actions        | 10      |
+| `CONFIG_ZMK_RGB_UNDERGLOW_BRT_STEP`  | int  | Brightness step in percent used by RGB actions        | 10      |
+| `CONFIG_ZMK_RGB_UNDERGLOW_HUE_START` | int  | Default hue in degrees (0-359)                        | 0       |
+| `CONFIG_ZMK_RGB_UNDERGLOW_SAT_START` | int  | Default saturation percent (0-100)                    | 100     |
+| `CONFIG_ZMK_RGB_UNDERGLOW_BRT_START` | int  | Default brightness in percent (0-100)                 | 100     |
+| `CONFIG_ZMK_RGB_UNDERGLOW_SPD_START` | int  | Default effect speed (1-5)                            | 3       |
+| `CONFIG_ZMK_RGB_UNDERGLOW_EFF_START` | int  | Default effect index from the effect list (see below) | 0       |
+| `CONFIG_ZMK_RGB_UNDERGLOW_ON_START`  | bool | Default on state                                      | y       |
+
+Values for `CONFIG_ZMK_RGB_UNDERGLOW_EFF_START`:
+
+| Value | Effect      |
+| ----- | ----------- |
+| 0     | Solid color |
+| 1     | Breathe     |
+| 2     | Spectrum    |
+| 3     | Swirl       |
+
+## Devicetree
+
+ZMK does not have any Devicetree properties of its own. See the Devicetree bindings for [Zephyr's LED strip driver](https://github.com/zephyrproject-rtos/zephyr/tree/master/dts/bindings/led_strip).
+
+See the [RGB underglow feature page](/docs/features/underglow) for examples of the properties that must be set to enable underglow.

--- a/docs/docs/config/underglow.md
+++ b/docs/docs/config/underglow.md
@@ -36,6 +36,10 @@ Values for `CONFIG_ZMK_RGB_UNDERGLOW_EFF_START`:
 | 2     | Spectrum    |
 | 3     | Swirl       |
 
+:::note
+The `*_START` settings only determine the initial underglow state. Any changes you make with the [underglow behavior](../behaviors/underglow.md) are saved to flash after a one minute delay and will be used after that.
+:::
+
 ## Devicetree
 
 ZMK does not have any Devicetree properties of its own. See the Devicetree bindings for [Zephyr's LED strip drivers](https://github.com/zephyrproject-rtos/zephyr/tree/main/dts/bindings/led_strip).

--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -23,7 +23,7 @@ The setup script creates a `config/<shield>.conf` file that allows you to add ad
 control what features and options are built into your firmware. Opening that file with your text editor will allow you to see the
 various config settings that can be commented/uncommented to modify how your firmware is built.
 
-Refer to the [Configuration](/docs/config/index) documentation for more details on this file.
+Refer to the [Configuration](/docs/config) documentation for more details on this file.
 
 ## Keymap
 

--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -9,10 +9,10 @@ with the main `zmk` firmware repository to build your desired firmware. The main
 working components of ZMK are kept separate from your personal keyboard settings, reducing the amount of file manipulation in the configuration process.
 This makes flashing ZMK to your keyboard much easier, especially because you don't need to keep an up-to-date copy of zmk on your computer at all times.
 
-On default `zmk-config` folder should contain two files:
+By default, the `zmk-config` folder should contain two files:
 
 - `<shield>.conf`
-- `<shield>`.keymap
+- `<shield>.keymap`
 
 However, your config folder can also be modified to include a `boards/` directory for keymaps and configurations for multiple boards/shields
 outside of the default keyboard setting definitions.
@@ -22,6 +22,8 @@ outside of the default keyboard setting definitions.
 The setup script creates a `config/<shield>.conf` file that allows you to add additional configuration options to
 control what features and options are built into your firmware. Opening that file with your text editor will allow you to see the
 various config settings that can be commented/uncommented to modify how your firmware is built.
+
+Refer to the [Configuration](/docs/config/index) documentation for more details on this file.
 
 ## Keymap
 

--- a/docs/docs/features/battery.md
+++ b/docs/docs/features/battery.md
@@ -20,6 +20,8 @@ To enable a battery sensor on a new board, add the driver for the sensor to your
 - `zmk,battery-voltage-divider`: Reads the voltage on an analog input pin.
 - `zmk,battery-nrf-vddh`: Reads the power supply voltage on a Nordic nRF52's VDDH pin.
 
+See the [battery level configuration page](../config/battery.md) for the configuration supported by each driver provided by ZMK.
+
 Zephyr also provides some drivers for fuel gauge ICs such as the TI bq274xx series and Maxim MAX17xxx series. If you use a battery sensor that does not have an existing driver, you will need to write a new driver that supports the `SENSOR_CHAN_GAUGE_STATE_OF_CHARGE` sensor channel and contribute it to Zephyr or ZMK.
 
 Once you have the sensor driver defined, add a `zmk,battery` property to the `chosen` node and set it to reference the sensor node. For example:

--- a/docs/docs/features/combos.md
+++ b/docs/docs/features/combos.md
@@ -25,7 +25,7 @@ Combos configured in your `.keymap` file, but are separate from the `keymap` nod
 
 - The name of the combo doesn't really matter, but convention is to start the node name with `combo_`.
 - The `compatible` property should always be `"zmk,combos"` for combos.
-- `timeout-ms` is the length of the window (in milliseconds) in which all keys of the combo must be pressed in order to successfully trigger the combo.
+- All the keys must be pressed within `timeout-ms` milliseconds to trigger the combo.
 - `key-positions` is an array of key positions. See the info section below about how to figure out the positions on your board.
 - `layers = <0 1...>` will allow limiting a combo to specific layers. This is an _optional_ parameter, when omitted it defaults to global scope.
 - `bindings` is the behavior that is activated when the behavior is pressed.
@@ -47,10 +47,4 @@ Key positions are numbered like the keys in your keymap, starting at 0. So, if t
 Invoking a source-specific behavior such as one of the [reset behaviors](behaviors/reset.md) using a combo will always trigger it on the central side of the keyboard, regardless of the side that the keys corresponding to `key-positions` are on.
 :::
 
-### Advanced configuration
-
-There are three global combo parameters which are set through KConfig. You can set them in the `<boardname>.conf` file in the same directory as your keymap file.
-
-- `CONFIG_ZMK_COMBO_MAX_PRESSED_COMBOS` is the number of combos that can be active at the same time. Default 4.
-- `CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY` is the maximum number of combos that can be active on a key position. Defaults to 5. (So you can have 5 separate combos that use position `3` for example)
-- `CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO` is the maximum number of keys that need to be pressed to activate a combo. Default 4. If you want a combo that triggers when pressing 5 keys, you'd set this to 5 for example.
+See [combo configuration](/docs/config/combos) for advanced configuration options.

--- a/docs/docs/features/combos.md
+++ b/docs/docs/features/combos.md
@@ -25,7 +25,7 @@ Combos configured in your `.keymap` file, but are separate from the `keymap` nod
 
 - The name of the combo doesn't really matter, but convention is to start the node name with `combo_`.
 - The `compatible` property should always be `"zmk,combos"` for combos.
-- All the keys must be pressed within `timeout-ms` milliseconds to trigger the combo.
+- All the keys in `key-positions` must be pressed within `timeout-ms` milliseconds to trigger the combo.
 - `key-positions` is an array of key positions. See the info section below about how to figure out the positions on your board.
 - `layers = <0 1...>` will allow limiting a combo to specific layers. This is an _optional_ parameter, when omitted it defaults to global scope.
 - `bindings` is the behavior that is activated when the behavior is pressed.

--- a/docs/docs/features/debouncing.md
+++ b/docs/docs/features/debouncing.md
@@ -19,13 +19,19 @@ socket or using some sharp tweezers to bend the contacts back together.
 
 ## Debounce Configuration
 
+:::note
+Currently only the `zmk,kscan-gpio-matrix` driver supports these options. The other drivers have not yet been updated to use the new debouncing code.
+:::
+
 ### Global Options
 
 You can set these options in your `.conf` file to control debouncing globally.
-Values must be <= 127.
+Values must be <= 16383.
 
 - `CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS`: Debounce time for key press in milliseconds. Default = 5.
 - `CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS`: Debounce time for key release in milliseconds. Default = 5.
+
+If one of these options is set, it overrides the matching per-driver option described below.
 
 For example, this would shorten the debounce time for both press and release:
 
@@ -37,7 +43,7 @@ CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=3
 ### Per-driver Options
 
 You can add these Devicetree properties to a kscan node to control debouncing for
-that instance of the driver. Values must be <= 127.
+that instance of the driver. Values must be <= 16383.
 
 - `debounce-press-ms`: Debounce time for key press in milliseconds. Default = 5.
 - `debounce-release-ms`: Debounce time for key release in milliseconds. Default = 5.

--- a/docs/docs/features/underglow.md
+++ b/docs/docs/features/underglow.md
@@ -34,7 +34,7 @@ CONFIG_ZMK_RGB_UNDERGLOW=y
 CONFIG_WS2812_STRIP=y
 ```
 
-See [Configuration Overview](/docs/config/index) for more instructions on how to
+See [Configuration Overview](/docs/config) for more instructions on how to
 use Kconfig.
 
 If your board or shield does not have RGB underglow configured, refer to [Adding RGB Underglow to a Board](#adding-rgb-underglow-to-a-board).

--- a/docs/docs/features/underglow.md
+++ b/docs/docs/features/underglow.md
@@ -25,7 +25,8 @@ Here you can see the RGB underglow feature in action using WS2812 LEDs.
 
 ## Enabling RGB Underglow
 
-To enable RGB underglow on your board or shield, simply enable the `CONFIG_ZMK_RGB_UNDERGLOW` and `X_STRIP` configuration values in the `.conf` file of your user config directory as such:
+To enable RGB underglow on your board or shield, simply enable the `CONFIG_ZMK_RGB_UNDERGLOW` and `CONFIG_*_STRIP` configuration values in the `.conf` file for your board or shield.
+For example:
 
 ```
 CONFIG_ZMK_RGB_UNDERGLOW=y
@@ -33,24 +34,14 @@ CONFIG_ZMK_RGB_UNDERGLOW=y
 CONFIG_WS2812_STRIP=y
 ```
 
+See [Configuration Overview](/docs/config/index) for more instructions on how to
+use Kconfig.
+
 If your board or shield does not have RGB underglow configured, refer to [Adding RGB Underglow to a Board](#adding-rgb-underglow-to-a-board).
 
 ## Configuring RGB Underglow
 
-There are various Kconfig options used to configure the RGB underglow feature. These can all be set in the `.conf` file.
-
-| Option                               | Description                                     | Default |
-| ------------------------------------ | ----------------------------------------------- | ------- |
-| `CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER` | Underglow toggling also controls external power | y       |
-| `CONFIG_ZMK_RGB_UNDERGLOW_HUE_STEP`  | Hue step in degrees of 360 used by RGB actions  | 10      |
-| `CONFIG_ZMK_RGB_UNDERGLOW_SAT_STEP`  | Saturation step in percent used by RGB actions  | 10      |
-| `CONFIG_ZMK_RGB_UNDERGLOW_BRT_STEP`  | Brightness step in percent used by RGB actions  | 10      |
-| `CONFIG_ZMK_RGB_UNDERGLOW_HUE_START` | Default hue 0-359 in degrees                    | 0       |
-| `CONFIG_ZMK_RGB_UNDERGLOW_SAT_START` | Default saturation 0-100 in percent             | 100     |
-| `CONFIG_ZMK_RGB_UNDERGLOW_BRT_START` | Default brightness 0-100 in percent             | 100     |
-| `CONFIG_ZMK_RGB_UNDERGLOW_SPD_START` | Default effect speed 1-5                        | 3       |
-| `CONFIG_ZMK_RGB_UNDERGLOW_EFF_START` | Default effect integer from the effect enum     | 0       |
-| `CONFIG_ZMK_RGB_UNDERGLOW_ON_START`  | Default on state                                | y       |
+See [RGB underglow configuration](/docs/config/underglow).
 
 ## Adding RGB Underglow to a Board
 
@@ -154,7 +145,7 @@ Once you have your `led_strip` properly defined you need to add it to the root d
 };
 ```
 
-Finally you need to enable the `CONFIG_ZMK_RGB_UNDERGLOW` and `X_STRIP` configuration values in the `.conf` file of your board (or set a default in the `Kconfig.defconfig`):
+Finally you need to enable the `CONFIG_ZMK_RGB_UNDERGLOW` and `CONFIG*_STRIP` configuration values in the `.conf` file of your board (or set a default in the `Kconfig.defconfig`):
 
 ```
 CONFIG_ZMK_RGB_UNDERGLOW=y

--- a/docs/docs/features/underglow.md
+++ b/docs/docs/features/underglow.md
@@ -145,7 +145,7 @@ Once you have your `led_strip` properly defined you need to add it to the root d
 };
 ```
 
-Finally you need to enable the `CONFIG_ZMK_RGB_UNDERGLOW` and `CONFIG*_STRIP` configuration values in the `.conf` file of your board (or set a default in the `Kconfig.defconfig`):
+Finally you need to enable the `CONFIG_ZMK_RGB_UNDERGLOW` and `CONFIG_*_STRIP` configuration values in the `.conf` file of your board (or set a default in the `Kconfig.defconfig`):
 
 ```
 CONFIG_ZMK_RGB_UNDERGLOW=y

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -53,6 +53,7 @@ module.exports = {
     ],
     Configuration: [
       "config/index",
+      "config/backlight",
       "config/behaviors",
       "config/combos",
       "config/displays",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -54,6 +54,7 @@ module.exports = {
     Configuration: [
       "config/index",
       "config/backlight",
+      "config/battery",
       "config/behaviors",
       "config/combos",
       "config/displays",
@@ -61,8 +62,8 @@ module.exports = {
       "config/keymap",
       "config/kscan",
       "config/power",
-      "config/system",
       "config/underglow",
+      "config/system",
     ],
     Development: [
       "development/clean-room",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -51,6 +51,18 @@ module.exports = {
       "codes/power",
       "codes/keymap-upgrader",
     ],
+    Configuration: [
+      "config/index",
+      "config/behaviors",
+      "config/combos",
+      "config/displays",
+      "config/encoders",
+      "config/keymap",
+      "config/kscan",
+      "config/power",
+      "config/system",
+      "config/underglow",
+    ],
     Development: [
       "development/clean-room",
       "development/documentation",


### PR DESCRIPTION
This adds a new "config" section to the sidebar with documentation on (most of) the Kconfig and Devicetree options we support.

I documented everything manually, because I didn't want to try to figure out how to write a Kconfig parser in JavaScript, get it reading files from outside the docs directory, and organize it in a reasonable way. As a future improvement, we could try to generate some of this dynamically so it can't get out of sync with the code.

This also adds a section describing how to actually edit configuration, and I replaced some redundant information in the rest of the documentation with links to the new pages.