### PR TITLE
Bump init delay to 50ms for nico-nano

### DIFF
--- a/app/boards/arm/nice_nano/nice_nano_v2.dts
+++ b/app/boards/arm/nice_nano/nice_nano_v2.dts
@@ -12,7 +12,7 @@
 		compatible = "zmk,ext-power-generic";
 		label = "EXT_POWER";
 		control-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-		init-delay-ms = <10>;
+		init-delay-ms = <50>;
 	};
 
 	vbatt {


### PR DESCRIPTION
Bump init delay to 50ms for nico-nano to prevent issues with OLED not being found. i.e.:

```
[00:00:00.303,375] <err> zmk: Failed to find display device
```