### PR TITLE
docs(docs): Document up-to-date Node.js repo

### DIFF
--- a/docs/docs/development/documentation.md
+++ b/docs/docs/development/documentation.md
@@ -19,7 +19,7 @@ If you are working with the documentation from within VS Code+Docker please be a
 :::
 
 :::note
-You will need `Node.js` and `npm` installed to update the documentation. If you're using the ZMK dev container (Docker) the necessary dependencies are already installed.
+You will need `Node.js` and `npm` installed to update the documentation. If you're using the ZMK dev container (Docker) the necessary dependencies are already installed. Otherwise, you must install these dependencies yourself. Since `Node.js` packages in Linux distributions tend to be outdated, it's recommended to install the current version from a repository like [NodeSource](https://github.com/nodesource/distributions) to avoid build errors.
 :::
 
 ## Testing Documentation Updates Locally


### PR DESCRIPTION
For example, Debian Bullseye (current stable) packages Node.js version
12, which is too old to build the docs successfully. At least version 14
is required, and version 16 is current. General advice seems to be to
install from the NodeSource repo instead of your distro's repo, so I
added a suggestion to the docs.