### PR TITLE
fix(docs): Fix issues with positional hold-tap example

### DIFF
--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -115,7 +115,7 @@ The following are suggested hold-tap configurations that work well with home row
 	behaviors {
 		lh_pht: left_hand_positional_hold_tap {
 			compatible = "zmk,behavior-hold-tap";
-			label = "POSITIONAL_HOLD_TAP";
+			label = "LEFT_POSITIONAL_HOLD_TAP";
 			#binding-cells = <2>;
 			flavor = "tap-unless-interrupted";
 			tapping-term-ms = <100>;                        // <---[[produces tap if held longer than tapping-term-ms]]

--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -129,8 +129,8 @@ The following are suggested hold-tap configurations that work well with home row
 		compatible = "zmk,keymap";
 		default_layer {
 			bindings = <
-				// position 0           pos 1             pos 2             pos 3       pos 4    pos 5    pos 6    pos 7    pos 8    pos 9     pos 10
-				&lh_pht LSFT A    &lh_pht LGUI S    &lh_pht LALT D    &lh_pht LCTL F    &kp G    &kp H    &kp I    &kp J    &kp K    &kp L    &kp SCLN
+				// position 0     pos 1             pos 2             pos 3             pos 4    pos 5    pos 6    pos 7    pos 8    pos 9    pos 10
+				&lh_pht LSFT A    &lh_pht LGUI S    &lh_pht LALT D    &lh_pht LCTL F    &kp G    &kp H    &kp I    &kp J    &kp K    &kp L    &kp SEMI
 			>;
 		};
 	};


### PR DESCRIPTION
This PR replaces the deprecated `SCLN` keycode in the positional hold-tap example, which fixes #646 (I found no other deprecated keycodes in the docs).

Also I tweaked the label of the behavior in the example. We see folks copying this behavior node and duplicating it for the right hand, then forgetting to modify the "label" value and getting confusing runtime ehavior. If we modify the label to be left-specific like this it might be a better hint to change it when duplicating it.

Two unrelated changes in one PR isn't ideal but they were small enough that I thought I shouldn't split them up; ideally we would not squash this if we merge the PR.
