### PR TITLE
Check if any device is busy before sleep

### DIFF
--- a/app/src/power.c
+++ b/app/src/power.c
@@ -24,7 +24,7 @@ bool is_usb_power_present() {
 }
 
 struct pm_state_info pm_policy_next_state(int32_t ticks) {
-    if (zmk_activity_get_state() == ZMK_ACTIVITY_SLEEP && !is_usb_power_present()) {
+    if (zmk_activity_get_state() == ZMK_ACTIVITY_SLEEP && !is_usb_power_present() && !device_any_busy_check()) {
         return (struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0};
     }
 


### PR DESCRIPTION
I implemented a new shield and kscan driver for the HHKB Pro 2 keyboard. The keyboard
uses capacitive sensing; it cannot be wake up by interrupts and must do active scans.
I'm using the ZMK activity tracking to adjust scan frequency but I can't allow the board going into
sleep because the  nRF52 board I'm using cannot wake up itself.

Some devices might be in the middle of something that can't be
interrupted. Device drivers can communicate with the power management
module with the device busy API but the pm module also needs to
check the busy flags.

I think this additional checking will allow other boards to utilize the device power management
API better.

Reference: https://docs.zephyrproject.org/latest/doxygen/html/group__subsys__pm__device.html#gabfaec92a92766154b8b9ac9dd29f2c1e