### PR TITLE
Added support for prefers-color-scheme in docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -10,6 +10,9 @@ module.exports = {
   projectName: "zmk", // Usually your repo name.
   plugins: [path.resolve(__dirname, "src/docusaurus-tree-sitter-plugin")],
   themeConfig: {
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
     googleAnalytics: {
       trackingID: "UA-145201102-2",
       anonymizeIP: true,


### PR DESCRIPTION
Now, instead of always defaulting to light theme, documentation, docs
will default to the color scheme based by the user preference (reported
by web browser as a `prefers-color-scheme` media query).

It is still possible for user to change the theme by using the switch
next to the search box. His preference will be remembered.

I've tested all existing documentation pages for compatibility with the dark
color theme and I've found no major ones.