### PR TITLE
feat(shields): Add Eternal Keypad

### DIFF
--- a/app/boards/shields/eternal_keypad/Kconfig.defconfig
+++ b/app/boards/shields/eternal_keypad/Kconfig.defconfig
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
-if SHIELD_ETERNAL_KEYPAD
+if SHIELD_ETERNAL_KEYPAD || SHIELD_ETERNAL_KEYPAD_LEFTY
 
 config ZMK_KEYBOARD_NAME
 	default "Eternal Keypad"

--- a/app/boards/shields/eternal_keypad/Kconfig.defconfig
+++ b/app/boards/shields/eternal_keypad/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_ETERNAL_KEYPAD
+
+config ZMK_KEYBOARD_NAME
+	default "Eternal Keypad"
+
+endif

--- a/app/boards/shields/eternal_keypad/Kconfig.shield
+++ b/app/boards/shields/eternal_keypad/Kconfig.shield
@@ -4,3 +4,5 @@
 config SHIELD_ETERNAL_KEYPAD
 	def_bool $(shields_list_contains,eternal_keypad)
 
+config SHIELD_ETERNAL_KEYPAD_LEFTY
+	def_bool $(shields_list_contains,eternal_keypad_lefty)

--- a/app/boards/shields/eternal_keypad/Kconfig.shield
+++ b/app/boards/shields/eternal_keypad/Kconfig.shield
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_ETERNAL_KEYPAD
+	def_bool $(shields_list_contains,eternal_keypad)
+

--- a/app/boards/shields/eternal_keypad/README.md
+++ b/app/boards/shields/eternal_keypad/README.md
@@ -1,0 +1,10 @@
+# Eternal Keypad
+
+Eternal Keypad is an open-source input device for gaming that can be assembled for both right and left hand mouse users.
+
+Firmware is described in the [Eternal Keypad](https://github.com/duckyb/eternal-keypad) repository [README](https://github.com/duckyb/eternal-keypad#firmware).
+
+Two keymaps are included:
+
+- eternal_keypad (default)
+- eternal_keypad_lefty (for left handed users)

--- a/app/boards/shields/eternal_keypad/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/eternal_keypad/boards/nice_nano_v2.overlay
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022  The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	/* Cannot be used together with i2c0. */
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "SK6812mini";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <8>;
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/eternal_keypad/eternal_keypad.conf
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Uncomment to turn on logging, and set ZMK logging to debug output
+# CONFIG_ZMK_USB_LOGGING=y
+

--- a/app/boards/shields/eternal_keypad/eternal_keypad.conf
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.conf
@@ -3,4 +3,3 @@
 
 # Uncomment to turn on logging, and set ZMK logging to debug output
 # CONFIG_ZMK_USB_LOGGING=y
-

--- a/app/boards/shields/eternal_keypad/eternal_keypad.conf
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.conf
@@ -3,3 +3,7 @@
 
 # Uncomment to turn on logging, and set ZMK logging to debug output
 # CONFIG_ZMK_USB_LOGGING=y
+
+# Uncomment the following lines to enable RGB underglow
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/eternal_keypad/eternal_keypad.dtsi
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.dtsi
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+  chosen {
+    zmk,kscan = &kscan0;
+    zmk,matrix_transform = &default_transform;
+  };
+
+  kscan0: kscan {
+    compatible = "zmk,kscan-gpio-matrix";
+    label = "KSCAN";
+
+    diode-direction = "col2row";
+
+    row-gpios
+      = <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      ;
+
+    col-gpios
+      = <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      ;
+  };
+
+  default_transform: keymap_transform_0 {
+    compatible = "zmk,matrix-transform";
+    columns = <8>;
+    rows = <5>;
+    map = <
+                    RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7)
+                    RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7)
+            RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7)
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7)
+            RC(4,0) RC(4,1) RC(4,2) RC(4,3)         RC(4,5)         RC(4,7)
+    >;
+  };
+};

--- a/app/boards/shields/eternal_keypad/eternal_keypad.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.keymap
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+#define BASE        0
+#define ARROW       1
+#define FUNC        2
+
+/ {
+  keymap {
+    compatible = "zmk,keymap";
+
+    default_layer {
+      bindings = <
+                    &kp ESC   &kp N1    &kp N2   &kp N3    &kp N4    &kp N5  &kp N6
+                    &kp TAB   &kp Q     &kp W    &kp E     &kp R     &kp T   &kp N7
+        &kp F13     &kp ENTER &kp A     &kp S    &kp D     &kp F     &kp G   &kp N8
+        &kp F14     &kp LSHFT &kp Z     &kp X    &kp C     &kp V     &kp B   &kp N9
+        &kp F15     &kp LCTRL &sl FUNC  &kp LALT           &kp SPACE         &lt ARROW N0
+      >;
+    };
+
+    arrow_layer {
+      bindings = <
+                    &trans    &trans    &trans   &trans    &trans    &trans  &trans
+                    &trans    &trans    &kp UP   &trans    &trans    &trans  &trans
+        &bt BT_CLR  &trans    &kp LEFT  &kp DOWN &kp RIGHT &trans    &trans  &trans
+        &reset      &trans    &trans    &trans   &trans    &trans    &trans  &trans
+        &bootloader &trans    &trans    &trans             &trans            &trans
+      >;
+    };
+
+    function_layer {
+      bindings = <
+                    &trans    &kp F1    &kp F2   &kp F3    &kp F4   &kp F5   &kp F6
+                    &trans    &kp P     &kp O    &kp I     &kp U    &kp Y    &kp F7
+        &bt BT_CLR  &kp BSPC  &kp SEMI  &kp L    &kp K     &kp J    &kp H    &kp F8
+        &bt BT_NXT  &trans    &kp LGUI  &kp M    &kp N     &kp F12  &kp F11  &kp F9
+        &bootloader &trans    &trans    &trans             &trans            &kp F10
+      >;
+    };
+  };
+};

--- a/app/boards/shields/eternal_keypad/eternal_keypad.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.keymap
@@ -14,6 +14,11 @@
 #define FUNC        2
 
 / {
+  chosen {
+      zmk,kscan = &kscan0;
+      zmk,matrix_transform = &default_transform;
+  };
+
   keymap {
     compatible = "zmk,keymap";
 

--- a/app/boards/shields/eternal_keypad/eternal_keypad.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.keymap
@@ -8,6 +8,7 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/rgb.h>
 
 #define BASE        0
 #define ARROW       1
@@ -34,11 +35,11 @@
 
     arrow_layer {
       bindings = <
-                    &bt BT_SEL 0 &bt BT_SEL 1 &trans     &trans    &trans  &out OUT_USB &out OUT_BLE
-                    &trans       &trans       &kp UP     &trans    &trans  &trans       &trans
-        &bt BT_CLR  &trans       &kp LEFT     &kp DOWN   &kp RIGHT &trans  &trans       &trans
-        &reset      &trans       &trans       &trans     &trans    &trans  &trans       &trans
-        &bootloader &trans       &trans       &trans               &trans               &trans
+                    &bt BT_SEL 0 &bt BT_SEL 1 &trans     &trans    &trans           &out OUT_USB     &out OUT_BLE
+                    &trans       &trans       &kp UP     &trans    &rgb_ug RGB_TOG  &rgb_ug RGB_HUI  &rgb_ug RGB_HUD
+        &bt BT_CLR  &trans       &kp LEFT     &kp DOWN   &kp RIGHT &trans           &rgb_ug RGB_BRI  &rgb_ug RGB_BRD
+        &reset      &trans       &trans       &trans     &trans    &trans           &rgb_ug RGB_EFF  &rgb_ug RGB_EFR
+        &bootloader &trans       &trans       &trans               &trans                            &trans
       >;
     };
 

--- a/app/boards/shields/eternal_keypad/eternal_keypad.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.keymap
@@ -7,6 +7,7 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
 
 #define BASE        0
 #define ARROW       1
@@ -28,11 +29,11 @@
 
     arrow_layer {
       bindings = <
-                    &trans    &trans    &trans   &trans    &trans    &trans  &trans
-                    &trans    &trans    &kp UP   &trans    &trans    &trans  &trans
-        &bt BT_CLR  &trans    &kp LEFT  &kp DOWN &kp RIGHT &trans    &trans  &trans
-        &reset      &trans    &trans    &trans   &trans    &trans    &trans  &trans
-        &bootloader &trans    &trans    &trans             &trans            &trans
+                    &bt BT_SEL 0 &bt BT_SEL 1 &trans     &trans    &trans  &out OUT_USB &out OUT_BLE
+                    &trans       &trans       &kp UP     &trans    &trans  &trans       &trans
+        &bt BT_CLR  &trans       &kp LEFT     &kp DOWN   &kp RIGHT &trans  &trans       &trans
+        &reset      &trans       &trans       &trans     &trans    &trans  &trans       &trans
+        &bootloader &trans       &trans       &trans               &trans               &trans
       >;
     };
 
@@ -41,7 +42,7 @@
                     &trans    &kp F1    &kp F2   &kp F3    &kp F4   &kp F5   &kp F6
                     &trans    &kp P     &kp O    &kp I     &kp U    &kp Y    &kp F7
         &bt BT_CLR  &kp BSPC  &kp SEMI  &kp L    &kp K     &kp J    &kp H    &kp F8
-        &bt BT_NXT  &trans    &kp LGUI  &kp M    &kp N     &kp F12  &kp F11  &kp F9
+        &reset      &trans    &kp LGUI  &kp M    &kp N     &kp F12  &kp F11  &kp F9
         &bootloader &trans    &trans    &trans             &trans            &kp F10
       >;
     };

--- a/app/boards/shields/eternal_keypad/eternal_keypad.overlay
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.overlay
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+  chosen {
+    zmk,kscan = &kscan0;
+    zmk,matrix_transform = &default_transform;
+  };
+
+  kscan0: kscan {
+    compatible = "zmk,kscan-gpio-matrix";
+    label = "KSCAN";
+
+    diode-direction = "col2row";
+
+    row-gpios
+      = <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      ;
+
+    col-gpios
+      = <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      , <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+      ;
+  };
+
+  default_transform: keymap_transform_0 {
+    compatible = "zmk,matrix-transform";
+    columns = <8>;
+    rows = <5>;
+    map = <
+                    RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7)
+                    RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7)
+            RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7)
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7)
+            RC(4,0) RC(4,1) RC(4,2) RC(4,3)         RC(4,5)         RC(4,7)
+    >;
+  };
+
+  lefty_transform: keymap_transform_1 {
+    compatible = "zmk,matrix-transform";
+    columns = <8>;
+    rows = <5>;
+    map = <
+            RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6)
+            RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6)
+            RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7)
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7)
+            RC(4,0)         RC(4,2)         RC(4,4) RC(4,5) RC(4,6) RC(4,7)
+    >;
+  };
+};

--- a/app/boards/shields/eternal_keypad/eternal_keypad.zmk.yml
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: eternal_keypad
+name: Eternal Keypad
+type: shield
+url: https://github.com/duckyb/eternal-keypad
+requires: [pro_micro]
+features:
+  - keys

--- a/app/boards/shields/eternal_keypad/eternal_keypad.zmk.yml
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.zmk.yml
@@ -6,3 +6,4 @@ url: https://github.com/duckyb/eternal-keypad
 requires: [pro_micro]
 features:
   - keys
+  - underglow

--- a/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
@@ -8,6 +8,7 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/rgb.h>
 
 #define BASE        0
 #define ARROW       1
@@ -34,11 +35,11 @@
 
     arrow_layer {
       bindings = <
-                    &bt BT_SEL 0 &bt BT_SEL 1 &trans     &trans    &trans  &out OUT_USB &out OUT_BLE
-                    &trans       &trans       &kp UP     &trans    &trans  &trans       &trans
-        &bt BT_CLR  &trans       &kp RIGHT    &kp DOWN   &kp RIGHT &trans  &trans       &trans
-        &reset      &trans       &trans       &trans     &trans    &trans  &trans       &trans
-        &bootloader &trans       &trans       &trans               &trans               &trans
+                    &bt BT_SEL 0 &bt BT_SEL 1 &trans     &trans    &trans           &out OUT_USB     &out OUT_BLE
+                    &trans       &trans       &kp UP     &trans    &rgb_ug RGB_TOG  &rgb_ug RGB_HUI  &rgb_ug RGB_HUD
+        &bt BT_CLR  &trans       &kp RIGHT    &kp DOWN   &kp RIGHT &trans           &rgb_ug RGB_BRI  &rgb_ug RGB_BRD
+        &reset      &trans       &trans       &trans     &trans    &trans           &rgb_ug RGB_EFF  &rgb_ug RGB_EFR
+        &bootloader &trans       &trans       &trans               &trans                            &trans
       >;
     };
 

--- a/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+#define BASE        0
+#define ARROW       1
+#define FUNC        2
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+  keymap {
+    compatible = "zmk,keymap";
+
+    default_layer {
+      bindings = <
+                    &kp ESC   &kp N1    &kp N2   &kp N3    &kp N4    &kp N5  &kp N6
+                    &kp TAB   &kp Q     &kp W    &kp E     &kp R     &kp T   &kp N7
+        &kp F13     &kp ENTER &kp D     &kp S    &kp A     &kp F     &kp G   &kp N8
+        &kp F14     &kp LSHFT &kp Z     &kp X    &kp C     &kp V     &kp B   &kp N9
+        &kp F15     &kp LCTRL &sl FUNC  &kp LALT           &kp SPACE         &lt ARROW N0
+      >;
+    };
+
+    arrow_layer {
+      bindings = <
+                    &trans    &trans    &trans   &trans    &trans    &trans  &trans
+                    &trans    &trans    &kp UP   &trans    &trans    &trans  &trans
+        &bt BT_CLR  &trans    &kp LEFT  &kp DOWN &kp RIGHT &trans    &trans  &trans
+        &reset      &trans    &trans    &trans   &trans    &trans    &trans  &trans
+        &bootloader &trans    &trans    &trans             &trans            &trans
+      >;
+    };
+
+    function_layer {
+      bindings = <
+                    &trans    &kp F1    &kp F2   &kp F3    &kp F4   &kp F5   &kp F6
+                    &trans    &kp P     &kp O    &kp I     &kp U    &kp Y    &kp F7
+        &bt BT_CLR  &kp BSPC  &kp SEMI  &kp L    &kp K     &kp J    &kp H    &kp F8
+        &bt BT_NXT  &trans    &kp LGUI  &kp M    &kp N     &kp F12  &kp F11  &kp F9
+        &bootloader &trans    &trans    &trans             &trans            &kp F10
+      >;
+    };
+  };
+};

--- a/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The ZMK Contributors
+ * Copyright (c) 2022 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */
@@ -7,16 +7,17 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
 
 #define BASE        0
 #define ARROW       1
 #define FUNC        2
 
 / {
-    chosen {
-        zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
-    };
+  chosen {
+      zmk,kscan = &kscan0;
+      zmk,matrix_transform = &default_transform;
+  };
 
   keymap {
     compatible = "zmk,keymap";
@@ -33,11 +34,11 @@
 
     arrow_layer {
       bindings = <
-                    &trans    &trans    &trans   &trans    &trans    &trans  &trans
-                    &trans    &trans    &kp UP   &trans    &trans    &trans  &trans
-        &bt BT_CLR  &trans    &kp LEFT  &kp DOWN &kp RIGHT &trans    &trans  &trans
-        &reset      &trans    &trans    &trans   &trans    &trans    &trans  &trans
-        &bootloader &trans    &trans    &trans             &trans            &trans
+                    &bt BT_SEL 0 &bt BT_SEL 1 &trans     &trans    &trans  &out OUT_USB &out OUT_BLE
+                    &trans       &trans       &kp UP     &trans    &trans  &trans       &trans
+        &bt BT_CLR  &trans       &kp RIGHT    &kp DOWN   &kp RIGHT &trans  &trans       &trans
+        &reset      &trans       &trans       &trans     &trans    &trans  &trans       &trans
+        &bootloader &trans       &trans       &trans               &trans               &trans
       >;
     };
 
@@ -46,7 +47,7 @@
                     &trans    &kp F1    &kp F2   &kp F3    &kp F4   &kp F5   &kp F6
                     &trans    &kp P     &kp O    &kp I     &kp U    &kp Y    &kp F7
         &bt BT_CLR  &kp BSPC  &kp SEMI  &kp L    &kp K     &kp J    &kp H    &kp F8
-        &bt BT_NXT  &trans    &kp LGUI  &kp M    &kp N     &kp F12  &kp F11  &kp F9
+        &reset      &trans    &kp LGUI  &kp M    &kp N     &kp F12  &kp F11  &kp F9
         &bootloader &trans    &trans    &trans             &trans            &kp F10
       >;
     };

--- a/app/boards/shields/eternal_keypad/eternal_keypad_lefty.overlay
+++ b/app/boards/shields/eternal_keypad/eternal_keypad_lefty.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 The ZMK Contributors
+ * Copyright (c) 202 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/boards/shields/eternal_keypad/eternal_keypad_lefty.zmk.yml
+++ b/app/boards/shields/eternal_keypad/eternal_keypad_lefty.zmk.yml
@@ -6,3 +6,4 @@ url: https://github.com/duckyb/eternal-keypad
 requires: [pro_micro]
 features:
   - keys
+  - underglow

--- a/app/boards/shields/eternal_keypad/eternal_keypad_lefty.zmk.yml
+++ b/app/boards/shields/eternal_keypad/eternal_keypad_lefty.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: eternal_keypad_lefty
+name: Eternal Keypad Left
+type: shield
+url: https://github.com/duckyb/eternal-keypad
+requires: [pro_micro]
+features:
+  - keys

--- a/app/boards/shields/eternal_keypad/eternal_keypad_lefty.zmk.yml
+++ b/app/boards/shields/eternal_keypad/eternal_keypad_lefty.zmk.yml
@@ -1,6 +1,6 @@
 file_format: "1"
 id: eternal_keypad_lefty
-name: Eternal Keypad Left
+name: Eternal Keypad Lefty
 type: shield
 url: https://github.com/duckyb/eternal-keypad
 requires: [pro_micro]


### PR DESCRIPTION
Add Eternal Keypad gaming keypad.

## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
