### PR TITLE
Create nice_nano_v2.overlay

### DIFF
--- a/app/boards/shields/reviung41/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/reviung41/boards/nice_nano_v2.overlay
@@ -1,0 +1,28 @@
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <11>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};


### PR DESCRIPTION
Defines nice_nano_v2.overlay file identical to nice_nano.overlay file for RGB SPI parameters