### PR TITLE
feat(ci): Use metadata for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,75 +9,19 @@ on:
     paths:
       - ".github/workflows/build.yml"
       - "app/**"
+  schedule:
+    - cron: '22 4 * * *'
 
 jobs:
   build:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     container:
       image: docker.io/zmkfirmware/zmk-build-arm:2.5
+    needs: compile-matrix
     strategy:
       matrix:
-        board:
-          - bluemicro840_v1
-          - nice_nano
-          - nice_nano_v2
-          - nrfmicro_13
-          - proton_c
-        shield:
-          - bfo9000_left
-          - bfo9000_right
-          - boardsource3x4
-          - corne_left
-          - corne_right
-          - cradio_left
-          - cradio_right
-          - crbn
-          - eek
-          - helix_left
-          - helix_right
-          - iris_left
-          - iris_right
-          - jian_left
-          - jian_right
-          - jorne_left
-          - jorne_right
-          - kyria_left
-          - kyria_right
-          - lily58_left
-          - lily58_right
-          - microdox_left
-          - microdox_right
-          - nibble
-          - qaz
-          - quefrency_left
-          - quefrency_right
-          - reviung41
-          - romac
-          - romac_plus
-          - settings_reset
-          - sofle_left
-          - sofle_right
-          - splitreus62_left
-          - splitreus62_right
-          - tg4x
-          - tidbit
-        cmake-args: [""]
-        include:
-          - board: bdn9_rev2
-          - board: dz60rgb_rev1
-          - board: nrf52840_m2
-            shield: m60
-          - board: planck_rev6
-          - board: proton_c
-            shield: clueboard_california
-          - board: nice_nano_v2
-            shield: kyria_left
-            cmake-args: -DCONFIG_ZMK_DISPLAY=y
-            skip-archive: true
-          - board: nice_nano_v2
-            shield: kyria_right
-            cmake-args: -DCONFIG_ZMK_DISPLAY=y
-            skip-archive: true
+        include: ${{ fromJSON(needs.compile-matrix.outputs.include-list) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -130,3 +74,359 @@ jobs:
             build/zephyr/zmk.hex
             build/zephyr/zmk.uf2
         continue-on-error: true
+  compile-matrix:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [core-coverage, board-changes, nightly]
+    outputs:
+      include-list: ${{ steps.compile-list.outputs.result }}
+    steps:
+      - name: Join build lists
+        uses: actions/github-script@v4
+        id: compile-list
+        with:
+          script: |
+            const coreCoverage = `${{ needs.core-coverage.outputs.core-include }}`;
+            const coreCoverageArray = coreCoverage ? JSON.parse(coreCoverage) : [];
+
+            const boardChanges = `${{ needs.board-changes.outputs.boards-include }}`;
+            const boardChangesArray = boardChanges ? JSON.parse(boardChanges) : [];
+
+            const nightly = `${{ needs.nightly.outputs.nightly-include }}`;
+            const nightlyArray = nightly ? JSON.parse(nightly) : [];
+
+            const combined = [...coreCoverageArray, ...boardChangesArray, ...nightlyArray];
+
+            return [...new Map(combined.map(el => [JSON.stringify(el), el])).values()];
+  core-coverage:
+    if: ${{ needs.get-changed-files.outputs.core-changes == 'true' }}
+    runs-on: ubuntu-latest
+    needs: get-changed-files
+    outputs:
+      core-include: ${{ steps.core-list.outputs.result }} 
+    steps:
+      - uses: actions/github-script@v4
+        id: core-list
+        with:
+          script: |
+            // break out to file
+            const coreCoverage = {
+              boards: [
+                'nice_nano_v2',
+                'nrfmicro_13',
+                'proton_c'
+              ],
+              shields: [
+                'corne_left',
+                'corne_right',
+                'romac',
+                'settings_reset',
+                'tidbit'
+              ],
+              include: [
+                {
+                  "board": "bdn9_rev2"
+                },
+                {
+                  "board": "nice60"
+                },
+                {
+                  "board": "nrf52840_m2",
+                  "shield": "m60"
+                },
+                {
+                  "board": "planck_rev6"
+                },
+                {
+                  "board": "proton_c",
+                  "shield": "clueboard_california"
+                },
+                {
+                  "board": "nice_nano_v2",
+                  "shield": "kyria_left",
+                  "cmake-args": "-DCONFIG_ZMK_DISPLAY=y",
+                },
+                {
+                  "board": "nice_nano_v2",
+                  "shield": "kyria_right",
+                  "cmake-args": "-DCONFIG_ZMK_DISPLAY=y",
+                },
+                {
+                  "board": "nice_nano",
+                  "shield": "romac_plus",
+                  "cmake-args": "-DCONFIG_ZMK_RGB_UNDERGLOW=y -DCONFIG_WS2812_STRIP=y"
+                }
+              ]
+            };
+
+            let include = [];
+            
+            coreCoverage.boards.forEach(b => {
+              coreCoverage.shields.forEach(s => {
+                include.push({
+                  board: b,
+                  shield: s
+                });
+              });
+            });
+
+            return [...include, ...coreCoverage.include];
+  board-changes:
+    if: ${{ needs.get-changed-files.outputs.board-changes == 'true' }}
+    runs-on: ubuntu-latest
+    needs: [get-grouped-hardware, get-changed-files]
+    outputs:
+      boards-include: ${{ steps.boards-list.outputs.result }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Install js-yaml
+        run: npm install js-yaml
+      - uses: actions/github-script@v4
+        id: boards-list
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
+            const changedFiles = JSON.parse(`${{ needs.get-changed-files.outputs.changed-files }}`);
+            const metadata = JSON.parse(`${{ needs.get-grouped-hardware.outputs.organized-metadata }}`);
+            const boardChanges = new Set(changedFiles.filter(f => f.startsWith('app/boards')).map(f => f.split('/').slice(0, 4).join('/')));
+
+            include = [];
+
+            for (const bc of boardChanges) {
+              const globber = await glob.create(bc + "/*.zmk.yml");
+              const files = await globber.glob();
+
+              const aggregated = files.flatMap((f) =>
+                yaml.loadAll(fs.readFileSync(f, "utf8"))
+              );
+
+              aggregated.forEach(hm => {
+                switch (hm.type) {
+                  case "board":
+                    if (hm.features && hm.features.includes("keys")) {
+                      if (hm.siblings) {
+                        hm.siblings.forEach(sib => {
+                          include.push({
+                            board: sib
+                          });
+                        });
+                      } else {
+                        include.push({
+                          board: hm.id
+                        });
+                      }
+                    } else if (hm.exposes) {
+                      hm.exposes.forEach(i => {
+                        metadata.interconnects[i].shields.forEach(s => {
+                          if (s.siblings) {
+                            s.siblings.forEach(sib => {
+                              include.push({
+                                board: hm.id,
+                                shield: sib
+                              });
+                            });
+                          } else {
+                            include.push({
+                              board: hm.id,
+                              shield: s.id
+                            });
+                          }
+                        });
+                      });
+                    } else {
+                      console.error("Board without keys or interconnect");
+                    }
+                    break;
+                  case "shield":
+                    if (hm.features && hm.features.includes("keys")) {
+                      hm.requires.forEach(i => {
+                        metadata.interconnects[i].boards.forEach(b => {
+                          if (hm.siblings) {
+                            hm.siblings.forEach(sib => {
+                              include.push({
+                                board: b.id,
+                                shield: sib
+                              });
+                            });
+                          } else {
+                            include.push({
+                              board: b.id,
+                              shield: hm.id
+                            });
+                          }
+                        });
+                      });
+                    }
+                    break;
+                  case "interconnect":
+                    break;
+                }
+              });
+            }
+                
+            return include;
+  nightly:
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    needs: get-grouped-hardware
+    outputs:
+      nightly-include: ${{ steps.nightly-list.outputs.result }}
+    steps:
+      - name: Create nightly list
+        uses: actions/github-script@v4
+        id: nightly-list
+        with:
+          script: |
+            const metadata = JSON.parse(`${{ needs.get-grouped-hardware.outputs.organized-metadata }}`);
+            let include = [];
+
+            metadata.onboard.forEach(b => {
+              if (b.siblings) {
+                b.siblings.forEach(sib => {
+                  include.push({
+                    board: sib
+                  });
+                });
+              } else {
+                include.push({
+                  board: b.id
+                });
+              }
+            });
+
+            Object.values(metadata.interconnects).forEach(i => {
+              i.boards.forEach(b => {
+                i.shields.forEach(s => {
+                  if (s.siblings) {
+                    s.siblings.forEach(sib => {
+                      include.push({
+                        board: b.id,
+                        shield: sib
+                      });
+                    });
+                  } else {
+                    include.push({
+                      board: b.id,
+                      shield: s.id
+                    });
+                  }
+                });
+              });
+            });
+
+            return include;
+  get-grouped-hardware:
+    runs-on: ubuntu-latest
+    outputs:
+      organized-metadata: ${{ steps.organize-metadata.outputs.result }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Install js-yaml
+        run: npm install js-yaml
+      - name: Aggregate Metadata
+        uses: actions/github-script@v4
+        id: aggregate-metadata
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
+            const globber = await glob.create("app/boards/**/*.zmk.yml");
+            const files = await globber.glob();
+
+            const aggregated = files.flatMap((f) =>
+              yaml.loadAll(fs.readFileSync(f, "utf8"))
+            );
+
+            return JSON.stringify(aggregated).replace(/\\/g,"\\\\");
+          result-encoding: string
+
+      - name: Organize Metadata
+        uses: actions/github-script@v4
+        id: organize-metadata
+        with:
+          script: |
+            const hardware = JSON.parse(`${{ steps.aggregate-metadata.outputs.result }}`);
+
+            const grouped = hardware.reduce((agg, hm) => {
+              switch (hm.type) {
+                case "board":
+                  if (hm.features && hm.features.includes("keys")) {
+                    agg.onboard.push(hm);
+                  } else if (hm.exposes) {
+                    hm.exposes.forEach((element) => {
+                      let ic = agg.interconnects[element] || {
+                        boards: [],
+                        shields: [],
+                      };
+                      ic.boards.push(hm);
+                      agg.interconnects[element] = ic;
+                    });
+                  } else {
+                    console.error("Board without keys or interconnect");
+                  }
+                  break;
+                case "shield":
+                  if (hm.features && hm.features.includes("keys")) {
+                    hm.requires.forEach((id) => {
+                      let ic = agg.interconnects[id] || { boards: [], shields: [] };
+                      ic.shields.push(hm);
+                      agg.interconnects[id] = ic;
+                    });
+                  }
+                  break;
+                case "interconnect":
+                  let ic = agg.interconnects[hm.id] || { boards: [], shields: [] };
+                  ic.interconnect = hm;
+                  agg.interconnects[hm.id] = ic;
+                  break;
+              }
+              return agg;
+            },
+            { onboard: [], interconnects: {} });
+
+            return JSON.stringify(grouped).replace(/\\/g,"\\\\");
+          result-encoding: string
+  get-changed-files:
+    if: ${{ github.event_name != 'schedule' }}
+    runs-on: ubuntu-latest
+    outputs:
+      changed-files: ${{ steps.changed-files.outputs.all }}
+      board-changes: ${{ steps.board-changes.outputs.result }}
+      core-changes: ${{ steps.core-changes.outputs.result }}
+    steps:
+      - uses: Ana06/get-changed-files@v2.0.0
+        id: changed-files
+        with:
+          format: 'json'
+      - uses: actions/github-script@v4
+        id: board-changes
+        with:
+          script: |
+            const changedFiles = JSON.parse(`${{ steps.changed-files.outputs.all }}`);
+            const boardChanges = changedFiles.filter(f => f.startsWith('app/boards'));
+            return boardChanges.length ? 'true' : 'false';
+          result-encoding: string
+      - uses: actions/github-script@v4
+        id: core-changes
+        with:
+          script: |
+            const changedFiles = JSON.parse(`${{ steps.changed-files.outputs.all }}`);
+            const boardChanges = changedFiles.filter(f => f.startsWith('app/boards'));
+            const appChanges = changedFiles.filter(f => f.startsWith('app'));
+            const ymlChanges = changedFiles.includes('.github/workflows/build.yml');
+            return boardChanges.length < appChanges.length || ymlChanges ? 'true' : 'false';
+          result-encoding: string
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,29 +73,30 @@ jobs:
               try {
                 const output = execSync(`west build -s app -p -b ${{ matrix.board }} -- ${shieldArgs.shield ? '-DSHIELD=' + shieldArgs.shield : ''} ${shieldArgs['cmake-args'] || ''}`);
 
+                console.log(`::group::${{ matrix.board}} ${shieldArgs.shield} Build`)
                 console.log(output.toString());
 
-                const fileExtensions = ['hex', 'uf2'];
-                let files = [];
+                const fileExtensions = ["hex", "uf2"];
 
-                for (const extension of fileExtensions) {
-                  const path = 'build/zephyr/zmk.' + extension;
-                  if (fs.existsSync(path)) {
-                    files.push(path);
-                  }
-                }
+                const files = fileExtensions
+                  .map(extension => "build/zephyr/zmk." + extension)
+                  .filter(path => fs.existsSync(path));
 
                 const rootDirectory = 'build/zephyr';
                 const options = {
                     continueOnError: true
                 }
-                const artifactName = `${{ matrix.board }}${shieldArgs.shield ? '-' + shieldArgs.shield : ''}-zmk`;
+
+                const cmakeName = shieldArgs['cmake-args'] ? '-' + (shieldArgs.nickname || shieldArgs['cmake-args'].split(' ').join('')) : '';
+                const artifactName = `${{ matrix.board }}${shieldArgs.shield ? '-' + shieldArgs.shield : ''}${cmakeName}-zmk`;
 
                 await artifactClient.uploadArtifact(artifactName, files, rootDirectory, options);
               } catch (e) {
-                console.error(`Failed to build or upload ${{ matrix.board }} ${shieldArgs.shield} ${shieldArgs['cmake-args']}`);
+                console.error(`::error::Failed to build or upload ${{ matrix.board }} ${shieldArgs.shield} ${shieldArgs['cmake-args']}`);
                 console.error(e);
                 error = true;
+              } finally {
+                console.log('::endgroup::');
               }
             }
 
@@ -114,16 +115,15 @@ jobs:
         id: compile-list
         with:
           script: |
-            const coreCoverage = `${{ needs.core-coverage.outputs.core-include }}`;
-            const coreCoverageArray = coreCoverage ? JSON.parse(coreCoverage) : [];
-
-            const boardChanges = `${{ needs.board-changes.outputs.boards-include }}`;
-            const boardChangesArray = boardChanges ? JSON.parse(boardChanges) : [];
-
-            const nightly = `${{ needs.nightly.outputs.nightly-include }}`;
-            const nightlyArray = nightly ? JSON.parse(nightly) : [];
-
-            const combined = [...coreCoverageArray, ...boardChangesArray, ...nightlyArray];
+            const coreCoverage = `${{ needs.core-coverage.outputs.core-include }}` || "[]";
+            const boardChanges = `${{ needs.board-changes.outputs.boards-include }}` || "[]";
+            const nightly = `${{ needs.nightly.outputs.nightly-include }}` || "[]";
+            
+            const combined = [
+              ...JSON.parse(coreCoverage),
+              ...JSON.parse(boardChanges),
+              ...JSON.parse(nightly)
+            ];
             const combinedUnique = [...new Map(combined.map(el => [JSON.stringify(el), el])).values()];
 
             const perBoard = {};
@@ -134,20 +134,15 @@ jobs:
               
               perBoard[configuration.board].push({
                 shield: configuration.shield,
-                'cmake-args': configuration['cmake-args']
+                'cmake-args': configuration['cmake-args'],
+                nickname: configuration.nickname
               })
             }
 
-            const includeList = [];
-
-            for (const [board, shieldArgs] of Object.entries(perBoard)) {
-              includeList.push({
-                board,
-                shieldArgs: JSON.stringify(shieldArgs)
-              });
-            }
-
-            return includeList;
+            return Object.entries(perBoard).map(([board, shieldArgs]) => ({
+              board,
+              shieldArgs: JSON.stringify(shieldArgs),
+            }));
   core-coverage:
     if: ${{ needs.get-changed-files.outputs.core-changes == 'true' }}
     runs-on: ubuntu-latest
@@ -155,70 +150,26 @@ jobs:
     outputs:
       core-include: ${{ steps.core-list.outputs.result }} 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Install js-yaml
+        run: npm install js-yaml
       - uses: actions/github-script@v4
         id: core-list
         with:
           script: |
-            // break out to file
-            const coreCoverage = {
-              boards: [
-                'nice_nano_v2',
-                'nrfmicro_13',
-                'proton_c'
-              ],
-              shields: [
-                'corne_left',
-                'corne_right',
-                'romac',
-                'settings_reset',
-                'tidbit'
-              ],
-              include: [
-                {
-                  "board": "bdn9_rev2"
-                },
-                {
-                  "board": "nice60"
-                },
-                {
-                  "board": "nrf52840_m2",
-                  "shield": "m60"
-                },
-                {
-                  "board": "planck_rev6"
-                },
-                {
-                  "board": "proton_c",
-                  "shield": "clueboard_california"
-                },
-                {
-                  "board": "nice_nano_v2",
-                  "shield": "kyria_left",
-                  "cmake-args": "-DCONFIG_ZMK_DISPLAY=y",
-                },
-                {
-                  "board": "nice_nano_v2",
-                  "shield": "kyria_right",
-                  "cmake-args": "-DCONFIG_ZMK_DISPLAY=y",
-                },
-                {
-                  "board": "nice_nano",
-                  "shield": "romac_plus",
-                  "cmake-args": "-DCONFIG_ZMK_RGB_UNDERGLOW=y -DCONFIG_WS2812_STRIP=y"
-                }
-              ]
-            };
+            const fs = require('fs');
+            const yaml = require('js-yaml');
 
-            let include = [];
+            const coreCoverage = yaml.load(fs.readFileSync('app/core-coverage.yml', 'utf8'));
             
-            coreCoverage.boards.forEach(b => {
-              coreCoverage.shields.forEach(s => {
-                include.push({
-                  board: b,
-                  shield: s
-                });
-              });
-            });
+            let include = coreCoverage.board.flatMap(board =>
+              coreCoverage.shield.map(shield => ({ board, shield }))
+            );
 
             return [...include, ...coreCoverage.include];
   board-changes:
@@ -247,9 +198,7 @@ jobs:
             const metadata = JSON.parse(`${{ needs.get-grouped-hardware.outputs.organized-metadata }}`);
             const boardChanges = new Set(changedFiles.filter(f => f.startsWith('app/boards')).map(f => f.split('/').slice(0, 4).join('/')));
 
-            include = [];
-
-            for (const bc of boardChanges) {
+            return (await Promise.all([...boardChanges].flatMap(async bc => {
               const globber = await glob.create(bc + "/*.zmk.yml");
               const files = await globber.glob();
 
@@ -257,71 +206,53 @@ jobs:
                 yaml.loadAll(fs.readFileSync(f, "utf8"))
               );
 
-              aggregated.forEach(hm => {
+              const boardAndShield = (b, s) => {
+                if (s.siblings) {
+                  return s.siblings.map(shield => ({
+                    board: b.id,
+                    shield,
+                  }));
+                } else {
+                  return {
+                    board: b.id,
+                    shield: s.id
+                  };
+                }
+              }
+
+              return aggregated.flatMap(hm => {
                 switch (hm.type) {
                   case "board":
                     if (hm.features && hm.features.includes("keys")) {
                       if (hm.siblings) {
-                        hm.siblings.forEach(sib => {
-                          include.push({
-                            board: sib
-                          });
-                        });
+                        return hm.siblings.map(board => ({
+                          board,
+                        }));
                       } else {
-                        include.push({
+                        return {
                           board: hm.id
-                        });
+                        };
                       }
                     } else if (hm.exposes) {
-                      hm.exposes.forEach(i => {
-                        metadata.interconnects[i].shields.forEach(s => {
-                          if (s.siblings) {
-                            s.siblings.forEach(sib => {
-                              include.push({
-                                board: hm.id,
-                                shield: sib
-                              });
-                            });
-                          } else {
-                            include.push({
-                              board: hm.id,
-                              shield: s.id
-                            });
-                          }
-                        });
-                      });
+                      return hm.exposes.flatMap(i => 
+                        metadata.interconnects[i].shields.flatMap(s => boardAndShield(hm, s))
+                      );
                     } else {
                       console.error("Board without keys or interconnect");
                     }
                     break;
                   case "shield":
                     if (hm.features && hm.features.includes("keys")) {
-                      hm.requires.forEach(i => {
-                        metadata.interconnects[i].boards.forEach(b => {
-                          if (hm.siblings) {
-                            hm.siblings.forEach(sib => {
-                              include.push({
-                                board: b.id,
-                                shield: sib
-                              });
-                            });
-                          } else {
-                            include.push({
-                              board: b.id,
-                              shield: hm.id
-                            });
-                          }
-                        });
-                      });
+                      return hm.requires.flatMap(i => 
+                        metadata.interconnects[i].boards.flatMap(b => boardAndShield(b, hm))
+                      );
                     }
                     break;
                   case "interconnect":
                     break;
                 }
               });
-            }
-                
-            return include;
+            }))).flat();
   nightly:
     if: ${{ github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
@@ -335,43 +266,38 @@ jobs:
         with:
           script: |
             const metadata = JSON.parse(`${{ needs.get-grouped-hardware.outputs.organized-metadata }}`);
-            let include = [];
-
-            metadata.onboard.forEach(b => {
+            
+            let includeOnboard = metadata.onboard.flatMap(b => {
               if (b.siblings) {
-                b.siblings.forEach(sib => {
-                  include.push({
-                    board: sib
-                  });
-                });
+                return b.siblings.map(board => ({
+                  board,
+                }));
               } else {
-                include.push({
-                  board: b.id
-                });
+                return {
+                  board: b.id,
+                };
               }
             });
 
-            Object.values(metadata.interconnects).forEach(i => {
-              i.boards.forEach(b => {
-                i.shields.forEach(s => {
+            let includeInterconnect = Object.values(metadata.interconnects).flatMap(i =>
+              i.boards.flatMap(b =>
+                i.shields.flatMap(s => {
                   if (s.siblings) {
-                    s.siblings.forEach(sib => {
-                      include.push({
-                        board: b.id,
-                        shield: sib
-                      });
-                    });
-                  } else {
-                    include.push({
+                    return s.siblings.map(shield => ({
                       board: b.id,
-                      shield: s.id
-                    });
+                      shield,
+                    }));
+                  } else {
+                    return {
+                      board: b.id,
+                      shield: s.id,
+                    };
                   }
-                });
-              });
-            });
+                })
+              )
+            );
 
-            return include;
+            return [...includeOnboard, ...includeInterconnect];
   get-grouped-hardware:
     runs-on: ubuntu-latest
     outputs:
@@ -479,4 +405,3 @@ jobs:
             const ymlChanges = changedFiles.includes('.github/workflows/build.yml');
             return boardChanges.length < appChanges.length || ymlChanges ? 'true' : 'false';
           result-encoding: string
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,32 +48,60 @@ jobs:
         run: west update
       - name: Export Zephyr CMake package (west zephyr-export)
         run: west zephyr-export
-      - name: Prepare variables
-        id: variables
-        run: |
-          SHIELD_ARG=
-          ARTIFACT_NAME="${{ matrix.board }}"
-
-          if [ -n "${{ matrix.shield }}" ]; then
-            SHIELD_ARG="-DSHIELD=${{ matrix.shield }}"
-            ARTIFACT_NAME="${ARTIFACT_NAME}-${{ matrix.shield }}"
-          fi
-
-          ARTIFACT_NAME="${ARTIFACT_NAME}-zmk"
-
-          echo ::set-output name=shield-arg::${SHIELD_ARG}
-          echo ::set-output name=artifact-name::${ARTIFACT_NAME}
-      - name: Build (west build)
-        run: west build -s app -b ${{ matrix.board }} -- ${{ steps.variables.outputs.shield-arg }} ${{ matrix.cmake-args }}
-      - name: Archive artifacts
-        if: ${{ !matrix.skip-archive }}
-        uses: actions/upload-artifact@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
         with:
-          name: "${{ steps.variables.outputs.artifact-name }}"
-          path: |
-            build/zephyr/zmk.hex
-            build/zephyr/zmk.uf2
-        continue-on-error: true
+          node-version: '14.x'
+      - name: Install @actions/artifact
+        run: npm install @actions/artifact
+      - name: Build and upload artifacts
+        uses: actions/github-script@v4
+        id: boards-list
+        with:
+          script: |
+            const fs = require('fs');
+            const artifact = require('@actions/artifact');
+            const artifactClient = artifact.create();
+
+            const execSync = require('child_process').execSync;
+            
+            const buildShieldArgs = JSON.parse(`${{ matrix.shieldArgs }}`);
+
+            let error = false;
+
+            for (const shieldArgs of buildShieldArgs) {
+              try {
+                const output = execSync(`west build -s app -p -b ${{ matrix.board }} -- ${shieldArgs.shield ? '-DSHIELD=' + shieldArgs.shield : ''} ${shieldArgs['cmake-args'] || ''}`);
+
+                console.log(output.toString());
+
+                const fileExtensions = ['hex', 'uf2'];
+                let files = [];
+
+                for (const extension of fileExtensions) {
+                  const path = 'build/zephyr/zmk.' + extension;
+                  if (fs.existsSync(path)) {
+                    files.push(path);
+                  }
+                }
+
+                const rootDirectory = 'build/zephyr';
+                const options = {
+                    continueOnError: true
+                }
+                const artifactName = `${{ matrix.board }}${shieldArgs.shield ? '-' + shieldArgs.shield : ''}-zmk`;
+
+                await artifactClient.uploadArtifact(artifactName, files, rootDirectory, options);
+              } catch (e) {
+                console.error(`Failed to build or upload ${{ matrix.board }} ${shieldArgs.shield} ${shieldArgs['cmake-args']}`);
+                console.error(e);
+                error = true;
+              }
+            }
+
+            if (error) {
+              throw new Error('Failed to build one or more configurations');
+            }
   compile-matrix:
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -96,8 +124,30 @@ jobs:
             const nightlyArray = nightly ? JSON.parse(nightly) : [];
 
             const combined = [...coreCoverageArray, ...boardChangesArray, ...nightlyArray];
+            const combinedUnique = [...new Map(combined.map(el => [JSON.stringify(el), el])).values()];
 
-            return [...new Map(combined.map(el => [JSON.stringify(el), el])).values()];
+            const perBoard = {};
+
+            for (const configuration of combinedUnique) {
+              if (!perBoard[configuration.board])
+                perBoard[configuration.board] = [];
+              
+              perBoard[configuration.board].push({
+                shield: configuration.shield,
+                'cmake-args': configuration['cmake-args']
+              })
+            }
+
+            const includeList = [];
+
+            for (const [board, shieldArgs] of Object.entries(perBoard)) {
+              includeList.push({
+                board,
+                shieldArgs: JSON.stringify(shieldArgs)
+              });
+            }
+
+            return includeList;
   core-coverage:
     if: ${{ needs.get-changed-files.outputs.core-changes == 'true' }}
     runs-on: ubuntu-latest

--- a/app/core-coverage.yml
+++ b/app/core-coverage.yml
@@ -1,0 +1,30 @@
+board:
+- nice_nano_v2
+- nrfmicro_13
+- proton_c
+shield:
+- corne_left
+- corne_right
+- romac
+- settings_reset
+- tidbit
+include:
+- board: bdn9_rev2
+- board: nice60
+- board: nrf52840_m2
+  shield: m60
+- board: planck_rev6
+- board: proton_c
+  shield: clueboard_california
+- board: nice_nano_v2
+  shield: kyria_left
+  cmake-args: "-DCONFIG_ZMK_DISPLAY=y"
+  nickname: "display"
+- board: nice_nano_v2
+  shield: kyria_right
+  cmake-args: "-DCONFIG_ZMK_DISPLAY=y"
+  nickname: "display"
+- board: nice_nano
+  shield: romac_plus
+  cmake-args: "-DCONFIG_ZMK_RGB_UNDERGLOW=y -DCONFIG_WS2812_STRIP=y"
+  nickname: "underglow"


### PR DESCRIPTION
Refactors the build workflow to use hardware metadata to accomplish the following:
 - Nightly, build every single onboard MCU board and board+shield combo possible
 - Whenever app/** is changed (minus app/boards), run a short, premade core builds list
 - Whenever app/boards is changed, build every board+shield combo that's affected by the changes

Here's a nightly build: https://github.com/Nicell/zmk/actions/runs/1519228121
Here's a boards change run: https://github.com/Nicell/zmk/actions/runs/1517831312
Here's a core run: https://github.com/Nicell/zmk/actions/runs/1517789825

Todo:

- [x] make the final compile-matrix output remove all duplicates includes.
- [x] add cmake-args to artifact name in some fashion
- [x] figure out 256 matrix job limit (do one job per board rather than one job per board + shield combo)
- [x] get-changed-files seems to fail after squashes and PRs (alternative action with fixes: https://github.com/Ana06/get-changed-files)
- [x] don't inline the core build list (use a separate .yml file)
- [ ] make sure to build setting-reset shield (update link to them on docs)