### PR TITLE
Fix Blue LED pin definition in BlueMicro840

### DIFF
--- a/app/boards/arm/bluemicro840/bluemicro840_v1.dts
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1.dts
@@ -21,7 +21,7 @@
 	leds {
 		compatible = "gpio-leds";
 		blue_led: led_0 {
-			gpios = <&gpio0 42 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 			label = "Blue LED";
 		};
 	};


### PR DESCRIPTION
This commit fixes the pin definition for BlueMicro840's blue led. Based on the
schematics, the blue led is at pin 1.10.

Signed-off-by: Anthony Amanse <ghieamanse@gmail.com>