### PR TITLE
Keymap adjustment: fixed right alt and added layer quick tap to the Jian

### DIFF
--- a/app/boards/shields/jian/jian.keymap
+++ b/app/boards/shields/jian/jian.keymap
@@ -13,6 +13,9 @@
 #define RSE 2
 #define ADJ 3
 
+&lt { quick_tap_ms = <200>; };
+&mt { quick_tap_ms = <200>; };
+
 / {
         keymap {
                 compatible = "zmk,keymap";
@@ -26,7 +29,7 @@
                         bindings = <
    &kp LWIN &kp GRAVE &kp Q &kp W &kp E &kp R &kp T &kp Y         &kp U  &kp I     &kp O   &kp P    &kp LBKT &mt RWIN RBKT
             &kp LCTRL &kp A &kp S &kp D &kp F &kp G &kp H         &kp J  &kp K     &kp L   &kp SEMI &mt RCTRL SQT
-            &kp LALT  &kp Z &kp X &kp C &kp V &kp B &kp N         &kp M  &kp COMMA &kp DOT &kp FSLH &kp BSLH
+            &kp LALT  &kp Z &kp X &kp C &kp V &kp B &kp N         &kp M  &kp COMMA &kp DOT &kp FSLH &mt RALT BSLH
                          &lt RSE TAB &mt LSHFT SPACE &lt LWR RET &lt LWR ESC &mt RSHFT BSPC &lt RSE DEL
                         >;
                 };


### PR DESCRIPTION
The quick tap feature was implemented after the Jian was merged, but it's an integral part of using the keymap. I've been using it for a couple months now, and it works great.

I've got a similar PR in the works for the Jorne, but that has some config issues regarding RGB.