### PR TITLE
fix(docs): Set "Mouse Keys" as "Under Development"

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -31,7 +31,7 @@ ZMK is currently missing some features found in other popular firmware. This tab
 | One Shot Keys                                                                                                                      | ✅  |    ✅     | ✅  |
 | [Combo Keys](features/combos.md)                                                                                                   | ✅  |           | ✅  |
 | Macros                                                                                                                             | 🚧  |    ✅     | ✅  |
-| Mouse Keys                                                                                                                         | 💡  |    ✅     | ✅  |
+| Mouse Keys                                                                                                                         | 🚧  |    ✅     | ✅  |
 | Low Active Power Usage                                                                                                             | ✅  |           |     |
 | Low Power Sleep States                                                                                                             | ✅  |    ✅     |     |
 | [Low Power Mode (VCC Shutoff)](behaviors/power.md)                                                                                 | ✅  |    ✅     |     |


### PR DESCRIPTION
This change updates the [feature comparison table](https://zmk.dev/docs) to show "Mouse Keys" as "Under Development" (instead of "Planned").

Mouse Keys development is happening in PR #778.