### PR TITLE
Fix searching for overlays and configs in zmk-config

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -507,6 +507,8 @@ rsource "boards/shields/*/Kconfig.shield"
 osource "$(ZMK_CONFIG)/boards/shields/*/Kconfig.defconfig"
 osource "$(ZMK_CONFIG)/boards/shields/*/Kconfig.shield"
 
+osource "$(ZMK_CONFIG)/boards/arm/*/Kconfig.defconfig"
+osource "$(ZMK_CONFIG)/boards/arm/*/Kconfig.boards"
 
 source "Kconfig.zephyr"
 

--- a/app/cmake/zmk_config.cmake
+++ b/app/cmake/zmk_config.cmake
@@ -97,6 +97,7 @@ endforeach()
 
 if (ZMK_CONFIG)
 	if (EXISTS ${ZMK_CONFIG})
+		message(STATUS "ZMK Config directory: ${ZMK_CONFIG}")
 		list(APPEND DTS_ROOT ${ZMK_CONFIG})
 		list(PREPEND KEYMAP_DIRS "${ZMK_CONFIG}")
 

--- a/app/cmake/zmk_config.cmake
+++ b/app/cmake/zmk_config.cmake
@@ -71,7 +71,7 @@ foreach(root ${BOARD_ROOT})
 	if (NOT DEFINED BOARD_DIR_NAME)
 		find_path(BOARD_DIR
 			NAMES ${BOARD}_defconfig
-			PATHS ${root}/boards/*/*
+			PATHS ${root}/boards/*/* ${root}/boards
 			NO_DEFAULT_PATH
 			)
 		if(BOARD_DIR)
@@ -83,13 +83,13 @@ foreach(root ${BOARD_ROOT})
 	if(DEFINED SHIELD)
 		find_path(shields_refs_list
 		    NAMES ${SHIELD}.overlay
-		    PATHS ${root}/boards/shields/*
+		    PATHS ${root}/boards/shields/* ${root}
 		    NO_DEFAULT_PATH)
 		foreach(shield_path ${shields_refs_list})
 			get_filename_component(SHIELD_DIR_NAME ${shield_path} NAME)
 			list(APPEND KEYMAP_DIRS ${shield_path})
 		endforeach()
-		
+
 		# make it consistent with other naming conventions used in project
 		set(SHIELD_DIR "${shields_refs_list}")
 	endif()

--- a/app/cmake/zmk_config.cmake
+++ b/app/cmake/zmk_config.cmake
@@ -97,7 +97,6 @@ endforeach()
 
 if (ZMK_CONFIG)
 	if (EXISTS ${ZMK_CONFIG})
-		message(STATUS "ZMK Config directory: ${ZMK_CONFIG}")
 		list(APPEND DTS_ROOT ${ZMK_CONFIG})
 		list(PREPEND KEYMAP_DIRS "${ZMK_CONFIG}")
 


### PR DESCRIPTION
Hi, 

I'm working on project to lunch particle xenon board with zmk split keyboard shield.
Shield details:
* bluetooth
* adafruit bootloader
* split keyboard
* hardwired

My shield is hardwired so there is no chance to add it to main repo.
I went after some discord advise and created my own zmk-config.

Everything went smoothly until i tried to build this think.
Base version made on my knee (works)
https://github.com/DuMaM/zmk-config
Under second attempt, I started to make it state-of-the-art
https://github.com/DuMaM/zmk-config/pull/1 (feel free to comment)

I faced some issues.
1. Some conf files are not loaded.
2. I don't know how should i extend/edit base behavior of particle_xenon

This PR solves first problem. This also fixes some issues spotted with flat structure of this project.
Described here.
https://zmk.dev/docs/customization/

I also find path like:
app/board/shield/board/<some>.overlay
app/board/shield/board/<some>.prj
Like kind of inconsistency of file tree, so if it's possible I would like to remove lines: 64-66

This PR should improve an experience for split keyboard users.