### PR TITLE
fix(docs): Fix Windows unicode macro example

### DIFF
--- a/docs/docs/behaviors/macros.md
+++ b/docs/docs/behaviors/macros.md
@@ -187,14 +187,14 @@ bindings
 
 ### Unicode Sequences
 
-Many operating systems allow a special sequence to input unicode characters, e.g. [Windows alt codes](https://support.microsoft.com/en-us/office/insert-ascii-or-unicode-latin-based-symbols-and-characters-d13f58d3-7bcb-44a7-a4d5-972ee12e50e0). You can use macros to insert there automatically, e.g.:
+Many operating systems allow a special sequence to input unicode characters, e.g. [Windows alt codes](https://support.microsoft.com/en-us/office/insert-ascii-or-unicode-latin-based-symbols-and-characters-d13f58d3-7bcb-44a7-a4d5-972ee12e50e0). You can use macros to automate inputting the sequences, e.g. below macro inserts `£` on Windows:
 
 ```
 wait-ms = <40>;
 tap-ms = <40>;
 bindings
     = <&macro_press   &kp LALT>
-    , <&macro_tap     &kp N0 &kp N1 &kp N6 &kp N3>
+    , <&macro_tap     &kp KP_N0 &kp KP_N1 &kp KP_N6 &kp KP_N3>
     , <&macro_release &kp LALT>
     ;
 ```


### PR DESCRIPTION
Windows unicode input using alt + number sequence requires using the keypad keycodes, as noted in [the linked doc](https://support.microsoft.com/en-us/office/insert-ascii-or-unicode-latin-based-symbols-and-characters-d13f58d3-7bcb-44a7-a4d5-972ee12e50e0):

>  You must use the numeric keypad to type the numbers, and not the keyboard. Make sure that the NUM LOCK key is on if your keyboard requires it to type numbers on the numeric keypad.

This PR fixes the example sequences and improves the description slightly. Tested before and after the fix and confirmed the keypad keycodes are required.