### PR TITLE
refactor(tests): Use GH Actions matrix for tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,24 @@ on:
       - "app/src/**"
 
 jobs:
-  integration_test:
+  collect-tests:
+    outputs:
+      test-dirs: ${{ steps.test-dirs.outputs.test-dirs }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Find test directories
+        id: test-dirs
+        run: |
+          cd app/tests/
+          export TESTS=$(ls -d * | jq -R -s -c 'split("\n")[:-1]')
+          echo "::set-output name=test-dirs::${TESTS}"
+  run-tests:
+    needs: collect-tests
+    strategy:
+      matrix:
+        test: ${{ fromJSON(needs.collect-tests.outputs.test-dirs) }}
     runs-on: ubuntu-latest
     container:
       image: docker.io/zmkfirmware/zmk-build-arm:3.0
@@ -43,8 +60,9 @@ jobs:
         run: west update
       - name: Export Zephyr CMake package (west zephyr-export)
         run: west zephyr-export
-      - name: Test all
-        run: west test
+      - name: Test ${{ matrix.test }}
+        working-directory: app
+        run: west test tests/${{ matrix.test }}
       - name: Archive artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/app/run-test.sh
+++ b/app/run-test.sh
@@ -15,7 +15,7 @@ fi
 
 testcases=$(find $path -name native_posix_64.keymap -exec dirname \{\} \;)
 num_cases=$(echo "$testcases" | wc -l)
-if [ $num_cases -gt 1 ]; then
+if [ $num_cases -gt 1 ] || [ "$testcases" != "$path" ]; then
 	echo "" > ./build/tests/pass-fail.log
 	echo "$testcases" | xargs -L 1 -P ${J:-4} ./run-test.sh
 	err=$?


### PR DESCRIPTION
* To parallelize our tests, generate a dynamic matrix
  of tests to run.

@Nicell Thoughts on this to cut down on our test time? See https://github.com/petejohanson/zmk/actions/runs/2084238754 for an example.

If we do this, we might be to the point we want to get a Teams subscription to GH, since that would bump our concurrent builds up from 20 to 60: https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration