### PR TITLE
feat(docs): Add remarks on bluetooth output with USB power

### DIFF
--- a/docs/docs/behaviors/outputs.md
+++ b/docs/docs/behaviors/outputs.md
@@ -12,6 +12,12 @@ keyboard to USB for power but outputting to a different device over bluetooth.
 By default, output is sent to USB when both USB and BLE are connected.
 Once you select a different output, it will be remembered until you change it again.
 
+:::note Powering the keyboard via USB
+ZMK is not always able to detect if the other end of a USB connection accepts keyboard input or not.
+So if you are using USB only to power your keyboard (for example with a charger or a portable power bank), you will want
+to select the BLE output through below behavior to be able to send keystrokes to the selected bluetooth profile.
+:::
+
 ## Output Command Defines
 
 Output command defines are provided through the [`dt-bindings/zmk/outputs.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/outputs.h)

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -3,9 +3,7 @@ title: Troubleshooting
 sidebar_title: Troubleshooting
 ---
 
-### Summary
-
-The following page provides suggestions for common errors that may occur during firmware compilation. If the information provided is insufficient to resolve the issue, feel free to seek out help from the [ZMK Discord](https://zmk.dev/community/discord/invite).
+The following page provides suggestions for common errors that may occur during firmware compilation or other issues with keyboard usage. If the information provided is insufficient to resolve the issue, feel free to seek out help from the [ZMK Discord](https://zmk.dev/community/discord/invite).
 
 ### File Transfer Error
 
@@ -76,3 +74,7 @@ CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
 ```
 
 For the `nRF52840`, the value `PLUS_8` can be set to any multiple of four between `MINUS_20` and `PLUS_8`. The default value for this config is `0`, but if you are having connection issues it is recommended to set it to `PLUS_8` because the power consumption difference is negligible. For more information on changing the transmit power of your BLE device, please refer to [the Zephyr docs.](https://docs.zephyrproject.org/latest/reference/kconfig/CONFIG_BT_CTLR_TX_PWR_PLUS_8.html)
+
+### Other notes and warnings
+
+- If you want to test bluetooth output on your keyboard and are powering it through the USB connection rather than a battery, you will be able to pair with a host device but may not see keystrokes sent. In this case you need to use the [output selection behavior](../docs/behaviors/outputs.md) to prefer sending keystrokes over bluetooth rather than USB. This might be necessary even if you are not powering from a device capable of receiving USB inputs, such as a USB charger.


### PR DESCRIPTION
Adds remarks in "Output Selection" behavior and "Troubleshooting" pagesto note that the output behavior should be used to direct keystrokes to bluetooth if USB is connected. This is a frequent issue users run into, where they might be powering the keyboard with a charger device that doesn't accept USB input so they expect ZMK to automatically output over bluetooth.

I also removed the extraneous "Summary" header in Troubleshooting page, which is consistent with other "Getting Started" subpages. I think it'd be good to remove it from other pages like behaviors as well but at least they are consistent between each other right now.