### PR TITLE
feat(behaviors): Adding global quick tap 

### DIFF
--- a/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
@@ -20,6 +20,8 @@ properties:
     default: -1
   quick_tap_ms: # deprecated
     type: int
+  global-quick-tap:
+    type: boolean
   flavor:
     type: string
     required: false

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -96,7 +96,7 @@ struct last_tapped {
     int64_t timestamp;
 };
 
-struct last_tapped last_tapped = { INT32_MIN, INT64_MIN };
+struct last_tapped last_tapped = {INT32_MIN, INT64_MIN};
 
 static void store_last_tapped(int64_t timestamp) {
     if (timestamp > last_tapped.timestamp) {

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -104,7 +104,7 @@ static void store_last_hold_tapped(struct active_hold_tap *hold_tap) {
 }
 
 // For global quick tap we just keep track of when the last key was pressed last
-int64_t last_key_tapped_timestamp;
+int64_t last_key_tapped_timestamp = INT64_MIN;
 
 static bool is_quick_tap(struct active_hold_tap *hold_tap) {
     if (hold_tap->config->global_quick_tap) {

--- a/app/tests/hold-tap/balanced/8-global-quick-tap/1-basic/events.patterns
+++ b/app/tests/hold-tap/balanced/8-global-quick-tap/1-basic/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/balanced/8-global-quick-tap/1-basic/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced/8-global-quick-tap/1-basic/keycode_events.snapshot
@@ -1,0 +1,24 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (balanced decision moment key-up)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (balanced decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (balanced decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (balanced decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced/8-global-quick-tap/1-basic/native_posix.keymap
+++ b/app/tests/hold-tap/balanced/8-global-quick-tap/1-basic/native_posix.keymap
@@ -1,0 +1,25 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		/* tap */
+		ZMK_MOCK_PRESS(0,0,10) 
+		ZMK_MOCK_RELEASE(0,0,10) 
+		/* normal quick tap */
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_RELEASE(0,0,400)
+		/* hold */
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,400)
+		/* global quick tap */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/app/tests/hold-tap/balanced/8-global-quick-tap/2-double-hold/events.patterns
+++ b/app/tests/hold-tap/balanced/8-global-quick-tap/2-double-hold/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/balanced/8-global-quick-tap/2-double-hold/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced/8-global-quick-tap/2-double-hold/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (balanced decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided hold-timer (balanced decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xe0 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0xe0 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced/8-global-quick-tap/2-double-hold/native_posix.keymap
+++ b/app/tests/hold-tap/balanced/8-global-quick-tap/2-double-hold/native_posix.keymap
@@ -1,0 +1,20 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		/* hold the first mod tap */
+		ZMK_MOCK_PRESS(0,0,400)
+		/* hold the second mod tap */
+		ZMK_MOCK_PRESS(0,1,400)
+		/* press the normal key */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+
+		/* release the hold taps */
+		ZMK_MOCK_RELEASE(0,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+	>;
+};

--- a/app/tests/hold-tap/balanced/8-global-quick-tap/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/balanced/8-global-quick-tap/behavior_keymap.dtsi
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+	behaviors {
+		ht_bal: behavior_balanced {
+			compatible = "zmk,behavior-hold-tap";
+			label = "MOD_TAP";
+			#binding-cells = <2>;
+			flavor = "balanced";
+			tapping-term-ms = <300>;
+			quick-tap-ms = <300>;
+			bindings = <&kp>, <&kp>;
+			global-quick-tap;
+		};
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&ht_bal LEFT_SHIFT F &ht_bal LEFT_CONTROL C
+				&kp D &none>;
+		};
+	};
+};

--- a/app/tests/hold-tap/hold-preferred/8-global-quick-tap/1-basic/events.patterns
+++ b/app/tests/hold-tap/hold-preferred/8-global-quick-tap/1-basic/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/hold-preferred/8-global-quick-tap/1-basic/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred/8-global-quick-tap/1-basic/keycode_events.snapshot
@@ -1,0 +1,24 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (hold-preferred decision moment key-up)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (hold-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-interrupt (hold-preferred decision moment other-key-down)
+kp_pressed: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (hold-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred/8-global-quick-tap/1-basic/native_posix.keymap
+++ b/app/tests/hold-tap/hold-preferred/8-global-quick-tap/1-basic/native_posix.keymap
@@ -1,0 +1,25 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		/* tap */
+		ZMK_MOCK_PRESS(0,0,10) 
+		ZMK_MOCK_RELEASE(0,0,10) 
+		/* normal quick tap */
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_RELEASE(0,0,400)
+		/* hold */
+		ZMK_MOCK_PRESS(0,0,10)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,400)
+		/* global quick tap */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/app/tests/hold-tap/hold-preferred/8-global-quick-tap/2-double-hold/events.patterns
+++ b/app/tests/hold-tap/hold-preferred/8-global-quick-tap/2-double-hold/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/hold-preferred/8-global-quick-tap/2-double-hold/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred/8-global-quick-tap/2-double-hold/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (hold-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided hold-timer (hold-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xe0 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0xe0 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred/8-global-quick-tap/2-double-hold/native_posix.keymap
+++ b/app/tests/hold-tap/hold-preferred/8-global-quick-tap/2-double-hold/native_posix.keymap
@@ -1,0 +1,20 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		/* hold the first mod tap */
+		ZMK_MOCK_PRESS(0,0,400)
+		/* hold the second mod tap */
+		ZMK_MOCK_PRESS(0,1,400)
+		/* press the normal key */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+
+		/* release the hold taps */
+		ZMK_MOCK_RELEASE(0,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+	>;
+};

--- a/app/tests/hold-tap/hold-preferred/8-global-quick-tap/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/hold-preferred/8-global-quick-tap/behavior_keymap.dtsi
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+	behaviors {
+		hp: behavior_hold_preferred {
+			compatible = "zmk,behavior-hold-tap";
+			label = "MOD_TAP";
+			#binding-cells = <2>;
+			flavor = "hold-preferred";
+			tapping-term-ms = <300>;
+			quick-tap-ms = <300>;
+			bindings = <&kp>, <&kp>;
+			global-quick-tap;
+		};
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&hp LEFT_SHIFT F &hp LEFT_CONTROL G
+				&kp D &none>;
+		};
+	};
+};

--- a/app/tests/hold-tap/tap-preferred/8-global-quick-tap/1-basic/events.patterns
+++ b/app/tests/hold-tap/tap-preferred/8-global-quick-tap/1-basic/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-preferred/8-global-quick-tap/1-basic/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-preferred/8-global-quick-tap/1-basic/keycode_events.snapshot
@@ -1,0 +1,24 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-preferred decision moment key-up)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (tap-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-preferred/8-global-quick-tap/1-basic/native_posix.keymap
+++ b/app/tests/hold-tap/tap-preferred/8-global-quick-tap/1-basic/native_posix.keymap
@@ -1,0 +1,25 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		/* tap */
+		ZMK_MOCK_PRESS(0,0,10) 
+		ZMK_MOCK_RELEASE(0,0,10) 
+		/* normal quick tap */
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_RELEASE(0,0,400)
+		/* hold */
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,400)
+		/* global quick tap */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/app/tests/hold-tap/tap-preferred/8-global-quick-tap/2-double-hold/events.patterns
+++ b/app/tests/hold-tap/tap-preferred/8-global-quick-tap/2-double-hold/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-preferred/8-global-quick-tap/2-double-hold/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-preferred/8-global-quick-tap/2-double-hold/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (tap-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided hold-timer (tap-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xe0 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xe1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0xe0 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-preferred/8-global-quick-tap/2-double-hold/native_posix.keymap
+++ b/app/tests/hold-tap/tap-preferred/8-global-quick-tap/2-double-hold/native_posix.keymap
@@ -1,0 +1,20 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		/* hold the first mod tap */
+		ZMK_MOCK_PRESS(0,0,400)
+		/* hold the second mod tap */
+		ZMK_MOCK_PRESS(0,1,400)
+		/* press the normal key */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+
+		/* release the hold taps */
+		ZMK_MOCK_RELEASE(0,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+	>;
+};

--- a/app/tests/hold-tap/tap-preferred/8-global-quick-tap/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-preferred/8-global-quick-tap/behavior_keymap.dtsi
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+	behaviors {
+		tp: behavior_tap_preferred {
+			compatible = "zmk,behavior-hold-tap";
+			label = "MOD_TAP";
+			#binding-cells = <2>;
+			flavor = "tap-preferred";
+			tapping-term-ms = <300>;
+			quick-tap-ms = <300>;
+			bindings = <&kp>, <&kp>;
+			global-quick-tap;
+		};
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&tp LEFT_SHIFT F &tp LEFT_CONTROL C
+				&kp D &none>;
+		};
+	};
+};

--- a/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/1-basic/events.patterns
+++ b/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/1-basic/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/1-basic/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/1-basic/keycode_events.snapshot
@@ -1,0 +1,24 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-unless-interrupted decision moment key-up)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-unless-interrupted decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-unless-interrupted decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-unless-interrupted decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/1-basic/native_posix.keymap
+++ b/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/1-basic/native_posix.keymap
@@ -1,0 +1,25 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		/* tap */
+		ZMK_MOCK_PRESS(0,0,10) 
+		ZMK_MOCK_RELEASE(0,0,10) 
+		/* normal quick tap */
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_RELEASE(0,0,400)
+		/* hold */
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,400)
+		/* global quick tap */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_PRESS(0,0,400)
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/2-double-hold/events.patterns
+++ b/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/2-double-hold/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/2-double-hold/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/2-double-hold/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-unless-interrupted decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided tap (tap-unless-interrupted decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0x0d implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0x0d implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/2-double-hold/native_posix.keymap
+++ b/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/2-double-hold/native_posix.keymap
@@ -1,0 +1,20 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+	events = <
+		/* hold the first mod tap */
+		ZMK_MOCK_PRESS(0,0,400)
+		/* hold the second mod tap */
+		ZMK_MOCK_PRESS(0,1,400)
+		/* press the normal key */
+		ZMK_MOCK_PRESS(1,0,10)
+		ZMK_MOCK_RELEASE(1,0,10)
+
+		/* release the hold taps */
+		ZMK_MOCK_RELEASE(0,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+	>;
+};

--- a/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-unless-interrupted/6-global-quick-tap/behavior_keymap.dtsi
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+	behaviors {
+		ht_tui: behavior_hold_tap_tap_unless_interrupted {
+			compatible = "zmk,behavior-hold-tap";
+			label = "hold_tap_tap_unless_interrupted";
+			#binding-cells = <2>;
+			flavor = "tap-unless-interrupted";
+			tapping-term-ms = <300>;
+			quick-tap-ms = <300>;
+			bindings = <&kp>, <&kp>;
+			global-quick-tap;
+		};
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&ht_tui LEFT_SHIFT F      &ht_tui LEFT_CONTROL J
+				&kp D      &kp RIGHT_CONTROL>;
+		};
+	};
+};

--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -50,7 +50,25 @@ In QMK, unlike ZMK, this functionality is enabled by default, and you turn it of
 
 #### `global-quick-tap`
 
-If global quick tap is enabled, then the quick tap will apply not only when the given hold tap is tapped, but for any key tap before it. This effectively disables the hold tap when typing quickly, which is can be quite useful for homerow mods. It can also have the effect of removing the input delay when typing quickly.
+If global quick tap is enabled, then the quick tap will apply not only when the given hold tap is tapped, but for any key tap before it. This effectively disables the hold tap when typing quickly, which can be quite useful for home row mods. It can also have the effect of removing the input delay when typing quickly.
+
+For example, the following hold tap configuration enables global quick tap with a 125 millisecond term.
+```
+gqt: global-quick-tap {
+	compatible = "zmk,behavior-hold-tap";
+	label = "GLOBAL_QUICK_TAP";
+	#binding-cells = <2>;
+	flavor = "tap-preferred";
+	tapping-term-ms = <200>;
+	quick-tap-ms = <125>;
+	global-quick-tap;
+	bindings = <&kp>, <&kp>;
+};
+```
+
+If you press `&kp A`, and then `&gqt LEFT_SHIFT B` **within** 125 ms after, then `ab` will be output. Importantly, the `b` will be output immediately since it was within the `quick-tap-ms`. This behavior will hold for any key that is output to the computer. The `&gqt LEFT_SHIFT B` binding will only have its underlying hold-tap behavior if it is pressed 125 ms **after** any keycode is sent to the computer.
+
+Note that the higher the `quick-tap-ms`, the harder it will be to use the hold behavior, making this unideal for capitalizing letter while typing normally. However, paired with [mod-tap](mod-tap.md)
 
 #### `retro-tap`
 

--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -50,9 +50,9 @@ In QMK, unlike ZMK, this functionality is enabled by default, and you turn it of
 
 #### `global-quick-tap`
 
-If global quick tap is enabled, then the quick tap will apply not only when the given hold tap is tapped, but for any key tap before it. This effectively disables the hold tap when typing quickly, which can be quite useful for home row mods. It can also have the effect of removing the input delay when typing quickly.
+If global quick tap is enabled, then `quick-tap-ms` will apply not only when the given hold-tap is tapped but for any key tap before it. This effectively disables the hold tap when typing quickly, which can be quite useful for home row mods. It can also have the effect of removing the input delay when typing quickly.
 
-For example, the following hold tap configuration enables global quick tap with a 125 millisecond term.
+For example, the following hold-tap configuration enables global quick tap with a 125 millisecond term.
 ```
 gqt: global-quick-tap {
 	compatible = "zmk,behavior-hold-tap";
@@ -66,9 +66,9 @@ gqt: global-quick-tap {
 };
 ```
 
-If you press `&kp A`, and then `&gqt LEFT_SHIFT B` **within** 125 ms after, then `ab` will be output. Importantly, the `b` will be output immediately since it was within the `quick-tap-ms`. This behavior will hold for any key that is output to the computer. The `&gqt LEFT_SHIFT B` binding will only have its underlying hold-tap behavior if it is pressed 125 ms **after** any keycode is sent to the computer.
+If you press `&kp A` and then `&gqt LEFT_SHIFT B` **within** 125 ms, then `ab` will be output. Importantly, `b` will be output immediately since it was within the `quick-tap-ms`. This quick-tap behavior will work for any key press, whether it is within a behavior like hold-tap, or a simple `&kp`. This means the `&gqt LEFT_SHIFT B` binding will only have its underlying hold-tap behavior if it is pressed 125 ms **after** a key press.
 
-Note that the higher the `quick-tap-ms`, the harder it will be to use the hold behavior, making this unideal for capitalizing letter while typing normally. However, paired with [mod-tap](mod-tap.md)
+Note that the higher the `quick-tap-ms` the harder it will be to use the hold behavior, making this less applicable for something like capitalizing letter while typing normally. However, if the hold behavior isn't used during fast typing, then it can be an effective way to mitigate misfires.
 
 #### `retro-tap`
 

--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -53,6 +53,7 @@ In QMK, unlike ZMK, this functionality is enabled by default, and you turn it of
 If global quick tap is enabled, then `quick-tap-ms` will apply not only when the given hold-tap is tapped but for any key tap before it. This effectively disables the hold tap when typing quickly, which can be quite useful for home row mods. It can also have the effect of removing the input delay when typing quickly.
 
 For example, the following hold-tap configuration enables global quick tap with a 125 millisecond term.
+
 ```
 gqt: global-quick-tap {
 	compatible = "zmk,behavior-hold-tap";

--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -48,6 +48,10 @@ If you press a tapped hold-tap again within `quick-tap-ms` milliseconds, it will
 
 In QMK, unlike ZMK, this functionality is enabled by default, and you turn it off using `TAPPING_FORCE_HOLD`.
 
+#### `global-quick-tap`
+
+If global quick tap is enabled, then the quick tap will apply not only when the given hold tap is tapped, but for any key tap before it. This effectively disables the hold tap when typing quickly, which is can be quite useful for homerow mods. It can also have the effect of removing the input delay when typing quickly.
+
 #### `retro-tap`
 
 If retro tap is enabled, the tap behavior is triggered when releasing the hold-tap key if no other key was pressed in the meantime.


### PR DESCRIPTION
Adding an additional option to hold taps to make the quick tap functionality apply to all taps, rather than just the given hold tap. The current implementation uses the key state listener and is perfectly functional. However, I would've liked to have been able to identify any key being tapped (even if it's internal) as well as ignore any time a key was tapped in conjunction with a hold. I looked into this but it seemed more complicated then it was worth since this current implementation covers almost all cases while being much simpler.

So far I've been daily driving this implementation for almost a week and loving it! The fact that it gets rid of almost all input delay when typing is an added bonus I hadn't even considered.