### PR TITLE
Add dactyl manuform 4x5 shield

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
           - cradio_left
           - cradio_right
           - crbn
+          - dactyl_manuform_4x5_left
+          - dactyl_manuform_4x5_right
           - eek
           - helix_left
           - helix_right

--- a/app/boards/shields/dactyl_manuform_4x5/Kconfig.defconfig
+++ b/app/boards/shields/dactyl_manuform_4x5/Kconfig.defconfig
@@ -1,0 +1,22 @@
+if SHIELD_DACTYL_MANUFORM_4X5_LEFT
+
+config ZMK_KEYBOARD_NAME
+    default "Dactyl 4x5 Left"
+
+config ZMK_SPLIT_BLE_ROLE_CENTRAL
+    default y
+
+endif
+
+if SHIELD_DACTYL_MANUFORM_4X5_RIGHT
+
+config ZMK_KEYBOARD_NAME
+    default "Dactyl 4x5 Right"
+
+endif
+
+if SHIELD_DACTYL_MANUFORM_4X5_LEFT || SHIELD_DACTYL_MANUFORM_4X5_RIGHT
+
+config ZMK_SPLIT
+    default y
+endif

--- a/app/boards/shields/dactyl_manuform_4x5/Kconfig.shield
+++ b/app/boards/shields/dactyl_manuform_4x5/Kconfig.shield
@@ -1,0 +1,5 @@
+config SHIELD_DACTYL_MANUFORM_4X5_LEFT
+    def_bool $(shields_list_contains,dactyl_manuform_4x5_left)
+
+config SHIELD_DACTYL_MANUFORM_4X5_RIGHT
+    def_bool $(shields_list_contains,dactyl_manuform_4x5_right)

--- a/app/boards/shields/dactyl_manuform_4x5/boards/nice_nano.overlay
+++ b/app/boards/shields/dactyl_manuform_4x5/boards/nice_nano.overlay
@@ -1,0 +1,8 @@
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+};

--- a/app/boards/shields/dactyl_manuform_4x5/boards/nice_nano.overlay
+++ b/app/boards/shields/dactyl_manuform_4x5/boards/nice_nano.overlay
@@ -1,8 +1,0 @@
-&spi1 {
-	compatible = "nordic,nrf-spim";
-	status = "okay";
-	mosi-pin = <6>;
-	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
-	sck-pin = <5>;
-	miso-pin = <7>;
-};

--- a/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5.conf
+++ b/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5.conf
@@ -1,0 +1,1 @@
+CONFIG_ZMK_SLEEP=y

--- a/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5.dtsi
+++ b/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5.dtsi
@@ -1,0 +1,46 @@
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <10>;
+        rows = <5>;
+// | SW5  | SW4  | SW3  | SW2  | SW1  |                 | SW1  | SW2  | SW3  | SW4  | SW5  |
+// | SW10 | SW9  | SW8  | SW7  | SW6  |                 | SW6  | SW7  | SW8  | SW9  | SW10 |
+// | SW15 | SW14 | SW13 | SW12 | SW11 |                 | SW11 | SW12 | SW13 | SW14 | SW15 |
+//        | SW17 | SW16 |                                             | SW16 | SW17 |
+//                      | SW19 | SW18 |                 | SW18 | SW19 |
+//                             | SW21 | SW20 |   | SW20 | SW21 |
+//                             | SW23 | SW22 |   | SW22 | SW23 |
+        map = <
+RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4)                 RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9)
+RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4)                 RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9)
+RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4)                 RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9)
+        RC(3,1) RC(3,2)                                                 RC(3,7) RC(3,8)
+                        RC(3,3) RC(3,4)                 RC(3,5) RC(3,6)
+                                RC(4,3) RC(4,4) RC(4,5) RC(4,6)
+                                RC(4,1) RC(4,2) RC(4,7) RC(4,8)
+
+        >;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+
+        diode-direction = "col2row";
+        row-gpios
+            = <&pro_micro_a 0  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row A from the schematic file
+            , <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row B from the schematic file
+            , <&pro_micro_d 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row C from the schematic file
+            , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row D from the schematic file
+            , <&pro_micro_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row E from the schematic file
+            ;
+
+    };
+};

--- a/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5.dtsi
+++ b/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5.dtsi
@@ -35,11 +35,11 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4)                 RC(2,5) RC(2,6) RC(2,7) 
 
         diode-direction = "col2row";
         row-gpios
-            = <&pro_micro_a 0  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row A from the schematic file
-            , <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row B from the schematic file
-            , <&pro_micro_d 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row C from the schematic file
-            , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row D from the schematic file
-            , <&pro_micro_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row E from the schematic file
+            = <&pro_micro_a 0  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
 
     };

--- a/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5.keymap
+++ b/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5.keymap
@@ -1,0 +1,97 @@
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+#define DEFAULT 0
+#define RAISE   1
+#define LOWER   2
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+// -------------------------------------------------------------------------------------------------------------------------
+// |    Q    |    W    |    E    |    R    |    T    |                   |    Y    |    U    |    I    |    O    |    P    |
+// |    A    |    S    |    D    |    F    |    G    |                   |    H    |    J    |    K    |    L    |    ;    |
+// |    Z    |    X    |    C    |    V    |    B    |                   |    N    |    M    |    ,    |    .    |    /    |
+//           |    [    |    ]    |                                                           |    -    |    =    |
+//                               |ESC+SHFT |BS + CTRL|                   |SPC + ALT|ENTR+SHFT|
+//                                         |   TAB   |   HOME  |   END   |   DEL   |
+//                                         |  Raise  |    ~    |   GUI   |  Lower  |
+            bindings = <
+    &kp Q     &kp W    &kp E     &kp R     &kp T                          &kp Y     &kp U     &kp I     &kp O     &kp P
+    &kp A     &kp S    &kp D     &kp F     &kp G                          &kp H     &kp J     &kp K     &kp L     &kp SEMI
+    &kp Z     &kp X    &kp C     &kp V     &kp B                          &kp N     &kp M     &kp COMMA &kp DOT   &kp FSLH
+              &kp LBKT &kp RBKT                                                               &kp MINUS  &kp EQUAL
+                                 &mt LSHFT ESC &mt LCTRL BSPC                   &mt LALT SPACE &mt LSHFT ENTER
+                                            &kp TAB  &kp HOME  &kp END    &kp DEL
+                                           &mo RAISE &kp GRAVE &kp LGUI   &mo LOWER
+            >;
+        };
+
+        raise {
+// ZMK doesn't support mouse behaviors, so unlike QMK, this default keymap
+// exchanges that behavior for Bluetooth behavior
+// -------------------------------------------------------------------------------------------------------------------------
+// |         |         |         |         |         |                   |  Vol +  |         |    up   |         |   PgUp  |
+// |   BT1   |   BT2   |   BT3   |   BT4   |   BT5   |                   |  Mute   |   left  |   down  |  right  |   PgDn  |
+// |         |         |  BTCLR  |  BTNXT  |  BTPRV  |                   |  Vol -  |    /    |    \    |    ?    |    |    |
+//           |         |         |                                                           |    -    |    +    |
+//                               |         |         |                   |         |         |
+//                                         |         |         |         |         |
+//                                         |         |         |         |         |
+            bindings = <
+    &trans    &trans    &trans    &trans    &trans                        &kp C_VOL_UP &trans &kp UP    &trans    &kp PG_UP
+    &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4      &kp C_MUTE &kp LEFT &kp DOWN  &kp RIGHT &kp PG_DN
+    &trans    &trans    &bt BT_CLR &bt BT_NXT &bt BT_PRV                  &kp C_VOL_DN &kp KP_SLASH &kp BSLH &kp QMARK &kp PIPE
+              &trans    &trans                                                                &kp MINUS &kp PLUS
+                                  &trans    &trans                        &trans     &trans
+                                            &trans    &trans    &trans    &trans
+                                            &trans    &trans    &trans    &trans
+            >;
+        };
+
+        lower {
+// -------------------------------------------------------------------------------------------------------------------------
+// |   F1    |   F2    |   F3    |   F4    |   F5    |                   |   F6    |   F7    |   F8    |   F9    |   F10   |
+// |    1    |    2    |    3    |    4    |    5    |                   |    6    |    7    |    8    |    9    |    0    |
+// |    !    |    @    |    #    |    $    |    %    |                   |    ^    |    &    |    *    |    (    |    )    |
+//           |         |   F11   |   F12                                                     |    -    |    =    |
+//                               |         |         |                   |         |         |
+//                                         |         |         |         |         |
+//                                         |         |         |         |         |
+            bindings = <
+    &kp F1    &kp F2   &kp F3    &kp F4    &kp F5                         &kp F6    &kp F7    &kp F8    &kp F9    &kp F10
+    &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_N4 &kp KP_N5                     &kp KP_N6 &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_N0
+    &kp EXCL  &kp AT   &kp HASH  &kp DLLR  &kp PRCNT                      &kp CARET &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR
+              &kp F11  &kp F12                                                                &kp MINUS &kp EQUAL
+                                 &trans    &trans                        &trans     &trans
+                                           &trans    &trans    &trans    &trans
+                                           &trans    &trans    &trans    &trans
+            >;
+        };
+
+        // This layer is for easier copy/paste when creating new keymaps, so you have transparent keys already added
+        trans {
+// -------------------------------------------------------------------------------------------------------------------------
+// |         |         |         |         |         |                   |         |         |         |         |         |
+// |         |         |         |         |         |                   |         |         |         |         |         |
+// |         |         |         |         |         |                   |         |         |         |         |         |
+//           |         |         |                                                           |         |         |
+//                               |         |         |                   |         |         |
+//                                         |         |         |         |         |
+//                                         |         |         |         |         |
+// I added a zero key because Zephyr won't compile with a only-transparent layer
+            bindings = <
+    &kp KP_N0 &trans    &trans    &trans    &trans                        &trans    &trans    &trans    &trans    &trans
+    &trans    &trans    &trans    &trans    &trans                        &trans    &trans    &trans    &trans    &trans
+    &trans    &trans    &trans    &trans    &trans                        &trans    &trans    &trans    &trans    &trans
+              &trans    &trans                                                                &trans    &trans
+                                  &trans    &trans                        &trans    &trans
+                                            &trans    &trans    &trans    &trans
+                                            &trans    &trans    &trans    &trans
+            >;
+        };
+    };
+};

--- a/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5_left.overlay
+++ b/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5_left.overlay
@@ -1,0 +1,11 @@
+#include "dactyl_manuform_4x5.dtsi"
+
+&kscan0 {
+    col-gpios
+        = <&pro_micro_d 5 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 7 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 8 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 9 GPIO_ACTIVE_HIGH>
+        ;
+};

--- a/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5_right.overlay
+++ b/app/boards/shields/dactyl_manuform_4x5/dactyl_manuform_4x5_right.overlay
@@ -1,0 +1,15 @@
+#include "dactyl_manuform_4x5.dtsi"
+
+&default_transform {
+    col-offset = <5>;
+};
+
+&kscan0 {
+    col-gpios
+        = <&pro_micro_d 9 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 8 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 7 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>
+        , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>
+        ;
+};

--- a/docs/docs/hardware.md
+++ b/docs/docs/hardware.md
@@ -40,6 +40,7 @@ That being said, there are currently only a few specific [boards](/docs/faq#what
 - [tidbit](https://nullbits.co/tidbit/) (`tidbit`)
 - [Eek!](https://www.cbkbd.com/product/eek-keyboard) (`eek`)
 - [BFO-9000](https://keeb.io/products/bfo-9000-keyboard-customizable-full-size-split-ortholinear) (`bfo9000_left` and `bfo9000_right`)
+- [Dactyl Manuform 4x5](https://github.com/abstracthat/dactyl-manuform) (`dactyl_manuform_4x5_left` and `dactyl_manuform_4x5_right`)
 
 ## Other Hardware
 

--- a/docs/static/setup.ps1
+++ b/docs/static/setup.ps1
@@ -58,11 +58,11 @@ catch [System.Management.Automation.CommandNotFoundException] {
 Test-Git-Config -Option "user.name" -ErrMsg "Git username not set!`nRun: git config --global user.name 'My Name'"
 Test-Git-Config -Option "user.email" -ErrMsg "Git email not set!`nRun: git config --global user.email 'example@myemail.com'"
 
-$permission = (Get-Acl $pwd).Access | 
+$permission = (Get-Acl $pwd).Access |
 ?{$_.IdentityReference -match $env:UserName `
 	-and $_.FileSystemRights -match "FullControl" `
-		-or $_.FileSystemRights -match "Write"	} | 
-			
+		-or $_.FileSystemRights -match "Write"	} |
+
 		Select IdentityReference,FileSystemRights
 
 If (-Not $permission){
@@ -90,9 +90,9 @@ Write-Host "Keyboard Shield Selection:"
 $prompt = "Pick a keyboard"
 
 # TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
-$options = "Kyria", "Lily58", "Corne", "Splitreus62", "Sofle", "Iris", "Reviung41", "RoMac", "RoMac+", "makerdiary M60", "Microdox", "TG4X", "QAZ", "NIBBLE", "Jorne", "Jian", "CRBN", "Tidbit", "Eek!", "BFO-9000", "Helix"
-$names = "kyria", "lily58", "corne", "splitreus62", "sofle", "iris", "reviung41", "romac", "romac_plus", "m60", "microdox", "tg4x", "qaz", "nibble", "jorne", "jian", "crbn", "tidbit", "eek", "bfo9000", "helix"
-$splits = "y", "y", "y", "y", "y", "y", "n", "n", "n", "n", "y", "n", "n", "n", "y", "y", "n", "n", "n", "n", "y"
+$options = "Kyria", "Lily58", "Corne", "Splitreus62", "Sofle", "Iris", "Reviung41", "RoMac", "RoMac+", "makerdiary M60", "Microdox", "TG4X", "QAZ", "NIBBLE", "Jorne", "Jian", "CRBN", "Tidbit", "Eek!", "BFO-9000", "Helix", "Dactyl Manuform 4x5"
+$names = "kyria", "lily58", "corne", "splitreus62", "sofle", "iris", "reviung41", "romac", "romac_plus", "m60", "microdox", "tg4x", "qaz", "nibble", "jorne", "jian", "crbn", "tidbit", "eek", "bfo9000", "helix", "dactyl_manuform_4x5"
+$splits = "y", "y", "y", "y", "y", "y", "n", "n", "n", "n", "y", "n", "n", "n", "y", "y", "n", "n", "n", "n", "y", "y"
 
 $choice = Get-Choice-From-Options -Options $options -Prompt $prompt
 $shield_title = $($options[$choice])

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -121,7 +121,7 @@ select opt in "${options[@]}" "Quit"; do
     19 ) shield_title="Eek!" shield="eek"; split="n" break;;
     20 ) shield_title="BFO-9000" shield="bfo9000"; split="y"; break;;
     21 ) shield_title="Helix" shield="helix"; split="y"; break;;
-    21 ) shield_title="Dactyl Manuform 4x5" shield="dactyl_manuform_4x5"; split="y"; break;;
+    22 ) shield_title="Dactyl Manuform 4x5" shield="dactyl_manuform_4x5"; split="y"; break;;
 
     # Add link to docs on adding your own custom shield in your ZMK config!
     # $(( ${#options[@]}+1 )) ) echo "Other!"; break;;

--- a/docs/static/setup.sh
+++ b/docs/static/setup.sh
@@ -91,7 +91,7 @@ echo ""
 echo "Keyboard Shield Selection:"
 
 prompt="Pick an keyboard:"
-options=("Kyria" "Lily58" "Corne" "Splitreus62" "Sofle" "Iris" "Reviung41" "RoMac" "RoMac+" "makerdiary M60" "Microdox" "TG4X" "QAZ" "NIBBLE" "Jorne" "Jian" "CRBN" "Tidbit" "Eek!" "BFO-9000" "Helix")
+options=("Kyria" "Lily58" "Corne" "Splitreus62" "Sofle" "Iris" "Reviung41" "RoMac" "RoMac+" "makerdiary M60" "Microdox" "TG4X" "QAZ" "NIBBLE" "Jorne" "Jian" "CRBN" "Tidbit" "Eek!" "BFO-9000" "Helix" "Dactyl Manuform 4x5")
 
 PS3="$prompt "
 # TODO: Add support for "Other" and linking to docs on adding custom shields in user config repos.
@@ -121,6 +121,7 @@ select opt in "${options[@]}" "Quit"; do
     19 ) shield_title="Eek!" shield="eek"; split="n" break;;
     20 ) shield_title="BFO-9000" shield="bfo9000"; split="y"; break;;
     21 ) shield_title="Helix" shield="helix"; split="y"; break;;
+    21 ) shield_title="Dactyl Manuform 4x5" shield="dactyl_manuform_4x5"; split="y"; break;;
 
     # Add link to docs on adding your own custom shield in your ZMK config!
     # $(( ${#options[@]}+1 )) ) echo "Other!"; break;;


### PR DESCRIPTION
Hello, hello!

I've added a default keymap for Dactyl Manuform 4x5 keebs, which should make it easier to add additional Dactyl's in the future. I used the [default config in the QMK repo](https://github.com/qmk/qmk_firmware/tree/master/keyboards/handwired/dactyl_manuform/4x5) for consistency.