### PR TITLE
feat(docs) Clarify Bluetooth profile pairing

### DIFF
--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -13,8 +13,6 @@ computer/laptop/keyboard should receive the keyboard input; many of the commands
 When pairing to a host device ZMK saves bond information to the selected profile. It will not replace this when you initiate pairing with another device. To pair with a new device select an unused profile with `BT_SEL`, `BT_NXT` or by clearing an existing profile using `BT_CLR`.
 
 A ZMK device may show as "connected" on multiple hosts at the same time. This is working as intended, and only the host associated with the active profile will receive keystrokes.
-
-Please note there are only five available Bluetooth profiles by default. If you need to increase the number of available profiles you can set `CONFIG_BT_MAX_CONN` in your `zmk-config` `.conf` file.
 :::
 
 ## Bluetooth Command Defines
@@ -82,6 +80,10 @@ ZMK support bluetooth “profiles” which allows connection to multiple devices
 - If a profile has been paired and is currently connected, ZMK will not advertise it as connectable.
 
 The bluetooth MAC address and negotiated keys during pairing are stored in the permanent storage on your chip and can be reused even after reflashing the firmware. If for some reason you want to delete the stored information, you can bind the `BT_CLR` behavior described above to a key and use it to clear the _current_ profile.
+
+:::note Number of Profiles
+Please note there are only five available Bluetooth profiles by default. If you need to increase the number of available profiles you can set `CONFIG_BT_MAX_CONN` in your `zmk-config` `.conf` file.
+:::
 
 :::note
 If you clear bond of a paired profile, make sure you do the same thing on the peer device as well (typically achieved by _removing_ or _forgetting_ the bluetooth connection). Otherwise the peer will try to connect to your keyboard whenever it discovers it. But while the MAC address of both devices could remain the same, the security key no longer match: the peer device still possess the old key negotiated in the previous pairing procedure, but our keyboard firmware has deleted that key. So the connection will fail. If you [enabled USB logging](../development/usb-logging.md), you might see a lot of failed connection attempts due to the reason of “Security failed”.

--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -7,7 +7,7 @@ sidebar_label: Bluetooth
 
 The bluetooth behavior allows management of various settings and states related to the bluetooth connection(s)
 between the keyboard and the host. By default, ZMK supports five "profiles" for selecting which bonded host
-computer/laptop/keyboard should receive the keyboard input; many of the commands here operation on those profiles.
+computer/laptop/keyboard should receive the keyboard input; many of the commands here operate on those profiles.
 
 :::note Connection Management
 When pairing to a host device ZMK saves bond information to the selected profile. It will not replace this when you initiate pairing with another device. To pair with a new device select an unused profile with `BT_SEL`, `BT_NXT` or by clearing an existing profile using `BT_CLR`.

--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -10,7 +10,7 @@ between the keyboard and the host. By default, ZMK supports five "profiles" for 
 computer/laptop/keyboard should receive the keyboard input; many of the commands here operate on those profiles.
 
 :::note Connection Management
-When pairing to a host device ZMK saves bond information to the selected profile. It will not replace this when you initiate pairing with another device. To pair with a new device select an unused profile with `BT_SEL`, `BT_NXT` or by clearing an existing profile using `BT_CLR`.
+When pairing to a host device ZMK saves bond information to the selected profile. It will not replace this when you initiate pairing with another device. To pair with a new device select an unused profile with `BT_SEL`, `BT_NXT` or `BT_PRV` bindings, or by clearing an existing profile using `BT_CLR`.
 
 A ZMK device may show as "connected" on multiple hosts at the same time. This is working as intended, and only the host associated with the active profile will receive keystrokes.
 :::

--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -9,12 +9,12 @@ The bluetooth behavior allows management of various settings and states related 
 between the keyboard and the host. By default, ZMK supports five "profiles" for selecting which bonded host
 computer/laptop/keyboard should receive the keyboard input; many of the commands here operation on those profiles.
 
-:::note Number of Profiles
-Please note there are only five available Bluetooth profiles by default. If you need to increase the number of available profiles you can set `CONFIG_BT_MAX_CONN` in your `zmk-config` `.conf` file.
-:::
-
 :::note Connection Management
+When pairing to a host device ZMK saves bond information to the selected profile. It will not replace this when you initiate pairing with another device. To pair with a new device select an unused profile with `BT_SEL`, `BT_NXT` or by clearing an existing profile using `BT_CLR`.
+
 A ZMK device may show as "connected" on multiple hosts at the same time. This is working as intended, and only the host associated with the active profile will receive keystrokes.
+
+Please note there are only five available Bluetooth profiles by default. If you need to increase the number of available profiles you can set `CONFIG_BT_MAX_CONN` in your `zmk-config` `.conf` file.
 :::
 
 ## Bluetooth Command Defines


### PR DESCRIPTION
As discussed here;
https://ptb.discord.com/channels/719497620560543766/719909884769992755/876550012153233420

It seems like the bluetooth pairing mechanism ZMK uses isn't always intuitive to new users who may expect a bluetooth device to replace the current bond when it is advertising. However since ZMK does not do this there are frequent questions on the discord and other things may be assumed at fault.

I've tried clarifying this behaviour and also moved the note about number of profiles down to reduce the amount of text in the note
There's some repetition with the `Bluetooth Pairing and Profiles` section but I think this is a tldr that will grab users attention a bit more

I've also fixed a small typo that existed here 1c05f37

See the preview here; https://deploy-preview-914--zmk.netlify.app/docs/behaviors/bluetooth
I'm open to any improvements in phrasing or layout to clarify this further


Cheers!