### PR TITLE
Fix power management to trigger low power devices

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -267,7 +267,7 @@ choice SYS_PM_POLICY
 	default PM_POLICY_APP
 endchoice
 
-config DEVICE_POWER_MANAGEMENT
+config PM_DEVICE
 	default y
 
 config ZMK_IDLE_SLEEP_TIMEOUT

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -7,6 +7,7 @@
 #include <device.h>
 #include <init.h>
 #include <kernel.h>
+#include <power/power.h>
 
 #include <logging/log.h>
 
@@ -55,6 +56,8 @@ void activity_work_handler(struct k_work *work) {
     int32_t inactive_time = current - activity_last_uptime;
 #if IS_ENABLED(CONFIG_ZMK_SLEEP)
     if (inactive_time > MAX_SLEEP_MS) {
+        // Put devices in low power mode before sleeping
+        pm_power_state_force((struct pm_state_info){PM_STATE_STANDBY, 0, 0});
         set_state(ZMK_ACTIVITY_SLEEP);
     } else
 #endif /* IS_ENABLED(CONFIG_ZMK_SLEEP) */

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -32,7 +32,7 @@ struct ext_power_generic_data {
 #if IS_ENABLED(CONFIG_SETTINGS)
     bool settings_init;
 #endif
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
     uint32_t pm_state;
 #endif
 };
@@ -143,7 +143,7 @@ static int ext_power_generic_init(const struct device *dev) {
         return -EIO;
     }
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
     data->pm_state = DEVICE_PM_ACTIVE_STATE;
 #endif
 
@@ -179,7 +179,7 @@ static int ext_power_generic_init(const struct device *dev) {
     return 0;
 }
 
-#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+#ifdef CONFIG_PM_DEVICE
 static int ext_power_generic_pm_control(const struct device *dev, uint32_t ctrl_command,
                                         void *context, device_pm_cb cb, void *arg) {
     int rc;
@@ -210,7 +210,7 @@ static int ext_power_generic_pm_control(const struct device *dev, uint32_t ctrl_
 
     return rc;
 }
-#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
+#endif /* CONFIG_PM_DEVICE */
 
 static const struct ext_power_generic_config config = {
     .label = DT_INST_GPIO_LABEL(0, control_gpios),


### PR DESCRIPTION
Fixes #882 

`PM_STATE_SOFT_OFF` doesn't tell devices to go into low power mode, so for now, I've added a line before going into sleep to force the standby state, which does tell devices to go into low power mode.

Related Zephyr fix: https://github.com/zephyrproject-rtos/zephyr/pull/37256

I've tested this with a nice!nano v2, and now VCC properly powers off during sleep.