### PR TITLE
fix(docs): Make the modifier function examples clearer.

### DIFF
--- a/docs/docs/codes/modifiers.mdx
+++ b/docs/docs/codes/modifiers.mdx
@@ -41,6 +41,6 @@ These functions take the form: `XX(code)`
 - Some basic codes already include a modifier function in their definition:
   - `DOLLAR` = `LS(NUMBER_4)`
 - There are left- and right-handed versions of each modifier (also see table above):
-  - `LS`, `LC`, `LA`, `LG`, `RS`, `RC`, `RA`, `RG`
+  - `LS(x)`, `LC(x)`, `LA(x)`, `LG(x)`, `RS(x)`, `RC(x)`, `RA(x)`, `RG(x)`
 - Modified keys can safely be rolled-over. Modifier functions are released when another key is pressed.
   - Press `&kp LS(A)`, then press `&kp B`, release `&kp LS(A)` and release `&kp B` results in **Ab**. Only the A is capitalized.


### PR DESCRIPTION
* Ensure the list of available modifier functions is clearly shown
  as macros, not as basic defines.
