### PR TITLE
fix: Exclude `sof` module to avoid build breakage.

### DIFF
--- a/app/west.yml
+++ b/app/west.yml
@@ -31,5 +31,6 @@ manifest:
           - openthread
           - edtt
           - trusted-firmware-m
+          - sof
   self:
     west-commands: scripts/west-commands.yml


### PR DESCRIPTION
Zephyr upstream seemed to have force-pushed to their `sof` module, causing the sha1 referenced from the Zephyr `west.yml` to be missing. Exclude for now, we don't use it.