### PR TITLE
The DZ60 uses dfu-util, but board.cmake included openocd.board.cmake

### DIFF
--- a/app/boards/arm/dz60rgb/board.cmake
+++ b/app/boards/arm/dz60rgb/board.cmake
@@ -3,5 +3,5 @@
 board_runner_args(dfu-util "--pid=0483:df11" "--alt=0" "--dfuse")
 board_runner_args(jlink "--device=STM32F303CC" "--speed=4000")
 
-include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/dfu-util.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
An incredibly minor first patch.