### PR TITLE
feat(kscan): Add toggle-mode to updated direct-wire kscan

### DIFF
--- a/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-direct.yaml
+++ b/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-direct.yaml
@@ -32,3 +32,6 @@ properties:
     type: int
     default: 10
     description: Time between reads in milliseconds when no key is pressed and ZMK_KSCAN_DIRECT_POLLING is enabled.
+  toggle-mode:
+    type: boolean
+    description: Enable toggle-switch mode.


### PR DESCRIPTION
An updated version of #1173. Currently being tested by @ebastler without any issues thus far.

Implements a `toggle-mode` boolean to direct-wire kscans to disable pullup/pulldown resistors on active pins, removing the 244.4uA quiescent current that would otherwise exist without this feature.