### PR TITLE
fix(docs): Remove code-snippet backticks from customization.md title

### DIFF
--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -1,5 +1,5 @@
 ---
-title: Customizing ZMK/`zmk-config` folders
+title: Customizing ZMK/zmk-config folders
 sidebar_label: Customizing ZMK
 ---
 


### PR DESCRIPTION
Discussed here: https://discord.com/channels/719497620560543766/883452966114324550/970385441134104747

Code snippets in titles are not formatted properly in page titles