### PR TITLE
fix(docs): Clarify `timeout-ms` for Combos

### DIFF
--- a/docs/docs/features/combos.md
+++ b/docs/docs/features/combos.md
@@ -25,7 +25,7 @@ Combos configured in your `.keymap` file, but are separate from the `keymap` nod
 
 - The name of the combo doesn't really matter, but convention is to start the node name with `combo_`.
 - The `compatible` property should always be `"zmk,combos"` for combos.
-- `timeout-ms` is the number of milliseconds that all keys of the combo must be pressed.
+- `timeout-ms` is the length of the window (in milliseconds) in which all keys of the combo must be pressed in order to successfully trigger the combo.
 - `key-positions` is an array of key positions. See the info section below about how to figure out the positions on your board.
 - `layers = <0 1...>` will allow limiting a combo to specific layers. This is an _optional_ parameter, when omitted it defaults to global scope.
 - `bindings` is the behavior that is activated when the behavior is pressed.


### PR DESCRIPTION
The PR rephrases the description of the `timeout-ms` configuration for Combos.

This is based on the message from `joshua.r.smith#6858` [on Discord](https://discord.com/channels/719497620560543766/719909884769992755/946023231431802910):

> I have a question about the combos feature. **There is a `timeout-ms` parameter for which the docs indicate the value is the number of ms the combo must be pressed for the combo effect to trigger. However, it seems like that value is the length of the window in which all of the keys in the combo must be pressed in order to successfully trigger the combo.** Regardless of the value of timeout-ms, as soon as all they keys are pressed in time, the combo is triggered. I would like to trigger the combo after holding the combo for a particular duration; specifically I want to hold a combo for 5s in order to toggle a layer with Bluetooth settings. Is there a way I can achieve that behavior? Thanks.

### Before:

https://zmk.dev/docs/features/combos/#configuration

> - `timeout-ms` is the number of milliseconds that all keys of the combo must be pressed.

### After:

https://deploy-preview-1277--zmk.netlify.app/docs/features/combos#configuration

> - `timeout-ms` is the length of the window (in milliseconds) in which all keys of the combo must be pressed in order to successfully trigger the combo.