### PR TITLE
fix(docs): Remove trailing whitespace (to appease prettier)

### DIFF
--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -55,7 +55,7 @@ config SHIELD_MY_BOARD
 	def_bool $(shields_list_contains,my_board)
 ```
 
-This will make sure that a new configuration value named `SHIELD_MY_BOARD` is set to true whenever `my_board` is used as the shield name, either as the `SHIELD` variable [in a local build](build-flash.md) or in your `build.yaml` file [when using Github Actions](../customization). Note that this configuration value will be used in `Kconfig.defconfig` to set other properties about your shield, so make sure that they match. 
+This will make sure that a new configuration value named `SHIELD_MY_BOARD` is set to true whenever `my_board` is used as the shield name, either as the `SHIELD` variable [in a local build](build-flash.md) or in your `build.yaml` file [when using Github Actions](../customization). Note that this configuration value will be used in `Kconfig.defconfig` to set other properties about your shield, so make sure that they match.
 
 **For split boards**, you will need to add configurations for the left and right sides. For example, if your split halves are named `my_board_left` and `my_board_right`, it would look like this:
 


### PR DESCRIPTION
This fixes the [prettier warning which causes the checks to fail](https://github.com/zmkfirmware/zmk/runs/5215608764?check_suite_focus=true#step:4:13) for 43ffa6c76077a446ee0ebc8ebc39ebc09eae4b57.

Currently:

```console
> prettier --check .
Checking formatting...
[warn] docs/development/new-shield.md
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
Error: Process completed with exit code 1.
```

With this PR, on my local machine, prettier is happy again:

```console
$ prettier --check .
Checking formatting...
All matched files use Prettier code style!
```
