### PR TITLE
fix: Use correct quotation marks on line 65

### DIFF
--- a/docs/src/templates/setup.ps1.mustache
+++ b/docs/src/templates/setup.ps1.mustache
@@ -62,7 +62,7 @@ function Test-CommandExists {
     param ($command)
 
     $oldPreference = $ErrorActionPreference
-    $ErrorActionPreference = ‘stop’
+    $ErrorActionPreference = "stop"
 
     try {
         if(Get-Command $command){ return $true }


### PR DESCRIPTION
Use correct quotation marks in order for the script to properly function on this line. 