### PR TITLE
added variations of breeze & default keymap

### DIFF
--- a/app/boards/shields/breeze/Kconfig.defconfig
+++ b/app/boards/shields/breeze/Kconfig.defconfig
@@ -4,7 +4,7 @@ if SHIELD_BREEZE_LEFT
 config ZMK_KEYBOARD_NAME
     default "Breeze"
 
-config ZMK_SPLIT_BLE_ROLE_CENTRAL
+config ZMK_SPLIT_ROLE_CENTRAL
     default y
 
 endif

--- a/app/boards/shields/breeze/Kconfig.defconfig
+++ b/app/boards/shields/breeze/Kconfig.defconfig
@@ -1,0 +1,17 @@
+
+if SHIELD_BREEZE_LEFT
+
+config ZMK_KEYBOARD_NAME
+    default "Breeze"
+
+config ZMK_SPLIT_BLE_ROLE_CENTRAL
+    default y
+
+endif
+
+if SHIELD_BREEZE_LEFT || SHIELD_BREEZE_RIGHT
+
+config ZMK_SPLIT
+    default y
+
+endif

--- a/app/boards/shields/breeze/Kconfig.shield
+++ b/app/boards/shields/breeze/Kconfig.shield
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_BREEZE_LEFT
+    def_bool $(shields_list_contains,breeze_left)
+
+config SHIELD_BREEZE_RIGHT
+    def_bool $(shields_list_contains,breeze_right) 

--- a/app/boards/shields/breeze/breeze.dtsi
+++ b/app/boards/shields/breeze/breeze.dtsi
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    // BREEZE
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <9>;
+        rows = <10>;
+// | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |                 | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  | MC1  | MC2  | MC3  |
+// | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |                 | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 | MC4  | MC5  | MC6  |
+// | SW18 | SW17 | SW16 | SW15 | SW14 | SW13 |                 | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 |      |  ↑   |      |
+// | SW24 | SW23 | SW22 | SW21 | SW20 | SW19 |                 | SW19 | SW20 | SW21 | SW22 | SW23 | SW24 |  ←   |  ↓   |  →   |
+//                      | TC4  | TC3  | TC2  | TC1  |   | TC1  | TC2  | TC3  | TC4  |
+        map = <
+RC(0,5) RC(0,4) RC(0,3) RC(0,2) RC(0,1) RC(0,0)                  RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5) RC(5,6) RC(5,7) RC(5,8)
+RC(1,5) RC(1,4) RC(1,3) RC(1,2) RC(1,1) RC(1,0)                  RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5) RC(6,6) RC(6,7) RC(6,8)
+RC(2,5) RC(2,4) RC(2,3) RC(2,2) RC(2,1) RC(2,0)                  RC(7,0) RC(7,1) RC(7,2) RC(7,3) RC(7,4) RC(7,5)         RC(7,7)
+RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                  RC(8,0) RC(8,1) RC(8,2) RC(8,3) RC(8,4) RC(8,5) RC(8,6) RC(8,7) RC(8,8)
+                        RC(4,3) RC(4,2) RC(4,1) RC(4,0)  RC(9,0) RC(9,1) RC(9,2) RC(9,3)
+        >;
+    };
+
+    // WINTER BREEZE
+    five_column_transform: keymap_transform_1 {
+        compatible = "zmk,matrix-transform";
+        columns = <6>;
+        rows = <10>;
+// | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |                 | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  |
+// | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |                 | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 |
+// | SW18 | SW17 | SW16 | SW15 | SW14 | SW13 |                 | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 |
+// | SW24 | SW23 | SW22 | SW21 | SW20 | SW19 |                 | SW19 | SW20 | SW21 | SW22 | SW23 | SW24 |
+//                      | TC4  | TC3  | TC2  | TC1  |   | TC1  | TC2  | TC3  | TC4  |
+        map = <
+RC(0,5) RC(0,4) RC(0,3) RC(0,2) RC(0,1) RC(0,0)                  RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5)
+RC(1,5) RC(1,4) RC(1,3) RC(1,2) RC(1,1) RC(1,0)                  RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5)
+RC(2,5) RC(2,4) RC(2,3) RC(2,2) RC(2,1) RC(2,0)                  RC(7,0) RC(7,1) RC(7,2) RC(7,3) RC(7,4) RC(7,5)
+RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                  RC(8,0) RC(8,1) RC(8,2) RC(8,3) RC(8,4) RC(8,5)
+                        RC(4,3) RC(4,2) RC(4,1) RC(4,0)  RC(9,0) RC(9,1) RC(9,2) RC(9,3)
+        >;
+    };
+
+    // SOUTHERN BREEZE
+    left_wing_transform: keymap_transform_1 {
+        compatible = "zmk,matrix-transform";
+        columns = <9>;
+        rows = <10>;
+// | MC3  | MC2  | MC1  | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |                 | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  |
+// | MC6  | MC5  | MC4  | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |                 | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 |
+// |      |  ↑   |      | SW18 | SW17 | SW16 | SW15 | SW14 | SW13 |                 | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 |
+// |  ←   |  ↓   |  →   | SW24 | SW23 | SW22 | SW21 | SW20 | SW19 |                 | SW19 | SW20 | SW21 | SW22 | SW23 | SW24 |
+//                                           | TC4  | TC3  | TC2  | TC1  |   | TC1  | TC2  | TC3  | TC4  |
+        map = <
+RC(0,8) RC(0,7) RC(0,6) RC(0,5) RC(0,4) RC(0,3) RC(0,2) RC(0,1) RC(0,0)                 RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5)
+RC(1,8) RC(1,7) RC(1,6) RC(1,5) RC(1,4) RC(1,3) RC(1,2) RC(1,1) RC(1,0)                 RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5)
+        RC(1,7)         RC(2,5) RC(2,4) RC(2,3) RC(2,2) RC(2,1) RC(2,0)                 RC(7,0) RC(7,1) RC(7,2) RC(7,3) RC(7,4) RC(7,5)
+RC(1,8) RC(1,7) RC(1,6) RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                 RC(8,0) RC(8,1) RC(8,2) RC(8,3) RC(8,4) RC(8,5)
+                                                RC(4,3) RC(4,2) RC(4,1) RC(4,0) RC(9,0) RC(9,1) RC(9,2) RC(9,3)
+        >;
+    };
+
+    // SUMMER BREEZE
+    both_wings_transform: keymap_transform_1 {
+        compatible = "zmk,matrix-transform";
+        columns = <9>;
+        rows = <10>;
+// | MC3  | MC2  | MC1  | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |                 | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  | MC1  | MC2  | MC3  |
+// | MC6  | MC5  | MC4  | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |                 | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 | MC4  | MC5  | MC6  |
+// |      |  ↑   |      | SW18 | SW17 | SW16 | SW15 | SW14 | SW13 |                 | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 |      |  ↑   |      |
+// |  ←   |  ↓   |  →   | SW24 | SW23 | SW22 | SW21 | SW20 | SW19 |                 | SW19 | SW20 | SW21 | SW22 | SW23 | SW24 |  ←   |  ↓   |  →   |
+//                                           | TC4  | TC3  | TC2  | TC1  |   | TC1  | TC2  | TC3  | TC4  |
+        map = <
+RC(0,8) RC(0,7) RC(0,6) RC(0,5) RC(0,4) RC(0,3) RC(0,2) RC(0,1) RC(0,0)                 RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5) RC(5,3) RC(5,4) RC(5,5) RC(5,6) RC(5,7) RC(5,8)
+RC(1,8) RC(1,7) RC(1,6) RC(1,5) RC(1,4) RC(1,3) RC(1,2) RC(1,1) RC(1,0)                 RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5) RC(6,3) RC(6,4) RC(6,5) RC(6,6) RC(6,7) RC(6,8)
+        RC(1,7)         RC(2,5) RC(2,4) RC(2,3) RC(2,2) RC(2,1) RC(2,0)                 RC(7,0) RC(7,1) RC(7,2) RC(7,3) RC(7,4) RC(7,5) RC(7,3) RC(7,4) RC(7,5)         RC(7,7)
+RC(1,8) RC(1,7) RC(1,6) RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                 RC(8,0) RC(8,1) RC(8,2) RC(8,3) RC(8,4) RC(8,5) RC(8,3) RC(8,4) RC(8,5) RC(8,6) RC(8,7) RC(8,8)
+                                                RC(4,3) RC(4,2) RC(4,1) RC(4,0) RC(9,0) RC(9,1) RC(9,2) RC(9,3)
+        >;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+
+        diode-direction = "col2row";
+        col-gpios
+            = <&pro_micro 16 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 2  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 3  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 4  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 5  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 6  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 7  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 8  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 9  GPIO_ACTIVE_HIGH>
+            ;
+
+        row-gpios
+            = <&pro_micro 21  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 20  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 19  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 18  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+    };
+};

--- a/app/boards/shields/breeze/breeze.dtsi
+++ b/app/boards/shields/breeze/breeze.dtsi
@@ -32,7 +32,7 @@ RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                  RC(8,0) RC(8,1)
     };
 
     // WINTER BREEZE
-    five_column_transform: keymap_transform_1 {
+    no_wing_transform: keymap_transform_1 {
         compatible = "zmk,matrix-transform";
         columns = <6>;
         rows = <10>;
@@ -51,7 +51,7 @@ RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)                  RC(8,0) RC(8,1)
     };
 
     // SOUTHERN BREEZE
-    left_wing_transform: keymap_transform_1 {
+    left_wing_transform: keymap_transform_2 {
         compatible = "zmk,matrix-transform";
         columns = <9>;
         rows = <10>;
@@ -70,7 +70,7 @@ RC(1,8) RC(1,7) RC(1,6) RC(3,5) RC(3,4) RC(3,3) RC(3,2) RC(3,1) RC(3,0)         
     };
 
     // SUMMER BREEZE
-    both_wings_transform: keymap_transform_1 {
+    both_wings_transform: keymap_transform_3 {
         compatible = "zmk,matrix-transform";
         columns = <9>;
         rows = <10>;

--- a/app/boards/shields/breeze/breeze.keymap
+++ b/app/boards/shields/breeze/breeze.keymap
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/ext_power.h>
+
+/ {
+    keymap {
+        // Ref: https://zmkfirmware.dev/docs/codes/
+        compatible = "zmk,keymap";
+
+        default_layer {
+            // ------------------------------------------                  --------------------------------------------------------------------
+            // |   `   |  1  |  2  |  3   |  4   |  5   |                  |  6   |  7    |  8    |  9   |   0   | BSPC | | -/_ | =/+  | HOME |
+            // |  TAB  |  Q  |  W  |  E   |  R   |  T   |                  |  Y   |  U    |  I    |  O   |   P   |  [   | |  ]  | DEL  | END  |
+            // | SHIFT |  A  |  S  |  D   |  F   |  G   |                  |  H   |  J    |  K    |  L   |   ;   |  '   | |     |  UP  |      |
+            // |  CTRL |  Z  |  X  |  C   |  V   |  B   |--------  --------|  N   |  M    |  ,    |  .   |   /   |  \   | |  L  |  DN  |  R   |
+            // --------------------| ESC  | GUI  | ALT  | SPACE |  | ENTER | RALT | RAISE | LOWER |--------------------------------------------
+            //                     ------------------------------  --------------------------------
+            bindings = <
+                &kp GRAVE  &kp N1  &kp N2 &kp N3  &kp N4   &kp N5               &kp N6   &kp N7   &kp N8    &kp N9  &kp N0   &kp BSPC   &kp MINUS &kp EQUAL &kp HOME
+                &kp TAB    &kp Q   &kp W  &kp E   &kp R    &kp T                &kp Y    &kp U    &kp I     &kp O   &kp P    &kp LBKT   &kp RBKT  &kp DEL   &kp END
+                &kp LSHFT  &kp A   &kp S  &kp D   &kp F    &kp G                &kp H    &kp J    &kp K     &kp L   &kp SEMI &kp APOS             &kp UP 
+                &kp LCTRL  &kp Z   &kp X  &kp C   &kp V    &kp B                &kp N    &kp M    &kp COMMA &kp DOT &kp FSLH &kp BSLH   &kp LEFT  &kp DOWN  &kp RIGHT
+                                   &kp ESC &kp LGUI &kp LALT &kp SPACE  &kp RET &kp RALT &mo 2    &mo 1
+            >;
+        };
+
+        lower_layer {
+            // -----------------------------------------------                    -----------------------------------------------------------------------
+            // | BTCLR |  BT1  |  BT2  |  BT3  |  BT4 |  BT5 |                    |      |       |       |       |       |       | | Mute | Vol- | Vol+ | 
+            // |  F1   |  F2   |  F3   |  F4   |  F5  |  F6  |                    |  F7  |  F8   |  F9   |  F10  |  F11  |  F12  | |      | SCR- | SCR+ | 
+            // |       |       |       |       |      |      |                    |      |       |       |       |       |       | |      |      |      | 
+            // |       |       |       |       |      |      |---------  ---------|      |       |       |       |       |       | |      |      |      | 
+            // ------------------------|       |      |      |        |  |        |      |       |       |-----------------------------------------------
+            //                         --------------------------------  ---------------------------------
+            bindings = <
+                &bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4                  &trans  &trans  &trans  &trans   &trans   &trans   &kp C_MUTE  &kp C_VOL_DN  &kp C_VOL_UP 
+                &kp F1      &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                        &kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12  &trans      &kp C_BRI_DN  &kp C_BRI_UP 
+                &trans      &trans        &trans        &trans        &trans        &trans                        &trans  &trans  &trans  &trans   &trans   &trans               &trans 
+                &trans      &trans        &trans        &trans        &trans        &trans                        &trans  &trans  &trans  &trans   &trans   &trans   &trans      &trans        &trans 
+                                                        &trans        &trans        &trans       &trans   &trans  &trans  &trans  &trans           
+            >;
+        };
+
+        raise_layer {
+            // -------------------------------------------                    --------------------------------------------------------------------- 
+            // |      |      |      |      |      |      |                    |      |       |       |      |       |  DEL  | |      |      |     | 
+            // |  `   |  1   |  2   |  3   |  4   |  5   |                    |  6   |   7   |   8   |  9   |   0   |       | |      |      |     | 
+            // |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |                    |      |   <-  |   v   |  ^   |  ->   |       | |      | PGUP |     | 
+            // |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |---------  ---------|  +   |   -   |   =   |  [   |   ]   |   \   | | HOME | PGDN | END | 
+            // ---------------------|      |      |      |        |  |        |      |       |       |---------------------------------------------
+            //                      -------------------------------  ---------------------------------
+            bindings = <
+                &trans     &trans   &trans  &trans   &trans   &trans                    &trans       &trans     &trans     &trans    &trans     &kp DEL  &trans    &trans     &trans 
+                &kp GRAVE  &kp N1   &kp N2  &kp N3   &kp N4   &kp N5                    &kp N6       &kp N7     &kp N8     &kp N9    &kp N0     &trans   &trans    &trans     &trans 
+                &kp F1     &kp F2   &kp F3  &kp F4   &kp F5   &kp F6                    &trans       &kp LEFT   &kp DOWN   &kp UP    &kp RIGHT  &trans             &kp PG_UP     
+                &kp F7     &kp F8   &kp F9  &kp F10  &kp F11  &kp F12                   &kp KP_PLUS  &kp MINUS  &kp EQUAL  &kp LBKT  &kp RBKT   &kp BSLH &kp HOME  &kp PG_DN  &kp END 
+                                            &trans   &trans   &trans   &trans   &trans  &trans       &trans     &trans
+            >;
+        };
+    };
+};

--- a/app/boards/shields/breeze/breeze.zmk.yml
+++ b/app/boards/shields/breeze/breeze.zmk.yml
@@ -1,0 +1,12 @@
+file_format: "1"
+id: breeze
+name: Breeze
+type: shield
+url: https://afternoonlabs.com/breeze/
+requires:
+    - pro_micro
+features:
+    - keys
+siblings:
+    - breeze_left
+    - breeze_right

--- a/app/boards/shields/breeze/breeze_left.overlay
+++ b/app/boards/shields/breeze/breeze_left.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "breeze.dtsi"

--- a/app/boards/shields/breeze/breeze_right.overlay
+++ b/app/boards/shields/breeze/breeze_right.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "breeze.dtsi"
+
+&default_transform {
+	row-offset = <5>;
+};


### PR DESCRIPTION
Add a shield definition for the Breeze split keyboard from Afternoon labs.

This is for the standard breeze variant by default, with the arrow cluster present on the right half but not the left.
Additional layouts 

The definition is based on a stagnant PR by @idan: https://github.com/zmkfirmware/zmk/pull/1125, which based on an abandoned PR by @devries: https://github.com/zmkfirmware/zmk/pull/735

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
