### PR TITLE
Add support for BLE connection interval

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -148,7 +148,7 @@ config BT_PERIPHERAL_PREF_MIN_INT
 config BT_PERIPHERAL_PREF_MAX_INT
 	default 12
 
-config BT_PERIPHERAL_PREF_SLAVE_LATENCY
+config BT_PERIPHERAL_PREF_LATENCY
 	default 30
 
 config BT_PERIPHERAL_PREF_TIMEOUT
@@ -175,6 +175,7 @@ menuconfig ZMK_SPLIT_BLE
 	depends on ZMK_BLE
 	default y
 	select BT_USER_PHY_UPDATE
+	select BT_AUTO_PHY_UPDATE
 
 if ZMK_SPLIT_BLE
 
@@ -222,6 +223,9 @@ config BT_MAX_PAIRED
 
 config BT_MAX_CONN
 	default 1
+
+config BT_PERIPHERAL_PREF_MAX_INT
+	default 6
 
 #!ZMK_SPLIT_BLE_ROLE_CENTRAL
 endif

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -142,6 +142,30 @@ config ZMK_BLE_PASSKEY_ENTRY
 	bool "Experimental: Requiring typing passkey from host to pair BLE connection"
 	default n
 
+config BT_GAP_AUTO_UPDATE_CONN_PARAMS
+	bool "Automatic Update of Connection Parameters"
+	default y
+
+config BT_GAP_PERIPHERAL_PREF_PARAMS
+	bool "Configure peripheral preferred connection parameters"
+	default y
+
+config BT_PERIPHERAL_PREF_MIN_INT
+	int "Peripheral preferred minimum connection interval in 1.25ms units"
+	default 6
+
+config BT_PERIPHERAL_PREF_MAX_INT
+	int "Peripheral preferred maximum connection interval in 1.25ms units"
+	default 12
+
+config BT_PERIPHERAL_PREF_SLAVE_LATENCY
+	int "Peripheral preferred slave latency in Connection Intervals"
+	default 30
+
+config BT_PERIPHERAL_PREF_TIMEOUT
+	int "Peripheral preferred supervision timeout in 10ms units"
+	default 400
+
 #ZMK_BLE
 endif
 
@@ -210,9 +234,6 @@ config BT_MAX_PAIRED
 
 config BT_MAX_CONN
 	default 1
-
-config BT_GAP_AUTO_UPDATE_CONN_PARAMS
-	default n
 
 #!ZMK_SPLIT_BLE_ROLE_CENTRAL
 endif

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -142,28 +142,16 @@ config ZMK_BLE_PASSKEY_ENTRY
 	bool "Experimental: Requiring typing passkey from host to pair BLE connection"
 	default n
 
-config BT_GAP_AUTO_UPDATE_CONN_PARAMS
-	bool "Automatic Update of Connection Parameters"
-	default y
-
-config BT_GAP_PERIPHERAL_PREF_PARAMS
-	bool "Configure peripheral preferred connection parameters"
-	default y
-
 config BT_PERIPHERAL_PREF_MIN_INT
-	int "Peripheral preferred minimum connection interval in 1.25ms units"
 	default 6
 
 config BT_PERIPHERAL_PREF_MAX_INT
-	int "Peripheral preferred maximum connection interval in 1.25ms units"
 	default 12
 
 config BT_PERIPHERAL_PREF_SLAVE_LATENCY
-	int "Peripheral preferred slave latency in Connection Intervals"
 	default 30
 
 config BT_PERIPHERAL_PREF_TIMEOUT
-	int "Peripheral preferred supervision timeout in 10ms units"
 	default 400
 
 #ZMK_BLE

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -398,15 +398,6 @@ static void connected(struct bt_conn *conn, uint8_t err) {
 
     LOG_DBG("Connected %s", log_strdup(addr));
 
-    err = bt_conn_le_param_update(conn, BT_LE_CONN_PARAM(0x0006, 0x000c, 30, 400));
-    if (err) {
-        LOG_WRN("Failed to update LE parameters (err %d)", err);
-    }
-
-#if IS_SPLIT_PERIPHERAL
-    bt_conn_le_phy_update(conn, BT_CONN_LE_PHY_PARAM_2M);
-#endif
-
     if (bt_conn_set_security(conn, BT_SECURITY_L2)) {
         LOG_ERR("Failed to set security");
     }

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -403,12 +403,6 @@ static bool split_central_eir_found(struct bt_data *data, void *user_data) {
                             BT_HCI_OP_LE_CREATE_CONN);
                     start_scan();
                 }
-
-                err = bt_conn_le_phy_update(slot->conn, BT_CONN_LE_PHY_PARAM_2M);
-                if (err) {
-                    LOG_ERR("Update phy conn failed (err %d)", err);
-                    start_scan();
-                }
             }
 
             return false;


### PR DESCRIPTION
Adds support for configuring the BLE connection interval to allow users to force a faster connection and lower the latency of BLE. The original idea came from @Nicell youtube video where he tested the latency of different things and showed that BLE with a forced connection interval of 7.5ms is as fast as wired when not using ZMKs 1ms polling.

The new configuration variables are
Setting the connection interval, setting both these to the same value forces a set polling rate so both 6 will give you 7.5 ms
CONFIG_BT_PERIPHERAL_PREF_MIN_INT=6 
CONFIG_BT_PERIPHERAL_PREF_MAX_INT=12

Setting for latency and timeout
CONFIG_BT_PERIPHERAL_PREF_SLAVE_LATENCY=30
CONFIG_BT_PERIPHERAL_PREF_TIMEOUT=400