### PR TITLE
feat(battery): Add Kconfig setting for battery level report interval

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -518,6 +518,11 @@ config ZMK_SETTINGS_SAVE_DEBOUNCE
 #SETTINGS
 endif
 
+config ZMK_BATTERY_REPORT_INTERVAL
+	depends on ZMK_BLE
+	int "Battery level report interval in seconds"
+	default 60
+
 #Advanced
 endmenu
 

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -104,7 +104,7 @@ static int zmk_battery_init(const struct device *_arg) {
         return rc;
     }
 
-    k_timer_start(&battery_timer, K_MINUTES(1), K_MINUTES(1));
+    k_timer_start(&battery_timer, K_MINUTES(1), K_SECONDS(CONFIG_ZMK_BATTERY_REPORT_INTERVAL));
 
     return 0;
 }


### PR DESCRIPTION
Makes the interval between BAS GATT reports for battery level configurable using a new `CONFIG_ZMK_BATTERY_REPORT_INTERVAL` setting. Related: https://github.com/zmkfirmware/zmk/issues/1273#issuecomment-1127103347

There are a few decisions I made that I am not 100% sure of, comments welcome:
- Location of Kconfig: right now this is under the battery driver, but it could be under `app/Kconfig` (in a new submenu under "Basic keyboard setup"?) or is there a better spot?
- Name of setting: I didn't mention BAS GATT since it is not very familiar to users. Should it have "level" in the name?
- Should the delay until first report also be configurable, or equal to the interval? I thought there isn't much use in making this configurable and 1 minute seems like a good value.
- Unit of interval: Minutes might be too coarse, milliseconds might be too fine, so I chose seconds.