### PR TITLE
fix(display): Initialize display on queue as well.

### DIFF
--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -11,6 +11,10 @@ menuconfig ZMK_DISPLAY
 
 if ZMK_DISPLAY
 
+config ZMK_DISPLAY_BLANK_ON_IDLE
+    bool "Blank display on idle"
+    default y
+
 choice LVGL_TXT_ENC
     default LVGL_TXT_ENC_UTF8
 

--- a/app/src/display/main.c
+++ b/app/src/display/main.c
@@ -111,8 +111,6 @@ void initialize_display(struct k_work *work) {
 K_WORK_DEFINE(init_work, initialize_display);
 
 int zmk_display_init() {
-    LOG_DBG("");
-
 #if IS_ENABLED(CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED)
     k_work_queue_start(&display_work_q, display_work_stack_area,
                        K_THREAD_STACK_SIZEOF(display_work_stack_area),
@@ -125,6 +123,7 @@ int zmk_display_init() {
     return 0;
 }
 
+#if IS_ENABLED(CONFIG_ZMK_DISPLAY_BLANK_ON_IDLE)
 int display_event_handler(const zmk_event_t *eh) {
     struct zmk_activity_state_changed *ev = as_zmk_activity_state_changed(eh);
     if (ev == NULL) {
@@ -148,3 +147,5 @@ int display_event_handler(const zmk_event_t *eh) {
 
 ZMK_LISTENER(display, display_event_handler);
 ZMK_SUBSCRIPTION(display, zmk_activity_state_changed);
+
+#endif /* IS_ENABLED(CONFIG_ZMK_DISPLAY_BLANK_ON_IDLE) */


### PR DESCRIPTION
A hopeful fix for slow initialization of devices with displays with slow response times, by moving the init to the display queue, which may be a secondary display queue, to free up system queue for handling inputs right away.