### PR TITLE
fix(setup): Fix sed delimiters for Cradio

### DIFF
--- a/docs/src/templates/setup.sh.mustache
+++ b/docs/src/templates/setup.sh.mustache
@@ -189,7 +189,7 @@ popd
 sed -i'.orig' \
     -e "s/BOARD_NAME/$board/" \
     -e "s/SHIELD_NAME/$shield/" \
-    -e "s/KEYBOARD_TITLE/$shield_title/" \
+    -e "s|KEYBOARD_TITLE|$shield_title|" \
     .github/workflows/build.yml
 
 if [ "$board" == "proton_c" ]; then


### PR DESCRIPTION
Fixes #949. Note that I couldn't test this end-to-end locally; it seems like a safe change but I will try it if netlify preview creates a custom link for setup.sh.

For reference, here are the display names currently in the repo:
```
$ rg -IN 'name:' **.zmk.yml
name: BDN9 Rev2
name: BlueMicro840 v1
name: Ferris 0.2
name: nice!60
name: nice!nano v1
name: nice!nano v2
name: nRF52840 M.2 Module
name: nRFMicro 1.1/1.2
name: nRFMicro 1.1 (flipped)
name: nRFMicro 1.3/1.4
name: Planck Rev6
name: QMK Proton-C
name: MakerDiary nRF52840 M.2
name: Pro Micro
name: A. Dux
name: BFO-9000
name: Boardsource 3x4 Macropad
name: Corne
name: Cradio/Sweep
name: CRBN Featherlight
name: eek!
name: Helix
name: Iris
name: Jian
name: Jorne
name: Kyria
name: MakerDiary m60
name: Microdox
name: Nibble
name: QAZ
name: Quefrency Rev. 1
name: REVIUNG41
name: Romac Macropad
name: Romac+ Macropad
name: Sofle
name: Splitreus62
name: Lily58
name: Tidbit Numpad
name: TG4x
```
Right now `|` seems like a safe bet.

Another concern is issues with the YAML string syntax since these are inserted as string values in the build.yml template, but I don't think characters in the current list pose an issue.