### PR TITLE
Mention "The ZMK Contributors" copyrights in PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
  - [ ] This board/shield is tested working on real hardware
  - [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
  - [ ] `.zmk.yml` metadata file added
- - [ ] Proper Copyright + License headers added to applicable files
+ - [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
  - [ ] General consistent formatting of DeviceTree files
  - [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
  - [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable


### PR DESCRIPTION
This small PR adds a note to the PR checklist to try and encourage standardised use of "The ZMK Contributors" in copyright headers.

Examples of current PRs where this may have been useful:

- https://github.com/zmkfirmware/zmk/pull/974#discussion_r726721950
- https://github.com/zmkfirmware/zmk/pull/967#pullrequestreview-771991003

Example of how the checklist renders with this change:

 - [ ] This board/shield is tested working on real hardware
 - [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [ ] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [ ] General consistent formatting of DeviceTree files
 - [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [ ] If split, no name added for the right/peripheral half
 - [ ] `.conf` file has optional extra features commented out
