### PR TITLE
feat(tests): Override test parallelism w/ `J=8` environment.

### DIFF
--- a/app/run-test.sh
+++ b/app/run-test.sh
@@ -17,7 +17,7 @@ testcases=$(find $path -name native_posix.keymap -exec dirname \{\} \;)
 num_cases=$(echo "$testcases" | wc -l)
 if [ $num_cases -gt 1 ]; then
 	echo "" > ./build/tests/pass-fail.log
-	echo "$testcases" | xargs -L 1 -P 4 ./run-test.sh
+	echo "$testcases" | xargs -L 1 -P ${J:-4} ./run-test.sh
 	err=$?
 	sort -k2 ./build/tests/pass-fail.log
 	exit $err


### PR DESCRIPTION
For comparison, default run locally:

```
PASS: tests/transparent/layered
PASS: tests/transparent/normal
PASS: tests/wpm/1-single_keypress
PASS: tests/wpm/2-multiple_keypress
west test  1238.57s user 269.31s system 654% cpu 3:50.43 total
```

WIth `J=8` on my laptop:

```
PASS: tests/wpm/1-single_keypress
PASS: tests/wpm/2-multiple_keypress
J=8 west test  468.36s user 117.44s system 595% cpu 1:38.44 total
```

It might be nice to pick a saner default based on the number of processors? Something like https://stackoverflow.com/a/23569003 ?