### PR TITLE
fix(display): Increase char buffer size to fit all symbols

### DIFF
--- a/app/src/display/widgets/output_status.c
+++ b/app/src/display/widgets/output_status.c
@@ -39,7 +39,7 @@ static struct output_status_state get_state(const zmk_event_t *_eh) {
 }
 
 static void set_status_symbol(lv_obj_t *label, struct output_status_state state) {
-    char text[6] = {};
+    char text[9] = {};
 
     switch (state.selected_endpoint) {
     case ZMK_ENDPOINT_USB:


### PR DESCRIPTION
Recent refactoring of the font handling seems to have broken the display
of the last symbol of the output status widget. From my analysis the
last symbol is truncated because the buffer simply is too small.
Increasing the buffer size to 9 fits all three possible symbols.