### PR TITLE
Behaviors: Fix memory leak in sticky keys

### DIFF
--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -226,7 +226,7 @@ static int sticky_key_keycode_state_changed_listener(const zmk_event_t *eh) {
                     // continue processing the event. Release the sticky key afterwards.
                     ZMK_EVENT_RAISE_AFTER(eh, behavior_sticky_key);
                     release_sticky_key_behavior(sticky_key, ev->timestamp);
-                    return ZMK_EV_EVENT_CAPTURED;
+                    return ZMK_EV_EVENT_HANDLED;
                 }
             }
             sticky_key->modified_key_usage_page = ev->usage_page;


### PR DESCRIPTION
Some handlers returned 'ZMK_EV_EVENT_CAPTURED' instead of
'ZMK_EV_EVENT_HANDLED' as they should, and did not free
the memory.
