### PR TITLE
fix(boards): Fix battery ADC channel for Mikoto

### DIFF
--- a/app/boards/arm/mikoto/mikoto_520.dts
+++ b/app/boards/arm/mikoto/mikoto_520.dts
@@ -38,7 +38,7 @@
 	vbatt: vbatt {
 		compatible = "zmk,battery-voltage-divider";
 		label = "BATTERY";
-		io-channels = <&adc 2>;
+		io-channels = <&adc 1>;
 		output-ohms = <10000000>;
 		full-ohms = <(10000000 + 4000000)>;
 	};


### PR DESCRIPTION
Mikoto uses P0.03 for the vbatt divider, which is AIN1 --- not AIN2 as claimed by the board config file. Again, should've caught this earlier, sorry.