### PR TITLE
fix(docs) omit layers -1 example, clarify it defaults when omitted

### DIFF
--- a/docs/docs/features/combos.md
+++ b/docs/docs/features/combos.md
@@ -18,7 +18,6 @@ Combos configured in your `.keymap` file, but are separate from the `keymap` nod
 			timeout-ms = <50>;
 			key-positions = <0 1>;
 			bindings = <&kp ESC>;
-			layers = <-1>;
 		};
 	};
 };
@@ -28,7 +27,7 @@ Combos configured in your `.keymap` file, but are separate from the `keymap` nod
 - The `compatible` property should always be `"zmk,combos"` for combos.
 - `timeout-ms` is the number of milliseconds that all keys of the combo must be pressed.
 - `key-positions` is an array of key positions. See the info section below about how to figure out the positions on your board.
-- `layers = <0 1...>` will allow limiting a combo to specific layers. this is an _optional_ parameter and defaults to `-1` which is global scope.
+- `layers = <0 1...>` will allow limiting a combo to specific layers. This is an _optional_ parameter, when omitted it defaults to `-1` which is global scope.
 - `bindings` is the behavior that is activated when the behavior is pressed.
 - (advanced) you can specify `slow-release` if you want the combo binding to be released when all key-positions are released. The default is to release the combo as soon as any of the keys in the combo is released.
 

--- a/docs/docs/features/combos.md
+++ b/docs/docs/features/combos.md
@@ -27,7 +27,7 @@ Combos configured in your `.keymap` file, but are separate from the `keymap` nod
 - The `compatible` property should always be `"zmk,combos"` for combos.
 - `timeout-ms` is the number of milliseconds that all keys of the combo must be pressed.
 - `key-positions` is an array of key positions. See the info section below about how to figure out the positions on your board.
-- `layers = <0 1...>` will allow limiting a combo to specific layers. This is an _optional_ parameter, when omitted it defaults to the global scope.
+- `layers = <0 1...>` will allow limiting a combo to specific layers. This is an _optional_ parameter, when omitted it defaults to global scope.
 - `bindings` is the behavior that is activated when the behavior is pressed.
 - (advanced) you can specify `slow-release` if you want the combo binding to be released when all key-positions are released. The default is to release the combo as soon as any of the keys in the combo is released.
 

--- a/docs/docs/features/combos.md
+++ b/docs/docs/features/combos.md
@@ -27,7 +27,7 @@ Combos configured in your `.keymap` file, but are separate from the `keymap` nod
 - The `compatible` property should always be `"zmk,combos"` for combos.
 - `timeout-ms` is the number of milliseconds that all keys of the combo must be pressed.
 - `key-positions` is an array of key positions. See the info section below about how to figure out the positions on your board.
-- `layers = <0 1...>` will allow limiting a combo to specific layers. This is an _optional_ parameter, when omitted it defaults to `-1` which is global scope.
+- `layers = <0 1...>` will allow limiting a combo to specific layers. This is an _optional_ parameter, when omitted it defaults to the global scope.
 - `bindings` is the behavior that is activated when the behavior is pressed.
 - (advanced) you can specify `slow-release` if you want the combo binding to be released when all key-positions are released. The default is to release the combo as soon as any of the keys in the combo is released.
 


### PR DESCRIPTION
A user on Discord was having trouble compiling their firmware with the combos example, this was due to the `<-1>` being invalid devicetree syntax for an array.
As @okke-formsma pointed out in #755 this is because array values are 32-bit unsigned.

I have removed the `layers = <-1>;` line in the combos example and clarified that it will default to the global scope when it is omitted.
I chose to remove the property because the example makes sense in a global scope and the property is optional, if the preference is to include it as example with valid layers let me know and I'll do that instead (e.g. `layers = <0 1>;`)