### PR TITLE
feat(boards): Add 1up sweet 16 macropad

### DIFF
--- a/app/boards/shields/sweet16/Kconfig.defconfig
+++ b/app/boards/shields/sweet16/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_SWEET16
+
+config ZMK_KEYBOARD_NAME
+    default "Sweet 16"
+
+endif

--- a/app/boards/shields/sweet16/Kconfig.shield
+++ b/app/boards/shields/sweet16/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_SWEET16
+    def_bool $(shields_list_contains,sweet16)

--- a/app/boards/shields/sweet16/boards/nice_nano_2.overlay
+++ b/app/boards/shields/sweet16/boards/nice_nano_2.overlay
@@ -1,0 +1,28 @@
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <45>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <12>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/sweet16/sweet16.conf
+++ b/app/boards/shields/sweet16/sweet16.conf
@@ -1,0 +1,3 @@
+# Uncomment the following lines to enable RGB underglow
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/sweet16/sweet16.keymap
+++ b/app/boards/shields/sweet16/sweet16.keymap
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/rgb.h>
+
+/ {
+        keymap {
+                compatible = "zmk,keymap";
+
+                default_layer {
+// --------------------------
+// | 7 |  8  |  9  | * |
+// | 4 |  5  |  6  | / |
+// | 1 |  2  |  3  | - |
+// | 0 | ENT | LWR | = |
+                        bindings = <
+   &kp N7 &kp N8    &kp N9 &kp ASTERISK
+   &kp N4 &kp N5    &kp N6 &kp SLASH
+   &kp N1 &kp N2    &kp N3 &kp MINUS
+   &kp N0 &kp ENTER &mo 1  &kp EQUAL
+                        >;
+                };
+
+                lower_layer {
+// ------------------------
+// | BT1 | BT2 | BT3 | BT4 |
+// |     |     |     |     |
+// |     |     |     |     |
+// |     |     |     |BTCLR|
+                        bindings = <
+   &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3
+   &none        &none        &none        &none 
+   &none        &none        &none        &none 
+   &none        &none        &trans       &bt BT_CLR 
+                        >;
+                };
+        };
+};

--- a/app/boards/shields/sweet16/sweet16.overlay
+++ b/app/boards/shields/sweet16/sweet16.overlay
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+    };
+
+    kscan0: kscan_0 {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "col2row";
+
+        col-gpios
+            = <&pro_micro 2 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 3 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 4 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 5 GPIO_ACTIVE_HIGH>
+            ;
+
+        row-gpios
+            = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+    };
+};

--- a/app/boards/shields/sweet16/sweet16.zmk.yml
+++ b/app/boards/shields/sweet16/sweet16.zmk.yml
@@ -1,0 +1,9 @@
+file_format: "1"
+id: sweet16
+name: Sweet 16
+type: shield
+url: https://1upkeyboards.com/shop/keyboard-kits/macro-pads/sweet16-macro-pad-white/
+requires: [pro_micro]
+features:
+  - keys
+  - underglow


### PR DESCRIPTION
Adding 1up sweet 16. Still needs to be tested on real hardware.
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [ ] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
