### PR TITLE
fix(sleep): use pm_power_state_force for proper device power management

### DIFF
--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -68,9 +68,9 @@ void activity_work_handler(struct k_work *work) {
     int32_t inactive_time = current - activity_last_uptime;
 #if IS_ENABLED(CONFIG_ZMK_SLEEP)
     if (inactive_time > MAX_SLEEP_MS && !is_usb_power_present()) {
-        // Put devices in low power mode before sleeping
+        // Put devices in suspend power mode before sleeping
         set_state(ZMK_ACTIVITY_SLEEP);
-        pm_power_state_set((struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
+        pm_power_state_force(0U, (struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
     } else
 #endif /* IS_ENABLED(CONFIG_ZMK_SLEEP) */
         if (inactive_time > MAX_IDLE_MS) {

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -176,10 +176,10 @@ static int ext_power_generic_init(const struct device *dev) {
 #ifdef CONFIG_PM_DEVICE
 static int ext_power_generic_pm_action(const struct device *dev, enum pm_device_action action) {
     switch (action) {
-    case PM_DEVICE_ACTION_TURN_ON:
+    case PM_DEVICE_ACTION_RESUME:
         ext_power_generic_enable(dev);
         return 0;
-    case PM_DEVICE_ACTION_TURN_OFF:
+    case PM_DEVICE_ACTION_SUSPEND:
         ext_power_generic_disable(dev);
         return 0;
     default:


### PR DESCRIPTION
When using `pm_power_state_set`, we skip over all of the device-related power management seen here: https://docs.zephyrproject.org/latest/services/pm/system.html#system-power-management

Although I wasn't able to 100% confirm this from reading Zephyr code, `pm_power_state_force` seems to force the next state to what you want, and then all of the rest of the diagram follows as expected setting device power states. In our case, `STATE_OFF` sets devices to standby, which is why those actions got updated.

We should probably be aware of the fact that this currently just sets CPU 0 to off. This may be an issue with dual/multi-core chips like the nrf5340. I'm not sure about that though.