### PR TITLE
refactor(display): Saner font selection/defaults.

### DIFF
--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -18,7 +18,6 @@ endchoice
 
 choice ZMK_DISPLAY_STATUS_SCREEN
     prompt "Default status screen for displays"
-    default ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN
 
 config ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN
     bool "Built in status screen"
@@ -51,6 +50,26 @@ config ZMK_DISPLAY_DEDICATED_THREAD_PRIORITY
     default 5
 
 endif # ZMK_DISPLAY_WORK_QUEUE_DEDICATED
+
+if ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN
+
+config LVGL_FONT_MONTSERRAT_16
+    default y
+
+choice LVGL_THEME_DEFAULT_FONT_NORMAL
+    default LVGL_THEME_DEFAULT_FONT_NORMAL_MONTSERRAT_16
+
+endchoice
+
+config LVGL_FONT_MONTSERRAT_12
+    default y
+    
+choice LVGL_THEME_DEFAULT_FONT_SMALL
+    default LVGL_THEME_DEFAULT_FONT_SMALL_MONTSERRAT_12
+
+endchoice
+
+endif # ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN
 
 rsource "widgets/Kconfig"
 

--- a/app/src/display/status_screen.c
+++ b/app/src/display/status_screen.c
@@ -48,6 +48,9 @@ lv_obj_t *zmk_display_status_screen() {
 
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_LAYER_STATUS)
     zmk_widget_layer_status_init(&layer_status_widget, screen);
+    lv_obj_set_style_local_text_font(zmk_widget_layer_status_obj(&layer_status_widget),
+                                     LV_LABEL_PART_MAIN, LV_STATE_DEFAULT,
+                                     lv_theme_get_font_small());
     lv_obj_align(zmk_widget_layer_status_obj(&layer_status_widget), NULL, LV_ALIGN_IN_BOTTOM_LEFT,
                  0, 0);
 #endif

--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -8,27 +8,23 @@ config ZMK_WIDGET_LAYER_STATUS
     default y
     depends on !ZMK_SPLIT || ZMK_SPLIT_BLE_ROLE_CENTRAL
     select LVGL_USE_LABEL
-    select LVGL_FONT_MONTSERRAT_12
 
 config ZMK_WIDGET_BATTERY_STATUS
     bool "Widget for battery charge information, using small icons"
     depends on BT
     default y if BT
     select LVGL_USE_LABEL
-    select LVGL_FONT_MONTSERRAT_16
 
 config ZMK_WIDGET_OUTPUT_STATUS
     bool "Widget for keyboard output status icons"
     depends on BT
     default y if BT
     select LVGL_USE_LABEL
-    select LVGL_FONT_MONTSERRAT_16
     
 config ZMK_WIDGET_WPM_STATUS
     bool "Widget for displaying typed words per minute"
     depends on !ZMK_SPLIT || ZMK_SPLIT_BLE_ROLE_CENTRAL
     select LVGL_USE_LABEL
-    select LVGL_FONT_MONTSERRAT_16
     select ZMK_WPM
 
 endmenu

--- a/app/src/display/widgets/battery_status.c
+++ b/app/src/display/widgets/battery_status.c
@@ -18,22 +18,6 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/events/battery_state_changed.h>
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
-static lv_style_t label_style;
-
-static bool style_initialized = false;
-
-void battery_status_init() {
-    if (style_initialized) {
-        return;
-    }
-
-    style_initialized = true;
-    lv_style_init(&label_style);
-    lv_style_set_text_color(&label_style, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-    lv_style_set_text_font(&label_style, LV_STATE_DEFAULT, &lv_font_montserrat_16);
-    lv_style_set_text_letter_space(&label_style, LV_STATE_DEFAULT, 1);
-    lv_style_set_text_line_space(&label_style, LV_STATE_DEFAULT, 1);
-}
 
 struct battery_status_state {
     uint8_t level;
@@ -90,9 +74,7 @@ ZMK_SUBSCRIPTION(widget_battery_status, zmk_usb_conn_state_changed);
 #endif /* IS_ENABLED(CONFIG_USB) */
 
 int zmk_widget_battery_status_init(struct zmk_widget_battery_status *widget, lv_obj_t *parent) {
-    battery_status_init();
     widget->obj = lv_label_create(parent, NULL);
-    lv_obj_add_style(widget->obj, LV_LABEL_PART_MAIN, &label_style);
 
     lv_obj_set_size(widget->obj, 40, 15);
 

--- a/app/src/display/widgets/layer_status.c
+++ b/app/src/display/widgets/layer_status.c
@@ -16,27 +16,11 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/keymap.h>
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
-static lv_style_t label_style;
-
-static bool style_initialized = false;
 
 struct layer_status_state {
     uint8_t index;
     const char *label;
 };
-
-static void layer_status_init() {
-    if (style_initialized) {
-        return;
-    }
-
-    style_initialized = true;
-    lv_style_init(&label_style);
-    lv_style_set_text_color(&label_style, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-    lv_style_set_text_font(&label_style, LV_STATE_DEFAULT, &lv_font_montserrat_12);
-    lv_style_set_text_letter_space(&label_style, LV_STATE_DEFAULT, 1);
-    lv_style_set_text_line_space(&label_style, LV_STATE_DEFAULT, 1);
-}
 
 static void set_layer_symbol(lv_obj_t *label, struct layer_status_state state) {
     if (state.label == NULL) {
@@ -70,9 +54,7 @@ ZMK_DISPLAY_WIDGET_LISTENER(widget_layer_status, struct layer_status_state, laye
 ZMK_SUBSCRIPTION(widget_layer_status, zmk_layer_state_changed);
 
 int zmk_widget_layer_status_init(struct zmk_widget_layer_status *widget, lv_obj_t *parent) {
-    layer_status_init();
     widget->obj = lv_label_create(parent, NULL);
-    lv_obj_add_style(widget->obj, LV_LABEL_PART_MAIN, &label_style);
 
     lv_obj_set_size(widget->obj, 40, 15);
 

--- a/app/src/display/widgets/output_status.c
+++ b/app/src/display/widgets/output_status.c
@@ -21,9 +21,6 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/endpoints.h>
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
-static lv_style_t label_style;
-
-static bool style_initialized = false;
 
 struct output_status_state {
     enum zmk_endpoint selected_endpoint;
@@ -31,19 +28,6 @@ struct output_status_state {
     bool active_profile_bonded;
     uint8_t active_profile_index;
 };
-
-static void output_status_init() {
-    if (style_initialized) {
-        return;
-    }
-
-    style_initialized = true;
-    lv_style_init(&label_style);
-    lv_style_set_text_color(&label_style, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-    lv_style_set_text_font(&label_style, LV_STATE_DEFAULT, &lv_font_montserrat_16);
-    lv_style_set_text_letter_space(&label_style, LV_STATE_DEFAULT, 1);
-    lv_style_set_text_line_space(&label_style, LV_STATE_DEFAULT, 1);
-}
 
 static struct output_status_state get_state(const zmk_event_t *_eh) {
     return (struct output_status_state){.selected_endpoint = zmk_endpoints_selected(),
@@ -97,10 +81,7 @@ ZMK_SUBSCRIPTION(widget_output_status, zmk_ble_active_profile_changed);
 #endif
 
 int zmk_widget_output_status_init(struct zmk_widget_output_status *widget, lv_obj_t *parent) {
-    output_status_init();
-
     widget->obj = lv_label_create(parent, NULL);
-    lv_obj_add_style(widget->obj, LV_LABEL_PART_MAIN, &label_style);
 
     lv_obj_set_size(widget->obj, 40, 15);
 

--- a/app/src/display/widgets/wpm_status.c
+++ b/app/src/display/widgets/wpm_status.c
@@ -15,26 +15,10 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/wpm.h>
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
-static lv_style_t label_style;
-
-static bool style_initialized = false;
 
 struct wpm_status_state {
     uint8_t wpm;
 };
-
-void wpm_status_init() {
-    if (style_initialized) {
-        return;
-    }
-
-    style_initialized = true;
-    lv_style_init(&label_style);
-    lv_style_set_text_color(&label_style, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-    lv_style_set_text_font(&label_style, LV_STATE_DEFAULT, &lv_font_montserrat_12);
-    lv_style_set_text_letter_space(&label_style, LV_STATE_DEFAULT, 1);
-    lv_style_set_text_line_space(&label_style, LV_STATE_DEFAULT, 1);
-}
 
 struct wpm_status_state wpm_status_get_state(const zmk_event_t *eh) {
     return (struct wpm_status_state){.wpm = zmk_wpm_get_state()};
@@ -59,10 +43,7 @@ ZMK_DISPLAY_WIDGET_LISTENER(widget_wpm_status, struct wpm_status_state, wpm_stat
 ZMK_SUBSCRIPTION(widget_wpm_status, zmk_wpm_state_changed);
 
 int zmk_widget_wpm_status_init(struct zmk_widget_wpm_status *widget, lv_obj_t *parent) {
-    wpm_status_init();
-
     widget->obj = lv_label_create(parent, NULL);
-    lv_obj_add_style(widget->obj, LV_LABEL_PART_MAIN, &label_style);
     lv_label_set_align(widget->obj, LV_LABEL_ALIGN_RIGHT);
 
     lv_obj_set_size(widget->obj, 40, 15);


### PR DESCRIPTION
* Only select fonts for the default built in status screen
* Leverage theme default fonts, instead of hardcoding theme
  details in each component.