### PR TITLE
fix(docs): Allow CORS for hardware-metadata.json

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -15,3 +15,8 @@
   from = "https://www.zmkfirmware.dev/*"
   to = "https://www.zmk.dev/:splat"
   force = true
+
+[[headers]]
+  for = "/hardware-metadata.json"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
Enabled CORS so external tools can fetch the metadata file.