### PR TITLE
fix(docs): Improve powershell command for setup script for failure cases

### DIFF
--- a/docs/docs/user-setup.md
+++ b/docs/docs/user-setup.md
@@ -82,7 +82,7 @@ bash -c "$(wget https://zmk.dev/setup.sh -O -)" '' --wget
 <TabItem value="PowerShell">
 
 ```
-iex ((New-Object System.Net.WebClient).DownloadString('https://zmk.dev/setup.ps1'))
+powershell -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://zmk.dev/setup.ps1'))"
 ```
 
 </TabItem>


### PR DESCRIPTION
This change tweaks the `powershell` setup script invocation in the docs so that if it exits with a failure it will not close the current terminal window. We saw quite a few folks in Discord confused because of this behavior.

From what I have tried this helps the current shell stay alive for error cases and doesn't persist a nested shell even after the command runs successfully. I tried with Windows 11 and Powershell version 5.1, but continues working if I try different versions down to `3` with `powershell -Version 3`.

That being said I am not very knowledgeable in Powershell and I don't know how backwards-compatible the `-Command` switch is. I would appreciate any advice or testing from folks with different Windows versions.

Fixes #1206.