### PR TITLE
RGB Underglow: Auto off on idle

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -341,6 +341,9 @@ config ZMK_RGB_UNDERGLOW_ON_START
 	bool "RGB underglow starts on by default"
 	default y
 
+config ZMK_RGB_UNDERGLOW_AUTO_OFF_IDLE
+	bool "Turn off RGB underglow when keyboard goes into idle state"
+
 #ZMK_RGB_UNDERGLOW
 endif
 


### PR DESCRIPTION
This PR adds an auto off on idle feature to the underglow. It's already supported for the backlight and this adds a similar setting to the underglow.

I have tested it on my sofle choc and it's working great.