### PR TITLE
feat(shield): Add Hillside support

### DIFF
--- a/app/boards/shields/hillside/Kconfig.defconfig
+++ b/app/boards/shields/hillside/Kconfig.defconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2021 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_HILLSIDE_LEFT
+
+config ZMK_KEYBOARD_NAME
+    default "Hillside"
+
+config ZMK_SPLIT_BLE_ROLE_CENTRAL
+    default y
+
+endif
+
+if SHIELD_HILLSIDE_LEFT || SHIELD_HILLSIDE_RIGHT
+
+config ZMK_SPLIT
+    default y
+
+endif

--- a/app/boards/shields/hillside/Kconfig.shield
+++ b/app/boards/shields/hillside/Kconfig.shield
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_HILLSIDE_LEFT
+    def_bool $(shields_list_contains,hillside_left)
+
+config SHIELD_HILLSIDE_RIGHT
+    def_bool $(shields_list_contains,hillside_right)

--- a/app/boards/shields/hillside/README.md
+++ b/app/boards/shields/hillside/README.md
@@ -1,0 +1,14 @@
+Hillside is a split ergonomic keyboard with 3x6+4+2 choc-spaced keys.
+It has the aggressive stagger of the Ferris but a longer thumb arc and a break-off outer pinky column.
+More information is at [github/mmccoyd](https://github.com/mmccoyd/hillside/).
+
+The default keymap is described in
+  [QMK](https://github.com/qmk/qmk_firmware/tree/master/keyboards/handwired/hillside/keymaps/default).
+For ZMK, the adjust layer has extra keys for bluetooth, reset, output, and a lack of RGB controls.
+
+If used, the following must be manually enabled in hillside.conf:
+- Encoders
+- Underglow
+
+If desired, you could hardwire a display to the I2C header,
+  which is arranged for a haptic feedback board.

--- a/app/boards/shields/hillside/boards/nice_nano.overlay
+++ b/app/boards/shields/hillside/boards/nice_nano.overlay
@@ -1,0 +1,28 @@
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI def, but not used by ws2812 driver.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <5>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/hillside/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/hillside/boards/nice_nano_v2.overlay
@@ -1,0 +1,28 @@
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI def, but not used by ws2812 driver.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <5>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/hillside/hillside.conf
+++ b/app/boards/shields/hillside/hillside.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2021 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Encoders (Uncomment these two line to add support to your firmware)
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# RGB Underglow (Uncomment these two lines to add support to your firmware)
+# RGB quickly drains battery power
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/hillside/hillside.dtsi
+++ b/app/boards/shields/hillside/hillside.dtsi
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <12>;
+        rows = <4>;
+// | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  |                                   | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |
+// | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 |                                   | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |
+// | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 / SW19 /                     \ SW19 \ SW18 | SW17 | SW16 | SW15 | SW14 | SW13 |
+//               | SW20       | SW21 / SW22 / SW23 / SW24 /         \ SW24 \ SW23 \ SW22 \ SW21      | SW20 |
+        map = <
+RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)                                   RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11)
+RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)                                   RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11)
+RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(3,5)                   RC(3,6) RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11)
+                RC(3,0)         RC(3,1) RC(3,2) RC(3,3) RC(3,4)   RC(3,7) RC(3,8) RC(3,9) RC(3,10)        RC(3,11)
+        >;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+
+        diode-direction = "col2row";
+        row-gpios
+            = <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+        
+    };
+
+    left_encoder: encoder_left {
+            compatible = "alps,ec11";
+            label = "LEFT_ENCODER";
+            a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+            b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+            resolution = <4>;
+            status = "disabled";
+        };
+
+    right_encoder: encoder_right {
+            compatible = "alps,ec11";
+            label = "RIGHT_ENCODER";
+            a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+            b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+            resolution = <4>;
+            status = "disabled";
+        };
+
+    sensors {
+            compatible = "zmk,keymap-sensors";
+            sensors = <&left_encoder &right_encoder>;
+        };
+    
+};

--- a/app/boards/shields/hillside/hillside.keymap
+++ b/app/boards/shields/hillside/hillside.keymap
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2021 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/ext_power.h>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/outputs.h>
+
+#define QWERTY_L 0
+#define DVORAK_L 1
+#define COLEMK_L 2
+#define NAV_L    3
+#define SYM_L    4
+#define NUM_L    5
+#define ADJ_L    6
+
+#define WORD_L   LC(LEFT)
+#define WORD_R   LC(RIGHT)
+
+/ {
+        keymap {
+                compatible = "zmk,keymap";
+
+                default_layer {
+/* QWERTY
+ * -------------------------------------------------------------------------------------------------------------------------------------
+ * | TAB   |   Q   |   W   |   E   |   R   |   T   |-----------------------------------|   Y   |   U   |   I   |   O   |   P   | BKSPC |
+ * | CTRL  |   A   |   S   |   D   |   F   |   G   |-----------------------------------|   H   |   J   |   K   |   L   |   ;   |  '    |
+ * | SHIFT |   Z   |   X   |   C   |   V   |   B   |   `   |-------------------|  ESC  |   N   |   M   |   ,   |   .   |   /   | SHIFT |
+ * ----------------| ENTER |-------|  GUI  |  ALT  |  Num  |  Nav  |---|  Sym  | SPACE |  ALT  |  GUI  |-------|  APP  |----------------
+ */
+                        bindings = <
+&kp  TAB      &kp  Q        &kp  W        &kp  E        &kp  R        &kp  T                                                                         &kp  Y        &kp  U        &kp  I        &kp  O        &kp  P        &kp  BSPC
+&kp  LCTRL    &kp  A        &kp  S        &kp  D        &kp  F        &kp  G                                                                         &kp  H        &kp  J        &kp  K        &kp  L        &kp  SEMI     &kp  SQT  
+&kp  LSHFT    &kp  Z        &kp  X        &kp  C        &kp  V        &kp  B        &kp  GRAVE                                         &kp   ESC     &kp  N        &kp  M        &kp  COMMA    &kp  DOT      &kp  SLASH    &kp  RSHFT
+                            &kp  ENTER                  &kp  LGUI     &kp  LALT     &mo  NUM_L    &mo  NAV_L             &mo  SYM_L    &kp  SPACE    &kp  RALT     &kp  RGUI                   &kp  K_APP    
+                        >;
+			
+                        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+                };
+		
+                dvorak_layer {
+/* DVORAK
+ * -------------------------------------------------------------------------------------------------------------------------------------
+ * | TAB   |   '   |   ,   |   .   |   P   |   Y   |-----------------------------------|   F   |   G   |   C   |   R   |   L   | BKSPC |
+ * | CTRL  |   A   |   O   |   E   |   U   |   I   |-----------------------------------|   D   |   H   |   T   |   N   |   S   |  /    |
+ * | SHIFT |   ;   |   Q   |   J   |   K   |   X   |   ~   |-------------------|  ESC  |   B   |   M   |   W   |   V   |   Z   | SHIFT |
+ * ----------------| ENTER |-------|  GUI  |  ALT  |  Num  |  Nav  |---|  Sym  | SPACE |  ALT  |  GUI  |-------|  APP  |----------------
+ */
+                        bindings = <
+&kp  TAB      &kp  SQT      &kp  COMMA    &kp  DOT      &kp  P        &kp  Y                                                                         &kp  F        &kp  G        &kp  C        &kp  R        &kp  L        &kp  BSPC
+&kp  LCTRL    &kp  A        &kp  O        &kp  E        &kp  U        &kp  I                                                                         &kp  D        &kp  H        &kp  T        &kp  N        &kp  S        &kp  SLASH
+&kp  LSHFT    &kp  SEMI     &kp  Q        &kp  J        &kp  K        &kp  X        &kp  GRAVE                                         &kp   ESC     &kp  B        &kp  M        &kp  W        &kp  V        &kp  Z        &kp  RSHFT
+                            &kp  ENTER                  &kp  LGUI     &kp  LALT     &mo  NUM_L    &mo  NAV_L             &mo  SYM_L    &kp  SPACE    &kp  RALT     &kp  RGUI                   &kp  K_APP    
+                        >;
+			
+                        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+                };
+		
+                colemak_layer {
+/* COLEMAK-DH
+ * -------------------------------------------------------------------------------------------------------------------------------------
+ * | TAB   |   Q   |   W   |   F   |   P   |   B   |-----------------------------------|   J   |   L   |   U   |   Y   |   ;   | BKSPC |
+ * | CTRL  |   A   |   R   |   S   |   T   |   G   |-----------------------------------|   M   |   N   |   E   |   I   |   O   |  '    |
+ * | SHIFT |   Z   |   X   |   C   |   D   |   V   |   `   |-------------------|  ESC  |   K   |   H   |   ,   |   .   |   /   | SHIFT |
+ * ----------------| ENTER |-------|  GUI  |  ALT  |  Num  |  Nav  |---|  Sym  | SPACE |  ALT  |  GUI  |-------|  APP  |----------------
+ */
+                        bindings = <
+&kp  TAB      &kp  Q        &kp  W        &kp  F        &kp  P        &kp  B                                                                         &kp  J        &kp  L        &kp  U        &kp  Y        &kp  SEMI     &kp  BSPC
+&kp  LCTRL    &kp  A        &kp  R        &kp  S        &kp  T        &kp  G                                                                         &kp  M        &kp  N        &kp  E        &kp  I        &kp  O        &kp  SQT  
+&kp  LSHFT    &kp  Z        &kp  X        &kp  C        &kp  D        &kp  V        &kp  GRAVE                                         &kp   ESC     &kp  K        &kp  H        &kp  COMMA    &kp  DOT      &kp  SLASH    &kp  RSHFT
+                            &kp  ENTER                  &kp  LGUI     &kp  LALT     &mo  NUM_L    &mo  NAV_L             &mo  SYM_L    &kp  SPACE    &kp  RALT     &kp  RGUI                   &kp  K_APP    
+                        >;
+			
+                        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+                };
+		
+                nav_layer {
+/* NAV   
+ * -------------------------------------------------------------------------------------------------------------------------------------
+ * | CAPS  |  INS  |       |       |       | VOL+  |-----------------------------------| PG_UP |  HOME |       |  END  |       |  DEL  |
+ * | Ctrl  |  GUI  |  ALT  | CTRL  | SHIFT | VOL-  |-----------------------------------| PG_DN |  LEFT |   UP  | RIGHT |       | CTRL  |
+ * | Shift | UNDO  |  CUT  | COPY  | PASTE | REDO  |  MUTE |-------------------|  ESC  |       | WORDL |  DOWN | WORDR | RALT  | SHIFT |
+ * ----------------|       |-------|       |       |       |       |---| ADJ_L | BSPC  |       |       |-------|       |----------------
+ */
+                        bindings = <
+&kp  CAPS     &kp  INS      &none         &none         &none         &kp  C_VOL_UP                                                                  &kp  PG_UP    &kp  HOME     &none         &kp  END      &none         &kp  DEL 
+&kp  LCTRL    &kp  LGUI     &kp  LALT     &kp  LCTRL    &kp  LSHFT    &kp  C_VOL_DN                                                                  &kp  PG_DN    &kp  LEFT     &kp  UP       &kp  RIGHT    &none         &kp  RCTRL
+&kp  LSHFT    &kp  LC(Z)    &kp  LC(X)    &kp  LC(C)    &kp  LC(V)    &kp  LC(Y)    &kp  C_MUTE                                        &kp  ESC      &none         &kp  WORD_L   &kp  DOWN     &kp  WORD_R   &kp  RALT     &kp  RSHFT
+                            &trans                      &trans        &trans        &trans        &trans                 &mo  ADJ_L    &kp  BSPC     &trans        &trans                      &trans    
+                        >;
+			
+                        sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
+                };
+		
+                sym_layer {
+/* SYM
+ * -------------------------------------------------------------------------------------------------------------------------------------
+ * | F12   |   !   |   @   |   #   |   $   |   %   |-----------------------------------|   ^   |   &   |   *   |   (   |   )   | BSPC  |
+ * | Ctrl  |  F1   |  F2   |  F3   |  F4   |  F5   |-----------------------------------|   |   | Shift | Ctrl  |  Alt  |  GUI  | CTRL  |
+ * | Shift |  F6   |  F7   |  F8   |  F9   |  F10  |   F11 |-------------------| ESC   |   \   |   [   |   ]   |   {   |   }   | SHIFT |
+ * ----------------|       |-------|       |       |       | ADJ_L |---|       |       |       |       |-------|       |----------------
+ */
+                        bindings = <
+&kp  F12      &kp  EXCL     &kp  AT       &kp  HASH     &kp  DOLLAR   &kp  PERCENT                                                                   &kp  CARET    &kp  AMPS     &kp  ASTRK    &kp  LPAR     &kp  RPAR     &kp  BSPC
+&kp  LCTRL    &kp  F1       &kp  F2       &kp  F3       &kp  F4       &kp  F5                                                                        &kp  PIPE     &kp  RSHFT    &kp  RCTRL    &kp  LALT     &kp  RGUI     &kp  RCTRL
+&kp  LSHFT    &kp  F6       &kp  F7       &kp  F8       &kp  F9       &kp  F10      &kp  F11                                           &kp  ESC      &kp  BSLH     &kp  LBKT     &kp  RBKT     &kp  LBRC     &kp  RBRC     &kp  RSHFT
+                            &trans                      &trans        &trans        &trans        &mo  ADJ_L             &trans        &trans        &trans        &trans                      &trans    
+                        >;
+			
+                        sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
+                };
+		
+                num_layer {
+/* NUM   
+ * -------------------------------------------------------------------------------------------------------------------------------------
+ * |       |   -   |   +   |   =   |   /   |   *   |-----------------------------------|   .   |   7   |   8   |   9   |       | BSPC  |
+ * | Ctrl  |  GUI  |  ALT  | CTRL  | SHIFT |       |-----------------------------------|   0   |   1   |   2   |   3   |   _   | CTRL  |
+ * | Shift |       |       |       |       |       |       |-------------------|  ESC  |   ,   |   4   |   5   |   6   |       | SHIFT |
+ * ----------------|       |-------|       |       |       |       |---|       | BSPC  |       |       |-------|       |----------------
+ */
+                        bindings = <
+&none         &kp  MINUS    &kp  PLUS     &kp  EQUAL    &kp  SLASH    &kp  ASTRK                                                                     &kp   DOT     &kp   N7      &kp   N8      &kp   N9      &none         &kp  BSPC
+&kp  LCTRL    &kp  LGUI     &kp  LALT     &kp  LCTRL    &kp  LSHFT    &none                                                                          &kp   N0      &kp   N1      &kp   N2      &kp   N3      &kp  UNDER    &kp  RCTRL
+&kp  LSHFT    &none         &none         &none         &none         &none         &none                                              &kp  ESC      &kp  COMMA    &kp   N4      &kp   N5      &kp   N6      &none         &kp  RSHFT
+                            &trans                      &trans        &trans        &trans        &none                  &none         &kp  BSPC     &trans        &trans                      &trans    
+                        >;
+			
+                        sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
+                };
+		
+                adj_layer {
+/* ADJUST
+ * -------------------------------------------------------------------------------------------------------------------------------------
+ * |       | QWERTY| DVORAK| COLEMK|       |       |-----------------------------------|       | EP_OFF| EP_ON |       |       |       |
+ * | BTCLR | BT 0  | BT 1  | BT 2  | BT 3  | BT 4  |-----------------------------------|       |       |       |       |       |       |
+ * | BOOTL | RESET |       |OUT_USB|OUT_BLE|       |       |-------------------|       |       |       |       |       |       |       |
+ * ----------------|       |-------|       |       |       |       |---|       |       |       |       |-------|       |----------------
+ */
+                        bindings = <
+&none         &to  QWERTY_L &to  DVORAK_L &to  COLEMK_L &none         &none                                                                             &none             &ext_power EP_OFF  &ext_power EP_ON &none           &none            &kp  DEL 
+&bt  BT_CLR   &bt  BT_SEL 0 &bt  BT_SEL 1 &bt  BT_SEL 2 &bt  BT_SEL 3 &bt  BT_SEL 4                                                                     &none             &none              &none            &none           &none            &kp  RCTRL
+&bootloader   &reset        &none         &out OUT_USB  &out OUT_BLE  &none         &none                                              &none            &none             &none              &none            &none           &none            &kp  RSHFT
+                            &trans                      &trans        &trans        &trans        &trans                 &trans        &trans           &trans            &trans                              &trans    
+                        >;
+			
+                        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+                };
+        };
+};

--- a/app/boards/shields/hillside/hillside.zmk.yml
+++ b/app/boards/shields/hillside/hillside.zmk.yml
@@ -1,0 +1,13 @@
+file_format: "1"
+id: hillside
+name: Hillside
+type: shield
+url: https://github.com/mmccoyd/hillside/
+requires: [pro_micro]
+features:
+  - keys
+  - encoder
+  - underglow
+siblings:
+  - hillside_left
+  - hillside_right

--- a/app/boards/shields/hillside/hillside_left.overlay
+++ b/app/boards/shields/hillside/hillside_left.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "hillside.dtsi" 
+
+&kscan0 {
+    col-gpios
+        = <&pro_micro 19 GPIO_ACTIVE_HIGH> // col0 in the schematic
+        , <&pro_micro 18 GPIO_ACTIVE_HIGH> // col1 in the schematic
+        , <&pro_micro 15 GPIO_ACTIVE_HIGH> // col2 in the schematic
+        , <&pro_micro 14 GPIO_ACTIVE_HIGH> // col3 in the schematic
+        , <&pro_micro 16 GPIO_ACTIVE_HIGH> // col4 in the schematic
+        , <&pro_micro 10 GPIO_ACTIVE_HIGH> // col5 in the schematic
+        ;
+};
+
+&left_encoder {
+    status = "okay";
+};

--- a/app/boards/shields/hillside/hillside_right.overlay
+++ b/app/boards/shields/hillside/hillside_right.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "hillside.dtsi" 
+
+&default_transform {
+    col-offset = <6>;
+};
+
+&kscan0 {
+    col-gpios
+        = <&pro_micro 10 GPIO_ACTIVE_HIGH> // col5 in the schematic
+        , <&pro_micro 16 GPIO_ACTIVE_HIGH> // col4 in the schematic
+        , <&pro_micro 14 GPIO_ACTIVE_HIGH> // col3 in the schematic
+        , <&pro_micro 15 GPIO_ACTIVE_HIGH> // col2 in the schematic
+        , <&pro_micro 18 GPIO_ACTIVE_HIGH> // col1 in the schematic
+        , <&pro_micro 19 GPIO_ACTIVE_HIGH> // col0 in the schematic
+        ;
+};
+
+&right_encoder {
+    status = "okay";
+};


### PR DESCRIPTION
Add Hillside support, tested on real hardware. (https://github.com/mmccoyd/hillside)

## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] `.conf` file has optional extra features commented out
