### PR TITLE
fix(keymaps): add row-offset property to matrix-transform

### DIFF
--- a/app/dts/bindings/zmk,matrix-transform.yaml
+++ b/app/dts/bindings/zmk,matrix-transform.yaml
@@ -13,6 +13,9 @@ properties:
   col-offset:
     type: int
     default: 0
+  row-offset:
+    type: int
+    default: 0
   map:
     type: array
     required: true


### PR DESCRIPTION
Closes #721.
Adds `row-offset` property to `matrix-transform`.

First fixed in #735 by @devriesp, but the PR went stale and is not atomic, so submitting a separate fix just for #721.
