### PR TITLE
  feat(shields): Add dumbpad

### DIFF
--- a/app/boards/shields/dumbpad/Kconfig.defconfig
+++ b/app/boards/shields/dumbpad/Kconfig.defconfig
@@ -21,12 +21,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/dumbpad/Kconfig.defconfig
+++ b/app/boards/shields/dumbpad/Kconfig.defconfig
@@ -1,0 +1,45 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_DUMBPAD
+
+config ZMK_KEYBOARD_NAME
+	default "DumbPad"
+
+if ZMK_DISPLAY
+
+config I2C
+	default y
+
+config SSD1306
+	default y
+
+config SSD1306_REVERSE_MODE
+	default y
+
+endif # ZMK_DISPLAY
+
+if LVGL
+
+config LVGL_HOR_RES_MAX
+	default 128
+
+config LVGL_VER_RES_MAX
+	default 32
+
+config LVGL_VDB_SIZE
+	default 64
+
+config LVGL_DPI
+	default 148
+
+config LVGL_BITS_PER_PIXEL
+	default 1
+
+choice LVGL_COLOR_DEPTH
+	default LVGL_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL
+
+endif

--- a/app/boards/shields/dumbpad/Kconfig.defconfig
+++ b/app/boards/shields/dumbpad/Kconfig.defconfig
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
-if SHIELD_DUMBPAD
+if SHIELD_DUMBPAD || SHIELD_DUMBPAD_OLED_TOP
 
 config ZMK_KEYBOARD_NAME
 	default "DumbPad"

--- a/app/boards/shields/dumbpad/Kconfig.shield
+++ b/app/boards/shields/dumbpad/Kconfig.shield
@@ -3,3 +3,6 @@
 
 config SHIELD_DUMBPAD
 	def_bool $(shields_list_contains,dumbpad)
+
+config SHIELD_DUMBPAD_OLED_TOP
+	def_bool $(shields_list_contains,dumbpad_oled_top)

--- a/app/boards/shields/dumbpad/Kconfig.shield
+++ b/app/boards/shields/dumbpad/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_DUMBPAD
+	def_bool $(shields_list_contains,dumbpad)

--- a/app/boards/shields/dumbpad/README.md
+++ b/app/boards/shields/dumbpad/README.md
@@ -1,0 +1,10 @@
+# Dumbpad
+
+The [dumbpad](https://github.com/imchipwood/dumbpad) is a 4x4 macropad with one or two optional rotary encoders.
+
+This shield includes optional support for an oled, as added in the [CustomKBD](https://customkbd.com/collections/complete-kits/products/dumbpad-4x4-macro-pad-with-rotary-encoder-support) version.
+
+Two keymaps are included:
+
+- dumbpad (default - oled/mcu oriented vertically on the left)
+- dumbpad_oled_top (oled/mcu oriented horizontally at the top)

--- a/app/boards/shields/dumbpad/dumbpad.conf
+++ b/app/boards/shields/dumbpad/dumbpad.conf
@@ -3,7 +3,6 @@
 
 # Uncomment to turn on logging, and set ZMK logging to debug output
 # CONFIG_ZMK_USB_LOGGING=y
-# CONFIG_SENSOR_LOG_LEVEL_DBG=y
 
 # Uncomment both to enable encoder
 # CONFIG_EC11=y

--- a/app/boards/shields/dumbpad/dumbpad.conf
+++ b/app/boards/shields/dumbpad/dumbpad.conf
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Uncomment to turn on logging, and set ZMK logging to debug output
+# CONFIG_ZMK_USB_LOGGING=y
+# CONFIG_SENSOR_LOG_LEVEL_DBG=y
+
+# Uncomment both to enable encoder
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Uncomment to enable OLED
+# CONFIG_ZMK_DISPLAY=y

--- a/app/boards/shields/dumbpad/dumbpad.dtsi
+++ b/app/boards/shields/dumbpad/dumbpad.dtsi
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    kscan0: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+		label = "KSCAN";
+
+		diode-direction = "col2row";
+
+		row-gpios
+			= <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			;
+
+		col-gpios
+			= <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			;
+
+	};
+
+	default_transform: keymap_transform_0 {
+		compatible = "zmk,matrix-transform";
+		columns = <5>;
+		rows = <4>;
+
+		map = <
+					RC(0,1) RC(0,2) RC(0,3) RC(0,4)
+					RC(1,1) RC(1,2) RC(1,3) RC(1,4)
+					RC(2,1) RC(2,2) RC(2,3) RC(2,4)
+			RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)
+		>;
+	};
+
+
+	oled_top_transform: keymap_transform_1 {
+		compatible = "zmk,matrix-transform";
+		columns = <5>;
+		rows = <4>;
+
+		map = <
+                    RC(3,0)
+                    RC(3,1) RC(2,1) RC(1,1) RC(0,1)
+                    RC(3,2) RC(2,2) RC(1,2) RC(0,2)
+                    RC(3,3) RC(2,3) RC(1,3) RC(0,3)
+                    RC(3,4) RC(2,4) RC(1,4) RC(0,4)
+		>;
+	};
+
+	left_encoder: encoder_left {
+		compatible = "alps,ec11";
+		label = "LEFT_ENCODER";
+		a-gpios = <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro 4  (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		resolution = <4>;
+	};
+
+	right_encoder: encoder_right {
+		compatible = "alps,ec11";
+		label = "RIGHT_ENCODER";
+		a-gpios = <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		resolution = <4>;
+	};
+
+};
+
+&pro_micro_i2c {
+	status = "okay";
+
+	oled: ssd1306@3c {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3c>;
+		label = "DISPLAY";
+		width = <128>;
+		height = <32>;
+		segment-offset = <0>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <31>;
+		segment-remap;
+		com-invdir;
+		com-sequential;
+		prechargep = <0x22>;
+	};
+};

--- a/app/boards/shields/dumbpad/dumbpad.keymap
+++ b/app/boards/shields/dumbpad/dumbpad.keymap
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/ext_power.h>
+
+
+#define TIMEOUT 50
+#define DEFAULT 0
+#define ADJUST  1
+
+&left_encoder {
+    status = "okay";
+};
+
+&right_encoder {
+    status = "disabled";
+};
+
+/ {
+/*  ------------------
+ *  |     0  1  2  3 |
+ *  |     4  5  6  7 |
+ *  |     8  9 10 11 |
+ *  | 12 13 14 15 16 |
+ *  ------------------
+ */
+    combos {
+        compatible = "zmk,combos";
+        combo_bootloader {
+            timeout-ms = <TIMEOUT>;
+            key-positions = <1 2>;
+            bindings = <&bootloader>;
+        };
+        combo_reset {
+            timeout-ms = <TIMEOUT>;
+            key-positions = <1 3>;
+            bindings = <&reset>;
+        };
+        combo_bt_nxt {
+            timeout-ms = <TIMEOUT>;
+            key-positions = <1 4>;
+            bindings = <&bt BT_NXT>;
+        };
+        combo_btclr {
+            timeout-ms = <TIMEOUT>;
+            key-positions = <1 6>;
+            bindings = <&bt BT_CLR>;
+        };
+    };
+
+    sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&left_encoder &right_encoder>;
+    };
+
+    keymap0: keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            label = "default layer";
+            bindings = <
+                            &kp KP_N7    &kp KP_N8       &kp KP_N9         &kp BSPC
+                            &kp KP_N4    &kp KP_N5       &kp KP_N6         &kp KP_PLUS
+                            &kp KP_N1    &kp KP_N2       &kp KP_N3         &kp KP_MULTIPLY
+                &kp C_PP    &mo ADJUST   &kp KP_N0       &kp KP_DOT        &kp KP_EQUAL
+            >;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+
+        };
+
+        fn_layer {
+            label = "fn layer";
+            bindings = <
+                            &kp ESC    &none         &bt BT_CLR      &kp DEL
+                            &none      &none         &none           &kp KP_MINUS
+                            &kp EP_TOG &kp EP_OFF    &kp EP_ON       &kp KP_DIVIDE
+                &trans      &trans     &none         &trans          &kp ENTER
+            >;
+            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
+        };
+    };
+};

--- a/app/boards/shields/dumbpad/dumbpad.overlay
+++ b/app/boards/shields/dumbpad/dumbpad.overlay
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    kscan0: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+		label = "KSCAN";
+
+		diode-direction = "col2row";
+
+		row-gpios
+			= <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			;
+
+		col-gpios
+			= <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			, <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+			;
+
+	};
+
+	default_transform: keymap_transform_0 {
+		compatible = "zmk,matrix-transform";
+		columns = <5>;
+		rows = <4>;
+
+		map = <
+					RC(0,1) RC(0,2) RC(0,3) RC(0,4)
+					RC(1,1) RC(1,2) RC(1,3) RC(1,4)
+					RC(2,1) RC(2,2) RC(2,3) RC(2,4)
+			RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)
+		>;
+	};
+
+
+	oled_top_transform: keymap_transform_1 {
+		compatible = "zmk,matrix-transform";
+		columns = <5>;
+		rows = <4>;
+
+		map = <
+                    RC(3,0)
+                    RC(3,1) RC(2,1) RC(1,1) RC(0,1)
+                    RC(3,2) RC(2,2) RC(1,2) RC(0,2)
+                    RC(3,3) RC(2,3) RC(1,3) RC(0,3)
+                    RC(3,4) RC(2,4) RC(1,4) RC(0,4)
+		>;
+	};
+
+	left_encoder: encoder_left {
+		compatible = "alps,ec11";
+		label = "LEFT_ENCODER";
+		a-gpios = <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro 4  (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		resolution = <4>;
+	};
+
+	right_encoder: encoder_right {
+		compatible = "alps,ec11";
+		label = "RIGHT_ENCODER";
+		a-gpios = <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		b-gpios = <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+		resolution = <4>;
+	};
+
+};
+
+&pro_micro_i2c {
+	status = "okay";
+
+	oled: ssd1306@3c {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3c>;
+		label = "DISPLAY";
+		width = <128>;
+		height = <32>;
+		segment-offset = <0>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <31>;
+		segment-remap;
+		com-invdir;
+		com-sequential;
+		prechargep = <0x22>;
+	};
+};

--- a/app/boards/shields/dumbpad/dumbpad.zmk.yml
+++ b/app/boards/shields/dumbpad/dumbpad.zmk.yml
@@ -1,0 +1,11 @@
+file_format: "1"
+id: dumbpad
+name: DumbPad
+type: shield
+url: https://github.com/imchipwood/dumbpad
+requires: [pro_micro]
+exposes: [i2c_oled]
+features:
+  - keys
+  - display
+  - encoder

--- a/app/boards/shields/dumbpad/dumbpad_oled_top.keymap
+++ b/app/boards/shields/dumbpad/dumbpad_oled_top.keymap
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/ext_power.h>
+
+
+#define TIMEOUT 50
+#define DEFAULT 0
+#define ADJUST  1
+
+&left_encoder {
+    status = "okay";
+};
+
+&right_encoder {
+    status = "disabled";
+};
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &oled_top_transform;
+    };
+
+/*  ---------------
+ *  |  0  [-----] |
+ *  |  1  2  3  4 |
+ *  |  5  6  7  8 |
+ *  |  9 10 11 12 |
+ *  | 13 14 15 16 |
+ *  ---------------
+ */
+    combos {
+        compatible = "zmk,combos";
+        combo_bootloader {
+            timeout-ms = <TIMEOUT>;
+            key-positions = <2 3>;
+            bindings = <&bootloader>;
+        };
+        combo_reset {
+            timeout-ms = <TIMEOUT>;
+            key-positions = <2 4>;
+            bindings = <&reset>;
+        };
+        combo_bt_nxt {
+            timeout-ms = <TIMEOUT>;
+            key-positions = <2 5>;
+            bindings = <&bt BT_NXT>;
+        };
+        combo_btclr {
+            timeout-ms = <TIMEOUT>;
+            key-positions = <2 7>;
+            bindings = <&bt BT_CLR>;
+        };
+    };
+
+    sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&left_encoder &right_encoder>;
+    };
+
+    keymap0: keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            label = "default layer";
+            bindings = <
+                            &kp C_PP
+                            &kp KP_N7    &kp KP_N8       &kp KP_N9         &kp BSPC
+                            &kp KP_N4    &kp KP_N5       &kp KP_N6         &kp KP_PLUS
+                            &kp KP_N1    &kp KP_N2       &kp KP_N3         &kp KP_MULTIPLY
+                            &mo ADJUST   &kp KP_N0       &kp KP_DOT        &kp KP_EQUAL
+            >;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
+        };
+
+        fn_layer {
+            label = "fn layer";
+            bindings = <
+                            &trans
+                            &kp ESC    &none         &bt BT_CLR      &kp DEL
+                            &none      &none         &none           &kp KP_MINUS
+                            &kp EP_TOG &kp EP_OFF    &kp EP_ON       &kp KP_DIVIDE
+                            &trans     &none         &trans          &kp ENTER
+            >;
+            sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
+        };
+    };
+};

--- a/app/boards/shields/dumbpad/dumbpad_oled_top.overlay
+++ b/app/boards/shields/dumbpad/dumbpad_oled_top.overlay
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: MIT
  */
 
- #include "dumbpad.dtsi"
+#include "dumbpad.dtsi"

--- a/app/boards/shields/dumbpad/dumbpad_oled_top.zmk.yml
+++ b/app/boards/shields/dumbpad/dumbpad_oled_top.zmk.yml
@@ -1,0 +1,11 @@
+file_format: "1"
+id: dumbpad_oled_top
+name: DumbPad oled top
+type: shield
+url: https://github.com/imchipwood/dumbpad
+requires: [pro_micro]
+exposes: [i2c_oled]
+features:
+  - keys
+  - display
+  - encoder


### PR DESCRIPTION
Add dumbpad macropad.

## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [ x Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
