### PR TITLE
feat(docs): Reference conditional layers from the layers behavior page

### DIFF
--- a/docs/docs/behaviors/layers.md
+++ b/docs/docs/behaviors/layers.md
@@ -123,3 +123,8 @@ Example:
 ```
 
 It is possible to use "toggle layer" to have keys that raise and lower the layers as well.
+
+## Conditional Layers
+
+The "conditional layers" feature enables a particular layer when all layers in a specified set are active.
+For more information, see [conditional layers](../features/conditional-layers.md).


### PR DESCRIPTION
Addresses at least part of #1043.  That issue also mentions linking to the conditional layers page on the Keymaps page, but I don't see a natural place to do that, as that page doesn't link to any of the other layers behaviors.