### PR TITLE
feat(shields): Add Breeze

### DIFF
--- a/app/boards/shields/breeze/Kconfig.defconfig
+++ b/app/boards/shields/breeze/Kconfig.defconfig
@@ -1,0 +1,17 @@
+
+if SHIELD_BREEZE_LEFT
+
+config ZMK_KEYBOARD_NAME
+	default "Breeze"
+
+config ZMK_SPLIT_BLE_ROLE_CENTRAL
+	default y
+
+endif
+
+if SHIELD_BREEZE_LEFT || SHIELD_BREEZE_RIGHT
+
+config ZMK_SPLIT
+	default y
+ 
+endif

--- a/app/boards/shields/breeze/Kconfig.shield
+++ b/app/boards/shields/breeze/Kconfig.shield
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_BREEZE_LEFT
+    def_bool $(shields_list_contains,breeze_left)
+
+config SHIELD_BREEZE_RIGHT
+    def_bool $(shields_list_contains,breeze_right)

--- a/app/boards/shields/breeze/breeze.dtsi
+++ b/app/boards/shields/breeze/breeze.dtsi
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+	chosen {
+		zmk,kscan = &kscan0;
+		zmk,matrix_transform = &default_transform;
+	};
+
+	default_transform: keymap_transform_0 {
+		compatible = "zmk,matrix-transform";
+		columns = <9>;
+		rows = <10>;
+// | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |                 | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  | MC1  | MC2  | MC3  |
+// | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |                 | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 | MC4  | MC5  | MC6  |
+// | SW18 | SW17 | SW16 | SW15 | SW14 | SW13 |                 | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 |      |  ↑   |      |
+// | SW24 | SW23 | SW22 | SW21 | SW20 | SW19 |                 | SW19 | SW20 | SW21 | SW22 | SW23 | SW24 |  ←   |  ↓   |  →   |
+//                      | TC4  | TC3  | TC2  | TC1  |   | TC1  | TC2  | TC3  | TC4  |
+		map = <
+RC(0,5) RC(0,4) RC(0,3) RC(0,2) RC(0,1) RC(0,0)                 RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5) RC(5,6) RC(5,7) RC(5,8)
+RC(1,5) RC(1,4) RC(1,3) RC(1,2) RC(1,1) RC(1,0)                 RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5) RC(6,6) RC(6,7) RC(6,8)
+RC(2,5) RC(2,4) RC(2,3) RC(2,2) RC(2,1) RC(2,0)                 RC(7,0) RC(7,1) RC(7,2) RC(7,3) RC(7,4) RC(7,5)         RC(7,7)
+RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                 RC(8,0) RC(8,1) RC(8,2) RC(8,3) RC(8,4) RC(8,5) RC(8,6) RC(8,7) RC(8,8)
+                        RC(4,3) RC(4,2) RC(4,1) RC(4,0) RC(9,0) RC(9,1) RC(9,2) RC(9,3)
+		>;
+	};
+
+	kscan0: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+		label = "KSCAN";
+
+		diode-direction = "col2row";
+        col-gpios
+			= <&pro_micro 16 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 2  GPIO_ACTIVE_HIGH>
+			, <&pro_micro 3  GPIO_ACTIVE_HIGH>
+			, <&pro_micro 4  GPIO_ACTIVE_HIGH>
+			, <&pro_micro 5  GPIO_ACTIVE_HIGH>
+			, <&pro_micro 6  GPIO_ACTIVE_HIGH>
+			, <&pro_micro 7  GPIO_ACTIVE_HIGH>
+			, <&pro_micro 8  GPIO_ACTIVE_HIGH>
+			, <&pro_micro 9  GPIO_ACTIVE_HIGH>
+			;
+	};
+};

--- a/app/boards/shields/breeze/breeze.dtsi
+++ b/app/boards/shields/breeze/breeze.dtsi
@@ -32,7 +32,7 @@ RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                 RC(8,0) RC(8,1) 
 
 	five_column_transform: keymap_transform_1 {
 		compatible = "zmk,matrix-transform";
-		columns = <5>;
+		columns = <6>;
 		rows = <10>;
 // | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |                 | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  |
 // | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |                 | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 |

--- a/app/boards/shields/breeze/breeze.dtsi
+++ b/app/boards/shields/breeze/breeze.dtsi
@@ -35,7 +35,7 @@ RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                 RC(8,0) RC(8,1) 
 		label = "KSCAN";
 
 		diode-direction = "col2row";
-        col-gpios
+		col-gpios
 			= <&pro_micro 16 GPIO_ACTIVE_HIGH>
 			, <&pro_micro 2  GPIO_ACTIVE_HIGH>
 			, <&pro_micro 3  GPIO_ACTIVE_HIGH>

--- a/app/boards/shields/breeze/breeze.dtsi
+++ b/app/boards/shields/breeze/breeze.dtsi
@@ -30,6 +30,25 @@ RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                 RC(8,0) RC(8,1) 
 		>;
 	};
 
+	five_column_transform: keymap_transform_1 {
+		compatible = "zmk,matrix-transform";
+		columns = <5>;
+		rows = <10>;
+// | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |                 | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  |
+// | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |                 | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 |
+// | SW18 | SW17 | SW16 | SW15 | SW14 | SW13 |                 | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 |
+// | SW24 | SW23 | SW22 | SW21 | SW20 | SW19 |                 | SW19 | SW20 | SW21 | SW22 | SW23 | SW24 |
+//                      | TC4  | TC3  | TC2  | TC1  |   | TC1  | TC2  | TC3  | TC4  |
+		map = <
+RC(0,5) RC(0,4) RC(0,3) RC(0,2) RC(0,1) RC(0,0)                 RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5)
+RC(1,5) RC(1,4) RC(1,3) RC(1,2) RC(1,1) RC(1,0)                 RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5)
+RC(2,5) RC(2,4) RC(2,3) RC(2,2) RC(2,1) RC(2,0)                 RC(7,0) RC(7,1) RC(7,2) RC(7,3) RC(7,4) RC(7,5)
+RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                 RC(8,0) RC(8,1) RC(8,2) RC(8,3) RC(8,4) RC(8,5)
+                        RC(4,3) RC(4,2) RC(4,1) RC(4,0) RC(9,0) RC(9,1) RC(9,2) RC(9,3)
+		>;
+	};
+
+
 	kscan0: kscan {
 		compatible = "zmk,kscan-gpio-matrix";
 		label = "KSCAN";

--- a/app/boards/shields/breeze/breeze.keymap
+++ b/app/boards/shields/breeze/breeze.keymap
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/ext_power.h>
+
+/ {
+	keymap {
+		compatible = "zmk,keymap";
+
+		default_layer {
+
+// Ref: https://zmkfirmware.dev/docs/codes/
+
+// ----------------------------------------------------------------------------------------------------------------------------------
+// | ESC/~ |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   | BSPC  | |  =  | HOME | PGUP |
+// |  TAB  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   |  [    | |  ]  | END  | PGDN |
+// |  CTRL |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   | ENTER | |     |  UP  |      |
+// | SHIFT |  Z  |  X  |  C   |  V   |  B   |                   |  N   |  M    |  ,    |  .   |   /   |  '    | |  L  |  DN  |  R   |
+//                     | CTRL | GUI  | ALT  |  SPACE |  | ENTER | BSPC | mo(2) | mo(1) |
+			bindings = <
+&gresc    &kp N1 &kp N2 &kp N3    &kp N4   &kp N5                     &kp N6   &kp N7   &kp N8    &kp N9  &kp N0   &kp BSPC   &kp EQUAL &kp HOME  &kp PG_UP
+&kp TAB   &kp Q  &kp W  &kp E     &kp R    &kp T                      &kp Y    &kp U    &kp I     &kp O   &kp P    &kp LBKT   &kp RBKT  &kp END   &kp PG_DN
+&kp LCTRL &kp A  &kp S  &kp D     &kp F    &kp G                      &kp H    &kp J    &kp K     &kp L   &kp SEMI &kp RET              &kp UP 
+&kp LSHFT &kp Z  &kp X  &kp C     &kp V    &kp B                      &kp N    &kp M    &kp COMMA &kp DOT &kp FSLH &kp APOS   &kp LEFT  &kp DOWN  &kp RIGHT
+                        &kp LCTRL &kp LGUI &kp LALT &kp SPACE &kp RET &kp BSPC &mo 2    &mo 1
+			>;
+		};
+
+		layer1 {
+// ---------------------------------------------------------------------------------------------------------------------------------- 
+// | BTCLR | BT1 | BT2 |  BT3 |  BT4 |  BT5 |                   |      |       |       |      |       |       | |      |      |      | 
+// |  F1   |  F2 |  F3 |  F4  |  F5  |  F6  |                   |  F7  |  F8   |  F9   |  F10 |  F11  |  F12  | |      | Mute | Play | 
+// |   `   |  !  |  @  |  #   |  $   |  %   |                   |  ^   |  &    |  *    |  (   |   )   |   ~   | |      | Vol+ |      | 
+// |       |     |     |      |      |      |                   |      |  _    |  +    |  {   |   }   |  "|"  | | Prev | Vol- | Next | 
+//                     |      |      |      |        |  |       |      |       |       |
+			bindings = <
+&bt BT_CLR &bt BT_SEL 0     &bt BT_SEL 1      &bt BT_SEL 2      &bt BT_SEL 3 &bt BT_SEL 4                 &trans    &trans    &trans          &trans    &trans    &trans    &trans     &trans        &trans    
+&kp F1     &kp F2           &kp F3            &kp F4            &kp F5       &kp F6                       &kp F7    &kp F8    &kp F9          &kp F10   &kp F11   &kp F12   &trans     &kp C_MUTE    &kp C_PLAY_PAUSE 
+&kp GRAVE  &kp EXCL         &kp AT            &kp HASH          &kp DOLLAR   &kp PRCNT                    &kp CARET &kp AMPS  &kp KP_MULTIPLY &kp LPAR  &kp RPAR  &kp TILDE            &kp C_VOL_UP 
+&trans     &ext_power EP_ON &ext_power EP_OFF &ext_power EP_TOG &trans       &trans                       &trans    &kp MINUS &kp KP_PLUS     &kp LBRC  &kp RBRC  &kp PIPE  &kp C_PREV &kp C_VOL_DN  &kp C_NEXT
+                                              &trans            &trans       &trans    &trans   &trans    &trans    &trans    &trans
+			>;
+		};
+
+		layer2 {
+// ---------------------------------------------------------------------------------------------------------------------------------- 
+// |       |     |     |      |      |      |                   |      |       |       |      |       |       | |     |      |      | 
+// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |   7   |   8   |  9   |   0   |       | |     |      |      | 
+// |   F1  |  F2 |  F3 |  F4  |  F5  |  F6  |                   |      |   <-  |   ^   |  v   |  ->   |       | |     |      |      | 
+// |   F7  |  F8 |  F9 |  F10 |  F11 |  F12 |                   |  +   |   -   |   =   |  [   |   ]   |   \   | |     |      |      | 
+//                     |      |      |      |        |  |       |      |       |       |
+			bindings = <
+&trans    &trans &trans &trans  &trans  &trans                       &trans      &trans    &trans    &trans   &trans    &trans    &trans    &trans    &trans 
+&kp GRAVE &kp N1 &kp N2 &kp N3  &kp N4  &kp N5                       &kp N6      &kp N7    &kp N8    &kp N9   &kp N0    &trans    &trans    &trans    &trans 
+&kp F1    &kp F2 &kp F3 &kp F4  &kp F5  &kp F6                       &trans      &kp LEFT  &kp DOWN  &kp UP   &kp RIGHT &trans              &trans           
+&kp F7    &kp F8 &kp F9 &kp F10 &kp F11 &kp F12                      &kp KP_PLUS &kp MINUS &kp EQUAL &kp LBKT &kp RBKT  &kp BSLH  &trans    &trans    &trans 
+                        &trans  &trans  &trans    &trans   &trans    &trans      &trans    &trans
+			>;
+		};
+	};
+};

--- a/app/boards/shields/breeze/breeze.keymap
+++ b/app/boards/shields/breeze/breeze.keymap
@@ -42,7 +42,7 @@
 			bindings = <
 &kp F1   &kp F2  &kp F3  &kp F4  &kp F5  &kp F6                       &kp F7  &kp F8  &kp F9  &kp F10 &kp F11 &kp F12 &kp PSCRN  &trans        &trans    
 &trans   &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans  &trans     &kp C_MUTE    &kp C_PLAY_PAUSE 
-&kp CAPS &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans  &trans     &kp C_VOL_UP  &trans
+&kp CAPS &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans             &kp C_VOL_UP
 &trans   &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans  &kp C_PREV &kp C_VOL_DN  &kp C_NEXT
                          &trans  &trans  &trans  &trans     &kp BSPC  &kp INS &trans  &trans
 			>;
@@ -56,11 +56,11 @@
 // | BT4 |     |     |      |      |        |                   |      |       |       |      |       |   \   | |     |      |      | 
 //                   |      |      |        |        |  |  DEL  |      |       |       |
 			bindings = <
-&bt BT_SEL 0 &trans &trans &trans  &trans  &bt BT_CLR                   &trans      &trans    &trans    &trans   &trans    &trans    &trans    &trans    &trans 
-&bt BT_SEL 1 &trans &trans &trans  &trans  &trans                       &trans      &trans    &trans    &trans   &trans    &trans    &trans    &trans    &trans
-&bt BT_SEL 2 &trans &trans &trans  &trans  &trans                       &trans      &kp LEFT  &kp DOWN  &kp UP   &kp RIGHT &trans              &trans           
-&bt BT_SEL 3 &trans &trans &trans  &trans  &trans                       &trans      &trans    &trans    &trans   &trans    &kp BSLH  &trans    &trans    &trans 
-                           &trans  &trans  &trans    &trans    &kp DEL  &trans      &trans    &trans
+&bt BT_SEL 0 &trans &trans &trans  &trans  &bt BT_CLR                   &trans  &trans   &trans   &trans  &trans    &trans     &trans &trans &trans 
+&bt BT_SEL 1 &trans &trans &trans  &trans  &trans                       &trans  &trans   &trans   &trans  &trans    &trans     &trans &trans &trans
+&bt BT_SEL 2 &trans &trans &trans  &trans  &trans                       &trans  &kp LEFT &kp DOWN &kp UP  &kp RIGHT &trans            &trans        
+&bt BT_SEL 3 &trans &trans &trans  &trans  &trans                       &trans  &trans   &trans   &trans  &trans    &kp BSLH   &trans &trans &trans 
+                           &trans  &trans  &trans    &trans    &kp DEL  &trans  &trans   &trans
 			>;
 		};
 	};

--- a/app/boards/shields/breeze/breeze.keymap
+++ b/app/boards/shields/breeze/breeze.keymap
@@ -18,49 +18,49 @@
 // Ref: https://zmkfirmware.dev/docs/codes/
 
 // ----------------------------------------------------------------------------------------------------------------------------------
-// | ESC/~ |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   | BSPC  | |  =  | HOME | PGUP |
-// |  TAB  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   |  [    | |  ]  | END  | PGDN |
-// |  CTRL |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   | ENTER | |     |  UP  |      |
-// | SHIFT |  Z  |  X  |  C   |  V   |  B   |                   |  N   |  M    |  ,    |  .   |   /   |  '    | |  L  |  DN  |  R   |
-//                     | CTRL | GUI  | ALT  |  SPACE |  | ENTER | BSPC | mo(2) | mo(1) |
+// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   | BSPC | | -/_ | =/+  | HOME |
+// |  TAB  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   |  [   | |  ]  | DEL  | END  |
+// | SHIFT |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   |  '   | |     |  UP  |      |
+// |  CTRL |  Z  |  X  |  C   |  V   |  B   |                   |  N   |  M    |  ,    |  .   |   /   |  \   | |  L  |  DN  |  R   |
+//                     | ESC  | GUI  | ALT  | SPACE |   | ENTER | RALT | RAISE | LOWER |
 			bindings = <
-&gresc    &kp N1 &kp N2 &kp N3    &kp N4   &kp N5                     &kp N6   &kp N7   &kp N8    &kp N9  &kp N0   &kp BSPC   &kp EQUAL &kp HOME  &kp PG_UP
-&kp TAB   &kp Q  &kp W  &kp E     &kp R    &kp T                      &kp Y    &kp U    &kp I     &kp O   &kp P    &kp LBKT   &kp RBKT  &kp END   &kp PG_DN
-&kp LCTRL &kp A  &kp S  &kp D     &kp F    &kp G                      &kp H    &kp J    &kp K     &kp L   &kp SEMI &kp RET              &kp UP 
-&kp LSHFT &kp Z  &kp X  &kp C     &kp V    &kp B                      &kp N    &kp M    &kp COMMA &kp DOT &kp FSLH &kp APOS   &kp LEFT  &kp DOWN  &kp RIGHT
-                        &kp LCTRL &kp LGUI &kp LALT &kp SPACE &kp RET &kp BSPC &mo 2    &mo 1
+&kp GRAVE &kp N1 &kp N2 &kp N3  &kp N4   &kp N5                     &kp N6   &kp N7   &kp N8    &kp N9  &kp N0   &kp BSPC   &kp MINUS &kp EQUAL &kp HOME
+&kp TAB   &kp Q  &kp W  &kp E   &kp R    &kp T                      &kp Y    &kp U    &kp I     &kp O   &kp P    &kp LBKT   &kp RBKT  &kp DEL   &kp END
+&kp LSHFT &kp A  &kp S  &kp D   &kp F    &kp G                      &kp H    &kp J    &kp K     &kp L   &kp SEMI &kp APOS             &kp UP 
+&kp LCTRL &kp Z  &kp X  &kp C   &kp V    &kp B                      &kp N    &kp M    &kp COMMA &kp DOT &kp FSLH &kp BSLH   &kp LEFT  &kp DOWN  &kp RIGHT
+                        &kp ESC &kp LGUI &kp LALT &kp SPACE &kp RET &kp RALT &mo 2    &mo 1
 			>;
 		};
 
-		layer1 {
+		lower_layer {
 // ---------------------------------------------------------------------------------------------------------------------------------- 
-// | BTCLR | BT1 | BT2 |  BT3 |  BT4 |  BT5 |                   |      |       |       |      |       |       | |      |      |      | 
-// |  F1   |  F2 |  F3 |  F4  |  F5  |  F6  |                   |  F7  |  F8   |  F9   |  F10 |  F11  |  F12  | |      | Mute | Play | 
-// |   `   |  !  |  @  |  #   |  $   |  %   |                   |  ^   |  &    |  *    |  (   |   )   |   ~   | |      | Vol+ |      | 
-// |       |     |     |      |      |      |                   |      |  _    |  +    |  {   |   }   |  "|"  | | Prev | Vol- | Next | 
-//                     |      |      |      |        |  |       |      |       |       |
+// |  F1  |  F2 |  F3 |  F4  |  F5  |  F6  |                   |  F7  |  F8  |  F9  |  F10 |  F11  |  F12  | | PSCRN |      |      | 
+// |      |     |     |      |      |      |                   |      |      |      |      |       |       | |       | Mute | Play | 
+// | CAPS |     |     |      |      |      |                   |      |      |      |      |       |       | |       | Vol+ |      | 
+// |      |     |     |      |      |      |                   |      |      |      |      |       |       | | Prev  | Vol- | Next | 
+//                    |      |      |      |        |  |  BSPC | INS  |      |      |
 			bindings = <
-&bt BT_CLR &bt BT_SEL 0     &bt BT_SEL 1      &bt BT_SEL 2      &bt BT_SEL 3 &bt BT_SEL 4                 &trans    &trans    &trans          &trans    &trans    &trans    &trans     &trans        &trans    
-&kp F1     &kp F2           &kp F3            &kp F4            &kp F5       &kp F6                       &kp F7    &kp F8    &kp F9          &kp F10   &kp F11   &kp F12   &trans     &kp C_MUTE    &kp C_PLAY_PAUSE 
-&kp GRAVE  &kp EXCL         &kp AT            &kp HASH          &kp DOLLAR   &kp PRCNT                    &kp CARET &kp AMPS  &kp KP_MULTIPLY &kp LPAR  &kp RPAR  &kp TILDE            &kp C_VOL_UP 
-&trans     &ext_power EP_ON &ext_power EP_OFF &ext_power EP_TOG &trans       &trans                       &trans    &kp MINUS &kp KP_PLUS     &kp LBRC  &kp RBRC  &kp PIPE  &kp C_PREV &kp C_VOL_DN  &kp C_NEXT
-                                              &trans            &trans       &trans    &trans   &trans    &trans    &trans    &trans
+&kp F1   &kp F2  &kp F3  &kp F4  &kp F5  &kp F6                       &kp F7  &kp F8  &kp F9  &kp F10 &kp F11 &kp F12 &kp PSCRN  &trans        &trans    
+&trans   &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans  &trans     &kp C_MUTE    &kp C_PLAY_PAUSE 
+&kp CAPS &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans  &trans     &kp C_VOL_UP  &trans
+&trans   &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans  &kp C_PREV &kp C_VOL_DN  &kp C_NEXT
+                         &trans  &trans  &trans  &trans     &kp BSPC  &kp INS &trans  &trans
 			>;
 		};
 
-		layer2 {
+		raise_layer {
 // ---------------------------------------------------------------------------------------------------------------------------------- 
-// |       |     |     |      |      |      |                   |      |       |       |      |       |       | |     |      |      | 
-// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |   7   |   8   |  9   |   0   |       | |     |      |      | 
-// |   F1  |  F2 |  F3 |  F4  |  F5  |  F6  |                   |      |   <-  |   ^   |  v   |  ->   |       | |     |      |      | 
-// |   F7  |  F8 |  F9 |  F10 |  F11 |  F12 |                   |  +   |   -   |   =   |  [   |   ]   |   \   | |     |      |      | 
-//                     |      |      |      |        |  |       |      |       |       |
+// | BT1 |     |     |      |      | BT_CLR |                   |      |       |       |      |       |       | |     |      |      | 
+// | BT2 |     |     |      |      |        |                   |      |       |       |      |       |       | |     |      |      | 
+// | BT3 |     |     |      |      |        |                   |      |   <-  |   ↓   |  ↑   |  ->   |       | |     |      |      | 
+// | BT4 |     |     |      |      |        |                   |      |       |       |      |       |   \   | |     |      |      | 
+//                   |      |      |        |        |  |  DEL  |      |       |       |
 			bindings = <
-&trans    &trans &trans &trans  &trans  &trans                       &trans      &trans    &trans    &trans   &trans    &trans    &trans    &trans    &trans 
-&kp GRAVE &kp N1 &kp N2 &kp N3  &kp N4  &kp N5                       &kp N6      &kp N7    &kp N8    &kp N9   &kp N0    &trans    &trans    &trans    &trans 
-&kp F1    &kp F2 &kp F3 &kp F4  &kp F5  &kp F6                       &trans      &kp LEFT  &kp DOWN  &kp UP   &kp RIGHT &trans              &trans           
-&kp F7    &kp F8 &kp F9 &kp F10 &kp F11 &kp F12                      &kp KP_PLUS &kp MINUS &kp EQUAL &kp LBKT &kp RBKT  &kp BSLH  &trans    &trans    &trans 
-                        &trans  &trans  &trans    &trans   &trans    &trans      &trans    &trans
+&bt BT_SEL 0 &trans &trans &trans  &trans  &bt BT_CLR                   &trans      &trans    &trans    &trans   &trans    &trans    &trans    &trans    &trans 
+&bt BT_SEL 1 &trans &trans &trans  &trans  &trans                       &trans      &trans    &trans    &trans   &trans    &trans    &trans    &trans    &trans
+&bt BT_SEL 2 &trans &trans &trans  &trans  &trans                       &trans      &kp LEFT  &kp DOWN  &kp UP   &kp RIGHT &trans              &trans           
+&bt BT_SEL 3 &trans &trans &trans  &trans  &trans                       &trans      &trans    &trans    &trans   &trans    &kp BSLH  &trans    &trans    &trans 
+                           &trans  &trans  &trans    &trans    &kp DEL  &trans      &trans    &trans
 			>;
 		};
 	};

--- a/app/boards/shields/breeze/breeze.keymap
+++ b/app/boards/shields/breeze/breeze.keymap
@@ -35,14 +35,14 @@
 		lower_layer {
 // ---------------------------------------------------------------------------------------------------------------------------------- 
 // |  F1  |  F2 |  F3 |  F4  |  F5  |  F6  |                   |  F7  |  F8  |  F9  |  F10 |  F11  |  F12  | | PSCRN |      |      | 
-// |      |     |     |      |      |      |                   |      |      |      |      |       |       | |       | Mute | Play | 
-// | CAPS |     |     |      |      |      |                   |      |      |      |      |       |       | |       | Vol+ |      | 
+// |      |     |  ↑  |      |      |      |                   |      |      |      |      |       |       | |       | Mute | Play | 
+// | CAPS |  ←  |  ↓  |  →   |      |      |                   |      |      |      |      |       |       | |       | Vol+ |      | 
 // |      |     |     |      |      |      |                   |      |      |      |      |       |       | | Prev  | Vol- | Next | 
 //                    |      |      |      |        |  |  BSPC | INS  |      |      |
 			bindings = <
 &kp F1   &kp F2  &kp F3  &kp F4  &kp F5  &kp F6                       &kp F7  &kp F8  &kp F9  &kp F10 &kp F11 &kp F12 &kp PSCRN  &trans        &trans    
-&trans   &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans  &trans     &kp C_MUTE    &kp C_PLAY_PAUSE 
-&kp CAPS &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans             &kp C_VOL_UP
+&trans   &trans  &kp UP  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans  &trans     &kp C_MUTE    &kp C_PLAY_PAUSE 
+&kp CAPS &kp LEFT &kp DOWN &kp RIGHT  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans             &kp C_VOL_UP
 &trans   &trans  &trans  &trans  &trans  &trans                       &trans  &trans  &trans  &trans  &trans  &trans  &kp C_PREV &kp C_VOL_DN  &kp C_NEXT
                          &trans  &trans  &trans  &trans     &kp BSPC  &kp INS &trans  &trans
 			>;
@@ -50,13 +50,13 @@
 
 		raise_layer {
 // ---------------------------------------------------------------------------------------------------------------------------------- 
-// | BT1 |     |     |      |      | BT_CLR |                   |      |       |       |      |       |       | |     |      |      | 
+// | BT1 |     |     |      |      | BT_CLR |                   |      |       |       |      |       |       | | LA PSCRN |      |      | 
 // | BT2 |     |     |      |      |        |                   |      |       |       |      |       |       | |     |      |      | 
-// | BT3 |     |     |      |      |        |                   |      |   <-  |   ↓   |  ↑   |  ->   |       | |     |      |      | 
+// | BT3 |     |     |      |      |        |                   |      |   <-  |   ↓   |  ↑   |  →   |       | |     |      |      | 
 // | BT4 |     |     |      |      |        |                   |      |       |       |      |       |   \   | |     |      |      | 
 //                   |      |      |        |        |  |  DEL  |      |       |       |
 			bindings = <
-&bt BT_SEL 0 &trans &trans &trans  &trans  &bt BT_CLR                   &trans  &trans   &trans   &trans  &trans    &trans     &trans &trans &trans 
+&bt BT_SEL 0 &trans &trans &trans  &trans  &bt BT_CLR                   &trans  &trans   &trans   &trans  &trans    &trans     &kp LA(PSCRN) &trans &trans 
 &bt BT_SEL 1 &trans &trans &trans  &trans  &trans                       &trans  &trans   &trans   &trans  &trans    &trans     &trans &trans &trans
 &bt BT_SEL 2 &trans &trans &trans  &trans  &trans                       &trans  &kp LEFT &kp DOWN &kp UP  &kp RIGHT &trans            &trans        
 &bt BT_SEL 3 &trans &trans &trans  &trans  &trans                       &trans  &trans   &trans   &trans  &trans    &kp BSLH   &trans &trans &trans 

--- a/app/boards/shields/breeze/breeze.zmk.yml
+++ b/app/boards/shields/breeze/breeze.zmk.yml
@@ -3,7 +3,7 @@ id: breeze
 name: Breeze
 type: shield
 url: https://afternoonlabs.com/breeze/
-requires: 
+requires:
   - pro_micro
 features:
   - keys

--- a/app/boards/shields/breeze/breeze.zmk.yml
+++ b/app/boards/shields/breeze/breeze.zmk.yml
@@ -1,0 +1,12 @@
+file_format: "1"
+id: breeze
+name: Breeze
+type: shield
+url: https://afternoonlabs.com/breeze/
+requires: 
+  - pro_micro
+features:
+  - keys
+siblings:
+  - breeze_left
+  - breeze_right

--- a/app/boards/shields/breeze/breeze_left.overlay
+++ b/app/boards/shields/breeze/breeze_left.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "breeze.dtsi"
+
+&kscan0 {
+		row-gpios
+			= <&pro_micro 21  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 20  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 19  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 18  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			;
+
+};

--- a/app/boards/shields/breeze/breeze_right.overlay
+++ b/app/boards/shields/breeze/breeze_right.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "breeze.dtsi"
+
+&default_transform {
+	row-offset = <5>;
+};
+
+&kscan0 {
+		row-gpios
+			= <&pro_micro 21  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 20  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 19  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 18  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			;
+};


### PR DESCRIPTION
Add a shield definition for the Breeze split keyboard from Afternoon
labs.

This is for the standard breeze variant, with the arrow keys present
on the right half but not the left.

Definition is based in part on an abandoned PR by @devries:
https://github.com/zmkfirmware/zmk/pull/735

Signed-off-by: Idan Gazit <idan@gazit.me>
Co-authored-by: devriesp <devriesp@users.noreply.github.com>

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
