### PR TITLE
fix(shields): Don't enable SSD1306 automatically.

### DIFF
--- a/app/boards/shields/murphpad/Kconfig.defconfig
+++ b/app/boards/shields/murphpad/Kconfig.defconfig
@@ -6,8 +6,6 @@ if SHIELD_MURPHPAD
 config ZMK_KEYBOARD_NAME
 	default "MurphPad"
 
-endif
-
 if ZMK_DISPLAY
 
 config I2C
@@ -43,3 +41,5 @@ choice LVGL_COLOR_DEPTH
 endchoice
 
 endif # LVGL
+
+endif


### PR DESCRIPTION
* Fix Murphpad conditional to ensure SSD1306 driver isn't
  enabled whenever `ZMK_DISPLAY` is enabled.

@Nicell Heads up, this was a bug with a couple shields that I *fixed* a while ago, but may be sneaking into shield PRs that were from a while ago. This causes issues for anyone using ZMK_DISPLAY with other drivers like Zaphod or Corne-ish Zen, because it enables the SSD1306 driver which then fails to build.