### PR TITLE
fix(hid): Basic consumer code fixes for signed logical max.

### DIFF
--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -143,12 +143,14 @@ static const uint8_t zmk_hid_report_desc[] = {
     /* LOGICAL_MINIMUM (0) */
     HID_GI_LOGICAL_MIN(1),
     0x00,
-    /* LOGICAL_MAXIMUM (0xFFFF) */
-    HID_GI_LOGICAL_MAX(1),
+    /* LOGICAL_MAXIMUM (0x00FF)  - little endian, and requires two bytes because logical max is
+       signed */
+    HID_GI_LOGICAL_MAX(2),
     0xFF,
+    0x00,
     HID_LI_USAGE_MIN(1),
     0x00,
-    /* USAGE_MAXIMUM (0xFFFF) */
+    /* USAGE_MAXIMUM (0xFF) */
     HID_LI_USAGE_MAX(1),
     0xFF,
     /* INPUT (Data,Ary,Abs) */


### PR DESCRIPTION
* Logical max values are signed, so for the report descriptor, use a two
  byte logical max descriptor item to impart proper 0xFF max logical
  value.
