### PR TITLE
Some light refactoring of the test code 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "files.associations": {
     "*.overlay": "dts",
     "*.keymap": "dts"
-  }
+  },
+  "python.formatting.provider": "black"
 }

--- a/app/run-test.sh
+++ b/app/run-test.sh
@@ -28,17 +28,17 @@ echo "Running $testcase:"
 
 west build -d build/$testcase -b native_posix -- -DZMK_CONFIG="$(pwd)/$testcase" > /dev/null 2>&1
 if [ $? -gt 0 ]; then
-	echo "FAIL: $testcase did not build" >> ./build/tests/pass-fail.log
+	echo "FAILED: $testcase did not build" >> ./build/tests/pass-fail.log
 	exit 1
 else
 	./build/$testcase/zephyr/zmk.exe | sed -e "s/.*> //" | tee build/$testcase/keycode_events_full.log | sed -n -f $testcase/events.patterns > build/$testcase/keycode_events.log
 	diff -au $testcase/keycode_events.snapshot build/$testcase/keycode_events.log
 	if [ $? -gt 0 ]; then
 		if [ -f $testcase/pending ]; then
-			echo "PEND: $testcase" >> ./build/tests/pass-fail.log
+			echo "PENDING: $testcase" >> ./build/tests/pass-fail.log
 			exit 0
 		else
-			echo "FAIL: $testcase" >> ./build/tests/pass-fail.log
+			echo "FAILED: $testcase" >> ./build/tests/pass-fail.log
 			exit 1
 		fi
 	else

--- a/app/run-test.sh
+++ b/app/run-test.sh
@@ -28,21 +28,20 @@ echo "Running $testcase:"
 
 west build -d build/$testcase -b native_posix -- -DZMK_CONFIG="$(pwd)/$testcase" > /dev/null 2>&1
 if [ $? -gt 0 ]; then
-	echo "FAILED: $testcase did not build" >> ./build/tests/pass-fail.log
+	echo "FAILED: $testcase did not build" | tee -a ./build/tests/pass-fail.log
 	exit 1
-else
-	./build/$testcase/zephyr/zmk.exe | sed -e "s/.*> //" | tee build/$testcase/keycode_events_full.log | sed -n -f $testcase/events.patterns > build/$testcase/keycode_events.log
-	diff -au $testcase/keycode_events.snapshot build/$testcase/keycode_events.log
-	if [ $? -gt 0 ]; then
-		if [ -f $testcase/pending ]; then
-			echo "PENDING: $testcase" >> ./build/tests/pass-fail.log
-			exit 0
-		else
-			echo "FAILED: $testcase" >> ./build/tests/pass-fail.log
-			exit 1
-		fi
-	else
-		echo "PASS: $testcase" >> ./build/tests/pass-fail.log
+fi
+
+./build/$testcase/zephyr/zmk.exe | sed -e "s/.*> //" | tee build/$testcase/keycode_events_full.log | sed -n -f $testcase/events.patterns > build/$testcase/keycode_events.log
+diff -au $testcase/keycode_events.snapshot build/$testcase/keycode_events.log
+if [ $? -gt 0 ]; then
+	if [ -f $testcase/pending ]; then
+		echo "PENDING: $testcase" | tee -a ./build/tests/pass-fail.log
 		exit 0
 	fi
+	echo "FAILED: $testcase" | tee -a ./build/tests/pass-fail.log
+	exit 1
 fi
+
+echo "PASS: $testcase" | tee -a ./build/tests/pass-fail.log
+exit 0

--- a/app/scripts/west_commands/metadata.py
+++ b/app/scripts/west_commands/metadata.py
@@ -1,59 +1,64 @@
 # Copyright (c) 2021 The ZMK Contributors
 # SPDX-License-Identifier: MIT
-'''Metadata command for ZMK.'''
+"""Metadata command for ZMK."""
 
 from functools import cached_property
 import glob
 import json
-from jsonschema import validate, ValidationError
-import os
+import jsonschema
 import sys
 import yaml
-from textwrap import dedent            # just for nicer code indentation
 
 from west.commands import WestCommand
-from west import log                   # use this for user output
+from west import log  # use this for user output
 
 
 class Metadata(WestCommand):
     def __init__(self):
         super().__init__(
-            'metadata',  # gets stored as self.name
-            'ZMK hardware metadata commands',  # self.help
-            # self.description:
-            dedent('''Operate on the board/shield metadata.'''))
+            name="metadata",
+            help="ZMK hardware metadata commands",
+            description="Operate on the board/shield metadata.",
+        )
 
     def do_add_parser(self, parser_adder):
-        parser = parser_adder.add_parser(self.name,
-                                         help=self.help,
-                                         description=self.description)
+        parser = parser_adder.add_parser(
+            self.name, help=self.help, description=self.description
+        )
 
-        parser.add_argument('subcommand', default="check",
-                            help='The subcommand to run. Defaults to "check".', nargs="?")
-        return parser           # gets stored as self.parser
+        parser.add_argument(
+            "subcommand",
+            default="check",
+            help='The subcommand to run. Defaults to "check".',
+            nargs="?",
+        )
+        return parser  # gets stored as self.parser
 
     @cached_property
     def schema(self):
-        return json.load(
-            open("../schema/hardware-metadata.schema.json", 'r'))
+        return json.load(open("../schema/hardware-metadata.schema.json", "r"))
 
     def validate_file(self, file):
         print("Validating: " + file)
-        with open(file, 'r') as stream:
+        with open(file, "r") as stream:
             try:
-                validate(yaml.safe_load(stream), self.schema)
+                jsonschema.validate(yaml.safe_load(stream), self.schema)
             except yaml.YAMLError as exc:
                 print("Failed loading metadata yaml: " + file)
                 print(exc)
                 return False
-            except ValidationError as vexc:
+            except jsonschema.ValidationError as vexc:
                 print("Failed validation of: " + file)
                 print(vexc)
                 return False
         return True
 
     def do_run(self, args, unknown_args):
-        status = all([self.validate_file(f) for f in glob.glob(
-            "boards/**/*.zmk.yml", recursive=True)])
+        status = all(
+            [
+                self.validate_file(f)
+                for f in glob.glob("boards/**/*.zmk.yml", recursive=True)
+            ]
+        )
 
         sys.exit(0 if status else 1)

--- a/app/scripts/west_commands/test.py
+++ b/app/scripts/west_commands/test.py
@@ -1,35 +1,41 @@
 # Copyright (c) 2020 The ZMK Contributors
 # SPDX-License-Identifier: MIT
-'''Test runner for ZMK.'''
+"""Test runner for ZMK."""
 
 import os
 import subprocess
-from textwrap import dedent            # just for nicer code indentation
 
 from west.commands import WestCommand
-from west import log                   # use this for user output
+from west import log  # use this for user output
 
 
 class Test(WestCommand):
     def __init__(self):
         super().__init__(
-            'test',  # gets stored as self.name
-            'run ZMK testsuite',  # self.help
-            # self.description:
-            dedent('''Run the ZMK testsuite.'''))
+            name="test",
+            help="run ZMK testsuite",
+            description="Run the ZMK testsuite.",
+        )
 
     def do_add_parser(self, parser_adder):
-        parser = parser_adder.add_parser(self.name,
-                                         help=self.help,
-                                         description=self.description)
+        parser = parser_adder.add_parser(
+            self.name,
+            help=self.help,
+            description=self.description,
+        )
 
-        parser.add_argument('test_path', default="all",
-                            help='The path to the test. Defaults to "all".', nargs="?")
-        return parser           # gets stored as self.parser
+        parser.add_argument(
+            "test_path",
+            default="all",
+            help='The path to the test. Defaults to "all".',
+            nargs="?",
+        )
+        return parser
 
     def do_run(self, args, unknown_args):
         # the run-test script assumes the app directory is the current dir.
-        os.chdir(f'{self.topdir}/app')
+        os.chdir(f"{self.topdir}/app")
         completed_process = subprocess.run(
-            [f'{self.topdir}/app/run-test.sh', args.test_path])
+            [f"{self.topdir}/app/run-test.sh", args.test_path]
+        )
         exit(completed_process.returncode)


### PR DESCRIPTION
* Rewrote some python code to be more pythonic, and applied 'black' formatter
* Tests now output "FAILED" instead of "FAIL" and "PENDING" instead of "PEND" so it's easier to scan the output when the messages are not all 4 characters long
* Tests now output the results while they're running so screwups can be identified faster locally