### PR TITLE
feat(shield): Add Bat43 shield

### DIFF
--- a/app/boards/shields/bat43/Kconfig.defconfig
+++ b/app/boards/shields/bat43/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2021 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_BAT43
+
+config ZMK_KEYBOARD_NAME
+    default "Bat43"
+
+endif

--- a/app/boards/shields/bat43/Kconfig.shield
+++ b/app/boards/shields/bat43/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2021 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_BAT43
+    def_bool $(shields_list_contains,bat43)

--- a/app/boards/shields/bat43/bat43.keymap
+++ b/app/boards/shields/bat43/bat43.keymap
@@ -23,7 +23,7 @@
             bindings = <
 &kp ESC      &kp Q     &kp W     &kp E     &kp R     &kp T            &kp Y     &kp U     &kp I     &kp O    &kp P       &kp MINUS
 &kp TAB      &kp A     &kp S     &kp D     &kp F     &kp G  &kp BSPC  &kp H     &kp J     &kp K     &kp L    &kp SEMI    &kp RSHFT
-&kp LCTL     &kp Z     &kp X     &kp C     &kp V     &kp B            &kp N     &kp M     &kp COMMA &kp DOT  &kp FSLH    &kp RCTL
+&kp LCTRL    &kp Z     &kp X     &kp C     &kp V     &kp B            &kp N     &kp M     &kp COMMA &kp DOT  &kp FSLH    &kp RCTRL
                               &kp LGUI  &kp LANG2    L_SPC            R_RET     &kp LANG1 &kp RALT
                                         &bt BT_CLR   &out OUT_TOG     &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2
             >;

--- a/app/boards/shields/bat43/bat43.keymap
+++ b/app/boards/shields/bat43/bat43.keymap
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+#define LOWER 1
+#define RAISE 2
+
+#define L_SPC &lt LOWER SPACE
+#define R_RET &lt RAISE RET
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+&kp ESC      &kp Q     &kp W     &kp E     &kp R     &kp T            &kp Y     &kp U     &kp I     &kp O    &kp P       &kp MINUS
+&kp TAB      &kp A     &kp S     &kp D     &kp F     &kp G  &kp BSPC  &kp H     &kp J     &kp K     &kp L    &kp SEMI    &kp RSHFT
+&kp LCTL     &kp Z     &kp X     &kp C     &kp V     &kp B            &kp N     &kp M     &kp COMMA &kp DOT  &kp FSLH    &kp RCTL
+                              &kp LGUI  &kp LANG2    L_SPC            R_RET     &kp LANG1 &kp RALT
+                                        &bt BT_CLR   &out OUT_TOG     &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2
+            >;
+        };
+        lower_layer {
+            bindings = <
+&trans      &none     &none     &none     &none     &none            &none     &kp EQUAL &kp PLUS  &kp STAR &kp PRCNT   &trans
+&trans      &kp N1    &kp N2    &kp N3    &kp N4    &kp N5 &trans    &kp N6    &kp N7    &kp N8    &kp N9   &kp N0      &trans
+&trans      &none     &none     &none     &none     &none            &none     &none     &trans    &trans   &trans      &trans
+                                &trans    &trans    &trans           &trans    &trans    &trans
+                                          &trans    &trans           &trans    &trans    &trans
+            >;
+        };
+        raise_layer {
+            bindings = <
+&trans      &kp BSLH  &kp EXCL  &kp AMPS  &kp PIPE  &none            &none     &kp EQUAL &kp PLUS  &kp STAR &kp PRCNT   &trans
+&trans      &kp HASH  &kp GRAVE &kp DQT   &kp SQT   &kp TILDE &trans &kp LEFT  &kp DOWN  &kp UP    &kp RIGHT &kp DLLR   &trans
+&trans      &none     &none     &kp LBRC  &kp LBKT  &kp LPAR         &kp RPAR  &kp RBKT  &kp RBRC  &kp AT    &kp CARET  &trans
+                                &trans    &trans    &trans           &trans    &trans    &trans
+                                          &trans    &trans           &trans    &trans    &trans
+            >;
+        };
+    };
+};

--- a/app/boards/shields/bat43/bat43.overlay
+++ b/app/boards/shields/bat43/bat43.overlay
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <6>;
+        rows = <7>;
+
+        map = <
+RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)         RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)
+RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(3,0) RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5)
+RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)         RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5)
+                        RC(3,3) RC(3,4) RC(3,5)         RC(7,0) RC(7,1) RC(7,2)
+                                RC(7,5) RC(7,4)         RC(7,3) RC(3,1) RC(3,2)
+        >;
+    };
+
+    kscan0: kscan_0 {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "col2row";
+
+        col-gpios
+            = <&pro_micro 10 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 16 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 14 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 15 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 9 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 8 GPIO_ACTIVE_HIGH>
+            ;
+
+        row-gpios
+            = <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+    };
+};

--- a/app/boards/shields/bat43/bat43.zmk.yml
+++ b/app/boards/shields/bat43/bat43.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: bat43
+name: BAT43
+type: shield
+url: https://kbd.dailycraft.jp/bat43/
+requires: [pro_micro]
+features:
+  - keys


### PR DESCRIPTION
See https://kbd.dailycraft.jp/bat43/ for details.

The shield uses the default keymap of the bat43, with the tiny tactile
pushbuttons used for output selection and bluetooth functions.
