### PR TITLE
Added support for 2% Milk (Updated with metadata)

### DIFF
--- a/app/boards/shields/two_percent_milk/Kconfig.defconfig
+++ b/app/boards/shields/two_percent_milk/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_TWO_PERCENT_MILK
+
+config ZMK_KEYBOARD_NAME
+    default "2% Milk"
+
+endif

--- a/app/boards/shields/two_percent_milk/Kconfig.shield
+++ b/app/boards/shields/two_percent_milk/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_TWO_PERCENT_MILK
+	def_bool $(shields_list_contains,two_percent_milk)

--- a/app/boards/shields/two_percent_milk/two_percent_milk.conf
+++ b/app/boards/shields/two_percent_milk/two_percent_milk.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT

--- a/app/boards/shields/two_percent_milk/two_percent_milk.keymap
+++ b/app/boards/shields/two_percent_milk/two_percent_milk.keymap
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+ #include <behaviors.dtsi>
+ #include <dt-bindings/zmk/keys.h>
+ #include <dt-bindings/zmk/bt.h>
+ 
+ / {
+     keymap {
+         compatible = "zmk,keymap";
+ 
+         default_layer {
+             bindings = <
+              &kp X
+              &kp Z
+             >;
+         };
+     };
+ };

--- a/app/boards/shields/two_percent_milk/two_percent_milk.overlay
+++ b/app/boards/shields/two_percent_milk/two_percent_milk.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/ {
+	chosen {
+		zmk,kscan = &kscan0;
+	};
+
+	kscan0: kscan {
+		compatible = "zmk,kscan-gpio-direct";
+
+		label = "KSCAN";
+
+		input-gpios
+			= <&pro_micro 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+			, <&pro_micro 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+			;
+
+	};
+
+};

--- a/app/boards/shields/two_percent_milk/two_percent_milk.zmk.yml
+++ b/app/boards/shields/two_percent_milk/two_percent_milk.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: two_percent_milk
+name: 2% Milk
+type: shield
+url: https://github.com/Spaceboards/SpaceboardsHardware/tree/master/Keyboards/2%25%20Milk
+requires: [pro_micro]
+features:
+  - keys


### PR DESCRIPTION
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)

2022 renewal of PR #684 with updated metadata file.