### PR TITLE
fix(docs): Ensure relative links always resolve

### DIFF
--- a/docs/docs/features/displays.md
+++ b/docs/docs/features/displays.md
@@ -6,5 +6,5 @@ sidebar_label: Displays
 Displays in ZMK are currently a proof of concept and official support is coming soon.
 
 :::info
-Although ZMK-powered keyboards _are_ capable of utilizing OLED and ePaper displays, the Displays feature is not yet considered production-ready due to an issue where the display remains blank after resuming from [external power cutoff](../behaviors/power#external-power-control). This issue can be tracked on GitHub at [zmkfirmware/zmk #674](https://github.com/zmkfirmware/zmk/issues/674).
+Although ZMK-powered keyboards _are_ capable of utilizing OLED and ePaper displays, the Displays feature is not yet considered production-ready due to an issue where the display remains blank after resuming from [external power cutoff](../behaviors/power.md#external-power-control). This issue can be tracked on GitHub at [zmkfirmware/zmk #674](https://github.com/zmkfirmware/zmk/issues/674).
 :::

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -32,7 +32,7 @@ ZMK is currently missing some features found in other popular firmware. This tab
 | [Backlight](features/backlight.md)                                                                                                 | ✅  |    ✅     | ✅  |
 | One Shot Keys                                                                                                                      | ✅  |    ✅     | ✅  |
 | [Combo Keys](features/combos.md)                                                                                                   | ✅  |           | ✅  |
-| [Macros](behaviors/macros)                                                                                                         | ✅  |    ✅     | ✅  |
+| [Macros](behaviors/macros.md)                                                                                                      | ✅  |    ✅     | ✅  |
 | Mouse Keys                                                                                                                         | 🚧  |    ✅     | ✅  |
 | Low Active Power Usage                                                                                                             | ✅  |           |     |
 | Low Power Sleep States                                                                                                             | ✅  |    ✅     |     |


### PR DESCRIPTION
After #1248 was merged, I noticed that the destination of the relative link can sometimes be incorrect depending on the trailing slash of the current URL:

* Access the Displays page _via the sidebar_ then the current URL is `https://zmk.dev/docs/features/displays` and the relative link works: `https://zmk.dev/docs/behaviors/power` ✅

* Access the Displays page _directly_ (or refresh the above) then the current URL becomes `https://zmk.dev/docs/features/displays/` (a trailing slash is added), so of course the relative link results in a 404: `https://zmk.dev/docs/features/behaviors/power` ❌

The fix is to link to the document _file path_ rather than the document _URL_; this ensures that the link resolves regardless of trailing slash config – Docusaurus just takes care of it. More information is at https://docusaurus.io/docs/docs-markdown-features. (Note: Other URLs in the docs already use this convention, but this particular link slipped through in the previous PR.)

We might want to look into changing the wider behaviour so that pages always have a trailing slash (or they do not), but that's probably for a separate thread. (Update: I opened #1250.)