### PR TITLE
Add new sensor channels to battery.c

### DIFF
--- a/app/include/zmk/events/battery_state_changed.h
+++ b/app/include/zmk/events/battery_state_changed.h
@@ -10,8 +10,40 @@
 #include <zmk/event_manager.h>
 
 struct zmk_battery_state_changed {
-    // TODO: Other battery channels
+    
+    /* Remaining capacity as a %age */
     uint8_t state_of_charge;
+
+    /* State of Health */
+    int16_t state_of_health;
+
+    /*  Current cell voltage in units of 1.25/16mV */
+    uint32_t voltage;
+
+    /* Average current in units of 1.5625uV / Rsense */
+    uint32_t current;
+
+    /* Standby current in mA? uA? */
+    int32_t current_standby;
+
+    /* Maximum Load Current in mA? uA? */
+    int32_t current_max_load;
+
+    /* Full charge capacity in 5/Rsense uA */
+    int32_t full_charge_capacity;
+
+    /* Remaining capacity in 5/Rsense uA */
+    int32_t remaining_charge_capacity;
+
+    int32_t nominal_available_capacity;
+
+    int32_t full_available_capacity;
+
+    /* Average power consumption in mA? uA? */
+    int32_t avg_power;
+
+    /* Internal temperature in units of 1/256 degrees C */
+    int32_t int_temp;
 };
 
 ZMK_EVENT_DECLARE(zmk_battery_state_changed);

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -110,7 +110,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The configured battery sensor does not support the channel: Voltage");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.voltage = voltage.val1; /*combine val1" and "val2" here*/
+        bat_state_data.voltage = voltage.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery voltage: %d.%dV", voltage.val1, voltage.val2);
     }
 
@@ -125,7 +125,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Average Current");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.current = current.val1; /*combine val1" and "val2" here*/
+        bat_state_data.current = current.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery Average Current: %d.%dA", current.val1, current.val2);
     }
 
@@ -140,7 +140,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Standby Current");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.current_standby = current_standby.val1; /*combine val1" and "val2" here*/
+        bat_state_data.current_standby = current_standby.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery Standby Current: %d.%dA", current_standby.val1,
                 current_standby.val2);
     }
@@ -156,7 +156,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Maximum Load Current");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.current_max_load = current_max_load.val1; /*combine val1" and "val2" here*/
+        bat_state_data.current_max_load = current_max_load.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery Maximum Load Current: %d.%dA", current_max_load.val1,
                 current_max_load.val2);
     }
@@ -172,7 +172,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Full Charge Capacity");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.full_charge_capacity = full_charge_capacity.val1; /*combine val1" and "val2" here*/
+        bat_state_data.full_charge_capacity = full_charge_capacity.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery Full Charge Capacity: %d.%dmAh", full_charge_capacity.val1,
                 full_charge_capacity.val2);
     }
@@ -188,7 +188,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Remaining Charge Capacity");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.remaining_charge_capacity = remaining_charge_capacity.val1; /*combine val1" and "val2" here*/
+        bat_state_data.remaining_charge_capacity = remaining_charge_capacity.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery Remaining Charge Capacity: %d.%dmAh", remaining_charge_capacity.val1,
                 remaining_charge_capacity.val2);
     }
@@ -204,7 +204,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Nominal Available Capacity");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.nominal_available_capacity = nominal_available_capacity.val1; /*combine val1" and "val2" here*/
+        bat_state_data.nominal_available_capacity = nominal_available_capacity.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery Nominal Available Capacity: %d.%dmAh", nominal_available_capacity.val1,
                 nominal_available_capacity.val2);
     }
@@ -220,7 +220,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Full Available Capacity");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.full_available_capacity = full_available_capacity.val1; /*combine val1" and "val2" here*/
+        bat_state_data.full_available_capacity = full_available_capacity.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery Full Available Capacity: %d.%dmAh", full_available_capacity.val1,
                 full_available_capacity.val2);
     }
@@ -236,7 +236,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Average Power Usage");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.avg_power = avg_power.val1; /*combine val1" and "val2" here*/
+        bat_state_data.avg_power = avg_power.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery Average Power Usage: %d.%dmW", avg_power.val1, avg_power.val2);
     }
 
@@ -251,7 +251,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Internal IC Temperature");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.int_temp = int_temp.val1; /*combine val1" and "val2" here*/
+        bat_state_data.int_temp = int_temp.val1; /*combine val1 and val2 here*/
         LOG_DBG("-----> battery Internal IC Temperature: %d.%d C", int_temp.val1, int_temp.val2);
     }
 

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -25,40 +25,242 @@ static uint8_t last_state_of_charge = 0;
 uint8_t zmk_battery_state_of_charge() { return last_state_of_charge; }
 
 static int zmk_battery_update(const struct device *battery) {
-    struct sensor_value state_of_charge;
+    struct sensor_value state_of_charge,
+                        state_of_health,
+                        voltage, 
+                        current,
+                        current_standby, 
+                        current_max_load, 
+                        full_charge_capacity,
+                        remaining_charge_capacity,
+                        nominal_available_capacity,
+                        full_available_capacity,
+                        avg_power, 
+                        int_temp;
 
-    int rc = sensor_sample_fetch_chan(battery, SENSOR_CHAN_GAUGE_STATE_OF_CHARGE);
+    int rc;
+    int status = 0;
+    int rv = 0;
+    
+    status = sensor_sample_fetch(battery);
 
-    if (rc != 0) {
-        LOG_DBG("Failed to fetch battery values: %d", rc);
-        return rc;
+    if (status < 0) {
+        LOG_ERR("Failed to fetch battery data from configured sensor. error: %d\n", status);
+        return status;
     }
 
-    rc = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_STATE_OF_CHARGE, &state_of_charge);
+    struct zmk_battery_state_changed bat_state_data;
 
-    if (rc != 0) {
-        LOG_DBG("Failed to get battery state of charge: %d", rc);
-        return rc;
+    /* ---------- get channel data for State of Charge ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_STATE_OF_CHARGE, &state_of_charge);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_WRN("Failed to get battery state of charge: %d", rc);
+        rv++;
     }
 
-    if (last_state_of_charge != state_of_charge.val1) {
-        last_state_of_charge = state_of_charge.val1;
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: State of Charge");
+    } else {
+        /* channel is supported by sensor */
+        /* ensure channel value has actually changed before updating it */
+        if (last_state_of_charge != state_of_charge.val1) {
+            last_state_of_charge = state_of_charge.val1;
 
-        LOG_DBG("Setting BAS GATT battery level to %d.", last_state_of_charge);
+            LOG_DBG("Setting BAS GATT battery level to %d%%", last_state_of_charge);
 
-        rc = bt_bas_set_battery_level(last_state_of_charge);
+            /* set BAS GATT battery level so it can be displayed at the host */
+            rc = bt_bas_set_battery_level(last_state_of_charge);
 
-        if (rc != 0) {
-            LOG_WRN("Failed to set BAS GATT battery level (err %d)", rc);
-            return rc;
+            if (rc != 0) {
+                LOG_WRN("Failed to set BAS GATT battery level (err %d)", rc);
+                rv++;
+            }
+
+            /* append this value to the battery state changed event */
+            bat_state_data.state_of_charge = last_state_of_charge;
+            LOG_DBG("-----> battery State of Charge: %d%%", last_state_of_charge);
+
         }
-
-        rc = ZMK_EVENT_RAISE(new_zmk_battery_state_changed(
-            (struct zmk_battery_state_changed){.state_of_charge = last_state_of_charge}));
     }
 
-    return rc;
-}
+    /* ---------- get channel data for State of Health ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_STATE_OF_HEALTH, &state_of_health);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery State of Health: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The configured battery sensor does not support the channel: State of Health");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.state_of_health = state_of_health.val1;
+        LOG_DBG("-----> battery State of Health: %d%%", state_of_health.val1);
+    }
+
+    /* ---------- get channel data for Voltage ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_VOLTAGE, &voltage);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery voltage: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The configured battery sensor does not support the channel: Voltage");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.voltage = voltage.val1;
+        LOG_DBG("-----> battery voltage: %d.%dV", voltage.val1, voltage.val2);
+    }
+
+    /* ---------- get channel data for Average Current ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_AVG_CURRENT, &current);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery Average Current: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: Average Current");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.current = current.val1;
+        LOG_DBG("-----> battery Average Current: %d.%dA", current.val1, current.val2);
+    }
+
+    /* ---------- get channel data for Standby Current ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_STDBY_CURRENT, &current_standby);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery Standby Current: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: Standby Current");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.current_standby = current_standby.val1;
+        LOG_DBG("-----> battery Standby Current: %d.%dA", current_standby.val1,
+                current_standby.val2);
+    }
+
+    /* ---------- get channel data for Maximum Load Current ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT, &current_max_load);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery Maximum Load Current: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: Maximum Load Current");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.current_max_load = current_max_load.val1;
+        LOG_DBG("-----> battery Maximum Load Current: %d.%dA", current_max_load.val1,
+                current_max_load.val2);
+    }
+
+    /* ---------- get channel data for Full Charge Capacity ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_FULL_CHARGE_CAPACITY, &full_charge_capacity);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery Full Charge Capacity: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: Full Charge Capacity");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.full_charge_capacity = full_charge_capacity.val1;
+        LOG_DBG("-----> battery Full Charge Capacity: %d.%dmAh", full_charge_capacity.val1,
+                full_charge_capacity.val2);
+    }
+
+    /* ---------- get channel data for Remaining Charge Capacity ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_REMAINING_CHARGE_CAPACITY, &remaining_charge_capacity);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery Remaining Charge Capacity: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: Remaining Charge Capacity");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.remaining_charge_capacity = remaining_charge_capacity.val1;
+        LOG_DBG("-----> battery Remaining Charge Capacity: %d.%dmAh", remaining_charge_capacity.val1,
+                remaining_charge_capacity.val2);
+    }
+
+    /* ---------- get channel data for Nominal Available Capacity ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_NOM_AVAIL_CAPACITY, &nominal_available_capacity);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery Nominal Available Capacity: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: Nominal Available Capacity");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.nominal_available_capacity = nominal_available_capacity.val1;
+        LOG_DBG("-----> battery Nominal Available Capacity: %d.%dmAh", nominal_available_capacity.val1,
+                nominal_available_capacity.val2);
+    }
+
+    /* ---------- get channel data for Full Available Capacity ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY, &full_available_capacity);;
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery Full Available Capacity: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: Full Available Capacity");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.full_available_capacity = full_available_capacity.val1;
+        LOG_DBG("-----> battery Full Available Capacity: %d.%dmAh", full_available_capacity.val1,
+                full_available_capacity.val2);
+    }
+
+    /* ---------- get channel data for Average Power Usage ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_AVG_POWER, &avg_power);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get battery Average Power Usage: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: Average Power Usage");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.avg_power = avg_power.val1;
+        LOG_DBG("-----> battery Average Power Usage: %d.%dmW", avg_power.val1, avg_power.val2);
+    }
+
+    /* ---------- get channel data for Internal IC Temperature ---------- */
+    status = sensor_channel_get(battery, SENSOR_CHAN_GAUGE_TEMP, &int_temp);
+
+    if (status != 0 && status != -ENOTSUP) {
+        LOG_DBG("Failed to get Internal IC Temperature: %d", status);
+        rv++;
+    }
+    if (status == -ENOTSUP) {
+        LOG_DBG("The battery sensor does not support the channel: Internal IC Temperature");
+    } else {
+        /* append this value to the battery state changed event */
+        bat_state_data.int_temp = int_temp.val1;
+        LOG_DBG("-----> battery Internal IC Temperature: %d.%d C", int_temp.val1, int_temp.val2);
+    }
+
+    /* trigger event to notify of battery sensor value changes */
+    ZMK_EVENT_RAISE(new_zmk_battery_state_changed(bat_state_data));
+
+    return rv;
+    
+} /* zmk_battery_update() */
 
 static void zmk_battery_work(struct k_work *work) {
     int rc = zmk_battery_update(battery);
@@ -85,7 +287,7 @@ static int zmk_battery_init(const struct device *_arg) {
     int rc = zmk_battery_update(battery);
 
     if (rc != 0) {
-        LOG_DBG("Failed to update battery value: %d.", rc);
+        LOG_WRN("Failed to update %d battery value(s) which the configured sensor supports.", rc);
         return rc;
     }
 

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -110,7 +110,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The configured battery sensor does not support the channel: Voltage");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.voltage = voltage.val1;
+        bat_state_data.voltage = voltage.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery voltage: %d.%dV", voltage.val1, voltage.val2);
     }
 
@@ -125,7 +125,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Average Current");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.current = current.val1;
+        bat_state_data.current = current.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery Average Current: %d.%dA", current.val1, current.val2);
     }
 
@@ -140,7 +140,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Standby Current");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.current_standby = current_standby.val1;
+        bat_state_data.current_standby = current_standby.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery Standby Current: %d.%dA", current_standby.val1,
                 current_standby.val2);
     }
@@ -156,7 +156,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Maximum Load Current");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.current_max_load = current_max_load.val1;
+        bat_state_data.current_max_load = current_max_load.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery Maximum Load Current: %d.%dA", current_max_load.val1,
                 current_max_load.val2);
     }
@@ -172,7 +172,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Full Charge Capacity");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.full_charge_capacity = full_charge_capacity.val1;
+        bat_state_data.full_charge_capacity = full_charge_capacity.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery Full Charge Capacity: %d.%dmAh", full_charge_capacity.val1,
                 full_charge_capacity.val2);
     }
@@ -188,7 +188,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Remaining Charge Capacity");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.remaining_charge_capacity = remaining_charge_capacity.val1;
+        bat_state_data.remaining_charge_capacity = remaining_charge_capacity.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery Remaining Charge Capacity: %d.%dmAh", remaining_charge_capacity.val1,
                 remaining_charge_capacity.val2);
     }
@@ -204,7 +204,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Nominal Available Capacity");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.nominal_available_capacity = nominal_available_capacity.val1;
+        bat_state_data.nominal_available_capacity = nominal_available_capacity.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery Nominal Available Capacity: %d.%dmAh", nominal_available_capacity.val1,
                 nominal_available_capacity.val2);
     }
@@ -220,7 +220,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Full Available Capacity");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.full_available_capacity = full_available_capacity.val1;
+        bat_state_data.full_available_capacity = full_available_capacity.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery Full Available Capacity: %d.%dmAh", full_available_capacity.val1,
                 full_available_capacity.val2);
     }
@@ -236,7 +236,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Average Power Usage");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.avg_power = avg_power.val1;
+        bat_state_data.avg_power = avg_power.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery Average Power Usage: %d.%dmW", avg_power.val1, avg_power.val2);
     }
 
@@ -251,7 +251,7 @@ static int zmk_battery_update(const struct device *battery) {
         LOG_DBG("The battery sensor does not support the channel: Internal IC Temperature");
     } else {
         /* append this value to the battery state changed event */
-        bat_state_data.int_temp = int_temp.val1;
+        bat_state_data.int_temp = int_temp.val1; /*combine val1" and "val2" here*/
         LOG_DBG("-----> battery Internal IC Temperature: %d.%d C", int_temp.val1, int_temp.val2);
     }
 

--- a/app/src/display/widgets/output_status.c
+++ b/app/src/display/widgets/output_status.c
@@ -13,6 +13,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/event_manager.h>
 #include <zmk/events/usb_conn_state_changed.h>
 #include <zmk/events/ble_active_profile_changed.h>
+#include <zmk/events/endpoint_selection_changed.h>
 #include <zmk/usb.h>
 #include <zmk/ble.h>
 #include <zmk/endpoints.h>
@@ -86,6 +87,8 @@ int output_status_listener(const zmk_event_t *eh) {
 }
 
 ZMK_LISTENER(widget_output_status, output_status_listener)
+ZMK_SUBSCRIPTION(widget_output_status, zmk_endpoint_selection_changed);
+
 #if defined(CONFIG_USB)
 ZMK_SUBSCRIPTION(widget_output_status, zmk_usb_conn_state_changed);
 #endif


### PR DESCRIPTION
This PR introduces a bunch of sensor channels that can be used by Zephyr-supported fuel gauge ICs on keyboards. It should still work fine if a board is using the local voltage divider driver, but expands the functionality for drivers that can provide more than just State Of Charge data.

**The gist of what the major changes consist of:**
1. The struct that currently holds the `zmk_battery_state_changed` event has been expanded to handle more data channels. The event is only raised after all the possible channel data is collected.
2. The code in batttery.c now checks to see if a channel is supported by the sensor, so that a "not supported" response from the driver does not constitute a failure.
3.  Errors while retrieving sensor channels now get counted and the total errors get returned to the main function call, rather than returning after the first error. This allow the debug to catch the state of all the channels, not just the ones prior to the error.

**I got stuck on one thing, and could use help from someone with better C skills than me:**

The sensor data gets returned from the driver in two parts. The whole integer part and the fractional part (the parts before and after the decimal in a float). These parts have to be combined back into one value again, and maybe rounded to two decimal places, so that the full value can be passed back to the `zmk_battery_state_changed` event in one piece. I just don't know how to achieve that. Right now I am simply returning the whole integer part. I have marked each place this needs to be changed with this comment: `/*combine val1 and val2 here*/`