### PR TITLE
Fix ext-power in Mikoto board definition

### DIFF
--- a/app/boards/arm/mikoto/mikoto_520.dts
+++ b/app/boards/arm/mikoto/mikoto_520.dts
@@ -29,7 +29,8 @@
 	ext-power {
 		compatible = "zmk,ext-power-generic";
 		label = "EXT_POWER";
-		control-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		control-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		init-delay-ms = <50>;
 	};
 
 	vbatt {


### PR DESCRIPTION
Fix the devicetree for the mikoto board definition. If my understanding of `GPIO_ACTIVE_HIGH` is correct (ie. it follows the name), then to enable external power, the pin should be driven high. This follows the schematic here:

<img width="349" alt="image" src="https://user-images.githubusercontent.com/500236/149012935-84cec0ad-d38a-4b71-873d-1dbe9bf6bebf.png">

The current active-low definition was probably an oversight from the initial commit. Anyway, I also added the `init-delay-ms` line from #1082, since whatever applies to the n!n probably applies here as well.

Disclaimer: I don't use zmk, and I don't have any spare boards to test with right now. However, this *is* my board, so I feel a little responsibility to fix it.