### PR TITLE
fix(keymaps): Locate shared conf and overlay for split boards.

### DIFF
--- a/app/cmake/zmk_config.cmake
+++ b/app/cmake/zmk_config.cmake
@@ -105,8 +105,10 @@ if (ZMK_CONFIG)
 		endif()
 
 		# TODO: Board revisions?
+		list(APPEND overlay_candidates "${ZMK_CONFIG}/${BOARD_DIR_NAME}.overlay")
 		list(APPEND overlay_candidates "${ZMK_CONFIG}/${BOARD}.overlay")
 		list(APPEND overlay_candidates "${ZMK_CONFIG}/default.overlay")
+		list(APPEND config_candidates "${ZMK_CONFIG}/${BOARD_DIR_NAME}.conf")
 		list(APPEND config_candidates "${ZMK_CONFIG}/${BOARD}.conf")
 		list(APPEND config_candidates "${ZMK_CONFIG}/default.conf")
 


### PR DESCRIPTION
Previously shared `<board>.conf` files in the ZMK config folder were not considered in the build for split boards (no shields), but only `<board>_left.conf`,  `<board>_right.conf`. It would make sense for them to be since `<board>.keymap` can now be used as a keymap and split shields also consider `<shield>.conf`. The shared `.conf` will also override any existing left- or right-specific `.conf` similar to how it works for split shields.

Since `.conf` and `.overlay` discovery logic seem to be very similar, I also added the same change for `<board>.overlay`.

Tested with the `corne-ish_zen` left and right boards in https://github.com/LOWPROKB/zmk/tree/Board-Corne-ish-Zen-dedicated-work-queue,