### PR TITLE
feat(kscan_gpio_direct) Add toggle-mode

### DIFF
--- a/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-direct.yaml
+++ b/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-direct.yaml
@@ -11,6 +11,8 @@ properties:
   input-gpios:
     type: phandle-array
     required: true
+  toggle-mode:
+    type: boolean
   debounce-period:
     type: int
     default: 5


### PR DESCRIPTION
feat(kscan_gpio_direct) Add toggle switch driver

Addresses #980 by adding a boolean `toggle-mode` to the direct-wire kscan that automatically sets the required pull for the input pin to remove any quiescent current.

Without `toggle-mode`, pins draw about 244.3uA of current. When `toggle-mode` is enabled, `ACTIVE_LOW` pins had a current drain of 0.0uA while `ACTIVE_HIGH` pins were recorded with a quiescent current of 0.2uA.