### PR TITLE
Feature: shell `tap` command

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -91,5 +91,6 @@ target_sources(app PRIVATE src/workqueue.c)
 target_sources(app PRIVATE src/main.c)
 
 add_subdirectory(src/display/)
+add_subdirectory(src/shell/)
 
 zephyr_cc_option(-Wfatal-errors)

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -380,6 +380,8 @@ endmenu
 
 menu "Advanced"
 
+rsource "src/shell/Kconfig"
+
 menu "Initialization Priorities"
 
 if USB_DEVICE_STACK

--- a/app/boards/native_posix_64.overlay
+++ b/app/boards/native_posix_64.overlay
@@ -14,5 +14,6 @@
         rows = <2>;
         columns = <2>;
         exit-after;
+        events = <>;
     };
 };

--- a/app/src/shell/CMakeLists.txt
+++ b/app/src/shell/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_sources_ifdef(CONFIG_ZMK_SHELL_KEY_POSITIONS app PRIVATE key_positions.c)

--- a/app/src/shell/Kconfig
+++ b/app/src/shell/Kconfig
@@ -1,0 +1,8 @@
+menu "Shell"
+
+config ZMK_SHELL_KEY_POSITIONS
+    bool "Key Position commands"
+    default y if !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
+    depends on SHELL
+
+endmenu

--- a/app/src/shell/key_positions.c
+++ b/app/src/shell/key_positions.c
@@ -1,0 +1,80 @@
+
+#include <stdlib.h>
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zmk/event_manager.h>
+#include <zmk/events/position_state_changed.h>
+
+#define HELP_NONE "[key_position]"
+
+static int parse_key_position(const struct shell *shell, char *pos_str) {
+    int position;
+    char *endptr;
+
+    position = strtoul(pos_str, &endptr, 10);
+
+    if (endptr == pos_str) {
+        shell_error(shell, "Enter an integer key position");
+        return -EINVAL;
+    }
+
+    return position;
+}
+
+static int parse_and_raise(const struct shell *shell, char *pos_str, bool pressed) {
+    int position = parse_key_position(shell, pos_str);
+
+    if (position < 0) {
+        return position;
+    }
+
+    ZMK_EVENT_RAISE(new_zmk_position_state_changed(
+        (struct zmk_position_state_changed){.source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
+                                            .state = pressed,
+                                            .position = position,
+                                            .timestamp = k_uptime_get()}));
+
+    return position;
+}
+
+static int cmd_key_tap(const struct shell *shell, size_t argc, char **argv) {
+    if (argc != 2) {
+        return -EINVAL;
+    }
+
+    parse_and_raise(shell, argv[1], true);
+
+    k_sleep(K_MSEC(50));
+
+    parse_and_raise(shell, argv[1], false);
+
+    return 0;
+};
+
+static int cmd_key_press(const struct shell *shell, size_t argc, char **argv) {
+    if (argc != 2) {
+        return -EINVAL;
+    }
+
+    parse_and_raise(shell, argv[1], true);
+
+    return 0;
+};
+
+static int cmd_key_release(const struct shell *shell, size_t argc, char **argv) {
+    if (argc != 2) {
+        return -EINVAL;
+    }
+
+    parse_and_raise(shell, argv[1], false);
+
+    return 0;
+};
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_key, SHELL_CMD(tap, NULL, HELP_NONE, cmd_key_tap),
+                               SHELL_CMD(press, NULL, HELP_NONE, cmd_key_press),
+                               SHELL_CMD(release, NULL, HELP_NONE, cmd_key_release),
+                               SHELL_SUBCMD_SET_END /* Array terminated. */
+);
+
+SHELL_CMD_REGISTER(key, &sub_key, "Key commands", NULL);


### PR DESCRIPTION
Initial work on making the [Zephyr Shell](https://docs.zephyrproject.org/latest/services/shell/index.html) useful for ZMK.

* Fixes for our Kconfig that enables `SENSOR` to not force it on all the time, which helps for `native_posix_64` target builds.
*Minor native_posix_64 tweaks to allow building without any simulated kscan events, since we will use the shell for that instead.
* Shell command! Can do `key tap 0` to generate press then release of the 0th key position.


This is useful for building a native posix executable to test ZMK by hand, generate key events, test changes to USB via the USB IP native driver, etc.