### PR TITLE
feat(shields): Add Hummingbird shield

### DIFF
--- a/app/boards/shields/hummingbird/Kconfig.defconfig
+++ b/app/boards/shields/hummingbird/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_HUMMINGBIRD
+
+config ZMK_KEYBOARD_NAME
+    default "Hummingbird"
+
+endif

--- a/app/boards/shields/hummingbird/Kconfig.shield
+++ b/app/boards/shields/hummingbird/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_HUMMINGBIRD
+   def_bool $(shields_list_contains,hummingbird)

--- a/app/boards/shields/hummingbird/hummingbird.keymap
+++ b/app/boards/shields/hummingbird/hummingbird.keymap
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+
+#define DEF_L 0
+#define NAV_L 1
+#define NUM_L 2
+#define SYM_L 3
+
+// Using layer taps on thumbs, having quick tap as well helps w/ repeating space/backspace
+&lt { quick_tap_ms = <200>; };
+
+/ {
+    behaviors {
+        hm: homerow_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "homerow mods";
+            #binding-cells = <2>;
+            tapping_term_ms = <225>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
+    combos {
+        compatible = "zmk,combos";
+        combo_z {
+            timeout-ms = <50>;
+            key-positions = <20 21>;
+            bindings = <&kp Z>;
+        };
+        combo_b {
+            timeout-ms = <50>;
+            key-positions = <21 22>;
+            bindings = <&kp B>;
+        };
+
+        combo_y {
+            timeout-ms = <50>;
+            key-positions = <23 24>;
+            bindings = <&kp Y>;
+        };
+
+        combo_slash {
+            timeout-ms = <50>;
+            key-positions = <24 25>;
+            bindings = <&kp SLASH>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &kp Q      &kp W      &kp E       &kp R           &kp T        &kp H            &kp U          &kp I       &kp O      &kp P
+                &hm LGUI A &hm LALT S &hm LCTRL D &hm LSHFT F     &kp G        &kp N            &hm RSHFT J    &hm RCTRL K &hm LALT L &hm RGUI QUOT
+                           &kp X      &kp C       &kp V                                         &kp M          &kp COMMA  &kp DOT
+                                                  &lt NAV_L TAB  &kp RET       &lt NUM_L SPACE  &lt SYM_L BKSP
+            >;
+        };
+
+        nav_layer {
+            label = "Nav";
+            bindings = <
+                &trans     &trans     &trans      &trans          &trans       &trans           &kp HOME       &kp UARW &kp PG_UP  &trans
+                &trans     &trans     &trans      &trans          &trans       &trans           &kp LARW       &kp DARW &kp RARW   &trans
+                           &trans     &trans      &trans                                        &kp END        &trans   &kp PG_DN
+                                                  &trans          &trans       &kp ESC          &kp DEL
+            >;
+        };
+
+        num_layer {
+            label = "Num";
+            bindings = <
+                &kp LBKT   &kp N7     &kp N8      &kp N9          &kp RBKT      &trans          &trans         &trans      &trans     &trans
+                &kp SEMI   &kp N4     &kp N5      &kp N6          &kp EQUAL     &trans          &trans         &trans      &trans     &trans
+                           &kp N1     &kp N2      &kp N3                                        &trans         &trans      &trans
+                                                  &kp N0          &kp MINUS     &trans          &trans
+            >;
+        };
+
+        sym_layer {
+            label = "Sym";
+            bindings = <
+                &kp LBRC   &kp LS(N7) &kp LS(N8)  &kp LS(N9)      &kp RBRC      &trans          &trans         &trans      &trans     &trans
+                &kp COLON  &kp LS(N4) &kp LS(N5)  &kp LS(N6)      &kp PLUS      &trans          &trans         &trans      &trans     &trans
+                           &kp LS(N1) &kp LS(N2)  &kp LS(N3)                                    &trans         &trans      &trans
+                                                  &kp LS(N0)      &kp UNDER     &trans          &trans
+            >;
+        };
+    };
+};

--- a/app/boards/shields/hummingbird/hummingbird.overlay
+++ b/app/boards/shields/hummingbird/hummingbird.overlay
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+	/delete-property/ zephyr,console;
+	/delete-property/ zephyr,shell-uart;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <7>;
+        rows = <6>;
+        map = <
+    RC(0,0) RC(1,0) RC(0,1) RC(1,1) RC(0,2) RC(1,2) RC(0,3) RC(1,3) RC(0,4) RC(1,4)
+    RC(2,0) RC(3,0) RC(2,1) RC(3,1) RC(2,2) RC(3,2) RC(2,3) RC(3,3) RC(2,4) RC(3,4)
+            RC(4,0) RC(5,0) RC(4,1)                 RC(5,2) RC(4,3) RC(5,3)
+                          RC(5,1) RC(4,2)       RC(5,4) RC(4,4)
+        >;
+    };
+
+
+    kscan0: kscan_0 {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "row2col";
+
+        col-gpios
+            = <&xiao_d 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&xiao_d 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&xiao_d 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&xiao_d 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&xiao_d 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+
+        row-gpios
+            = <&xiao_d 0 GPIO_ACTIVE_HIGH>
+            , <&xiao_d 1 GPIO_ACTIVE_HIGH>
+            , <&xiao_d 2 GPIO_ACTIVE_HIGH>
+            , <&xiao_d 3 GPIO_ACTIVE_HIGH>
+            , <&xiao_d 4 GPIO_ACTIVE_HIGH>
+            , <&xiao_d 5 GPIO_ACTIVE_HIGH>
+            ;
+    };
+    
+};
+
+&xiao_spi { status = "disabled"; };
+&xiao_i2c { status = "disabled"; };
+&xiao_serial { status = "disabled"; };

--- a/app/boards/shields/hummingbird/hummingbird.zmk.yml
+++ b/app/boards/shields/hummingbird/hummingbird.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: hummingbird
+name: Hummingbird
+type: shield
+url: https://github.com/PJE66/hummingbird
+requires: [seeed_xiao]
+features:
+  - keys


### PR DESCRIPTION
* Reference shield for the Seeed(uino) XIAO interconnect.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
