### PR TITLE
Add Osprette to build targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           - microdox_left
           - microdox_right
           - nibble
+          - osprette
           - qaz
           - quefrency_left
           - quefrency_right


### PR DESCRIPTION
Osprette is in master but does not build with the rest of the boards when the build workflow is invoked