### PR TITLE
Update macos GCC embedded section with brew cmd

### DIFF
--- a/docs/docs/development/setup.md
+++ b/docs/docs/development/setup.md
@@ -338,6 +338,7 @@ Since the Zephyr™ SDK is not available for Windows, we recommending following 
 Since the Zephyr™ SDK is not available for macOS, we recommending following the steps to install the [GNU ARM Embedded](https://docs.zephyrproject.org/2.3.0/getting_started/toolchain_3rd_party_x_compilers.html#gnu-arm-embedded).
 
 The install command is:
+
 ```
 brew install --cask gcc-arm-embedded
 ```

--- a/docs/docs/development/setup.md
+++ b/docs/docs/development/setup.md
@@ -337,6 +337,11 @@ Since the Zephyr™ SDK is not available for Windows, we recommending following 
 
 Since the Zephyr™ SDK is not available for macOS, we recommending following the steps to install the [GNU ARM Embedded](https://docs.zephyrproject.org/2.3.0/getting_started/toolchain_3rd_party_x_compilers.html#gnu-arm-embedded).
 
+The install command is:
+```
+brew install --cask gcc-arm-embedded
+```
+
 :::warning Security Controls Workaround
 
 Please be sure to read the [additional setup instructions](https://docs.zephyrproject.org/2.3.0/getting_started/installation_mac.html#mac-gatekeeper) needed to address security controls found in macOS 10.15 Catalina and newer


### PR DESCRIPTION
Brew has a cask for GCC embedded, so we can make this guide more user friendly by providing it.