### PR TITLE
refactor: Move to explicit docker.io/* image references.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM zmkfirmware/zmk-dev-arm:2.5
+FROM docker.io/zmkfirmware/zmk-dev-arm:2.5
 
 COPY .bashrc tmp
 RUN mv /tmp/.bashrc ~/.bashrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: zmkfirmware/zmk-build-arm:2.5
+      image: docker.io/zmkfirmware/zmk-build-arm:2.5
     strategy:
       matrix:
         board:

--- a/.github/workflows/hardware-metadata-validation.yml
+++ b/.github/workflows/hardware-metadata-validation.yml
@@ -29,7 +29,7 @@ jobs:
   validate-metadata:
     runs-on: ubuntu-latest
     container:
-      image: zmkfirmware/zmk-dev-arm:2.5
+      image: docker.io/zmkfirmware/zmk-dev-arm:2.5
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   integration_test:
     runs-on: ubuntu-latest
     container:
-      image: zmkfirmware/zmk-build-arm:2.5
+      image: docker.io/zmkfirmware/zmk-build-arm:2.5
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
* Some runtimes (e.g. podman), require explicit registries in image URLs
 or will prompt for the user to select one, which breaks things like
 VSCode remote container rebuilds.
