### PR TITLE
feat(boards): Add BDN9 rev2 RGB support

### DIFF
--- a/app/boards/arm/bdn9/Kconfig.defconfig
+++ b/app/boards/arm/bdn9/Kconfig.defconfig
@@ -1,6 +1,6 @@
 # keeb.io BDN9 board configuration
 
-# Copyright (c) 2020 Pete Johanson
+# Copyright (c) 2020 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
 if BOARD_BDN9
@@ -13,5 +13,9 @@ config ZMK_KEYBOARD_NAME
 
 config ZMK_USB
 	default y
+
+config ZMK_RGB_UNDERGLOW
+	select SPI
+	select WS2812_STRIP
 
 endif # BOARD_BDN9

--- a/app/boards/arm/bdn9/bdn9_rev2.conf
+++ b/app/boards/arm/bdn9/bdn9_rev2.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Uncomment the line below to enable RGB.
+# CONFIG_ZMK_RGB_UNDERGLOW=y

--- a/app/boards/arm/bdn9/bdn9_rev2.dts
+++ b/app/boards/arm/bdn9/bdn9_rev2.dts
@@ -18,9 +18,7 @@
 		zephyr,flash = &flash0;
 		zephyr,console = &cdc_acm_uart;
 		zmk,kscan = &kscan;
-		/* TODO: Enable once the GPIO bitbanging driver supports STM32
 		zmk,underglow = &led_strip;
-		*/
 	};
 
 	kscan: kscan {
@@ -39,17 +37,6 @@
 			, <&gpiof 0  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 			;
 	};
-
-	/*
-	led_strip: ws2812 {
-		compatible = "worldsemi,ws2812-gpio";
-		label = "WS2812";
-
-		in-gpios = <&gpiob 15 0>;
-
-		chain-length = <9>;
-	};
-	*/
 
 	left_encoder: encoder_left {
 		compatible = "alps,ec11";
@@ -80,6 +67,28 @@
 		compatible = "zmk,keymap-sensors";
 		status = "disabled";
 		sensors = <>;
+	};
+};
+
+&spi2 {
+	status = "okay";
+	pinctrl-0 = <&spi2_sck_pb13 &spi2_miso_pb14 &spi2_mosi_pb15>;
+	pinctrl-names = "default";
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <9>;
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
 	};
 };
 


### PR DESCRIPTION
Tested on my BDN9. Skipping the two actual underglow LEDs in the chain for now, so we use underglow just for the per-key LEDs.