### PR TITLE
feat!: Add chosen node for battery

### DIFF
--- a/app/boards/arm/bluemicro840/bluemicro840_v1.dts
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &cdc_acm_uart;
+		zmk,battery = &vbatt;
 	};
 
 	leds {
@@ -34,7 +35,7 @@
 		control-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "zmk,battery-voltage-divider";
 		label = "BATTERY";
 		io-channels = <&adc 7>;

--- a/app/boards/arm/bt60/bt60.dtsi
+++ b/app/boards/arm/bt60/bt60.dtsi
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &cdc_acm_uart;
+		zmk,battery = &vbatt;
 		zmk,kscan = &kscan0;
 		zmk,matrix_transform = &default_transform;
 	};
@@ -46,7 +47,7 @@
 		};
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "zmk,battery-voltage-divider";
 		label = "BATTERY";
 		io-channels = <&adc 2>;

--- a/app/boards/arm/mikoto/mikoto_520.dts
+++ b/app/boards/arm/mikoto/mikoto_520.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &cdc_acm_uart;
+		zmk,battery = &vbatt;
 	};
 
 	leds {
@@ -34,7 +35,7 @@
 		init-delay-ms = <50>;
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "zmk,battery-voltage-divider";
 		label = "BATTERY";
 		io-channels = <&adc 2>;

--- a/app/boards/arm/nice60/nice60.dts
+++ b/app/boards/arm/nice60/nice60.dts
@@ -19,6 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &cdc_acm_uart;
+		zmk,battery = &vbatt;
 		zmk,kscan = &kscan0;
 		zmk,matrix_transform = &default_transform;
 		zmk,underglow = &led_strip;
@@ -81,7 +82,7 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
 		control-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "zmk,battery-voltage-divider";
 		label = "BATTERY";
 		io-channels = <&adc 2>;

--- a/app/boards/arm/nice_nano/nice_nano.dts
+++ b/app/boards/arm/nice_nano/nice_nano.dts
@@ -8,13 +8,17 @@
 #include "nice_nano.dtsi"
 
 / {
+	chosen {
+		zmk,battery = &vbatt;
+	};
+
 	ext-power {
 		compatible = "zmk,ext-power-generic";
 		label = "EXT_POWER";
 		control-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "zmk,battery-voltage-divider";
 		label = "BATTERY";
 		io-channels = <&adc 2>;

--- a/app/boards/arm/nice_nano/nice_nano_v2.dts
+++ b/app/boards/arm/nice_nano/nice_nano_v2.dts
@@ -8,6 +8,10 @@
 #include "nice_nano.dtsi"
 
 / {
+	chosen {
+		zmk,battery = &vbatt;
+	};
+
 	ext-power {
 		compatible = "zmk,ext-power-generic";
 		label = "EXT_POWER";
@@ -15,7 +19,7 @@
 		init-delay-ms = <50>;
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "zmk,battery-nrf-vddh";
 		label = "BATTERY";
 	};

--- a/app/boards/arm/nrfmicro/nrfmicro_13.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &cdc_acm_uart;
+		zmk,battery = &vbatt;
 	};
 
 	leds {
@@ -33,7 +34,7 @@
 		control-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "zmk,battery-voltage-divider";
 		label = "BATTERY";
 		io-channels = <&adc 2>;

--- a/app/boards/arm/s40nc/s40nc.dts
+++ b/app/boards/arm/s40nc/s40nc.dts
@@ -17,6 +17,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,console = &cdc_acm_uart;
+		zmk,battery = &vbatt;
 		zmk,kscan = &kscan0;
 		zmk,matrix_transform = &default_transform;
 	};
@@ -69,7 +70,7 @@
 		};
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "zmk,battery-voltage-divider";
 		label = "BATTERY";
 		io-channels = <&adc 2>;

--- a/app/boards/seeeduino_xiao_ble.overlay
+++ b/app/boards/seeeduino_xiao_ble.overlay
@@ -8,9 +8,10 @@
 / {
 	chosen {
 		zephyr,console = &cdc_acm_uart;
+		zmk,battery = &vbatt;
 	};
 
-	vbatt {
+	vbatt: vbatt {
 		compatible = "zmk,battery-voltage-divider";
 		label = "BATTERY";
 		io-channels = <&adc 7>;

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -26,6 +26,8 @@ uint8_t zmk_battery_state_of_charge() { return last_state_of_charge; }
 #if DT_HAS_CHOSEN(zmk_battery)
 static const struct device *const battery = DEVICE_DT_GET(DT_CHOSEN(zmk_battery));
 #else
+#warning                                                                                           \
+    "Using a node labeled BATTERY for the battery sensor is deprecated. Set a zmk,battery chosen node instead. (Ignore this if you don't have a battery sensor.)"
 static const struct device *battery;
 #endif
 

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -5,6 +5,7 @@
  */
 
 #include <device.h>
+#include <devicetree.h>
 #include <init.h>
 #include <kernel.h>
 #include <drivers/sensor.h>
@@ -18,11 +19,15 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/battery.h>
 #include <zmk/events/battery_state_changed.h>
 
-const struct device *battery;
-
 static uint8_t last_state_of_charge = 0;
 
 uint8_t zmk_battery_state_of_charge() { return last_state_of_charge; }
+
+#if DT_HAS_CHOSEN(zmk_battery)
+static const struct device *const battery = DEVICE_DT_GET(DT_CHOSEN(zmk_battery));
+#else
+static const struct device *battery;
+#endif
 
 static int zmk_battery_update(const struct device *battery) {
     struct sensor_value state_of_charge;
@@ -75,10 +80,18 @@ static void zmk_battery_timer(struct k_timer *timer) { k_work_submit(&battery_wo
 K_TIMER_DEFINE(battery_timer, zmk_battery_timer, NULL);
 
 static int zmk_battery_init(const struct device *_arg) {
+#if !DT_HAS_CHOSEN(zmk_battery)
     battery = device_get_binding("BATTERY");
 
     if (battery == NULL) {
-        LOG_DBG("No battery device labelled BATTERY found.");
+        return -ENODEV;
+    }
+
+    LOG_WRN("Finding battery device labeled BATTERY is deprecated. Use zmk,battery chosen node.");
+#endif
+
+    if (!device_is_ready(battery)) {
+        LOG_ERR("Battery device \"%s\" is not ready", battery->name);
         return -ENODEV;
     }
 

--- a/docs/docs/features/battery.md
+++ b/docs/docs/features/battery.md
@@ -1,0 +1,38 @@
+---
+title: Battery Level
+sidebar_label: Battery Level
+---
+
+If your keyboard has a battery sensor, ZMK will report its battery level to the connected bluetooth host and show it on the keyboard's display, if it has one.
+
+For split keyboards, only the battery level of the central (usually left) side is reported over bluetooth.
+
+:::note
+
+Windows may not properly ask the keyboard to notify it of changes in battery level, so the level shown may be out of date.
+
+:::
+
+## Adding a Battery Sensor to a Board
+
+To enable a battery sensor on a new board, add the driver for the sensor to your board's `.dts` file. ZMK provides two drivers for estimating the battery level using its voltage:
+
+- `zmk,battery-voltage-divider`: Reads the voltage on an analog input pin.
+- `zmk,battery-nrf-vddh`: Reads the power supply voltage on a Nordic nRF52's VDDH pin.
+
+Zephyr also provides some drivers for fuel gauge ICs such as the TI bq274xx series and Maxim MAX17xxx series. If you use a battery sensor that does not have an existing driver, you will need to write a new driver that supports the `SENSOR_CHAN_GAUGE_STATE_OF_CHARGE` sensor channel and contribute it to Zephyr or ZMK.
+
+Once you have the sensor driver defined, add a `zmk,battery` property to the `chosen` node and set it to reference the sensor node. For example:
+
+```
+/ {
+    chosen {
+      zmk,battery = &vbatt;
+    };
+
+    vbatt: vbatt {
+        compatible = "zmk,battery-nrf-vddh";
+        label = "VBATT";
+    };
+}
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -17,6 +17,7 @@ module.exports = {
       "features/encoders",
       "features/underglow",
       "features/backlight",
+      "features/battery",
       "features/beta-testing",
     ],
     Behaviors: [


### PR DESCRIPTION
battery.c now uses the `zmk,battery` chosen node to select a battery sensor. Using the node labeled `"BATTERY"` is maintained as a fallback, but is now deprecated. Custom boards/shields should switch to using the chosen node.

Also changed to fetch all channels to support fuel gauge sensors that don't support fetching individual channels like max17055.