### PR TITLE
fix(split): Raise split notification stack size.

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -192,7 +192,7 @@ if !ZMK_SPLIT_BLE_ROLE_CENTRAL
 
 config ZMK_SPLIT_BLE_PERIPHERAL_STACK_SIZE
 	int "BLE split peripheral notify thread stack size"
-	default 512
+	default 650
 
 config ZMK_SPLIT_BLE_PERIPHERAL_PRIORITY
 	int "BLE split peripheral notify thread priority"


### PR DESCRIPTION
* Larger stack for split peripheral notifications
  to avois stack overflow with logging on.
