### PR TITLE
Stop persisted binding keypress fallthrough

### DIFF
--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -50,7 +50,8 @@ static struct k_work_delayable ext_power_save_work;
 
 int ext_power_save_state() {
 #if IS_ENABLED(CONFIG_SETTINGS)
-    return k_work_reschedule(&ext_power_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
+    int ret = k_work_reschedule(&ext_power_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
+    return MIN(ret, 0);
 #else
     return 0;
 #endif

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -272,7 +272,8 @@ static int zmk_rgb_underglow_init(const struct device *_arg) {
 
 int zmk_rgb_underglow_save_state() {
 #if IS_ENABLED(CONFIG_SETTINGS)
-    return k_work_reschedule(&underglow_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
+    int ret = k_work_reschedule(&underglow_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
+    return MIN(ret, 0);
 #else
     return 0;
 #endif


### PR DESCRIPTION
Needed because k_work_reschedule can return positive success codes.

This fixes an issue where bindings such as `RGB_TOG` or `EP_OFF` would also press the key underneath them in the keymap, and never release it.