### PR TITLE
Adding Kitsune Keyboards - Shapeshifter4060 board

### DIFF
--- a/app/boards/shields/osprette/osprette.overlay
+++ b/app/boards/shields/osprette/osprette.overlay
@@ -30,23 +30,23 @@ RC(0,0) RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) 
         diode-direction = "row2col";
 
         col-gpios
-            = <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            = <&pro_micro 14 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 15 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 18 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 19 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 20 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 3  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 4  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 5  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 6  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 7  GPIO_ACTIVE_HIGH>
             ;
 
         row-gpios
-            = <&pro_micro 16 GPIO_ACTIVE_HIGH>
-            , <&pro_micro 10 GPIO_ACTIVE_HIGH>
-            , <&pro_micro 8 GPIO_ACTIVE_HIGH>
-            , <&pro_micro 9 GPIO_ACTIVE_HIGH>
+            = <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 8  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 9  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };
 };

--- a/app/boards/shields/osprette/osprette.overlay
+++ b/app/boards/shields/osprette/osprette.overlay
@@ -30,23 +30,23 @@ RC(0,0) RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) 
         diode-direction = "row2col";
 
         col-gpios
-            = <&pro_micro 14 GPIO_ACTIVE_HIGH>
-            , <&pro_micro 15 GPIO_ACTIVE_HIGH>
-            , <&pro_micro 18 GPIO_ACTIVE_HIGH>
-            , <&pro_micro 19 GPIO_ACTIVE_HIGH>
-            , <&pro_micro 20 GPIO_ACTIVE_HIGH>
-            , <&pro_micro 3  GPIO_ACTIVE_HIGH>
-            , <&pro_micro 4  GPIO_ACTIVE_HIGH>
-            , <&pro_micro 5  GPIO_ACTIVE_HIGH>
-            , <&pro_micro 6  GPIO_ACTIVE_HIGH>
-            , <&pro_micro 7  GPIO_ACTIVE_HIGH>
+            = <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
 
         row-gpios
-            = <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 8  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&pro_micro 9  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            = <&pro_micro 16 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 10 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 8 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 9 GPIO_ACTIVE_HIGH>
             ;
     };
 };

--- a/app/boards/shields/shapeshifter4060/Kconfig.defconfig
+++ b/app/boards/shields/shapeshifter4060/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_SHAPESHIFTER4060
+
+config ZMK_KEYBOARD_NAME
+    default "Shapeshifter4060"
+
+endif

--- a/app/boards/shields/shapeshifter4060/Kconfig.shield
+++ b/app/boards/shields/shapeshifter4060/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_SHAPESHIFTER4060
+    def_bool $(shields_list_contains,shapshifter4060)

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            // ----------------------------------------------------------------------------------------------------------
+            // |  ESC  |  1   |  2   |  3   |  4   |  5   |-------|-------|   6   |  7    |  8   |  9   |   0   | BSPC  |
+            // |  TAB  |  Q   |  W   |  E   |  R   |  T   |-------|-------|   Y   |  U    |  I   |  O   |   P   |  \    |
+            // | SHIFT |  A   |  S   |  D   |  F   |  G   |-------|-------|   H   |  J    |  K   |  L   |   ;   |  '    |
+            // | CTRL  |  Z   |  X   |  C   |  V   |  B   |-------|-------|   N   |  M    |  ,   |  .   |   /   | ENTER |
+            // |-------|ADJUST| LCTL | LALT | LGUI | LOWR | SPACE | SPACE |  RAIS | LARW | DARW | UARW  | RARW  |-------|
+
+
+            bindings = <
+                &kp ESC    &kp N1 &kp N2    &kp N3   &kp N4   &kp N5                    &kp N6 &kp N7   &kp N8    &kp N9  &kp N0    &kp BSPC
+                &kp TAB    &kp Q  &kp W     &kp E    &kp R    &kp T                     &kp Y  &kp U    &kp I     &kp O   &kp P     &kp BSLH
+                &kp LSHFT  &kp A  &kp S     &kp D    &kp F    &kp G                     &kp H  &kp J    &kp K     &kp L   &kp SEMI  &kp SQT
+                &kp LCTRL  &kp Z  &kp X     &kp C    &kp V    &kp B                     &kp N  &kp M    &kp COMMA &kp DOT &kp FSLH  &kp RET
+                           &mo 3  &kp LCTRL &kp LALT &kp LGUI &mo 1 &kp SPACE &kp SPACE &mo 2  &kp LEFT &kp DOWN  &kp UP  &kp RIGHT 
+            >;
+        };
+
+        lower {
+            // ----------------------------------------------------------------------------------------------------------
+            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|   F7  |  F8   |  F9  | F10  |  F11  |  F12  |
+            // |   ~   |  !   |  @   |  #   |  $   |  %   |-------|-------|   ^   |   &   |  *   |  (   |   )   |  DEL  |
+            // |       |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|   F6  |   _   |  +   |  {   |   }   |   |   |
+            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|   F12 | LS(#) |LS(|) |      |       |       |
+            // |-------|      |      |      |      |      |       |       |       | NEXT  | Vol- | Vol+ | PLAY  |-------|
+            bindings = <
+                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                  &kp F7    &kp F8              &kp F9              &kp F10      &kp F11          &kp F12
+                &kp TILDE &kp EXCL &kp AT   &kp HASH &kp DLLR  &kp PRCNT               &kp CARET &kp AMPS            &kp ASTRK           &kp LPAR     &kp RPAR         &kp DEL
+                &trans    &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                  &kp F6    &kp UNDER           &kp PLUS            &kp LBRC     &kp RBRC         &kp PIPE
+                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11                 &kp F12   &kp LS(NON_US_HASH) &kp LS(NON_US_BSLH) &trans    &trans        &trans
+                          &trans   &trans   &trans   &trans    &trans    &trans &trans &mo 3     &kp C_NEXT          &kp C_VOL_DN        &kp C_VOL_UP &kp C_PLAY_PAUSE 
+            >;
+        };
+
+        raise {
+            // ----------------------------------------------------------------------------------------------------------
+            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|  F7   |  F8   |  F9  | F10  |  F11  |  F12  |
+            // |   ~   |  1   |  2   |  3   |  4   |  5   |-------|-------|  6    |   7   |  8   |  9   |   0   |  DEL  |
+            // |  DEL  |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|  F6   |   -   |  =   |  [   |   ]   |   \   |
+            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |
+            // |-------|      |      |      |      |      |       |       |       |       |      |      |       |-------|
+            bindings = <
+                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                &kp F7    &kp F8          &kp F9          &kp F10      &kp F11          &kp F12
+                &kp TILDE &kp N1   &kp N2   &kp N3   &kp N4    &kp N5                &kp N6    &kp N7          &kp N8          &kp N9       &kp N0           &kp DEL
+                &kp DEL   &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                &kp F6    &kp MINUS       &kp EQUAL       &kp LBKT     &kp RBKT         &kp BSLH
+                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11               &kp F12   &kp NON_US_HASH &kp NON_US_BSLH &trans       &trans           &trans
+                          &trans   &trans   &trans   &trans    &mo 3   &trans &trans &trans    &trans          &trans          &trans       &trans
+            >;
+        };
+
+        adjust {
+            // ----------------------------------------------------------------------------------------------------------
+            // |tog(4)|  F2  |  F3  |  F4  |  F5  |  F6  |------|------|  F7  |  F8  |  F9  |  F10 |  F11 |    F12    |
+            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LALT(PRTSN)|
+            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |   PRTSN   |
+            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LCTRL(DEL) |
+            // |------|      |      |      |      |      |BOOTLD|BOOTLD|      |      |      |      |      |-----------|
+            bindings = <
+                &tog 4 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6                         &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12
+                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp LA(PSCRN)
+                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp PSCRN
+                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp LC(DEL)
+                       &trans &trans &trans &trans &trans &bootloader &bootloader &trans &trans &trans &trans  &trans
+            >;
+        };
+
+        flock {
+            // ----------------------------------------------------------------------------------------------------------
+            // |tog(4) |  F2    |   F3   |   F4   |   F5   |   F6   |-------|-------|  F7  |  F8  |  F9  | F10 | F11 |      |
+            // |out tog|BT_SEL 0|BT_SEL 1|BT_SEL 2|BT_SEL 3|BT_SEL 4|-------|-------|BT_PRV|BT_NXT|BT_CLR|     |     |      |
+            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
+            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
+            // |-------|        |        |        |        |        |       |       |      |      |      |     |     |------|
+            bindings = <
+                &tog 4       &kp F2       &kp F3       &kp F4       &kp F5       &kp F6                     &kp F7     &kp F8     &kp F9     &kp F10 &kp F11 &trans
+                &out OUT_TOG &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4               &bt BT_PRV &bt BT_NXT &bt BT_CLR &trans  &trans  &trans
+                &trans       &trans       &trans       &trans       &trans       &trans                     &trans     &trans     &trans     &trans  &trans  &trans
+                &trans       &trans       &trans       &trans       &trans       &trans                     &trans     &trans     &trans     &trans  &trans  &trans
+                             &trans       &trans       &trans       &trans       &trans       &trans &trans &trans     &trans     &trans     &trans  &trans
+            >;
+        };
+    };
+};

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
@@ -23,10 +23,10 @@
 
 
 			bindings = <
-            &kp TAB   &kp Q    &kp W    &kp E     &kp R  &kp T                  &kp Y     &kp U  &kp I     &kp O    &kp P    &kp DEL
-            &kp ESC   &kp A    &kp S    &kp D     &kp F  &kp G                  &kp H     &kp J  &kp K     &kp L    &kp SEMI &kp SQT
+            &kp ESC   &kp Q    &kp W    &kp E     &kp R  &kp T                  &kp Y     &kp U  &kp I     &kp O    &kp P    &kp DEL
+            &kp TAB   &kp A    &kp S    &kp D     &kp F  &kp G                  &kp H     &kp J  &kp K     &kp L    &kp SEMI &kp SQT
             &kp LSHFT &kp Z    &kp X    &kp C     &kp V  &kp B                  &kp N     &kp M  &kp COMMA &kp DOT  &kp BSLH &kp RET
-                &trans    &kp LGUI &kp LALT &kp LCTRL &trans &trans     &kp SPACE &trans &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
+            &kp &LCTRL   &kp LGUI &kp LALT &kp LCTRL &kp BSCP  &kp DEL     &kp SPACE &kp RET &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
 			>;
         };
 

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
@@ -26,7 +26,7 @@
             &kp ESC   &kp Q    &kp W    &kp E     &kp R  &kp T                  &kp Y     &kp U  &kp I     &kp O    &kp P    &kp DEL
             &kp TAB   &kp A    &kp S    &kp D     &kp F  &kp G                  &kp H     &kp J  &kp K     &kp L    &kp SEMI &kp SQT
             &kp LSHFT &kp Z    &kp X    &kp C     &kp V  &kp B                  &kp N     &kp M  &kp COMMA &kp DOT  &kp BSLH &kp RET
-            &kp &LCTRL   &kp LGUI &kp LALT &kp LCTRL &kp BSCP  &kp DEL     &kp SPACE &kp RET &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
+            &kp LCTRL   &kp LGUI &kp LALT &kp LCTRL &kp BSCP  &kp DEL     &kp SPACE &kp RET &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
 			>;
         };
 

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
@@ -22,12 +22,12 @@
             // |-------|ADJUST| LCTL | LALT | LGUI | LOWR | SPACE | SPACE |  RAIS | LARW | DARW | UARW  | RARW  |-------|
 
 
-            bindings = <
-                &kp A &kp N1 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp M
-                &kp A &kp N2 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &out OUT_USB
-                &kp A &kp N3 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &out OUT_BLE
-                &kp A &kp N4 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &bt BT_CLR &out OUT_TOG
-            >;
+			bindings = <
+            &kp TAB   &kp Q    &kp W    &kp E     &kp R  &kp T                  &kp Y     &kp U  &kp I     &kp O    &kp P    &kp DEL
+            &kp ESC   &kp A    &kp S    &kp D     &kp F  &kp G                  &kp H     &kp J  &kp K     &kp L    &kp SEMI &kp SQT
+            &kp LSHFT &kp Z    &kp X    &kp C     &kp V  &kp B                  &kp N     &kp M  &kp COMMA &kp DOT  &kp BSLH &kp RET
+                &trans    &kp LGUI &kp LALT &kp LCTRL &trans &trans     &kp SPACE &trans &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
+			>;
         };
 
 //        lower {

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
@@ -9,7 +9,6 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
 
-
 / {
     keymap {
         compatible = "zmk,keymap";
@@ -24,10 +23,10 @@
 
 
             bindings = <
-                &kp A &kp 1 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp L
-                &kp A &kp 2 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp L
-                &kp A &kp 3 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp L
-                &kp A &kp 4 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp L
+                &kp A &kp 1 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp M
+                &kp A &kp 2 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &out OUT_USB
+                &kp A &kp 3 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &out OUT_BLE
+                &kp A &kp 4 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &bt BT_CLR &out OUT_TOG
             >;
         };
 

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
@@ -24,76 +24,75 @@
 
 
             bindings = <
-                &kp ESC    &kp N1 &kp N2    &kp N3   &kp N4   &kp N5                    &kp N6 &kp N7   &kp N8    &kp N9  &kp N0    &kp BSPC
-                &kp TAB    &kp Q  &kp W     &kp E    &kp R    &kp T                     &kp Y  &kp U    &kp I     &kp O   &kp P     &kp BSLH
-                &kp LSHFT  &kp A  &kp S     &kp D    &kp F    &kp G                     &kp H  &kp J    &kp K     &kp L   &kp SEMI  &kp SQT
-                &kp LCTRL  &kp Z  &kp X     &kp C    &kp V    &kp B                     &kp N  &kp M    &kp COMMA &kp DOT &kp FSLH  &kp RET
-                           &mo 3  &kp LCTRL &kp LALT &kp LGUI &mo 1 &kp SPACE &kp SPACE &mo 2  &kp LEFT &kp DOWN  &kp UP  &kp RIGHT 
+                &kp A &kp 1 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp L
+                &kp A &kp 2 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp L
+                &kp A &kp 3 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp L
+                &kp A &kp 4 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp L
             >;
         };
 
-        lower {
-            // ----------------------------------------------------------------------------------------------------------
-            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|   F7  |  F8   |  F9  | F10  |  F11  |  F12  |
-            // |   ~   |  !   |  @   |  #   |  $   |  %   |-------|-------|   ^   |   &   |  *   |  (   |   )   |  DEL  |
-            // |       |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|   F6  |   _   |  +   |  {   |   }   |   |   |
-            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|   F12 | LS(#) |LS(|) |      |       |       |
-            // |-------|      |      |      |      |      |       |       |       | NEXT  | Vol- | Vol+ | PLAY  |-------|
-            bindings = <
-                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                  &kp F7    &kp F8              &kp F9              &kp F10      &kp F11          &kp F12
-                &kp TILDE &kp EXCL &kp AT   &kp HASH &kp DLLR  &kp PRCNT               &kp CARET &kp AMPS            &kp ASTRK           &kp LPAR     &kp RPAR         &kp DEL
-                &trans    &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                  &kp F6    &kp UNDER           &kp PLUS            &kp LBRC     &kp RBRC         &kp PIPE
-                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11                 &kp F12   &kp LS(NON_US_HASH) &kp LS(NON_US_BSLH) &trans    &trans        &trans
-                          &trans   &trans   &trans   &trans    &trans    &trans &trans &mo 3     &kp C_NEXT          &kp C_VOL_DN        &kp C_VOL_UP &kp C_PLAY_PAUSE 
-            >;
-        };
-
-        raise {
-            // ----------------------------------------------------------------------------------------------------------
-            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|  F7   |  F8   |  F9  | F10  |  F11  |  F12  |
-            // |   ~   |  1   |  2   |  3   |  4   |  5   |-------|-------|  6    |   7   |  8   |  9   |   0   |  DEL  |
-            // |  DEL  |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|  F6   |   -   |  =   |  [   |   ]   |   \   |
-            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |
-            // |-------|      |      |      |      |      |       |       |       |       |      |      |       |-------|
-            bindings = <
-                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                &kp F7    &kp F8          &kp F9          &kp F10      &kp F11          &kp F12
-                &kp TILDE &kp N1   &kp N2   &kp N3   &kp N4    &kp N5                &kp N6    &kp N7          &kp N8          &kp N9       &kp N0           &kp DEL
-                &kp DEL   &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                &kp F6    &kp MINUS       &kp EQUAL       &kp LBKT     &kp RBKT         &kp BSLH
-                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11               &kp F12   &kp NON_US_HASH &kp NON_US_BSLH &trans       &trans           &trans
-                          &trans   &trans   &trans   &trans    &mo 3   &trans &trans &trans    &trans          &trans          &trans       &trans
-            >;
-        };
-
-        adjust {
-            // ----------------------------------------------------------------------------------------------------------
-            // |tog(4)|  F2  |  F3  |  F4  |  F5  |  F6  |------|------|  F7  |  F8  |  F9  |  F10 |  F11 |    F12    |
-            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LALT(PRTSN)|
-            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |   PRTSN   |
-            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LCTRL(DEL) |
-            // |------|      |      |      |      |      |BOOTLD|BOOTLD|      |      |      |      |      |-----------|
-            bindings = <
-                &tog 4 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6                         &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12
-                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp LA(PSCRN)
-                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp PSCRN
-                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp LC(DEL)
-                       &trans &trans &trans &trans &trans &bootloader &bootloader &trans &trans &trans &trans  &trans
-            >;
-        };
-
-        flock {
-            // ----------------------------------------------------------------------------------------------------------
-            // |tog(4) |  F2    |   F3   |   F4   |   F5   |   F6   |-------|-------|  F7  |  F8  |  F9  | F10 | F11 |      |
-            // |out tog|BT_SEL 0|BT_SEL 1|BT_SEL 2|BT_SEL 3|BT_SEL 4|-------|-------|BT_PRV|BT_NXT|BT_CLR|     |     |      |
-            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
-            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
-            // |-------|        |        |        |        |        |       |       |      |      |      |     |     |------|
-            bindings = <
-                &tog 4       &kp F2       &kp F3       &kp F4       &kp F5       &kp F6                     &kp F7     &kp F8     &kp F9     &kp F10 &kp F11 &trans
-                &out OUT_TOG &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4               &bt BT_PRV &bt BT_NXT &bt BT_CLR &trans  &trans  &trans
-                &trans       &trans       &trans       &trans       &trans       &trans                     &trans     &trans     &trans     &trans  &trans  &trans
-                &trans       &trans       &trans       &trans       &trans       &trans                     &trans     &trans     &trans     &trans  &trans  &trans
-                             &trans       &trans       &trans       &trans       &trans       &trans &trans &trans     &trans     &trans     &trans  &trans
-            >;
-        };
+//        lower {
+//            // ----------------------------------------------------------------------------------------------------------
+//            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|   F7  |  F8   |  F9  | F10  |  F11  |  F12  |
+//            // |   ~   |  !   |  @   |  #   |  $   |  %   |-------|-------|   ^   |   &   |  *   |  (   |   )   |  DEL  |
+//            // |       |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|   F6  |   _   |  +   |  {   |   }   |   |   |
+//            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|   F12 | LS(#) |LS(|) |      |       |       |
+//            // |-------|      |      |      |      |      |       |       |       | NEXT  | Vol- | Vol+ | PLAY  |-------|
+//            bindings = <
+//                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                  &kp F7    &kp F8              &kp F9              &kp F10      &kp F11          &kp F12
+//                &kp TILDE &kp EXCL &kp AT   &kp HASH &kp DLLR  &kp PRCNT               &kp CARET &kp AMPS            &kp ASTRK           &kp LPAR     &kp RPAR         &kp DEL
+//                &trans    &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                  &kp F6    &kp UNDER           &kp PLUS            &kp LBRC     &kp RBRC         &kp PIPE
+//                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11                 &kp F12   &kp LS(NON_US_HASH) &kp LS(NON_US_BSLH) &trans    &trans        &trans
+//                          &trans   &trans   &trans   &trans    &trans    &trans &trans &mo 3     &kp C_NEXT          &kp C_VOL_DN        &kp C_VOL_UP &kp C_PLAY_PAUSE
+//            >;
+//        };
+//
+//        raise {
+//            // ----------------------------------------------------------------------------------------------------------
+//            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|  F7   |  F8   |  F9  | F10  |  F11  |  F12  |
+//            // |   ~   |  1   |  2   |  3   |  4   |  5   |-------|-------|  6    |   7   |  8   |  9   |   0   |  DEL  |
+//            // |  DEL  |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|  F6   |   -   |  =   |  [   |   ]   |   \   |
+//            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |
+//            // |-------|      |      |      |      |      |       |       |       |       |      |      |       |-------|
+//            bindings = <
+//                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                &kp F7    &kp F8          &kp F9          &kp F10      &kp F11          &kp F12
+//                &kp TILDE &kp N1   &kp N2   &kp N3   &kp N4    &kp N5                &kp N6    &kp N7          &kp N8          &kp N9       &kp N0           &kp DEL
+//                &kp DEL   &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                &kp F6    &kp MINUS       &kp EQUAL       &kp LBKT     &kp RBKT         &kp BSLH
+//                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11               &kp F12   &kp NON_US_HASH &kp NON_US_BSLH &trans       &trans           &trans
+//                          &trans   &trans   &trans   &trans    &mo 3   &trans &trans &trans    &trans          &trans          &trans       &trans
+//            >;
+//        };
+//
+//        adjust {
+//            // ----------------------------------------------------------------------------------------------------------
+//            // |tog(4)|  F2  |  F3  |  F4  |  F5  |  F6  |------|------|  F7  |  F8  |  F9  |  F10 |  F11 |    F12    |
+//            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LALT(PRTSN)|
+//            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |   PRTSN   |
+//            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LCTRL(DEL) |
+//            // |------|      |      |      |      |      |BOOTLD|BOOTLD|      |      |      |      |      |-----------|
+//            bindings = <
+//                &tog 4 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6                         &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12
+//                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp LA(PSCRN)
+//                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp PSCRN
+//                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp LC(DEL)
+//                       &trans &trans &trans &trans &trans &bootloader &bootloader &trans &trans &trans &trans  &trans
+//            >;
+//        };
+//
+//        flock {
+//            // ----------------------------------------------------------------------------------------------------------
+//            // |tog(4) |  F2    |   F3   |   F4   |   F5   |   F6   |-------|-------|  F7  |  F8  |  F9  | F10 | F11 |      |
+//            // |out tog|BT_SEL 0|BT_SEL 1|BT_SEL 2|BT_SEL 3|BT_SEL 4|-------|-------|BT_PRV|BT_NXT|BT_CLR|     |     |      |
+//            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
+//            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
+//            // |-------|        |        |        |        |        |       |       |      |      |      |     |     |------|
+//            bindings = <
+//                &tog 4       &kp F2       &kp F3       &kp F4       &kp F5       &kp F6                     &kp F7     &kp F8     &kp F9     &kp F10 &kp F11 &trans
+//                &out OUT_TOG &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4               &bt BT_PRV &bt BT_NXT &bt BT_CLR &trans  &trans  &trans
+//                &trans       &trans       &trans       &trans       &trans       &trans                     &trans     &trans     &trans     &trans  &trans  &trans
+//                &trans       &trans       &trans       &trans       &trans       &trans                     &trans     &trans     &trans     &trans  &trans  &trans
+//                             &trans       &trans       &trans       &trans       &trans       &trans &trans &trans     &trans     &trans     &trans  &trans
+//            >;
+//        };
     };
 };

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
@@ -24,7 +24,7 @@
             &kp ESC   &kp Q    &kp W    &kp E     &kp R     &kp T               &kp Y     &kp U   &kp I     &kp O    &kp P    &kp DEL
             &kp TAB   &kp A    &kp S    &kp D     &kp F     &kp G               &kp H     &kp J   &kp K     &kp L    &kp SEMI &kp SQT
             &kp LSHFT &kp Z    &kp X    &kp C     &kp V     &kp B               &kp N     &kp M   &kp COMMA &kp DOT  &kp BSLH &kp RET
-            &kp LCTRL &kp LGUI &kp LALT &kp LCTRL &kp BSCP  &kp DEL             &kp SPACE &kp RET &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
+            &kp LCTRL &kp LGUI &kp LALT &kp LCTRL &kp BSPC  &kp DEL             &kp SPACE &kp RET &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
 			>;
         };
 

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
@@ -20,13 +20,11 @@
             // | SHIFT |  A   |  S   |  D   |  F   |  G   |-------|-------|   H   |  J    |  K   |  L   |   ;   |  '    |
             // | CTRL  |  Z   |  X   |  C   |  V   |  B   |-------|-------|   N   |  M    |  ,   |  .   |   /   | ENTER |
             // |-------|ADJUST| LCTL | LALT | LGUI | LOWR | SPACE | SPACE |  RAIS | LARW | DARW | UARW  | RARW  |-------|
-
-
 			bindings = <
-            &kp ESC   &kp Q    &kp W    &kp E     &kp R  &kp T                  &kp Y     &kp U  &kp I     &kp O    &kp P    &kp DEL
-            &kp TAB   &kp A    &kp S    &kp D     &kp F  &kp G                  &kp H     &kp J  &kp K     &kp L    &kp SEMI &kp SQT
-            &kp LSHFT &kp Z    &kp X    &kp C     &kp V  &kp B                  &kp N     &kp M  &kp COMMA &kp DOT  &kp BSLH &kp RET
-            &kp LCTRL   &kp LGUI &kp LALT &kp LCTRL &kp BSCP  &kp DEL     &kp SPACE &kp RET &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
+            &kp ESC   &kp Q    &kp W    &kp E     &kp R     &kp T               &kp Y     &kp U   &kp I     &kp O    &kp P    &kp DEL
+            &kp TAB   &kp A    &kp S    &kp D     &kp F     &kp G               &kp H     &kp J   &kp K     &kp L    &kp SEMI &kp SQT
+            &kp LSHFT &kp Z    &kp X    &kp C     &kp V     &kp B               &kp N     &kp M   &kp COMMA &kp DOT  &kp BSLH &kp RET
+            &kp LCTRL &kp LGUI &kp LALT &kp LCTRL &kp BSCP  &kp DEL             &kp SPACE &kp RET &kp LEFT  &kp DOWN &kp UP   &kp RIGHT
 			>;
         };
 

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.keymap
@@ -23,10 +23,10 @@
 
 
             bindings = <
-                &kp A &kp 1 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp M
-                &kp A &kp 2 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &out OUT_USB
-                &kp A &kp 3 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &out OUT_BLE
-                &kp A &kp 4 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &bt BT_CLR &out OUT_TOG
+                &kp A &kp N1 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &kp M
+                &kp A &kp N2 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &out OUT_USB
+                &kp A &kp N3 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &kp K &out OUT_BLE
+                &kp A &kp N4 &kp B &kp C &kp D &kp E &kp F &kp G &kp H &kp J &bt BT_CLR &out OUT_TOG
             >;
         };
 

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.overlay
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.overlay
@@ -14,6 +14,13 @@
         label = "KSCAN";
         diode-direction = "row2col";
 
+        row-gpios
+            = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 0
+            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 1
+            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 2
+            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 3
+            ;
+
         col-gpios
             = <&pro_micro 3 GPIO_ACTIVE_HIGH> // col 0
             , <&pro_micro 2 GPIO_ACTIVE_HIGH> // col 1
@@ -27,13 +34,6 @@
             , <&pro_micro 6 GPIO_ACTIVE_HIGH> // col 9
             , <&pro_micro 5 GPIO_ACTIVE_HIGH> // col 10
             , <&pro_micro 4 GPIO_ACTIVE_HIGH> // col 11
-            ;
-
-        row-gpios
-            = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 0
-            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 1
-            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 2
-            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 3
             ;
     };
 };

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.overlay
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.overlay
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+    };
+
+    kscan0: kscan_0 {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "row2col";
+
+        col-gpios
+            = <&pro_micro 3 GPIO_ACTIVE_HIGH> // col 0
+            , <&pro_micro 2 GPIO_ACTIVE_HIGH> // col 1
+            , <&pro_micro 15 GPIO_ACTIVE_HIGH> // col 2
+            , <&pro_micro 14 GPIO_ACTIVE_HIGH> // col 3
+            , <&pro_micro 16 GPIO_ACTIVE_HIGH> // col 4
+            , <&pro_micro 10 GPIO_ACTIVE_HIGH> // col 5
+            , <&pro_micro 9 GPIO_ACTIVE_HIGH> // col 6
+            , <&pro_micro 8 GPIO_ACTIVE_HIGH> // col 7
+            , <&pro_micro 7 GPIO_ACTIVE_HIGH> // col 8
+            , <&pro_micro 6 GPIO_ACTIVE_HIGH> // col 9
+            , <&pro_micro 5 GPIO_ACTIVE_HIGH> // col 10
+            , <&pro_micro 4 GPIO_ACTIVE_HIGH> // col 11
+            ;
+
+        row-gpios
+            = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 0
+            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 1
+            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 2
+            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 3
+            ;
+    };
+};

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.overlay
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.overlay
@@ -15,25 +15,25 @@
         diode-direction = "row2col";
 
         row-gpios
-            = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 0
-            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 1
-            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 2
-            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 3
+            = <&pro_micro 21 (GPIO_ACTIVE_HIGH)> // row 0
+            , <&pro_micro 20 (GPIO_ACTIVE_HIGH)> // row 1
+            , <&pro_micro 19 (GPIO_ACTIVE_HIGH)> // row 2
+            , <&pro_micro 18 (GPIO_ACTIVE_HIGH)> // row 3
             ;
 
         col-gpios
-            = <&pro_micro 3 GPIO_ACTIVE_HIGH> // col 0
-            , <&pro_micro 2 GPIO_ACTIVE_HIGH> // col 1
-            , <&pro_micro 15 GPIO_ACTIVE_HIGH> // col 2
-            , <&pro_micro 14 GPIO_ACTIVE_HIGH> // col 3
-            , <&pro_micro 16 GPIO_ACTIVE_HIGH> // col 4
-            , <&pro_micro 10 GPIO_ACTIVE_HIGH> // col 5
-            , <&pro_micro 9 GPIO_ACTIVE_HIGH> // col 6
-            , <&pro_micro 8 GPIO_ACTIVE_HIGH> // col 7
-            , <&pro_micro 7 GPIO_ACTIVE_HIGH> // col 8
-            , <&pro_micro 6 GPIO_ACTIVE_HIGH> // col 9
-            , <&pro_micro 5 GPIO_ACTIVE_HIGH> // col 10
-            , <&pro_micro 4 GPIO_ACTIVE_HIGH> // col 11
+            = <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 0
+            , <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 1
+            , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 2
+            , <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 3
+            , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 4
+            , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 5
+            , <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 6
+            , <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 7
+            , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 8
+            , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 9
+            , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 10
+            , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 11
             ;
     };
 };

--- a/app/boards/shields/shapeshifter4060/shapeshifter4060.zmk.yml
+++ b/app/boards/shields/shapeshifter4060/shapeshifter4060.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: shapeshifter4060
+name: Shapeshifter4060
+type: shield
+url: https://kitsunekeyboards.com/
+requires: [pro_micro]
+features:
+  - keys


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [ ] This board/shield is tested working on real hardware
 - [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [ ] `.zmk.yml` metadata file added
 - [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [ ] General consistent formatting of DeviceTree files
 - [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [ ] If split, no name added for the right/peripheral half
 - [ ] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [ ] `.conf` file has optional extra features commented out
 - [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
