### PR TITLE
Strip board revision so keymap file use only board name

### DIFF
--- a/app/cmake/zmk_config.cmake
+++ b/app/cmake/zmk_config.cmake
@@ -45,6 +45,16 @@ endif()
 # Store the selected user_config in the cache
 set(CACHED_ZMK_CONFIG ${ZMK_CONFIG} CACHE STRING "Selected user ZMK config")
 
+string(FIND "${BOARD}" "@" REVISION_SEPARATOR_INDEX)
+if(NOT (REVISION_SEPARATOR_INDEX EQUAL -1))
+  message(STATUS "Board with revision: ${BOARD}")
+  math(EXPR BOARD_REVISION_INDEX "${REVISION_SEPARATOR_INDEX} + 1")
+  string(SUBSTRING ${BOARD} ${BOARD_REVISION_INDEX} -1 BOARD_REVISION)
+  string(SUBSTRING ${BOARD} 0 ${REVISION_SEPARATOR_INDEX} BOARD)
+  message(STATUS "Board without revision: ${BOARD}")
+endif()
+
+
 if (ZMK_CONFIG)
 	set(ENV{ZMK_CONFIG} "${ZMK_CONFIG}")
 	if(EXISTS ${ZMK_CONFIG}/boards)


### PR DESCRIPTION
Zephyr upstream has native board revision support. 
https://docs.zephyrproject.org/latest/guides/porting/board_porting.html#multiple-board-revisions

At present, ZMK does not make use of this feature and relies on creating different boards for different revisions.
This may not not be optimal if a keyboard has many revisions.

Made a quick try at zephyr's revision for cyber60 keyboard,
https://github.com/megamind4089/zmk-config-4pplet/tree/unify_rev_with_buzzer/config/boards/arm/cyber60

With this change, we can compile different revisions using
```
west build -p -d build cyber60@B
west build -p -d build cyber60@C
```

But the only issue I faced was, ZMK was not able to find the keymap file properly.
Had to workaround this by specifying the keymap file in build command like this:
https://github.com/megamind4089/zmk-config-4pplet/blob/unify_rev_with_buzzer/.github/workflows/build.yaml#L63

The changes in this PR is to make ZMK aware of board revisions (partially) and choose the appropriate keymap file.
Also, this changes does not impact the existing boards/shields since none of them uses revisions yet