### PR TITLE
Feature/usb report leds

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -424,6 +424,10 @@ choice CBPRINTF_IMPLEMENTATION
 
 endchoice
 
+config ZMK_USB_REPORT_LEDS
+  bool "Enable usb report leds"
+  select ENABLE_HID_INT_OUT_EP
+
 module = ZMK
 module-str = zmk
 source "subsys/logging/Kconfig.template.log_config"

--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -135,6 +135,38 @@ static const uint8_t zmk_hid_report_desc[] = {
     ZMK_HID_CONSUMER_NKRO_SIZE,
     HID_MI_INPUT,
     0x00,
+
+#ifdef CONFIG_ZMK_USB_REPORT_LEDS
+    /* LED */
+    0x85, 0x01,
+    /* REPORT_COUNT (5) */
+    HID_GI_REPORT_COUNT,
+    0x05,
+    /* REPORT_SIZE (1) */
+	  HID_GI_REPORT_SIZE,
+    0x01,
+    /* USAGE_PAGE (Page# for LEDs) */
+	  HID_GI_USAGE_PAGE,
+    0x08,
+    /* USAGE_MINIMUM (1) */
+	  0x19, 0x01,
+    /* USAGE_MAXIMUM (5) */
+	  0x29, 0x05,
+    /* OUTPUT (Data, Variable, Absolute), */
+	  HID_MI_OUTPUT,
+    0x02,
+	  /* LED REPORT */
+    /* REPORT_COUNT (1) */
+	  HID_GI_REPORT_COUNT,
+    0x01,
+    /* REPORT_SIZE (3) */
+	  HID_GI_REPORT_SIZE,
+    0x03,
+    /* OUTPUT (Data, Variable, Absolute), */
+	  HID_MI_OUTPUT,
+    0x01,
+#endif /* CONFIG_ZMK_USB_REPORT_LEDS */
+
     /* END COLLECTION */
     HID_MI_COLLECTION_END,
 };

--- a/app/include/zmk/usb.h
+++ b/app/include/zmk/usb.h
@@ -26,4 +26,7 @@ static inline bool zmk_usb_is_hid_ready() { return zmk_usb_get_conn_state() == Z
 
 #ifdef CONFIG_ZMK_USB
 int zmk_usb_hid_send_report(const uint8_t *report, size_t len);
+#ifdef CONFIG_ZMK_USB_REPORT_LEDS
+int zmk_usb_hid_receive_report(uint8_t *report, size_t len);
+#endif /* CONFIG_ZMK_USB_REPORT_LEDS */
 #endif /* CONFIG_ZMK_USB */

--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -38,6 +38,22 @@ static const struct hid_ops ops = {
     .int_in_ready = in_ready_cb,
 };
 
+#ifdef CONFIG_ZMK_USB_REPORT_LEDS
+
+int zmk_usb_hid_receive_report(uint8_t *report, size_t len) {
+    k_sem_take(&hid_sem, K_MSEC(30));
+    int err = hid_int_ep_read(hid_dev, report, len, NULL);
+
+    if (err) {
+        k_sem_give(&hid_sem);
+        LOG_ERR("Error receive report %d", err);
+    }
+
+    return err;
+}
+
+#endif /* CONFIG_ZMK_USB_REPORT_LEDS */
+
 int zmk_usb_hid_send_report(const uint8_t *report, size_t len) {
     switch (usb_status) {
     case USB_DC_SUSPEND:


### PR DESCRIPTION
Feature: Read report leds from usb

Example to test it

1. In board_file.conf add: `CONFIG_ZMK_USB_REPORT_LEDS=y`
2. In rgb_underglow.c add: 

```
int zmk_rgb_hid_listener(const zmk_event_t *eh) {
    const struct zmk_keycode_state_changed *ev = as_zmk_keycode_state_changed(eh);
    uint8_t receive_report[2] = { 0, 0 };
    if (ev && !ev->state) {
        zmk_usb_hid_receive_report((uint8_t *)receive_report, 2);   
        if (receive_report[0]) {
            if (receive_report[1] == HID_USAGE_LED_CAPS_LOCK) {
                zmk_rgb_underglow_on();
            } else {
                zmk_rgb_underglow_off();
            }
        }
    }
    return 0;
}

ZMK_LISTENER(zmk_rgb_hid_listener, zmk_rgb_hid_listener);
ZMK_SUBSCRIPTION(zmk_rgb_hid_listener, zmk_keycode_state_changed);`
```


this example code will turn on the LEDs when caps is locked