### PR TITLE
Sofle Shield: Add underglow support and increase encoder sensitivity

### DIFF
--- a/app/boards/shields/sofle/Kconfig.defconfig
+++ b/app/boards/shields/sofle/Kconfig.defconfig
@@ -8,7 +8,7 @@ config ZMK_KEYBOARD_NAME
 
 config ZMK_SPLIT_ROLE_CENTRAL
 	default y
-	
+
 endif
 
 if SHIELD_SOFLE_LEFT || SHIELD_SOFLE_RIGHT
@@ -45,5 +45,11 @@ choice LVGL_COLOR_DEPTH
 endchoice
 
 endif # LVGL
+
+if ZMK_RGB_UNDERGLOW
+
+config WS2812_STRIP
+	default y
+endif
 
 endif

--- a/app/boards/shields/sofle/boards/nice_nano.overlay
+++ b/app/boards/shields/sofle/boards/nice_nano.overlay
@@ -1,0 +1,35 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+   compatible = "nordic,nrf-spim";
+   status = "okay";
+   mosi-pin = <6>;
+   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+   sck-pin = <5>;
+   miso-pin = <7>;
+
+   led_strip: ws2812@0 {
+      compatible = "worldsemi,ws2812-spi";
+      label = "WS2812";
+
+      /* SPI */
+      reg = <0>; /* ignored, but necessary for SPI bindings */
+      spi-max-frequency = <4000000>;
+
+      /* WS2812 */
+      chain-length = <29>; /* arbitrary; change at will */
+      spi-one-frame = <0x70>;
+      spi-zero-frame = <0x40>;
+      color-mapping = <
+         LED_COLOR_ID_GREEN
+         LED_COLOR_ID_RED
+         LED_COLOR_ID_BLUE
+      >;
+   };
+};
+
+/ {
+   chosen {
+      zmk,underglow = &led_strip;
+   };
+};

--- a/app/boards/shields/sofle/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/sofle/boards/nice_nano_v2.overlay
@@ -1,0 +1,35 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+   compatible = "nordic,nrf-spim";
+   status = "okay";
+   mosi-pin = <6>;
+   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+   sck-pin = <5>;
+   miso-pin = <7>;
+
+   led_strip: ws2812@0 {
+      compatible = "worldsemi,ws2812-spi";
+      label = "WS2812";
+
+      /* SPI */
+      reg = <0>; /* ignored, but necessary for SPI bindings */
+      spi-max-frequency = <4000000>;
+
+      /* WS2812 */
+      chain-length = <29>; /* arbitrary; change at will */
+      spi-one-frame = <0x70>;
+      spi-zero-frame = <0x40>;
+      color-mapping = <
+         LED_COLOR_ID_GREEN
+         LED_COLOR_ID_RED
+         LED_COLOR_ID_BLUE
+      >;
+   };
+};
+
+/ {
+   chosen {
+      zmk,underglow = &led_strip;
+   };
+};

--- a/app/boards/shields/sofle/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/sofle/boards/nrfmicro_11.overlay
@@ -1,0 +1,35 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+   compatible = "nordic,nrf-spim";
+   status = "okay";
+   mosi-pin = <6>;
+   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+   sck-pin = <5>;
+   miso-pin = <7>;
+
+   led_strip: ws2812@0 {
+      compatible = "worldsemi,ws2812-spi";
+      label = "WS2812";
+
+      /* SPI */
+      reg = <0>; /* ignored, but necessary for SPI bindings */
+      spi-max-frequency = <4000000>;
+
+      /* WS2812 */
+      chain-length = <29>; /* arbitrary; change at will */
+      spi-one-frame = <0x70>;
+      spi-zero-frame = <0x40>;
+      color-mapping = <
+         LED_COLOR_ID_GREEN
+         LED_COLOR_ID_RED
+         LED_COLOR_ID_BLUE
+      >;
+   };
+};
+
+/ {
+   chosen {
+      zmk,underglow = &led_strip;
+   };
+};

--- a/app/boards/shields/sofle/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/sofle/boards/nrfmicro_13.overlay
@@ -1,0 +1,35 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+   compatible = "nordic,nrf-spim";
+   status = "okay";
+   mosi-pin = <6>;
+   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+   sck-pin = <5>;
+   miso-pin = <7>;
+
+   led_strip: ws2812@0 {
+      compatible = "worldsemi,ws2812-spi";
+      label = "WS2812";
+
+      /* SPI */
+      reg = <0>; /* ignored, but necessary for SPI bindings */
+      spi-max-frequency = <4000000>;
+
+      /* WS2812 */
+      chain-length = <29>; /* arbitrary; change at will */
+      spi-one-frame = <0x70>;
+      spi-zero-frame = <0x40>;
+      color-mapping = <
+         LED_COLOR_ID_GREEN
+         LED_COLOR_ID_RED
+         LED_COLOR_ID_BLUE
+      >;
+   };
+};
+
+/ {
+   chosen {
+      zmk,underglow = &led_strip;
+   };
+};

--- a/app/boards/shields/sofle/sofle.conf
+++ b/app/boards/shields/sofle/sofle.conf
@@ -7,3 +7,11 @@
 # Uncomment these two lines to add support for encoders
 # CONFIG_EC11=y
 # CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Uncomment this line below to add rgb underglow / backlight support
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+
+# Uncomment the line below to disable external power toggling by the underglow.
+# By default toggling the underglow on and off also toggles external power
+# on and off. This also causes the display to turn off.
+# CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER=n

--- a/app/boards/shields/sofle/sofle.keymap
+++ b/app/boards/shields/sofle/sofle.keymap
@@ -7,8 +7,25 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/ext_power.h>
+
+#define BASE 0
+#define LOWER 1
+#define RAISE 2
+#define ADJUST 3
 
 / {
+
+   // Activate ADJUST layer by pressing raise and lower
+    conditional_layers {
+        compatible = "zmk,conditional-layers";
+        adjust_layer {
+            if-layers = <LOWER RAISE>;
+            then-layer = <ADJUST>;
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 
@@ -24,7 +41,7 @@
 &kp ESC   &kp Q  &kp W    &kp E    &kp R     &kp T                       &kp Y  &kp U     &kp I     &kp O    &kp P    &kp BSPC
 &kp TAB   &kp A  &kp S    &kp D    &kp F     &kp G                       &kp H  &kp J     &kp K     &kp L    &kp SEMI &kp SQT
 &kp LSHFT &kp Z  &kp X    &kp C    &kp V     &kp B  &kp C_MUTE &none     &kp N  &kp M     &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-                 &kp LGUI &kp LALT &kp LCTRL &mo 1  &kp RET    &kp SPACE &mo 2  &kp RCTRL &kp RALT  &kp RGUI
+                 &kp LGUI &kp LALT &kp LCTRL &mo LOWER  &kp RET    &kp SPACE &mo RAISE  &kp RCTRL &kp RALT  &kp RGUI
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
@@ -66,5 +83,23 @@
 
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
+
+// ------------------------------------------------------------------------------------------------------------
+// |BTCLR | BT1   | BT2   |  BT3  |  BT4  |  BT5  |                |      |      |       |      |       |       |
+// |EXTPWR|RGB_HUD|RGB_HUI|RGB_SAD|RGB_SAI|RGB_EFF|                |      |      |       |      |       |       |
+// |      |RGB_BRD|RGB_BRI|       |       |       |                |      |      |       |      |       |       |
+// |      |       |       |       |       |       |RGB_TOG| |      |      |      |       |      |       |       |
+//                |       |       |       |       |       | |      |      |      |       |      |
+
+        Adjust_layer {
+        bindings = <
+&bt BT_CLR                      &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                    &none &none &none &none &none &none
+&ext_power EXT_POWER_TOGGLE_CMD &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                                 &none &none &none &none &none &none
+&none                           &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                           &none &none &none &none &none &none
+&none                           &none           &none           &none           &none           &none               &rgb_ug RGB_TOG  &none      &none &none &none &none &none &none
+                                                &none           &none           &none           &none               &none            &none      &none &none &none &none
+        >;
+        };
+
     };
 };

--- a/app/boards/shields/sofle/sofle.zmk.yml
+++ b/app/boards/shields/sofle/sofle.zmk.yml
@@ -9,6 +9,7 @@ features:
   - keys
   - display
   - encoder
+  - underglow
 siblings:
   - sofle_left
   - sofle_right


### PR DESCRIPTION
This PR adds underglow support to the sofle keyboard. I used the kyria shield as a reference.

It's been tested on a sofle choc, but the pins are the same on the sofle RGB and there should be no issues.


## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
