### PR TITLE
Add missing semicolon to examples in doc

### DIFF
--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -56,7 +56,7 @@ For example, if you press `&mt LEFT_SHIFT A` and then release it without pressin
 ```
 &mt {
 	retro-tap;
-}
+};
 ```
 
 #### Home row mods

--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -22,21 +22,20 @@ An example of how to implement the mod-morph "Grave Escape":
 
 ```
 / {
-behaviors {
-    gresc: grave_escape {
-        compatible = "zmk,behavior-mod-morph";
-        label = "GRAVE_ESCAPE";
-        #binding-cells = <0>;
-        bindings = <&kp ESC>, <&kp GRAVE>;
-        mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
-    }
-
-};
+    behaviors {
+        gresc: grave_escape {
+            compatible = "zmk,behavior-mod-morph";
+            label = "GRAVE_ESCAPE";
+            #binding-cells = <0>;
+            bindings = <&kp ESC>, <&kp GRAVE>;
+            mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
+        };
+    };
 
     keymap {
         ...
-    }
-}
+    };
+};
 ```
 
 Note that this specific mod-morph exists in ZMK by default using code `&gresc`.

--- a/docs/docs/behaviors/mod-tap.md
+++ b/docs/docs/behaviors/mod-tap.md
@@ -40,8 +40,8 @@ You can configure a different tapping term in your keymap:
 / {
     keymap {
         ...
-    }
-}
+    };
+};
 ```
 
 ### Additional information

--- a/docs/docs/behaviors/sticky-key.md
+++ b/docs/docs/behaviors/sticky-key.md
@@ -38,8 +38,8 @@ You can configure a different `release-after-ms` in your keymap:
 / {
     keymap {
         ...
-    }
-}
+    };
+};
 ```
 
 ### Advanced usage

--- a/docs/docs/behaviors/sticky-layer.md
+++ b/docs/docs/behaviors/sticky-layer.md
@@ -32,8 +32,8 @@ You can configure a different `release-after-ms` in your keymap:
 / {
     keymap {
         ...
-    }
-}
+    };
+};
 ```
 
 ### Advanced usage


### PR DESCRIPTION
I was running into errors when copying example code from the documentation to my personal zmk-config. This was due to missing semicolons in at least two cases, so I want to fix those errors in the doc to maybe save others some time.

Not too experienced with contributing to open source projects. I ran through the Development Guidelines in the doc and executed the checks / linting / build, hope this is all that is required :)