### PR TITLE
Add Contra shield underglow strip LED support

### DIFF
--- a/app/boards/shields/contra/boards/nice_nano.overlay
+++ b/app/boards/shields/contra/boards/nice_nano.overlay
@@ -1,0 +1,28 @@
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <45>; // Data cable is on D15 of Nice!NanoV2
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "SK6812mini";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <6>; /* Change this according to how many leds are on the strip */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/contra/contra.conf
+++ b/app/boards/shields/contra/contra.conf
@@ -1,0 +1,3 @@
+#Uncomment the following lines to enable the Contra RGB Underglow
+#CONFIG_ZMK_RGB_UNDERGLOW=y
+#CONFIG_WS2812_STRIP=y


### PR DESCRIPTION
Added nice_nano.overlay file for WS2812 LED support for Contra shield
Added commented out conf file changes for LED support
The changes are tested on working hardware as can be seem on https://github.com/arpacique/zmk-config