### PR TITLE
fix(hid): Use a full valid range for consumer page

### DIFF
--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -78,9 +78,9 @@ static const uint8_t zmk_hid_report_desc[] = {
     HID_REPORT_SIZE(0x08),
 #elif IS_ENABLED(CONFIG_ZMK_HID_CONSUMER_REPORT_USAGES_FULL)
     HID_LOGICAL_MIN8(0x00),
-    HID_LOGICAL_MAX16(0xFF, 0xFF),
+    HID_LOGICAL_MAX16(0xFF, 0x0F),
     HID_USAGE_MIN8(0x00),
-    HID_USAGE_MAX16(0xFF, 0xFF),
+    HID_USAGE_MAX16(0xFF, 0x0F),
     HID_REPORT_SIZE(0x10),
 #else
 #error "A proper consumer HID report usage range must be selected"


### PR DESCRIPTION
* Switch to a logical max for the consumer page
  that avoid signed issue, and still allows
  full range of documented consumer page
  values.
