### PR TITLE
fix(docs): Standardize URLs with no trailing slash

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -6,6 +6,7 @@ module.exports = {
   url: "https://zmk.dev",
   baseUrl: "/",
   favicon: "img/favicon.ico",
+  trailingSlash: "false",
   organizationName: "zmkfirmware", // Usually your GitHub org/user name.
   projectName: "zmk", // Usually your repo name.
   plugins: [


### PR DESCRIPTION
This PR aims to make trailing slashes in URLs more consistent on https://zmk.dev.

### Before:

Wherever we link to a page (in the sidebar and in other menus), the links do not include a trailing slash – e.g. `href="zmk.dev/blog"`, `href="zmk.dev/docs/displays"`, etc. This is fine. 

However, accessing a page directly via it's URL (or refreshing a page that you're already on) will cause a trailing slash to be added to the URL – e.g. `zmk.dev/blog/`, `zmk.dev/docs/displays/`, etc.

Easiest to demonstrate in a quick video clip:

https://user-images.githubusercontent.com/60922914/163870576-43fc4d16-e900-414b-9da4-9a6af7c60e11.mov

### After:

With the Docusaurus configuration option [`trailingSlash`](https://docusaurus.io/docs/api/docusaurus-config#trailing-slash) set to `false`, all URLs are without a trailing slash consistently. 

https://user-images.githubusercontent.com/60922914/163870500-24b72e2a-e95e-4117-bf1a-a1721cad4e68.mov

According to the deploy preview, this change shouldn't cause any issues with external links to zmk.dev (or people's bookmarks, etc.), because accessing pages via links that contain a trailing slash simply 301 redirects to the non trailing slash version (see for example [`docs/` → `docs`](https://deploy-preview-1250--zmk.netlify.app/docs/), or [`macros/#common-patterns` → `macros#common-patterns`](https://deploy-preview-1250--zmk.netlify.app/docs/behaviors/macros/#common-patterns)). 

### Deploy preview: 

https://deploy-preview-1250--zmk.netlify.app