### PR TITLE
fix: Planck rev 6.1

### DIFF
--- a/app/boards/arm/planck/planck_rev6.dts
+++ b/app/boards/arm/planck/planck_rev6.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include <st/f3/stm32f303Xc.dtsi>
+#include <dt-bindings/zmk/matrix_transform.h>
 
 / {
 	model = "Plack PCD, rev6";
@@ -15,11 +16,13 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zmk,kscan = &kscan0;
+                zmk,matrix_transform = &layout_grid_transform;
 	};
 
 	kscan0: kscan {
 		compatible = "zmk,kscan-gpio-matrix";
 		label = "KSCAN";
+                diode-direction = "col2row";
 		row-gpios
 			= <&gpioa 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
 			, <&gpioa 9  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
@@ -40,6 +43,42 @@
 			;
 	};
 
+layout_grid_transform:
+	keymap_transform_0 {
+	    compatible = "zmk,matrix-transform";
+	    columns = <6>;
+	    rows = <8>;
+	    map = <
+		RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)
+		RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5)
+		RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5)
+		RC(3,0) RC(3,1) RC(3,2) RC(7,3) RC(7,4) RC(7,5) RC(7,0) RC(7,1) RC(7,2) RC(3,3) RC(3,4) RC(3,5)
+		>;
+	};
+layout_mit_transform:
+	keymap_transform_1 {
+	    compatible = "zmk,matrix-transform";
+	    columns = <6>;
+	    rows = <8>;
+	    map = <
+		RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)
+		RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5)
+		RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5)
+		RC(3,0) RC(3,1) RC(3,2) RC(7,3) RC(7,4)     RC(7,0)     RC(7,1) RC(7,2) RC(3,3) RC(3,4) RC(3,5)
+		>;
+	};
+layout_2x2u_transform:
+	keymap_transform_2 {
+	    compatible = "zmk,matrix-transform";
+	    columns = <6>;
+	    rows = <8>;
+	    map = <
+		RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)
+		RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5)
+		RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5)
+		RC(3,0) RC(3,1) RC(3,2) RC(7,3)     RC(7,5)         RC(7,1)     RC(7,2) RC(3,3) RC(3,4) RC(3,5)
+		>;
+	};
 };
 
 &usb {


### PR DESCRIPTION
My Planck rev 6.1 would not register any keys without "col2row".
I also had to apply a matrix_transform in order to move them to the
correct position. Peeking into #228 helped for finding this.