### PR TITLE
Add delay on initializing external power control for BlueMicro840

### DIFF
--- a/app/boards/arm/bluemicro840/bluemicro840_v1.dts
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1.dts
@@ -29,6 +29,7 @@
 	ext-power {
 		compatible = "zmk,ext-power-generic";
 		label = "EXT_POWER";
+		init-delay-ms = <20>;
 		control-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 	};
 


### PR DESCRIPTION
This commits adds a delay of 100ms on initializing the external
power control driver. Previously, OLED's i2c driver is failing to
initialize the display. This commit fixes that issue.

Signed-off-by: Anthony Amanse <ghieamanse@gmail.com>