### PR TITLE
Fix nibble demux scan errors on encoder row

### DIFF
--- a/app/drivers/kscan/kscan_gpio_demux.c
+++ b/app/drivers/kscan/kscan_gpio_demux.c
@@ -113,6 +113,8 @@ struct kscan_gpio_item_config {
                     &kscan_gpio_output_configs_##n(dev)[bit];                                      \
                 gpio_pin_set(out_dev, out_cfg->pin, state);                                        \
             }                                                                                      \
+            /* Let the col settle before reading the rows */                                       \
+            k_usleep(1);                                                                           \
                                                                                                    \
             for (int i = 0; i < INST_MATRIX_INPUTS(n); i++) {                                      \
                 /* Get the input device (port) */                                                  \


### PR DESCRIPTION
I was getting erroneous presses when pressing the encoder. This PR fixes that.

+ Add a 1us sleep to let the column selection settle in order to avoid spurious keypresses when row capacitance is high (like on the encoder row)