### PR TITLE
fix(docs): Add `behaviors/key-repeat` to sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -29,6 +29,7 @@ module.exports = {
       "behaviors/sticky-key",
       "behaviors/sticky-layer",
       "behaviors/caps-word",
+      "behaviors/key-repeat",
       "behaviors/reset",
       "behaviors/bluetooth",
       "behaviors/outputs",


### PR DESCRIPTION
Currently, the documentation for `&key_repeat` [exists](https://zmk.dev/docs/behaviors/key-repeat/) but is not accessible via the sidebar. 

This small PR adds the page to the sidebar:

https://deploy-preview-1129--zmk.netlify.app/docs/behaviors/key-repeat

<img width="1244" alt="Screenshot 2022-02-12 at 08 58 09" src="https://user-images.githubusercontent.com/60922914/153704726-0456180a-8afb-4bec-9973-41ed09527d52.png">
