### PR TITLE
feat: append the current profile number to the advertised name

### DIFF
--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -78,11 +78,13 @@ static uint8_t active_profile;
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
 
+static uint8_t device_name[17] = DEVICE_NAME;
+
 BUILD_ASSERT(DEVICE_NAME_LEN <= 16, "ERROR: BLE device name is too long. Max length: 16");
 
-static const struct bt_data zmk_ble_ad[] = {
+static struct bt_data zmk_ble_ad[] = {
 #if IS_HOST_PERIPHERAL
-    BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_NAME, DEVICE_NAME_LEN),
+    BT_DATA(BT_DATA_NAME_COMPLETE, device_name, 16),
     BT_DATA_BYTES(BT_DATA_GAP_APPEARANCE, 0xC1, 0x03),
 #endif
     BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),
@@ -182,6 +184,12 @@ int update_advertising() {
     bt_addr_le_t *addr;
     struct bt_conn *conn;
     enum advertising_type desired_adv = ZMK_ADV_NONE;
+
+    uint8_t max_device_name_length = (active_profile > 9) ? 13 : 14;
+    // need to store the temporary device name because Zephyr *printf doesn't support string precision
+    char temp_device_name[14];
+    snprintf(temp_device_name, max_device_name_length, "%s", DEVICE_NAME);
+    snprintf(device_name, 16, "%s~%d", temp_device_name, active_profile);
 
     if (zmk_ble_active_profile_is_open()) {
         desired_adv = ZMK_ADV_CONN;


### PR DESCRIPTION
This commit adds the string "~#" to the end of the keyboard name for advertising purposes. If the name is too long to fit this string, the end of the keyboard name is overwritten. KeyboardName would become KeyboardName~2 while LongKeyboardName would become LongKeyboardNa~2 if profile 2 is active.

I did make the assumption that no (sane) person would have more than 99 profiles (i.e. the length of the active profile would never be more than 2 characters).

I've tested this on Windows, macOS and Android and all reflected the name change (albeit with various amounts of delay and macOS seems to like to store the old name).

There may be better ways to do this - I haven't written in C (or really any non-scripting language) in at least a dozen years.