### PR TITLE
Add Board Shield for Reviung 39

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,8 @@ jobs:
           - qaz
           - quefrency_left
           - quefrency_right
-          - reviung41
           - reviung39
+          - reviung41
           - romac
           - romac_plus
           - settings_reset

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
           - quefrency_left
           - quefrency_right
           - reviung41
+          - reviung39
           - romac
           - romac_plus
           - settings_reset

--- a/app/boards/shields/reviung39/Kconfig.defconfig
+++ b/app/boards/shields/reviung39/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_REVIUNG39
+
+config ZMK_KEYBOARD_NAME
+    default "Reviung39"
+
+endif

--- a/app/boards/shields/reviung39/Kconfig.shield
+++ b/app/boards/shields/reviung39/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_REVIUNG39
+    def_bool $(shields_list_contains,reviung39)

--- a/app/boards/shields/reviung39/boards/nice_nano.overlay
+++ b/app/boards/shields/reviung39/boards/nice_nano.overlay
@@ -1,0 +1,28 @@
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <11>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/reviung39/reviung39.conf
+++ b/app/boards/shields/reviung39/reviung39.conf
@@ -1,0 +1,3 @@
+# Uncomment the following lines to enable RGB underglow
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/reviung39/reviung39.keymap
+++ b/app/boards/shields/reviung39/reviung39.keymap
@@ -60,7 +60,7 @@
 // | RGB BRI+ | RGB SAT+ | RGB HUE+ | RGB ANI+ |    | RGB TOG |   |  BT1  | BT2 | BT3 | BT4 | BT5 | BT CLR |
 // | RGB BRI- | RGB SAT- | RGB HUE- | RGB ANI+ |    |         |   |       |     |     |     |     |        |
 // |          |          |          |          |    |         |   | RESET |     |     |     |     |        |
-//                                              |     |     |     |     |     |
+//                                      |     |      |     |
                         bindings = <
    &rgb_ug RGB_BRI &rgb_ug RGB_SAI &rgb_ug RGB_HUI &rgb_ug RGB_EFF &none &rgb_ug RGB_TOG    &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &bt BT_CLR
    &rgb_ug RGB_BRD &rgb_ug RGB_SAD &rgb_ug RGB_HUD &rgb_ug RGB_EFR &none &none              &none        &none        &none        &none        &none        &none

--- a/app/boards/shields/reviung39/reviung39.keymap
+++ b/app/boards/shields/reviung39/reviung39.keymap
@@ -37,7 +37,7 @@
    &trans &kp N1    &kp N2    &kp N3    &kp N4    &kp N5        &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp DEL
    &trans &none     &kp HOME  &kp PG_UP &kp PG_DN &kp END       &kp GRAVE &kp MINUS &kp EQUAL &kp LBKT  &kp RBKT  &kp RGUI
    &trans &kp LGUI  &kp LALT  &kp LCTRL &none     &none         &kp BSLH  &kp UNDER &kp PLUS  &kp LBRC  &kp RBRC  &kp RALT
-                                            &mo 3       &kp BSPC        &trans
+                                             &trans       &kp BKSP        &mo 3
                         >;
                 };
                 
@@ -51,7 +51,7 @@
    &trans &kp EXCL  &kp AT      &kp HASH &kp DLLR &kp PRCNT      &kp CARET &kp AMPS &kp STAR  &kp LPAR  &kp RPAR  &kp DEL
    &trans &none     &none       &none    &none    &none          &kp LEFT  &kp DOWN &kp UP    &kp RIGHT &none     &none
    &trans &none     &none       &none    &none    &none          &none     &none    &kp RCTRL &kp RALT  &kp RGUI  &none
-                                             &trans       &kp RET        &mo 3
+                                            &mo 3       &kp RET         &trans
                         >;
                 };
 

--- a/app/boards/shields/reviung39/reviung39.keymap
+++ b/app/boards/shields/reviung39/reviung39.keymap
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/rgb.h>
+
+/ {
+        keymap {
+                compatible = "zmk,keymap";
+
+                default_layer {
+// -------------------------------------------------------------------------------------
+// |  TAB |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  |   BKSP    |
+// | CTRL |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |    '      |
+// | SHFT |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | SHFT(RET) |
+//                                 LWR | SPC | RSE               
+                        bindings = <
+   &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
+   &kp LCTRL &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
+   &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &mt RSHFT RET
+                                  &mo 1 &kp SPACE &mo 2
+                        >;
+                };
+
+                lower_layer {
+// ----------------------------------------------------------------------------------
+// |    |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  (  |  )  |    DEL    |
+// |    |  _  |  +  |  {  |  }  | "|" |   | LFT | DWN |  UP | RGT |  `  |     ~     |
+// |    | ESC | GUI | ALT | CAPS|  "  |   | HOME| END | PGUP| PGDN| PRSC| SHFT(RET) |
+//                             |     | RET | ADJ |
+                        bindings = <
+   &trans &kp EXCL  &kp AT      &kp HASH &kp DLLR &kp PRCNT      &kp CARET &kp AMPS &kp N8    &kp LPAR  &kp RPAR  &kp DEL
+   &trans &kp MINUS &kp KP_PLUS &kp LBRC &kp RBRC &kp PIPE       &kp LEFT  &kp DOWN &kp UP    &kp RIGHT &kp GRAVE &kp GRAVE
+   &trans &kp ESC   &kp LGUI    &kp LALT &kp CLCK &kp SQT        &kp HOME  &kp END  &kp PG_UP &kp PG_DN &kp PSCRN &mt RSHFT RET
+                                             &trans       &kp RET        &mo 3
+                        >;
+                };
+
+                raise_layer {
+// -----------------------------------------------------------------------------------------
+// |    |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  | DEL |
+// |    |  -  |  =  |  [  |  ]  |  \  |   | F1  | F2  | F3  | F4  | F5  | F6  |
+// |    | ESC | GUI | ALT | CAPS|  "  |   | F7  | F8  | F9  | F10 | F11 | F12 |
+//                             | ADJ | BKSP |    |
+                        bindings = <
+   &trans &kp N1    &kp N2    &kp N3    &kp N4    &kp N5        &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp DEL
+   &trans &kp MINUS &kp EQUAL &kp LBKT  &kp RBKT  &kp BSLH      &kp F1    &kp F2    &kp F3    &kp F4    &kp F5    &kp F6
+   &trans &kp ESC   &kp LGUI  &kp RALT  &kp CLCK  &kp SQT       &kp F7    &kp F8    &kp F9    &kp F10   &kp F11   &kp F12
+                                            &mo 3       &kp BSPC        &trans
+                        >;
+                };
+
+                adjust_layer {
+// -----------------------------------------------------------------------------------------
+// | RGB BRI+ | RGB SAT+ | RGB HUE+ | RGB ANI+ |    | RGB TOG |   |  BT1  | BT2 | BT3 | BT4 | BT5 | BT CLR |
+// | RGB BRI- | RGB SAT- | RGB HUE- | RGB ANI+ |    |         |   |       |     |     |     |     |        |
+// |          |          |          |          |    |         |   | RESET |     |     |     |     |        |
+//                                              |     |     |     |     |     |
+                        bindings = <
+   &rgb_ug RGB_BRI &rgb_ug RGB_SAI &rgb_ug RGB_HUI &rgb_ug RGB_EFF &none &rgb_ug RGB_TOG    &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &bt BT_CLR
+   &rgb_ug RGB_BRD &rgb_ug RGB_SAD &rgb_ug RGB_HUD &rgb_ug RGB_EFR &none &none              &none        &none        &none        &none        &none        &none
+   &none           &none           &none           &none           &none &none              &reset       &none        &none        &none        &none        &none
+                                            &trans       &tog 3        &trans
+                        >;
+                };
+        };
+};

--- a/app/boards/shields/reviung39/reviung39.keymap
+++ b/app/boards/shields/reviung39/reviung39.keymap
@@ -60,7 +60,7 @@
 // | F1 | F2  | F3  | F4   | F5  | F6  |   | F7   | F8  | F9  | F10 | F11 | F12  |
 // |    | BRI+| BACK| PL/PS| FWD | CAPS|   | BT1  | BT2 | BT3 | BT4 | BT5 | BTCLR|
 // |    | BRI-| VOL-| MUTE | VOL+|     |   | RESET|     |     |     |     |      |
-//                          |     |     |     |
+//                              |     |     |     |
                         bindings = <
    &kp F1          &kp F2          &kp F3          &kp F4          &kp F5        &kp F6      &kp F7       &kp F8       &kp F9       &kp F10      &kp F11      &kp F12
    &none           &kp C_BRI_UP    &kp C_PREV      &kp C_PP        &kp C_NEXT    &kp CAPS    &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &bt BT_CLR

--- a/app/boards/shields/reviung39/reviung39.keymap
+++ b/app/boards/shields/reviung39/reviung39.keymap
@@ -14,58 +14,58 @@
                 compatible = "zmk,keymap";
 
                 default_layer {
-// -------------------------------------------------------------------------------------
-// |  TAB |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  |   BKSP    |
-// | CTRL |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |    '      |
-// | SHFT |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | SHFT(RET) |
-//                                 LWR | SPC | RSE               
+// -----------------------------------------------------------------------------------------
+// | TAB      |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  |   BKSP    |
+// | CTRL     |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |    '      |
+// | SHFT(ESC)|  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | SHFT(RET) |
+//                                     LWR | SPC | RSE               
                         bindings = <
-   &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
-   &kp LCTRL &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
-   &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &mt RSHFT RET
+   &kp TAB       &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
+   &kp LCTRL     &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
+   &mt LSHFT ESC &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &mt RSHFT RET
                                   &mo 1 &kp SPACE &mo 2
                         >;
                 };
 
                 lower_layer {
 // ----------------------------------------------------------------------------------
-// |    |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  (  |  )  |    DEL    |
-// |    |  _  |  +  |  {  |  }  | "|" |   | LFT | DWN |  UP | RGT |  `  |     ~     |
-// |    | ESC | GUI | ALT | CAPS|  "  |   | HOME| END | PGUP| PGDN| PRSC| SHFT(RET) |
-//                             |     | RET | ADJ |
+// | TAB      |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  | DEL |
+// | CTRL     |     | HOME| PGUP| PGDN| END |   |  `  |  -  |  =  |  [  |  ]  | GUI |
+// | SHFT(ESC)| GUI | ALT | CTRL|     |     |   |  \  |  _  |  +  |  {  |  }  | ALT |
+//                                   | ADJ | BKSP |    |
                         bindings = <
-   &trans &kp EXCL  &kp AT      &kp HASH &kp DLLR &kp PRCNT      &kp CARET &kp AMPS &kp N8    &kp LPAR  &kp RPAR  &kp DEL
-   &trans &kp MINUS &kp KP_PLUS &kp LBRC &kp RBRC &kp PIPE       &kp LEFT  &kp DOWN &kp UP    &kp RIGHT &kp GRAVE &kp GRAVE
-   &trans &kp ESC   &kp LGUI    &kp LALT &kp CLCK &kp SQT        &kp HOME  &kp END  &kp PG_UP &kp PG_DN &kp PSCRN &mt RSHFT RET
+   &trans &kp N1    &kp N2    &kp N3    &kp N4    &kp N5        &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp DEL
+   &trans &none     &kp HOME  &kp PG_UP &kp PG_DN &kp END       &kp GRAVE &kp MINUS &kp EQUAL &kp LBKT  &kp RBKT  &kp RGUI
+   &trans &kp LGUI  &kp LALT  &kp LCTRL &none     &none         &kp BSLH  &kp UNDER &kp PLUS  &kp LBRC  &kp RBRC  &kp RALT
+                                            &mo 3       &kp BSPC        &trans
+                        >;
+                };
+                
+                raise_layer {
+// ----------------------------------------------------------------------------------
+// | TAB      |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  (  |  )  | DEL |
+// | CTRL     |     |     |     |     |     |   | LFT | DWN |  UP | RGT |     |     |
+// | SHFT(ESC)|     |     |     |     |     |   |     |     | CTRL| ALT | GUI |     |
+//                                   |     | RET | ADJ |
+                        bindings = <
+   &trans &kp EXCL  &kp AT      &kp HASH &kp DLLR &kp PRCNT      &kp CARET &kp AMPS &kp STAR  &kp LPAR  &kp RPAR  &kp DEL
+   &trans &none     &none       &none    &none    &none          &kp LEFT  &kp DOWN &kp UP    &kp RIGHT &none     &none
+   &trans &none     &none       &none    &none    &none          &none     &none    &kp RCTRL &kp RALT  &kp RGUI  &none
                                              &trans       &kp RET        &mo 3
                         >;
                 };
 
-                raise_layer {
-// -----------------------------------------------------------------------------------------
-// |    |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  | DEL |
-// |    |  -  |  =  |  [  |  ]  |  \  |   | F1  | F2  | F3  | F4  | F5  | F6  |
-// |    | ESC | GUI | ALT | CAPS|  "  |   | F7  | F8  | F9  | F10 | F11 | F12 |
-//                             | ADJ | BKSP |    |
-                        bindings = <
-   &trans &kp N1    &kp N2    &kp N3    &kp N4    &kp N5        &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp DEL
-   &trans &kp MINUS &kp EQUAL &kp LBKT  &kp RBKT  &kp BSLH      &kp F1    &kp F2    &kp F3    &kp F4    &kp F5    &kp F6
-   &trans &kp ESC   &kp LGUI  &kp RALT  &kp CLCK  &kp SQT       &kp F7    &kp F8    &kp F9    &kp F10   &kp F11   &kp F12
-                                            &mo 3       &kp BSPC        &trans
-                        >;
-                };
-
                 adjust_layer {
-// -----------------------------------------------------------------------------------------
-// | RGB BRI+ | RGB SAT+ | RGB HUE+ | RGB ANI+ |    | RGB TOG |   |  BT1  | BT2 | BT3 | BT4 | BT5 | BT CLR |
-// | RGB BRI- | RGB SAT- | RGB HUE- | RGB ANI+ |    |         |   |       |     |     |     |     |        |
-// |          |          |          |          |    |         |   | RESET |     |     |     |     |        |
-//                                      |     |      |     |
+// -------------------------------------------------------------------------------
+// | F1 | F2  | F3  | F4   | F5  | F6  |   | F7   | F8  | F9  | F10 | F11 | F12  |
+// |    | BRI+| BACK| PL/PS| FWD | CAPS|   | BT1  | BT2 | BT3 | BT4 | BT5 | BTCLR|
+// |    | BRI-| VOL-| MUTE | VOL+|     |   | RESET|     |     |     |     |      |
+//                          |     |     |     |
                         bindings = <
-   &rgb_ug RGB_BRI &rgb_ug RGB_SAI &rgb_ug RGB_HUI &rgb_ug RGB_EFF &none &rgb_ug RGB_TOG    &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &bt BT_CLR
-   &rgb_ug RGB_BRD &rgb_ug RGB_SAD &rgb_ug RGB_HUD &rgb_ug RGB_EFR &none &none              &none        &none        &none        &none        &none        &none
-   &none           &none           &none           &none           &none &none              &reset       &none        &none        &none        &none        &none
-                                            &trans       &tog 3        &trans
+   &kp F1          &kp F2          &kp F3          &kp F4          &kp F5        &kp F6      &kp F7       &kp F8       &kp F9       &kp F10      &kp F11      &kp F12
+   &none           &kp C_BRI_UP    &kp C_PREV      &kp C_PP        &kp C_NEXT    &kp CAPS    &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &bt BT_CLR
+   &none           &kp C_BRI_DN    &kp C_VOL_DN    &kp C_MUTE      &kp C_VOL_UP  &none       &reset       &none        &none        &none        &none        &none
+                                                                      &trans       &tog 3        &trans
                         >;
                 };
         };

--- a/app/boards/shields/reviung39/reviung39.overlay
+++ b/app/boards/shields/reviung39/reviung39.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <6>;
+        rows = <7>;
+
+        map = <
+RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)
+RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)
+RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5)
+                                RC(6,0)     RC(6,1)     RC(6,2)  
+        >;
+    };
+
+    kscan0: kscan_0 {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "col2row";
+
+        col-gpios
+            = <&pro_micro_d 4 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 7 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 8 GPIO_ACTIVE_HIGH>
+            , <&pro_micro_d 9 GPIO_ACTIVE_HIGH>
+            ;
+
+        row-gpios
+            = <&pro_micro_a 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_a 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_a 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_a 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+    };
+};

--- a/app/boards/shields/reviung39/reviung39.overlay
+++ b/app/boards/shields/reviung39/reviung39.overlay
@@ -45,7 +45,7 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(5,0) RC(5,1) RC(5,2) RC(5,3) 
             , <&pro_micro_a 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pro_micro_a 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro_d 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };

--- a/app/boards/shields/reviung39/reviung39.overlay
+++ b/app/boards/shields/reviung39/reviung39.overlay
@@ -45,7 +45,7 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(5,0) RC(5,1) RC(5,2) RC(5,3) 
             , <&pro_micro_a 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pro_micro_a 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pro_micro_d 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro_d 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };


### PR DESCRIPTION

I added support for the Reviung 39 board using the nice!nano. 
All the files specified in the ``New Keyboard Shield`` section of the documentation were added.
``build.yml`` was updated to reflect the presence of the board.

All this was tested by running it on my new Reviung 39. It works wired and wireless, supporting multiple connections just like it should.
