### PR TITLE
fix(boards): Set nice!60 nRF subfamily for openocd

### DIFF
--- a/app/boards/arm/nice60/board.cmake
+++ b/app/boards/arm/nice60/board.cmake
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 Nick Winans
 # SPDX-License-Identifier: MIT
 
+set(OPENOCD_NRF5_SUBFAMILY nrf52)
 board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)


### PR DESCRIPTION
Currently doing a fresh build fails due to the nRF subfamily not being set on the nice!60. It's usually inferred based on the board name (seems like a silly optimization in my opinion, but maybe I'm missing something). This allows for clean builds to function once more.