### PR TITLE
Core encoder/sensor refactor

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -77,8 +77,8 @@ endif()
 target_sources_ifdef(CONFIG_ZMK_RGB_UNDERGLOW app PRIVATE src/behaviors/behavior_rgb_underglow.c)
 target_sources_ifdef(CONFIG_ZMK_BACKLIGHT app PRIVATE src/behaviors/behavior_backlight.c)
 
-target_sources_ifdef(CONFIG_ZMK_BLE app PRIVATE src/events/battery_state_changed.c)
-target_sources_ifdef(CONFIG_ZMK_BLE app PRIVATE src/battery.c)
+target_sources_ifdef(CONFIG_ZMK_BATTERY_REPORTING app PRIVATE src/events/battery_state_changed.c)
+target_sources_ifdef(CONFIG_ZMK_BATTERY_REPORTING app PRIVATE src/battery.c)
 
 target_sources_ifdef(CONFIG_ZMK_SPLIT app PRIVATE src/events/split_peripheral_status_changed.c)
 add_subdirectory(src/split)

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -190,18 +190,6 @@ rsource "src/split/Kconfig"
 #Basic Keyboard Setup
 endmenu
 
-menu "Encoders"
-
-config ZMK_ENCODERS_DEFAULT_TRIGGERS_PER_ROTATION
-    int "Default behavior triggers per rotation"
-    help
-      Unless overridden for a specific behavior in the keymap/devicetree, this value
-      determines how many times to trigger the bound behavior per full rotation.
-      For tactile encoders with detents, this usually should match the number of
-      detents per rotation of the encoder.
-    default 30
-
-endmenu
 menu "Display/LED Options"
 
 rsource "src/display/Kconfig"
@@ -544,6 +532,11 @@ if ZMK_KEYMAP_SENSORS
 
 config ZMK_KEYMAP_SENSORS_DEFAULT_TRIGGERS_PER_ROTATION
     int "Default triggers per rotation"
+    help
+      Unless overridden for a sensor in the board/shield/devicetree, this value
+      determines how many times to trigger the bound behavior per full rotation.
+      For tactile encoders with detents, this usually should match the number of
+      detents per rotation of the encoder.
     default 20
 
 endif # ZMK_KEYMAP_SENSORS

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -131,7 +131,7 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 
 config ZMK_BLE_THREAD_STACK_SIZE
     int "BLE notify thread stack size"
-    default 512
+    default 768
 
 config ZMK_BLE_THREAD_PRIORITY
     int "BLE notify thread priority"

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -190,6 +190,18 @@ rsource "src/split/Kconfig"
 #Basic Keyboard Setup
 endmenu
 
+menu "Encoders"
+
+config ZMK_ENCODERS_DEFAULT_TRIGGERS_PER_ROTATION
+    int "Default behavior triggers per rotation"
+    help
+      Unless overridden for a specific behavior in the keymap/devicetree, this value
+      determines how many times to trigger the bound behavior per full rotation.
+      For tactile encoders with detents, this usually should match the number of
+      detents per rotation of the encoder.
+    default 30
+
+endmenu
 menu "Display/LED Options"
 
 rsource "src/display/Kconfig"
@@ -518,6 +530,14 @@ config ZMK_WPM
 
 config SENSOR
     default y
+
+if ZMK_KEYMAP_SENSORS
+
+config ZMK_KEYMAP_SENSORS_DEFAULT_TRIGGERS_PER_ROTATION
+    int "Default triggers per rotation"
+    default 20
+
+endif # ZMK_KEYMAP_SENSORS
 
 choice CBPRINTF_IMPLEMENTATION
     default CBPRINTF_NANO

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -114,9 +114,9 @@ menuconfig ZMK_BLE
     select BT_SMP_APP_PAIRING_ACCEPT
     select BT_PERIPHERAL
     select BT_DIS
-    select BT_BAS
     select BT_SETTINGS
     select SETTINGS
+    imply ZMK_BATTERY_REPORTING
 
 if ZMK_BLE
 
@@ -317,6 +317,12 @@ endif
 endmenu
 
 menu "Power Management"
+
+config ZMK_BATTERY_REPORTING
+    bool "Battery level detection/reporting"
+    default n
+    select SENSOR
+    select BT_BAS if ZMK_BLE
 
 config ZMK_IDLE_TIMEOUT
     int "Milliseconds of inactivity before entering idle state (OLED shutoff, etc)"

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -528,8 +528,11 @@ config ZMK_WPM
     bool "Calculate WPM"
     default n
 
-config SENSOR
+config ZMK_KEYMAP_SENSORS
+    bool "Enable Keymap Sensors support"
     default y
+    depends on DT_HAS_ZMK_KEYMAP_SENSORS_ENABLED
+    select SENSOR
 
 if ZMK_KEYMAP_SENSORS
 

--- a/app/boards/shields/zmk_uno/boards/nrf52840dk_nrf52840.overlay
+++ b/app/boards/shields/zmk_uno/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,24 @@
+
+/ {
+    // First, delete the existing basic GPIO based instance.
+    /delete-node/ encoder;
+};
+
+&pinctrl {
+    qdec_default: qdec_default {
+        group1 {
+            psels = <NRF_PSEL(QDEC_A, 1, 11)>,
+                    <NRF_PSEL(QDEC_B, 1, 10)>;
+            bias-pull-up;
+        };
+    };
+};
+
+// Set up the QDEC hardware based driver and give it the same label as the deleted node.
+encoder: &qdec0 {
+    status = "okay";
+    led-pre = <0>;
+    steps = <80>;
+    pinctrl-0 = <&qdec_default>;
+    pinctrl-names = "default";
+};

--- a/app/boards/shields/zmk_uno/zmk_uno.overlay
+++ b/app/boards/shields/zmk_uno/zmk_uno.overlay
@@ -40,10 +40,10 @@
 
     // Commented out until we add more powerful power domain support
     // external_power {
-    //  compatible = "zmk,ext-power-generic";
-    //  label = "EXT_POWER";
-    //  init-delay-ms = <200>;
-    //  control-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>;
+        //  compatible = "zmk,ext-power-generic";
+        //  label = "EXT_POWER";
+        //  init-delay-ms = <200>;
+        //  control-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>;
     // };
 
     rgb_power {
@@ -128,14 +128,14 @@
         diode-direction = "col2row";
 
         col-gpios
-            = <&arduino_header 10 GPIO_ACTIVE_HIGH>
-            , <&arduino_header 9  GPIO_ACTIVE_HIGH>
-            ;
+        = <&arduino_header 10 GPIO_ACTIVE_HIGH>
+        , <&arduino_header 9  GPIO_ACTIVE_HIGH>
+        ;
 
         row-gpios
-            = <&arduino_header 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&arduino_header 11 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            ;
+        = <&arduino_header 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+        , <&arduino_header 11 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+        ;
 
     };
 
@@ -144,11 +144,11 @@
         status = "disabled";
 
         input-gpios
-            = <&arduino_header 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-            , <&arduino_header 9  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-            , <&arduino_header 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-            , <&arduino_header 11 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-            ;
+        = <&arduino_header 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+        , <&arduino_header 9  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+        , <&arduino_header 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+        , <&arduino_header 11 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+        ;
 
     };
 
@@ -157,23 +157,26 @@
         toggle-mode;
 
         input-gpios
-            = <&arduino_header 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-            , <&arduino_header 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-            , <&arduino_header 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-            ;
+        = <&arduino_header 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+        , <&arduino_header 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+        , <&arduino_header 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+        ;
     };
 
     encoder: encoder {
         label = "ENCODER";
-        resolution = <4>;
+        steps = <80>;
         compatible = "alps,ec11";
-        a-gpios = <&arduino_header 14 GPIO_PULL_UP>;
-        b-gpios = <&arduino_header 15 GPIO_PULL_UP>;
+        a-gpios = <&arduino_header 15 GPIO_PULL_UP>;
+        b-gpios = <&arduino_header 14 GPIO_PULL_UP>;
     };
-
     sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&encoder>;
+        triggers-per-rotation = <20>;
+        left {
+            triggers-per-rotation = <20>;
+        };
     };
 
 };

--- a/app/drivers/sensor/ec11/Kconfig
+++ b/app/drivers/sensor/ec11/Kconfig
@@ -3,6 +3,8 @@
 
 menuconfig EC11
     bool "EC11 Incremental Encoder Sensor"
+    default y
+    depends on DT_HAS_ALPS_EC11_ENABLED
     depends on GPIO
     help
       Enable driver for EC11 incremental encoder sensors.

--- a/app/drivers/sensor/ec11/ec11.c
+++ b/app/drivers/sensor/ec11/ec11.c
@@ -16,6 +16,8 @@
 
 #include "ec11.h"
 
+#define FULL_ROTATION 360
+
 LOG_MODULE_REGISTER(EC11, CONFIG_SENSOR_LOG_LEVEL);
 
 static int ec11_get_ab_state(const struct device *dev) {
@@ -59,9 +61,14 @@ static int ec11_sample_fetch(const struct device *dev, enum sensor_channel chan)
     drv_data->pulses += delta;
     drv_data->ab_state = val;
 
-    drv_data->ticks = drv_data->pulses / drv_cfg->resolution;
-    drv_data->delta = delta;
-    drv_data->pulses %= drv_cfg->resolution;
+    // TODO: Temporary code for backwards compatibility to support
+    // the sensor channel rotation reporting *ticks* instead of delta of degrees.
+    // REMOVE ME
+    if (drv_cfg->steps == 0) {
+        drv_data->ticks = drv_data->pulses / drv_cfg->resolution;
+        drv_data->delta = delta;
+        drv_data->pulses %= drv_cfg->resolution;
+    }
 
     return 0;
 }
@@ -69,13 +76,26 @@ static int ec11_sample_fetch(const struct device *dev, enum sensor_channel chan)
 static int ec11_channel_get(const struct device *dev, enum sensor_channel chan,
                             struct sensor_value *val) {
     struct ec11_data *drv_data = dev->data;
+    const struct ec11_config *drv_cfg = dev->config;
+    int32_t pulses = drv_data->pulses;
 
     if (chan != SENSOR_CHAN_ROTATION) {
         return -ENOTSUP;
     }
 
-    val->val1 = drv_data->ticks;
-    val->val2 = drv_data->delta;
+    drv_data->pulses = 0;
+
+    if (drv_cfg->steps > 0) {
+        val->val1 = (pulses * FULL_ROTATION) / drv_cfg->steps;
+        val->val2 = (pulses * FULL_ROTATION) % drv_cfg->steps;
+        if (val->val2 != 0) {
+            val->val2 *= 1000000;
+            val->val2 /= drv_cfg->steps;
+        }
+    } else {
+        val->val1 = drv_data->ticks;
+        val->val2 = drv_data->delta;
+    }
 
     return 0;
 }
@@ -132,7 +152,8 @@ int ec11_init(const struct device *dev) {
     const struct ec11_config ec11_cfg_##n = {                                                      \
         .a = GPIO_DT_SPEC_INST_GET(n, a_gpios),                                                    \
         .b = GPIO_DT_SPEC_INST_GET(n, b_gpios),                                                    \
-        COND_CODE_0(DT_INST_NODE_HAS_PROP(n, resolution), (1), (DT_INST_PROP(n, resolution))),     \
+        .resolution = DT_INST_PROP_OR(n, resolution, 1),                                           \
+        .steps = DT_INST_PROP_OR(n, steps, 0),                                                     \
     };                                                                                             \
     DEVICE_DT_INST_DEFINE(n, ec11_init, NULL, &ec11_data_##n, &ec11_cfg_##n, POST_KERNEL,          \
                           CONFIG_SENSOR_INIT_PRIORITY, &ec11_driver_api);

--- a/app/drivers/sensor/ec11/ec11.h
+++ b/app/drivers/sensor/ec11/ec11.h
@@ -14,6 +14,7 @@ struct ec11_config {
     const struct gpio_dt_spec a;
     const struct gpio_dt_spec b;
 
+    const uint16_t steps;
     const uint8_t resolution;
 };
 

--- a/app/drivers/zephyr/dts/bindings/sensor/alps,ec11.yaml
+++ b/app/drivers/zephyr/dts/bindings/sensor/alps,ec11.yaml
@@ -18,4 +18,9 @@ properties:
   resolution:
     type: int
     description: Number of pulses per tick
+    deprecated: true
+    required: false
+  steps:
+    type: int
+    description: Number of pulses in one full rotation
     required: false

--- a/app/dts/bindings/zmk,keymap-sensors.yaml
+++ b/app/dts/bindings/zmk,keymap-sensors.yaml
@@ -9,4 +9,14 @@ compatible: "zmk,keymap-sensors"
 properties:
   sensors:
     type: phandles
-    required: true
+    required: false
+  triggers-per-rotation:
+    type: int
+    required: false
+
+child-binding:
+  description: Per-sensor configuration settings
+  properties:
+    triggers-per-rotation:
+      type: int
+      required: false

--- a/app/include/drivers/behavior.h
+++ b/app/include/drivers/behavior.h
@@ -23,9 +23,17 @@
  * (Internal use only.)
  */
 
+enum behavior_sensor_binding_process_mode {
+    BEHAVIOR_SENSOR_BINDING_PROCESS_MODE_TRIGGER,
+    BEHAVIOR_SENSOR_BINDING_PROCESS_MODE_DISCARD,
+};
+
 typedef int (*behavior_keymap_binding_callback_t)(struct zmk_behavior_binding *binding,
                                                   struct zmk_behavior_binding_event event);
-typedef int (*behavior_sensor_keymap_binding_callback_t)(
+typedef int (*behavior_sensor_keymap_binding_process_callback_t)(
+    struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
+    enum behavior_sensor_binding_process_mode mode);
+typedef int (*behavior_sensor_keymap_binding_data_callback_t)(
     struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
     const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
     const struct zmk_sensor_channel_data channel_data[channel_data_size]);
@@ -41,7 +49,8 @@ __subsystem struct behavior_driver_api {
     behavior_keymap_binding_callback_t binding_convert_central_state_dependent_params;
     behavior_keymap_binding_callback_t binding_pressed;
     behavior_keymap_binding_callback_t binding_released;
-    behavior_sensor_keymap_binding_callback_t sensor_binding_triggered;
+    behavior_sensor_keymap_binding_data_callback_t sensor_binding_data;
+    behavior_sensor_keymap_binding_process_callback_t sensor_binding_process;
 };
 /**
  * @endcond
@@ -151,7 +160,7 @@ static inline int z_impl_behavior_keymap_binding_released(struct zmk_behavior_bi
 }
 
 /**
- * @brief Handle the a sensor keymap binding being triggered
+ * @brief Handle the a sensor keymap binding processing any incoming data from the sensor
  * @param binding Sensor keymap binding which was triggered.
  * @param sensor Pointer to the sensor device structure for the sensor driver instance.
  * @param virtual_key_position ZMK_KEYMAP_LEN + sensor number
@@ -160,12 +169,12 @@ static inline int z_impl_behavior_keymap_binding_released(struct zmk_behavior_bi
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-__syscall int behavior_sensor_keymap_binding_triggered(
+__syscall int behavior_sensor_keymap_binding_data(
     struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
     const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
     const struct zmk_sensor_channel_data *channel_data);
 
-static inline int z_impl_behavior_sensor_keymap_binding_triggered(
+static inline int z_impl_behavior_sensor_keymap_binding_data(
     struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
     const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
     const struct zmk_sensor_channel_data *channel_data) {
@@ -177,12 +186,46 @@ static inline int z_impl_behavior_sensor_keymap_binding_triggered(
 
     const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->api;
 
-    if (api->sensor_binding_triggered == NULL) {
+    if (api->sensor_binding_data == NULL) {
         return -ENOTSUP;
     }
 
-    return api->sensor_binding_triggered(binding, event, sensor_config, channel_data_size,
-                                         channel_data);
+    return api->sensor_binding_data(binding, event, sensor_config, channel_data_size, channel_data);
+}
+
+/**
+ * @brief Handle the keymap sensor binding being triggered after updating any local data
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param param1 User parameter specified at time of behavior binding.
+ * @param param2 User parameter specified at time of behavior binding.
+ *
+ * @retval 0 If successful.
+ * @retval Negative errno code if failure.
+ */
+// clang-format off
+__syscall int behavior_sensor_keymap_binding_process(
+    struct zmk_behavior_binding *binding,
+    struct zmk_behavior_binding_event event,
+    enum behavior_sensor_binding_process_mode mode);
+// clang-format on
+
+static inline int
+z_impl_behavior_sensor_keymap_binding_process(struct zmk_behavior_binding *binding,
+                                              struct zmk_behavior_binding_event event,
+                                              enum behavior_sensor_binding_process_mode mode) {
+    const struct device *dev = device_get_binding(binding->behavior_dev);
+
+    if (dev == NULL) {
+        return -EINVAL;
+    }
+
+    const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->api;
+
+    if (api->sensor_binding_process == NULL) {
+        return -ENOTSUP;
+    }
+
+    return api->sensor_binding_process(binding, event, mode);
 }
 
 /**

--- a/app/include/drivers/behavior.h
+++ b/app/include/drivers/behavior.h
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <zephyr/device.h>
 #include <zmk/keys.h>
+#include <zmk/sensors.h>
 #include <zmk/behavior.h>
 
 /**
@@ -24,9 +25,10 @@
 
 typedef int (*behavior_keymap_binding_callback_t)(struct zmk_behavior_binding *binding,
                                                   struct zmk_behavior_binding_event event);
-typedef int (*behavior_sensor_keymap_binding_callback_t)(struct zmk_behavior_binding *binding,
-                                                         const struct device *sensor,
-                                                         struct zmk_behavior_binding_event event);
+typedef int (*behavior_sensor_keymap_binding_callback_t)(
+    struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
+    const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
+    const struct zmk_sensor_channel_data channel_data[channel_data_size]);
 
 enum behavior_locality {
     BEHAVIOR_LOCALITY_CENTRAL,
@@ -158,14 +160,15 @@ static inline int z_impl_behavior_keymap_binding_released(struct zmk_behavior_bi
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-__syscall int behavior_sensor_keymap_binding_triggered(struct zmk_behavior_binding *binding,
-                                                       const struct device *sensor,
-                                                       struct zmk_behavior_binding_event event);
+__syscall int behavior_sensor_keymap_binding_triggered(
+    struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
+    const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
+    const struct zmk_sensor_channel_data *channel_data);
 
-static inline int
-z_impl_behavior_sensor_keymap_binding_triggered(struct zmk_behavior_binding *binding,
-                                                const struct device *sensor,
-                                                struct zmk_behavior_binding_event event) {
+static inline int z_impl_behavior_sensor_keymap_binding_triggered(
+    struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
+    const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
+    const struct zmk_sensor_channel_data *channel_data) {
     const struct device *dev = device_get_binding(binding->behavior_dev);
 
     if (dev == NULL) {
@@ -178,7 +181,8 @@ z_impl_behavior_sensor_keymap_binding_triggered(struct zmk_behavior_binding *bin
         return -ENOTSUP;
     }
 
-    return api->sensor_binding_triggered(binding, sensor, event);
+    return api->sensor_binding_triggered(binding, event, sensor_config, channel_data_size,
+                                         channel_data);
 }
 
 /**

--- a/app/include/drivers/behavior.h
+++ b/app/include/drivers/behavior.h
@@ -33,7 +33,7 @@ typedef int (*behavior_keymap_binding_callback_t)(struct zmk_behavior_binding *b
 typedef int (*behavior_sensor_keymap_binding_process_callback_t)(
     struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
     enum behavior_sensor_binding_process_mode mode);
-typedef int (*behavior_sensor_keymap_binding_data_callback_t)(
+typedef int (*behavior_sensor_keymap_binding_accept_data_callback_t)(
     struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
     const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
     const struct zmk_sensor_channel_data channel_data[channel_data_size]);
@@ -49,7 +49,7 @@ __subsystem struct behavior_driver_api {
     behavior_keymap_binding_callback_t binding_convert_central_state_dependent_params;
     behavior_keymap_binding_callback_t binding_pressed;
     behavior_keymap_binding_callback_t binding_released;
-    behavior_sensor_keymap_binding_data_callback_t sensor_binding_data;
+    behavior_sensor_keymap_binding_accept_data_callback_t sensor_binding_data;
     behavior_sensor_keymap_binding_process_callback_t sensor_binding_process;
 };
 /**
@@ -169,12 +169,12 @@ static inline int z_impl_behavior_keymap_binding_released(struct zmk_behavior_bi
  * @retval 0 If successful.
  * @retval Negative errno code if failure.
  */
-__syscall int behavior_sensor_keymap_binding_data(
+__syscall int behavior_sensor_keymap_binding_accept_data(
     struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
     const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
     const struct zmk_sensor_channel_data *channel_data);
 
-static inline int z_impl_behavior_sensor_keymap_binding_data(
+static inline int z_impl_behavior_sensor_keymap_binding_accept_data(
     struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
     const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
     const struct zmk_sensor_channel_data *channel_data) {

--- a/app/include/drivers/behavior.h
+++ b/app/include/drivers/behavior.h
@@ -49,7 +49,7 @@ __subsystem struct behavior_driver_api {
     behavior_keymap_binding_callback_t binding_convert_central_state_dependent_params;
     behavior_keymap_binding_callback_t binding_pressed;
     behavior_keymap_binding_callback_t binding_released;
-    behavior_sensor_keymap_binding_accept_data_callback_t sensor_binding_data;
+    behavior_sensor_keymap_binding_accept_data_callback_t sensor_binding_accept_data;
     behavior_sensor_keymap_binding_process_callback_t sensor_binding_process;
 };
 /**
@@ -186,11 +186,12 @@ static inline int z_impl_behavior_sensor_keymap_binding_accept_data(
 
     const struct behavior_driver_api *api = (const struct behavior_driver_api *)dev->api;
 
-    if (api->sensor_binding_data == NULL) {
+    if (api->sensor_binding_accept_data == NULL) {
         return -ENOTSUP;
     }
 
-    return api->sensor_binding_data(binding, event, sensor_config, channel_data_size, channel_data);
+    return api->sensor_binding_accept_data(binding, event, sensor_config, channel_data_size,
+                                           channel_data);
 }
 
 /**

--- a/app/include/zmk/events/sensor_event.h
+++ b/app/include/zmk/events/sensor_event.h
@@ -16,12 +16,12 @@
 #define ZMK_SENSOR_EVENT_MAX_CHANNELS 1
 
 struct zmk_sensor_event {
-    uint8_t sensor_position;
-
     size_t channel_data_size;
     struct zmk_sensor_channel_data channel_data[ZMK_SENSOR_EVENT_MAX_CHANNELS];
 
     int64_t timestamp;
+
+    uint8_t sensor_index;
 };
 
 ZMK_EVENT_DECLARE(zmk_sensor_event);

--- a/app/include/zmk/events/sensor_event.h
+++ b/app/include/zmk/events/sensor_event.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
-
+#include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
+
 #include <zmk/event_manager.h>
 #include <zmk/sensors.h>
-#include <device.h>
 
 // TODO: Move to Kconfig when we need more than one channel
 #define ZMK_SENSOR_EVENT_MAX_CHANNELS 1

--- a/app/include/zmk/events/sensor_event.h
+++ b/app/include/zmk/events/sensor_event.h
@@ -6,12 +6,21 @@
 
 #pragma once
 
-#include <zephyr/kernel.h>
+
+#include <zephyr/drivers/sensor.h>
 #include <zmk/event_manager.h>
-#include <zephyr/device.h>
+#include <zmk/sensors.h>
+#include <device.h>
+
+// TODO: Move to Kconfig when we need more than one channel
+#define ZMK_SENSOR_EVENT_MAX_CHANNELS 1
+
 struct zmk_sensor_event {
-    uint8_t sensor_number;
-    const struct device *sensor;
+    uint8_t sensor_position;
+
+    size_t channel_data_size;
+    struct zmk_sensor_channel_data channel_data[ZMK_SENSOR_EVENT_MAX_CHANNELS];
+
     int64_t timestamp;
 };
 

--- a/app/include/zmk/sensors.h
+++ b/app/include/zmk/sensors.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <drivers/sensor.h>
+
+#define _SENSOR_CHILD_LEN(node) 1 +
 #define ZMK_KEYMAP_SENSORS_NODE DT_INST(0, zmk_keymap_sensors)
 #define ZMK_KEYMAP_HAS_SENSORS DT_NODE_HAS_STATUS(ZMK_KEYMAP_SENSORS_NODE, okay)
 #define ZMK_KEYMAP_SENSORS_BY_IDX(idx) DT_PHANDLE_BY_IDX(ZMK_KEYMAP_SENSORS_NODE, sensors, idx)
@@ -15,3 +18,14 @@
 #else
 #define ZMK_KEYMAP_SENSORS_LEN 0
 #endif
+
+const struct zmk_sensor_config *zmk_sensors_get_config_at_position(uint8_t sensor_position);
+
+struct zmk_sensor_config {
+    uint16_t triggers_per_rotation;
+};
+
+struct zmk_sensor_channel_data {
+    enum sensor_channel channel;
+    struct sensor_value value;
+};

--- a/app/include/zmk/sensors.h
+++ b/app/include/zmk/sensors.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <drivers/sensor.h>
+#include <zephyr/drivers/sensor.h>
 
 #define _SENSOR_CHILD_LEN(node) 1 +
 #define ZMK_KEYMAP_SENSORS_NODE DT_INST(0, zmk_keymap_sensors)

--- a/app/include/zmk/sensors.h
+++ b/app/include/zmk/sensors.h
@@ -8,7 +8,6 @@
 
 #include <zephyr/drivers/sensor.h>
 
-#define _SENSOR_CHILD_LEN(node) 1 +
 #define ZMK_KEYMAP_SENSORS_NODE DT_INST(0, zmk_keymap_sensors)
 #define ZMK_KEYMAP_HAS_SENSORS DT_NODE_HAS_STATUS(ZMK_KEYMAP_SENSORS_NODE, okay)
 #define ZMK_KEYMAP_SENSORS_BY_IDX(idx) DT_PHANDLE_BY_IDX(ZMK_KEYMAP_SENSORS_NODE, sensors, idx)
@@ -19,7 +18,7 @@
 #define ZMK_KEYMAP_SENSORS_LEN 0
 #endif
 
-const struct zmk_sensor_config *zmk_sensors_get_config_at_position(uint8_t sensor_position);
+const struct zmk_sensor_config *zmk_sensors_get_config_at_index(uint8_t sensor_index);
 
 struct zmk_sensor_config {
     uint16_t triggers_per_rotation;

--- a/app/include/zmk/virtual_key_position.h
+++ b/app/include/zmk/virtual_key_position.h
@@ -15,6 +15,11 @@
 #define ZMK_VIRTUAL_KEY_POSITION_SENSOR(index) (ZMK_KEYMAP_LEN + (index))
 
 /**
+ * Gets the sensor number from the virtual key position.
+ */
+#define ZMK_SENSOR_POSITION_FROM_VIRTUAL_KEY_POSITION(vkp) ((vkp)-ZMK_KEYMAP_LEN)
+
+/**
  * Gets the virtual key position to use for the combo with the given index.
  */
 #define ZMK_VIRTUAL_KEY_POSITION_COMBO(index) (ZMK_KEYMAP_LEN + ZMK_KEYMAP_SENSORS_LEN + (index))

--- a/app/src/behaviors/behavior_sensor_rotate.c
+++ b/app/src/behaviors/behavior_sensor_rotate.c
@@ -13,7 +13,7 @@
 #include "behavior_sensor_rotate_common.h"
 
 static const struct behavior_driver_api behavior_sensor_rotate_driver_api = {
-    .sensor_binding_data = zmk_behavior_sensor_rotate_common_data,
+    .sensor_binding_accept_data = zmk_behavior_sensor_rotate_common_accept_data,
     .sensor_binding_process = zmk_behavior_sensor_rotate_common_process};
 
 static int behavior_sensor_rotate_init(const struct device *dev) { return 0; };

--- a/app/src/behaviors/behavior_sensor_rotate.c
+++ b/app/src/behaviors/behavior_sensor_rotate.c
@@ -33,8 +33,10 @@ static int behavior_sensor_rotate_init(const struct device *dev) { return 0; };
         .tap_ms = DT_INST_PROP_OR(n, tap_ms, 5),                                                   \
         .override_params = false,                                                                  \
     };                                                                                             \
-    DEVICE_DT_INST_DEFINE(                                                                         \
-        n, behavior_sensor_rotate_init, NULL, NULL, &behavior_sensor_rotate_config_##n,            \
-        APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_sensor_rotate_driver_api);
+    static struct behavior_sensor_rotate_data behavior_sensor_rotate_data_##n = {};                \
+    DEVICE_DT_INST_DEFINE(n, behavior_sensor_rotate_init, NULL, &behavior_sensor_rotate_data_##n,  \
+                          &behavior_sensor_rotate_config_##n, APPLICATION,                         \
+                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                                     \
+                          &behavior_sensor_rotate_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SENSOR_ROTATE_INST)

--- a/app/src/behaviors/behavior_sensor_rotate.c
+++ b/app/src/behaviors/behavior_sensor_rotate.c
@@ -13,7 +13,8 @@
 #include "behavior_sensor_rotate_common.h"
 
 static const struct behavior_driver_api behavior_sensor_rotate_driver_api = {
-    .sensor_binding_triggered = zmk_behavior_sensor_rotate_common_trigger};
+    .sensor_binding_data = zmk_behavior_sensor_rotate_common_data,
+    .sensor_binding_process = zmk_behavior_sensor_rotate_common_process};
 
 static int behavior_sensor_rotate_init(const struct device *dev) { return 0; };
 

--- a/app/src/behaviors/behavior_sensor_rotate_common.c
+++ b/app/src/behaviors/behavior_sensor_rotate_common.c
@@ -21,7 +21,7 @@ int zmk_behavior_sensor_rotate_common_data(struct zmk_behavior_binding *binding,
 
     const struct sensor_value value = channel_data[0].value;
     int triggers;
-    int sensor_position = ZMK_SENSOR_POSITION_FROM_VIRTUAL_KEY_POSITION(event.position);
+    int sensor_index = ZMK_SENSOR_POSITION_FROM_VIRTUAL_KEY_POSITION(event.position);
 
     // Some funky special casing for "old encoder behavior" where ticks where reported in val2 only,
     // instead of rotational degrees in val1.
@@ -29,7 +29,7 @@ int zmk_behavior_sensor_rotate_common_data(struct zmk_behavior_binding *binding,
     if (value.val1 == 0) {
         triggers = value.val2;
     } else {
-        struct sensor_value remainder = data->remainder[sensor_position];
+        struct sensor_value remainder = data->remainder[sensor_index];
 
         remainder.val1 += value.val1;
         remainder.val2 += value.val2;
@@ -43,15 +43,15 @@ int zmk_behavior_sensor_rotate_common_data(struct zmk_behavior_binding *binding,
         triggers = remainder.val1 / trigger_degrees;
         remainder.val1 %= trigger_degrees;
 
-        data->remainder[sensor_position] = remainder;
+        data->remainder[sensor_index] = remainder;
     }
 
     LOG_DBG(
         "val1: %d, val2: %d, remainder: %d/%d triggers: %d inc keycode 0x%02X dec keycode 0x%02X",
-        value.val1, value.val2, data->remainder[sensor_position].val1,
-        data->remainder[sensor_position].val2, triggers, binding->param1, binding->param2);
+        value.val1, value.val2, data->remainder[sensor_index].val1,
+        data->remainder[sensor_index].val2, triggers, binding->param1, binding->param2);
 
-    data->triggers[sensor_position] = triggers;
+    data->triggers[sensor_index] = triggers;
     return 0;
 }
 
@@ -62,14 +62,14 @@ int zmk_behavior_sensor_rotate_common_process(struct zmk_behavior_binding *bindi
     const struct behavior_sensor_rotate_config *cfg = dev->config;
     struct behavior_sensor_rotate_data *data = dev->data;
 
-    const int sensor_position = ZMK_SENSOR_POSITION_FROM_VIRTUAL_KEY_POSITION(event.position);
+    const int sensor_index = ZMK_SENSOR_POSITION_FROM_VIRTUAL_KEY_POSITION(event.position);
 
     if (mode != BEHAVIOR_SENSOR_BINDING_PROCESS_MODE_TRIGGER) {
-        data->triggers[sensor_position] = 0;
+        data->triggers[sensor_index] = 0;
         return 0;
     }
 
-    int triggers = data->triggers[sensor_position];
+    int triggers = data->triggers[sensor_index];
 
     struct zmk_behavior_binding triggered_binding;
     if (triggers > 0) {

--- a/app/src/behaviors/behavior_sensor_rotate_common.c
+++ b/app/src/behaviors/behavior_sensor_rotate_common.c
@@ -11,13 +11,12 @@
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
-int zmk_behavior_sensor_rotate_common_trigger(struct zmk_behavior_binding *binding,
-                                              struct zmk_behavior_binding_event event,
-                                              const struct zmk_sensor_config *sensor_config,
-                                              size_t channel_data_size,
-                                              const struct zmk_sensor_channel_data *channel_data) {
+int zmk_behavior_sensor_rotate_common_data(struct zmk_behavior_binding *binding,
+                                           struct zmk_behavior_binding_event event,
+                                           const struct zmk_sensor_config *sensor_config,
+                                           size_t channel_data_size,
+                                           const struct zmk_sensor_channel_data *channel_data) {
     const struct device *dev = device_get_binding(binding->behavior_dev);
-    const struct behavior_sensor_rotate_config *cfg = dev->config;
     struct behavior_sensor_rotate_data *data = dev->data;
 
     const struct sensor_value value = channel_data[0].value;
@@ -51,6 +50,26 @@ int zmk_behavior_sensor_rotate_common_trigger(struct zmk_behavior_binding *bindi
         "val1: %d, val2: %d, remainder: %d/%d triggers: %d inc keycode 0x%02X dec keycode 0x%02X",
         value.val1, value.val2, data->remainder[sensor_position].val1,
         data->remainder[sensor_position].val2, triggers, binding->param1, binding->param2);
+
+    data->triggers[sensor_position] = triggers;
+    return 0;
+}
+
+int zmk_behavior_sensor_rotate_common_process(struct zmk_behavior_binding *binding,
+                                              struct zmk_behavior_binding_event event,
+                                              enum behavior_sensor_binding_process_mode mode) {
+    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct behavior_sensor_rotate_config *cfg = dev->config;
+    struct behavior_sensor_rotate_data *data = dev->data;
+
+    const int sensor_position = ZMK_SENSOR_POSITION_FROM_VIRTUAL_KEY_POSITION(event.position);
+
+    if (mode != BEHAVIOR_SENSOR_BINDING_PROCESS_MODE_TRIGGER) {
+        data->triggers[sensor_position] = 0;
+        return 0;
+    }
+
+    int triggers = data->triggers[sensor_position];
 
     struct zmk_behavior_binding triggered_binding;
     if (triggers > 0) {

--- a/app/src/behaviors/behavior_sensor_rotate_common.c
+++ b/app/src/behaviors/behavior_sensor_rotate_common.c
@@ -11,11 +11,10 @@
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
-int zmk_behavior_sensor_rotate_common_data(struct zmk_behavior_binding *binding,
-                                           struct zmk_behavior_binding_event event,
-                                           const struct zmk_sensor_config *sensor_config,
-                                           size_t channel_data_size,
-                                           const struct zmk_sensor_channel_data *channel_data) {
+int zmk_behavior_sensor_rotate_common_accept_data(
+    struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
+    const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
+    const struct zmk_sensor_channel_data *channel_data) {
     const struct device *dev = device_get_binding(binding->behavior_dev);
     struct behavior_sensor_rotate_data *data = dev->data;
 

--- a/app/src/behaviors/behavior_sensor_rotate_common.c
+++ b/app/src/behaviors/behavior_sensor_rotate_common.c
@@ -5,48 +5,75 @@
 #include <zephyr/kernel.h>
 
 #include <zmk/behavior_queue.h>
+#include <zmk/virtual_key_position.h>
 
 #include "behavior_sensor_rotate_common.h"
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 int zmk_behavior_sensor_rotate_common_trigger(struct zmk_behavior_binding *binding,
-                                              const struct device *sensor,
-                                              struct zmk_behavior_binding_event event) {
+                                              struct zmk_behavior_binding_event event,
+                                              const struct zmk_sensor_config *sensor_config,
+                                              size_t channel_data_size,
+                                              const struct zmk_sensor_channel_data *channel_data) {
     const struct device *dev = device_get_binding(binding->behavior_dev);
     const struct behavior_sensor_rotate_config *cfg = dev->config;
+    struct behavior_sensor_rotate_data *data = dev->data;
 
-    struct sensor_value value;
+    const struct sensor_value value = channel_data[0].value;
+    int triggers;
+    int sensor_position = ZMK_SENSOR_POSITION_FROM_VIRTUAL_KEY_POSITION(event.position);
 
-    const int err = sensor_channel_get(sensor, SENSOR_CHAN_ROTATION, &value);
+    // Some funky special casing for "old encoder behavior" where ticks where reported in val2 only,
+    // instead of rotational degrees in val1.
+    // REMOVE ME: Remove after a grace period of old ec11 sensor behavior
+    if (value.val1 == 0) {
+        triggers = value.val2;
+    } else {
+        struct sensor_value remainder = data->remainder[sensor_position];
 
-    if (err < 0) {
-        LOG_WRN("Failed to get sensor rotation value: %d", err);
-        return err;
+        remainder.val1 += value.val1;
+        remainder.val2 += value.val2;
+
+        if (remainder.val2 >= 1000000 || remainder.val2 <= 1000000) {
+            remainder.val1 += remainder.val2 / 1000000;
+            remainder.val2 %= 1000000;
+        }
+
+        int trigger_degrees = 360 / sensor_config->triggers_per_rotation;
+        triggers = remainder.val1 / trigger_degrees;
+        remainder.val1 %= trigger_degrees;
+
+        data->remainder[sensor_position] = remainder;
     }
 
+    LOG_DBG(
+        "val1: %d, val2: %d, remainder: %d/%d triggers: %d inc keycode 0x%02X dec keycode 0x%02X",
+        value.val1, value.val2, data->remainder[sensor_position].val1,
+        data->remainder[sensor_position].val2, triggers, binding->param1, binding->param2);
+
     struct zmk_behavior_binding triggered_binding;
-    switch (value.val1) {
-    case 1:
+    if (triggers > 0) {
         triggered_binding = cfg->cw_binding;
         if (cfg->override_params) {
             triggered_binding.param1 = binding->param1;
         }
-        break;
-    case -1:
+    } else if (triggers < 0) {
+        triggers = -triggers;
         triggered_binding = cfg->ccw_binding;
         if (cfg->override_params) {
             triggered_binding.param1 = binding->param2;
         }
-        break;
-    default:
-        return -ENOTSUP;
+    } else {
+        return 0;
     }
 
     LOG_DBG("Sensor binding: %s", binding->behavior_dev);
 
-    zmk_behavior_queue_add(event.position, triggered_binding, true, cfg->tap_ms);
-    zmk_behavior_queue_add(event.position, triggered_binding, false, 0);
+    for (int i = 0; i < triggers; i++) {
+        zmk_behavior_queue_add(event.position, triggered_binding, true, cfg->tap_ms);
+        zmk_behavior_queue_add(event.position, triggered_binding, false, 0);
+    }
 
     return ZMK_BEHAVIOR_OPAQUE;
 }

--- a/app/src/behaviors/behavior_sensor_rotate_common.h
+++ b/app/src/behaviors/behavior_sensor_rotate_common.h
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <drivers/behavior.h>
 #include <zmk/behavior.h>
 #include <zmk/sensors.h>
 
@@ -16,10 +17,14 @@ struct behavior_sensor_rotate_config {
 
 struct behavior_sensor_rotate_data {
     struct sensor_value remainder[ZMK_KEYMAP_SENSORS_LEN];
+    int triggers[ZMK_KEYMAP_SENSORS_LEN];
 };
 
-int zmk_behavior_sensor_rotate_common_trigger(struct zmk_behavior_binding *binding,
+int zmk_behavior_sensor_rotate_common_data(struct zmk_behavior_binding *binding,
+                                           struct zmk_behavior_binding_event event,
+                                           const struct zmk_sensor_config *sensor_config,
+                                           size_t channel_data_size,
+                                           const struct zmk_sensor_channel_data *channel_data);
+int zmk_behavior_sensor_rotate_common_process(struct zmk_behavior_binding *binding,
                                               struct zmk_behavior_binding_event event,
-                                              const struct zmk_sensor_config *sensor_config,
-                                              size_t channel_data_size,
-                                              const struct zmk_sensor_channel_data *channel_data);
+                                              enum behavior_sensor_binding_process_mode mode);

--- a/app/src/behaviors/behavior_sensor_rotate_common.h
+++ b/app/src/behaviors/behavior_sensor_rotate_common.h
@@ -20,11 +20,10 @@ struct behavior_sensor_rotate_data {
     int triggers[ZMK_KEYMAP_SENSORS_LEN];
 };
 
-int zmk_behavior_sensor_rotate_common_data(struct zmk_behavior_binding *binding,
-                                           struct zmk_behavior_binding_event event,
-                                           const struct zmk_sensor_config *sensor_config,
-                                           size_t channel_data_size,
-                                           const struct zmk_sensor_channel_data *channel_data);
+int zmk_behavior_sensor_rotate_common_accept_data(
+    struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
+    const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
+    const struct zmk_sensor_channel_data *channel_data);
 int zmk_behavior_sensor_rotate_common_process(struct zmk_behavior_binding *binding,
                                               struct zmk_behavior_binding_event event,
                                               enum behavior_sensor_binding_process_mode mode);

--- a/app/src/behaviors/behavior_sensor_rotate_common.h
+++ b/app/src/behaviors/behavior_sensor_rotate_common.h
@@ -1,5 +1,11 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #include <zmk/behavior.h>
+#include <zmk/sensors.h>
 
 struct behavior_sensor_rotate_config {
     struct zmk_behavior_binding cw_binding;
@@ -8,6 +14,12 @@ struct behavior_sensor_rotate_config {
     bool override_params;
 };
 
+struct behavior_sensor_rotate_data {
+    struct sensor_value remainder[ZMK_KEYMAP_SENSORS_LEN];
+};
+
 int zmk_behavior_sensor_rotate_common_trigger(struct zmk_behavior_binding *binding,
-                                              const struct device *sensor,
-                                              struct zmk_behavior_binding_event event);
+                                              struct zmk_behavior_binding_event event,
+                                              const struct zmk_sensor_config *sensor_config,
+                                              size_t channel_data_size,
+                                              const struct zmk_sensor_channel_data *channel_data);

--- a/app/src/behaviors/behavior_sensor_rotate_var.c
+++ b/app/src/behaviors/behavior_sensor_rotate_var.c
@@ -13,7 +13,8 @@
 #include "behavior_sensor_rotate_common.h"
 
 static const struct behavior_driver_api behavior_sensor_rotate_var_driver_api = {
-    .sensor_binding_triggered = zmk_behavior_sensor_rotate_common_trigger};
+    .sensor_binding_data = zmk_behavior_sensor_rotate_common_data,
+    .sensor_binding_process = zmk_behavior_sensor_rotate_common_process};
 
 static int behavior_sensor_rotate_var_init(const struct device *dev) { return 0; };
 

--- a/app/src/behaviors/behavior_sensor_rotate_var.c
+++ b/app/src/behaviors/behavior_sensor_rotate_var.c
@@ -24,8 +24,10 @@ static int behavior_sensor_rotate_var_init(const struct device *dev) { return 0;
         .tap_ms = DT_INST_PROP(n, tap_ms),                                                         \
         .override_params = true,                                                                   \
     };                                                                                             \
+    static struct behavior_sensor_rotate_data behavior_sensor_rotate_var_data_##n = {};            \
     DEVICE_DT_INST_DEFINE(                                                                         \
-        n, behavior_sensor_rotate_var_init, NULL, NULL, &behavior_sensor_rotate_var_config_##n,    \
-        APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_sensor_rotate_var_driver_api);
+        n, behavior_sensor_rotate_var_init, NULL, &behavior_sensor_rotate_var_data_##n,            \
+        &behavior_sensor_rotate_var_config_##n, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  \
+        &behavior_sensor_rotate_var_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SENSOR_ROTATE_VAR_INST)

--- a/app/src/behaviors/behavior_sensor_rotate_var.c
+++ b/app/src/behaviors/behavior_sensor_rotate_var.c
@@ -13,7 +13,7 @@
 #include "behavior_sensor_rotate_common.h"
 
 static const struct behavior_driver_api behavior_sensor_rotate_var_driver_api = {
-    .sensor_binding_data = zmk_behavior_sensor_rotate_common_data,
+    .sensor_binding_accept_data = zmk_behavior_sensor_rotate_common_accept_data,
     .sensor_binding_process = zmk_behavior_sensor_rotate_common_process};
 
 static int behavior_sensor_rotate_var_init(const struct device *dev) { return 0; };

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -252,48 +252,59 @@ int zmk_keymap_position_state_changed(uint8_t source, uint32_t position, bool pr
 }
 
 #if ZMK_KEYMAP_HAS_SENSORS
-int zmk_keymap_sensor_triggered(
-    uint8_t sensor_position, size_t channel_data_size,
-    const struct zmk_sensor_channel_data channel_data[channel_data_size], int64_t timestamp) {
-    for (int layer = ZMK_KEYMAP_LAYERS_LEN - 1; layer >= _zmk_keymap_layer_default; layer--) {
-        if (zmk_keymap_layer_active(layer)) {
-            struct zmk_behavior_binding *binding = &zmk_sensor_keymap[layer][sensor_position];
-            const struct device *behavior;
-            int ret;
+int zmk_keymap_sensor_event(uint8_t sensor_position, size_t channel_data_size,
+                            const struct zmk_sensor_channel_data channel_data[channel_data_size],
+                            int64_t timestamp) {
+    bool opaque_response = false;
 
-            LOG_DBG("layer: %d sensor_position: %d, binding name: %s", layer, sensor_position,
-                    binding->behavior_dev);
+    for (int layer = ZMK_KEYMAP_LAYERS_LEN - 1; layer >= 0; layer--) {
+        struct zmk_behavior_binding *binding = &zmk_sensor_keymap[layer][sensor_position];
+        const struct device *behavior;
+        int ret;
 
-            behavior = device_get_binding(binding->behavior_dev);
+        LOG_DBG("layer: %d sensor_position: %d, binding name: %s", layer, sensor_position,
+                binding->behavior_dev);
 
-            if (!behavior) {
-                LOG_DBG("No behavior assigned to %d on layer %d", sensor_position, layer);
-                continue;
-            }
+        behavior = device_get_binding(binding->behavior_dev);
 
-            struct zmk_behavior_binding_event event = {
-                .layer = layer,
-                .position = ZMK_VIRTUAL_KEY_POSITION_SENSOR(sensor_position),
-                .timestamp = timestamp,
-            };
+        if (!behavior) {
+            LOG_DBG("No behavior assigned to %d on layer %d", sensor_position, layer);
+            continue;
+        }
 
-            ret = behavior_sensor_keymap_binding_triggered(
-                binding, event, zmk_sensors_get_config_at_position(sensor_position),
-                channel_data_size, channel_data);
+        struct zmk_behavior_binding_event event = {
+            .layer = layer,
+            .position = ZMK_VIRTUAL_KEY_POSITION_SENSOR(sensor_position),
+            .timestamp = timestamp,
+        };
 
-            if (ret > 0) {
-                LOG_DBG("behavior processing to continue to next layer");
-                continue;
-            } else if (ret < 0) {
-                LOG_DBG("Behavior returned error: %d", ret);
-                return ret;
-            } else {
-                return ret;
-            }
+        ret = behavior_sensor_keymap_binding_data(
+            binding, event, zmk_sensors_get_config_at_position(sensor_position), channel_data_size,
+            channel_data);
+
+        if (ret > 0) {
+            LOG_DBG("behavior processing to continue to next layer");
+            continue;
+        }
+
+        enum behavior_sensor_binding_process_mode mode =
+            (!opaque_response && layer >= _zmk_keymap_layer_default &&
+             zmk_keymap_layer_active(layer))
+                ? BEHAVIOR_SENSOR_BINDING_PROCESS_MODE_TRIGGER
+                : BEHAVIOR_SENSOR_BINDING_PROCESS_MODE_DISCARD;
+
+        ret = behavior_sensor_keymap_binding_process(binding, event, mode);
+
+        if (ret == ZMK_BEHAVIOR_OPAQUE) {
+            LOG_DBG("sensor event processing complete, behavior response was opaque");
+            opaque_response = true;
+        } else if (ret < 0) {
+            LOG_DBG("Behavior returned error: %d", ret);
+            return ret;
         }
     }
 
-    return -ENOTSUP;
+    return 0;
 }
 
 #endif /* ZMK_KEYMAP_HAS_SENSORS */
@@ -308,8 +319,8 @@ int keymap_listener(const zmk_event_t *eh) {
 #if ZMK_KEYMAP_HAS_SENSORS
     const struct zmk_sensor_event *sensor_ev;
     if ((sensor_ev = as_zmk_sensor_event(eh)) != NULL) {
-        return zmk_keymap_sensor_triggered(sensor_ev->sensor_position, sensor_ev->channel_data_size,
-                                           sensor_ev->channel_data, sensor_ev->timestamp);
+        return zmk_keymap_sensor_event(sensor_ev->sensor_position, sensor_ev->channel_data_size,
+                                       sensor_ev->channel_data, sensor_ev->timestamp);
     }
 #endif /* ZMK_KEYMAP_HAS_SENSORS */
 

--- a/app/src/sensors.c
+++ b/app/src/sensors.c
@@ -19,10 +19,10 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #if ZMK_KEYMAP_HAS_SENSORS
 
 struct sensors_item_cfg {
-    uint8_t sensor_index;
     const struct zmk_sensor_config *config;
     const struct device *dev;
     struct sensor_trigger trigger;
+    uint8_t sensor_index;
 };
 
 #define _SENSOR_ITEM(idx, node)                                                                    \
@@ -43,7 +43,11 @@ struct sensors_item_cfg {
                                   CONFIG_ZMK_KEYMAP_SENSORS_DEFAULT_TRIGGERS_PER_ROTATION))        \
     }
 #define SENSOR_CHILD_DEFAULTS(idx, arg)                                                            \
-    { .triggers_per_rotation = DT_PROP_OR(ZMK_KEYMAP_SENSORS_NODE, triggers_per_rotation, 20) }
+    {                                                                                              \
+        .triggers_per_rotation =                                                                   \
+            DT_PROP_OR(ZMK_KEYMAP_SENSORS_NODE, triggers_per_rotation,                             \
+                       CONFIG_ZMK_KEYMAP_SENSORS_DEFAULT_TRIGGERS_PER_ROTATION)                    \
+    }
 
 static struct zmk_sensor_config configs[] = {
 #if ZMK_KEYMAP_SENSORS_CHILD_COUNT > 0
@@ -85,6 +89,7 @@ static void trigger_sensor_data_for_position(uint32_t sensor_index) {
 
     ZMK_EVENT_RAISE(new_zmk_sensor_event(
         (struct zmk_sensor_event){.sensor_index = item->sensor_index,
+                                  .channel_data_size = 1,
                                   .channel_data = {(struct zmk_sensor_channel_data){
                                       .value = value, .channel = item->trigger.chan}},
                                   .timestamp = k_uptime_get()}));

--- a/app/src/sensors.c
+++ b/app/src/sensors.c
@@ -19,7 +19,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #if ZMK_KEYMAP_HAS_SENSORS
 
 struct sensors_item_cfg {
-    uint8_t sensor_position;
+    uint8_t sensor_index;
     const struct zmk_sensor_config *config;
     const struct device *dev;
     struct sensor_trigger trigger;
@@ -57,17 +57,17 @@ static struct sensors_item_cfg sensors[] = {LISTIFY(ZMK_KEYMAP_SENSORS_LEN, SENS
 
 static ATOMIC_DEFINE(pending_sensors, ZMK_KEYMAP_SENSORS_LEN);
 
-const struct zmk_sensor_config *zmk_sensors_get_config_at_position(uint8_t sensor_position) {
-    if (sensor_position > ARRAY_SIZE(configs)) {
+const struct zmk_sensor_config *zmk_sensors_get_config_at_index(uint8_t sensor_index) {
+    if (sensor_index > ARRAY_SIZE(configs)) {
         return NULL;
     }
 
-    return &configs[sensor_position];
+    return &configs[sensor_index];
 }
 
-static void trigger_sensor_data_for_position(uint32_t sensor_position) {
+static void trigger_sensor_data_for_position(uint32_t sensor_index) {
     int err;
-    const struct sensors_item_cfg *item = &sensors[sensor_position];
+    const struct sensors_item_cfg *item = &sensors[sensor_index];
 
     err = sensor_sample_fetch(item->dev);
     if (err) {
@@ -84,7 +84,7 @@ static void trigger_sensor_data_for_position(uint32_t sensor_position) {
     }
 
     ZMK_EVENT_RAISE(new_zmk_sensor_event(
-        (struct zmk_sensor_event){.sensor_position = item->sensor_position,
+        (struct zmk_sensor_event){.sensor_index = item->sensor_index,
                                   .channel_data = {(struct zmk_sensor_channel_data){
                                       .value = value, .channel = item->trigger.chan}},
                                   .timestamp = k_uptime_get()}));
@@ -122,7 +122,7 @@ static void zmk_sensors_trigger_handler(const struct device *dev,
 static void zmk_sensors_init_item(uint8_t i) {
     LOG_DBG("Init sensor at index %d", i);
 
-    sensors[i].sensor_position = i;
+    sensors[i].sensor_index = i;
 
     if (!sensors[i].dev) {
         LOG_DBG("No local device for %d", i);

--- a/app/src/sensors.c
+++ b/app/src/sensors.c
@@ -18,65 +18,128 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #if ZMK_KEYMAP_HAS_SENSORS
 
-struct sensors_data_item {
-    uint8_t sensor_number;
+struct sensors_item_cfg {
+    uint8_t sensor_position;
+    const struct zmk_sensor_config *config;
     const struct device *dev;
     struct sensor_trigger trigger;
 };
 
-#define _SENSOR_ITEM(node)                                                                         \
+#define _SENSOR_ITEM(idx, node)                                                                    \
     {                                                                                              \
-        .dev = NULL, .trigger = {.type = SENSOR_TRIG_DELTA, .chan = SENSOR_CHAN_ROTATION }         \
+        .dev = DEVICE_DT_GET_OR_NULL(node),                                                        \
+        .trigger = {.type = SENSOR_TRIG_DATA_READY, .chan = SENSOR_CHAN_ROTATION},                 \
+        .config = &configs[idx]                                                                    \
+    }
+#define SENSOR_ITEM(idx, _i) _SENSOR_ITEM(idx, ZMK_KEYMAP_SENSORS_BY_IDX(idx))
+
+#define PLUS_ONE(n) +1
+#define ZMK_KEYMAP_SENSORS_CHILD_COUNT (0 DT_FOREACH_CHILD(ZMK_KEYMAP_SENSORS_NODE, PLUS_ONE))
+#define SENSOR_CHILD_ITEM(node)                                                                    \
+    {                                                                                              \
+        .triggers_per_rotation =                                                                   \
+            DT_PROP_OR(node, triggers_per_rotation,                                                \
+                       DT_PROP_OR(ZMK_KEYMAP_SENSORS_NODE, triggers_per_rotation,                  \
+                                  CONFIG_ZMK_KEYMAP_SENSORS_DEFAULT_TRIGGERS_PER_ROTATION))        \
+    }
+#define SENSOR_CHILD_DEFAULTS(idx, arg)                                                            \
+    { .triggers_per_rotation = DT_PROP_OR(ZMK_KEYMAP_SENSORS_NODE, triggers_per_rotation, 20) }
+
+static struct zmk_sensor_config configs[] = {
+#if ZMK_KEYMAP_SENSORS_CHILD_COUNT > 0
+    DT_FOREACH_CHILD_SEP(ZMK_KEYMAP_SENSORS_NODE, SENSOR_CHILD_ITEM, (, ))
+#else
+    LISTIFY(ZMK_KEYMAP_SENSORS_LEN, SENSOR_CHILD_DEFAULTS, (, ), 0)
+#endif
+};
+
+static struct sensors_item_cfg sensors[] = {LISTIFY(ZMK_KEYMAP_SENSORS_LEN, SENSOR_ITEM, (, ), 0)};
+
+static ATOMIC_DEFINE(pending_sensors, ZMK_KEYMAP_SENSORS_LEN);
+
+const struct zmk_sensor_config *zmk_sensors_get_config_at_position(uint8_t sensor_position) {
+    if (sensor_position > ARRAY_SIZE(configs)) {
+        return NULL;
     }
 
-#define SENSOR_ITEM(idx, _node)                                                                    \
-    COND_CODE_1(DT_NODE_HAS_STATUS(ZMK_KEYMAP_SENSORS_BY_IDX(idx), okay),                          \
-                (_SENSOR_ITEM(ZMK_KEYMAP_SENSORS_BY_IDX(idx))), ({}))
+    return &configs[sensor_position];
+}
 
-static struct sensors_data_item sensors[] = {LISTIFY(ZMK_KEYMAP_SENSORS_LEN, SENSOR_ITEM, (, ), 0)};
-
-static void zmk_sensors_trigger_handler(const struct device *dev,
-                                        const struct sensor_trigger *trigger) {
+static void trigger_sensor_data_for_position(uint32_t sensor_position) {
     int err;
-    const struct sensors_data_item *item = CONTAINER_OF(trigger, struct sensors_data_item, trigger);
+    const struct sensors_item_cfg *item = &sensors[sensor_position];
 
-    LOG_DBG("sensor %d", item->sensor_number);
-
-    err = sensor_sample_fetch(dev);
+    err = sensor_sample_fetch(item->dev);
     if (err) {
         LOG_WRN("Failed to fetch sample from device %d", err);
         return;
     }
 
-    ZMK_EVENT_RAISE(new_zmk_sensor_event((struct zmk_sensor_event){
-        .sensor_number = item->sensor_number, .sensor = dev, .timestamp = k_uptime_get()}));
-}
+    struct sensor_value value;
+    err = sensor_channel_get(item->dev, item->trigger.chan, &value);
 
-static void zmk_sensors_init_item(const char *node, uint8_t i, uint8_t abs_i) {
-    LOG_DBG("Init %s at index %d with sensor_number %d", node, i, abs_i);
-
-    sensors[i].dev = device_get_binding(node);
-    sensors[i].sensor_number = abs_i;
-
-    if (!sensors[i].dev) {
-        LOG_WRN("Failed to find device for %s", node);
+    if (err) {
+        LOG_WRN("Failed to get channel data from device %d", err);
         return;
     }
 
-    sensor_trigger_set(sensors[i].dev, &sensors[i].trigger, zmk_sensors_trigger_handler);
+    ZMK_EVENT_RAISE(new_zmk_sensor_event(
+        (struct zmk_sensor_event){.sensor_position = item->sensor_position,
+                                  .channel_data = {(struct zmk_sensor_channel_data){
+                                      .value = value, .channel = item->trigger.chan}},
+                                  .timestamp = k_uptime_get()}));
 }
 
-#define _SENSOR_INIT(node)                                                                         \
-    zmk_sensors_init_item(DT_PROP(node, label), local_index++, absolute_index++);
-#define SENSOR_INIT(idx, _i)                                                                       \
-    COND_CODE_1(DT_NODE_HAS_STATUS(ZMK_KEYMAP_SENSORS_BY_IDX(idx), okay),                          \
-                (_SENSOR_INIT(ZMK_KEYMAP_SENSORS_BY_IDX(idx))), (absolute_index++;))
+static void run_sensors_data_trigger(struct k_work *work) {
+    for (int i = 0; i < ARRAY_SIZE(sensors); i++) {
+        if (atomic_test_and_clear_bit(pending_sensors, i)) {
+            trigger_sensor_data_for_position(i);
+        }
+    }
+}
+
+K_WORK_DEFINE(sensor_data_work, run_sensors_data_trigger);
+
+static void zmk_sensors_trigger_handler(const struct device *dev,
+                                        const struct sensor_trigger *trigger) {
+    const struct sensors_item_cfg *test_item =
+        CONTAINER_OF(trigger, struct sensors_item_cfg, trigger);
+    int sensor_index = test_item - sensors;
+
+    if (sensor_index < 0 || sensor_index >= ARRAY_SIZE(sensors)) {
+        LOG_ERR("Invalid sensor item triggered our callback");
+        return;
+    }
+
+    if (k_is_in_isr()) {
+        atomic_set_bit(pending_sensors, sensor_index);
+        k_work_submit(&sensor_data_work);
+    } else {
+        trigger_sensor_data_for_position(sensor_index);
+    }
+}
+
+static void zmk_sensors_init_item(uint8_t i) {
+    LOG_DBG("Init sensor at index %d", i);
+
+    sensors[i].sensor_position = i;
+
+    if (!sensors[i].dev) {
+        LOG_DBG("No local device for %d", i);
+        return;
+    }
+
+    int err = sensor_trigger_set(sensors[i].dev, &sensors[i].trigger, zmk_sensors_trigger_handler);
+    if (err) {
+        LOG_WRN("Failed to set sensor trigger (%d)", err);
+    }
+}
+
+#define SENSOR_INIT(idx, _t) zmk_sensors_init_item(idx);
 
 static int zmk_sensors_init(const struct device *_arg) {
-    int local_index = 0;
-    int absolute_index = 0;
-
     LISTIFY(ZMK_KEYMAP_SENSORS_LEN, SENSOR_INIT, (), 0)
+
     return 0;
 }
 

--- a/docs/blog/2023-06-18-encoder-refactors.md
+++ b/docs/blog/2023-06-18-encoder-refactors.md
@@ -1,0 +1,119 @@
+---
+title: "Major Encoder Refactor"
+author: Pete Johanson
+author_title: Project Creator
+author_url: https://gitlab.com/petejohanson
+author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+tags: [firmware, zephyr, sensors, encoders]
+---
+
+Today, we merged a significant change to the low level sensor code that is used to support encoders. In particular,
+this paves the way for completing the work on supporting split peripheral sensors/encoders, and other future sensors
+like pointing devices.
+
+As part of the work, backwards compatibility for existing shields has been retained, but only for a grace period to allow out-of-tree shields to move to the new approach for encoders.
+
+Special thanks to [joelspadin] for the _thorough_ code review and testing throughout the development of the refactor.
+
+## Summary of Changes
+
+The following items have been merged:
+
+1. Split configuration of hardware details, and behavior configuration to allow more flexible functionality of sensors/encoders, in particular linear encoders that lack detents/"clicks" as they rotate.
+2. Support for upstream Zephyr sensor drivers, including the NRFX QDEC driver that can be used on nRF52 based keyboards.
+3. Sensor data handling changes that pave the way for split sensor handling easily.
+
+## Configuration Changes
+
+The major changes to configuration in the devicetree files relates to how the number of steps/triggers for a given encoder are set. In particular, the number of pulses/steps for a given encoder is configured first, allowing ZMK to determine the exact angular degrees of change that is represented by a single pulse on the data lines to that encoder.
+
+Once that angular degrees mapping is completed, now independently there is a configuration setting to control how many triggers of the behavior in the keymap should occur for each full rotation of the sensor. Another way to think of this is "how many degrees of rotation results in a triggering of the sensor behavior in your keymap layer".
+
+Splitting these two parts of the encoder configuration allows greater flexibility, and fine grained control of encoder behavior for linear encoders that don't have fixed detents.
+
+### Old Configuration
+
+Previously, an encoder configuration looked like:
+
+```
+    left_encoder: encoder_left {
+        compatible = "alps,ec11";
+        label = "LEFT_ENCODER";
+        a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+        b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+        resolution = <4>;
+    };
+```
+
+Here, the `resolution` property was used to indicate how many encoder pulses should trigger the sensor behavior one time. Next, the encoder is selected in the sensors node:
+
+```
+    sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&left_encoder &right_encoder>;
+    };
+```
+
+That was the entirety of the configuration for encoders.
+
+### New Configuration
+
+```
+    left_encoder: encoder_left {
+        compatible = "alps,ec11";
+        label = "LEFT_ENCODER";
+        a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+        b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+        steps = <80>;
+    };
+```
+
+Here, the `steps` property is now used to indicate how many encoder pulses there are in a single complete rotation of the encoder. Next, the encoder is selected in the sensors node as before, but an additional configuration is used to indicate how many times the encoder should trigger the behavior in your keymap per rotation:
+
+```
+    sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&left_encoder &right_encoder>;
+        triggers-per-rotation = <20>;
+    };
+```
+
+For tactile encoders that have detents, the `triggers-per-rotation` would match the number of detents on the encoder. For linear encoders, the value can be chosen to suit your needs.
+
+## Zephyr Sensor Drivers
+
+The configuration changes bring ZMK's code in line with how upstream Zephyr sensor drivers handle rotations. This has the added advantage of allowing us to leverage other sensor drivers. On Nordic MCUs, like nRF52840, the NRFX QDEC driver can be used, for example:
+
+```
+&pinctrl {
+    qdec_default: qdec_default {
+        group1 {
+            psels = <NRF_PSEL(QDEC_A, 1, 11)>,
+                    <NRF_PSEL(QDEC_B, 1, 10)>;
+            bias-pull-up;
+        };
+    };
+};
+
+// Set up the QDEC hardware based driver and give it the same label as the deleted node.
+encoder: &qdec0 {
+    status = "okay";
+    led-pre = <0>;
+    steps = <80>;
+    pinctrl-0 = <&qdec_default>;
+    pinctrl-names = "default";
+};
+```
+
+The NRFX QDEC driver has the advantage of supporting optical encoders as well, and although it polls, it does so in hardware without waking the MCU core; initial basic power profiling is promising.
+
+## Split Sensor/Encoder Support
+
+In addition to the refactors for splitting the configuration, the changes merged included refactors designed to simplify and move forward with the long outstanding feature of supporting encoders on the peripheral side of split keyboards. That work is planned as a follow up.
+
+## Deprecation
+
+The old configuration will be supported for a period of one month, and then removed, giving users a grace period to complete the migration to the new separated configuration.
+
+[petejohanson]: https://github.com/petejohanson
+[joelspadin]: https://github.com/joelspadin


### PR DESCRIPTION
Some major refactors to sensors:

* Refactor ec11 sensor driver to align w/ Zephyr degree channel convention, that sensor data for that channel is in degrees of change since the last event.
* Refactor to allow specitying what angle delta triggers a given behavior.
* Move channel data into the sensor event, instead of requiring listeners to probe the sensor themselves upon events.