### PR TITLE
fix(setup): Use right flags for curl when wget doesn't exist.

### DIFF
--- a/docs/src/templates/setup.sh.mustache
+++ b/docs/src/templates/setup.sh.mustache
@@ -54,7 +54,7 @@ if [[ $curl_exists == "true" && $wget_exists == "true" ]]; then
         download_command="curl -fsOL "
     fi
 elif [[ $curl_exists == "true" ]]; then
-    download_command="curl -O "
+    download_command="curl -fsOL "
 elif [[ $wget_exists == "true" ]]; then
     download_command="wget "
 else


### PR DESCRIPTION
Looks like the flags for `curl` download were modified in #975 but not for the special case where `curl` exists but `wget` doesn't. From my testing using the modified flags prevents error messages from being written to the target file and makes it properly return a non-zero exit code.

I also checked that #1055 only happens with `curl -O` and not `wget` or `Invoke-RestMethod`, so this PR is supposed to fix #1055.