### PR TITLE
feat(battery)!: Make sensor fetch configurable

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -323,6 +323,23 @@ config ZMK_EXT_POWER
 	bool "Enable support to control external power output"
 	default y
 
+choice ZMK_BATTERY_FETCH
+	prompt "Battery sensor fetch mode"
+
+config ZMK_BATTERY_FETCH_INDIVIDUAL_CHANNELS
+	bool "Use sensor_sample_fetch_chan()"
+	help
+	  Use sensor_sample_fetch_chan() to fetch the individual battery sensor
+	  channels instead of fetching all channels.
+
+config ZMK_BATTERY_FETCH_ALL
+	bool "Use sensor_sample_fetch()"
+	help
+	  Use sensor_sample_fetch() to fetch all battery sensor channels. Use this
+	  if your battery sensor driver requires fetching SENSOR_CHAN_ALL.
+
+endchoice
+
 #Power Management
 endmenu
 

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -34,7 +34,13 @@ static const struct device *battery;
 static int zmk_battery_update(const struct device *battery) {
     struct sensor_value state_of_charge;
 
+#if defined(CONFIG_ZMK_BATTERY_FETCH_ALL)
+    int rc = sensor_sample_fetch(battery);
+#elif defined(CONFIG_ZMK_BATTERY_FETCH_INDIVIDUAL_CHANNELS)
     int rc = sensor_sample_fetch_chan(battery, SENSOR_CHAN_GAUGE_STATE_OF_CHARGE);
+#else
+#error "No value selected for ZMK_BATTERY_FETCH"
+#endif
 
     if (rc != 0) {
         LOG_DBG("Failed to fetch battery values: %d", rc);


### PR DESCRIPTION
Added a ZMK_BATTERY_FETCH Kconfig option to control how battery.c fetches sensor samples. This allows compatibility with more fuel gauge drivers, as some assert if asked to fetch individual channels, while others assert if asked to fetch all channels.

The new default behavior is to use sensor_sample_fetch() to fetch all channels at once. If your driver does not support this, set
CONFIG_ZMK_BATTERY_FETCH_INDIVIDUAL_CHANNELS=y to return to the previous behavior of using sensor_sample_fetch_chan().