### PR TITLE
feat(boards): Add nullbits SNAP shield

### DIFF
--- a/app/boards/shields/snap/Kconfig.defconfig
+++ b/app/boards/shields/snap/Kconfig.defconfig
@@ -1,0 +1,49 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_SNAP_LEFT
+
+config ZMK_KEYBOARD_NAME
+	default "SNAP"
+
+config ZMK_SPLIT_ROLE_CENTRAL
+	default y
+
+endif
+
+if SHIELD_SNAP_LEFT || SHIELD_SNAP_RIGHT
+
+config ZMK_SPLIT
+	default y
+ 
+if ZMK_DISPLAY
+
+config I2C
+	default y
+
+config SSD1306
+	default y
+
+config SSD1306_REVERSE_MODE
+	default y
+
+endif # ZMK_DISPLAY
+
+if LVGL
+
+config LVGL_VDB_SIZE
+	default 64
+
+config LVGL_DPI
+	default 148
+
+config LVGL_BITS_PER_PIXEL
+	default 1
+
+choice LVGL_COLOR_DEPTH
+	default LVGL_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL
+
+endif

--- a/app/boards/shields/snap/Kconfig.shield
+++ b/app/boards/shields/snap/Kconfig.shield
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_SNAP_LEFT
+	def_bool $(shields_list_contains,snap_left)
+
+config SHIELD_SNAP_RIGHT
+	def_bool $(shields_list_contains,snap_right)

--- a/app/boards/shields/snap/boards/nice_nano.overlay
+++ b/app/boards/shields/snap/boards/nice_nano.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <10>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <5>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/snap/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/snap/boards/nice_nano_v2.overlay
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <10>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <5>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/snap/snap.conf
+++ b/app/boards/shields/snap/snap.conf
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Uncomment these two lines to add support for encoders to your firmware
+# and enable the encoders
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Uncomment the following line to enable the OLED Display
+# CONFIG_ZMK_DISPLAY=y
+
+# Uncomment the following lines to enable the RGB underglow
+# CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER=n
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y
+# CONFIG_ZMK_RGB_UNDERGLOW_HUE_STEP=5
+# CONFIG_ZMK_RGB_UNDERGLOW_SPD_START=1

--- a/app/boards/shields/snap/snap.dtsi
+++ b/app/boards/shields/snap/snap.dtsi
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+	chosen {
+		zephyr,display = &oled;
+		zmk,kscan = &kscan_composite;
+		zmk,matrix_transform = &default_transform;
+	};
+
+	left_encoder: encoder_left {
+		compatible = "alps,ec11";
+		label = "LEFT_ENCODER";
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	right_encoder: encoder_right {
+		compatible = "alps,ec11";
+		label = "RIGHT_ENCODER";
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	default_transform: keymap_transform_0 {
+		compatible = "zmk,matrix-transform";
+		columns = <17>;
+		rows = <6>;
+
+//        | R0C06L | R0C05L | R0C04L | R0C03L | R0C02L | R0C01L | R0C00L | | R0C15R | R0C14R | R0C13R | R0C12R | R0C11R | R0C10R | R0C09R | R0C08R |
+// R1C07L | R1C06L | R1C05L | R1C04L | R1C03L | R1C02L | R1C01L | R1C00L | | R1C15R | R1C14R | R1C13R | R1C12R | R1C11R | R1C10R | R1C09R | R1C08R | R2C0XR |
+// R2C07L | R2C06L | R2C05L | R2C04L | R2C03L | R2C02L |          R2C00L | | R2C15R | R2C14R | R2C13R | R2C12R | R2C11R | R2C10R | R2C09R | R3C08R | R2C08R |
+// R3C07L | R3C06L | R3C05L | R3C04L | R3C03L | R3C02L |          R3C00L | | R3C15R | R3C14R | R3C13R | R3C12R | R3C11R | R3C10R | R3C09R |          R4C08R |
+// R4C07L | R4C06L | R4C05L | R4C04L | R4C03L | R4C02L | R4C01L | R4C00L | | R4C15R | R4C14R | R4C13R | R4C12R | R4C11R | R4C10R |          R4C09R | R5C08R |
+// R5C07L | R5C06L | R5C05L | R5C04L |          R5C02L |          R5C00L | | R5C15R |                   R5C14R | R5C13R | R5C12R | R5C11R | R5C10R | R5C09R |
+		
+	map = <
+		RC(0,6) RC(0,5) RC(0,4) RC(0,3) RC(0,2) RC(0,1) RC(0,0)    RC(0,15) RC(0,14) RC(0,13) RC(0,12) RC(0,11) RC(0,10) RC(0,9)  RC(0,8)
+RC(1,7) RC(1,6) RC(1,5) RC(1,4) RC(1,3) RC(1,2) RC(1,1) RC(1,0)    RC(1,15) RC(1,14) RC(1,13) RC(1,12) RC(1,11) RC(1,10) RC(1,9)  RC(1,8)  RC(1,16)
+RC(2,7) RC(2,6) RC(2,5) RC(2,4) RC(2,3) RC(2,2)         RC(2,0)    RC(2,15) RC(2,14) RC(2,13) RC(2,12) RC(2,11) RC(2,10) RC(2,9)  RC(3,8)  RC(2,8)
+RC(3,7) RC(3,6) RC(3,5) RC(3,4) RC(3,3) RC(3,2)         RC(3,0)    RC(3,15) RC(3,14) RC(3,13) RC(3,12) RC(3,11) RC(3,10) RC(3,9)           RC(4,8)
+RC(4,7) RC(4,6) RC(4,5) RC(4,4) RC(4,3) RC(4,2) RC(4,1) RC(4,0)    RC(4,15) RC(4,14) RC(4,13) RC(4,12) RC(4,11) RC(4,10)          RC(4,9)  RC(5,8)
+RC(5,7) RC(5,6) RC(5,5) RC(5,4)         RC(5,2)         RC(5,0)    RC(5,15)                   RC(5,14) RC(5,13) RC(5,12) RC(5,11) RC(5,10) RC(5,9)
+		>;
+	};
+
+	kscan_composite: kscan {
+		compatible = "zmk,kscan-composite";
+		label = "KSCAN";
+		rows = <6>;
+		columns = <17>;
+
+		demux {
+			kscan = <&kscan_demux>;
+		};
+	};
+
+	kscan_demux: kscan_demux {
+		compatible = "zmk,kscan-gpio-demux";
+		label = "DEMUX";
+		polling-interval-msec = <25>;
+	};
+};
+
+&pro_micro_i2c {
+	status = "okay";
+
+	oled: ssd1306@3c {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3c>;
+		label = "DISPLAY";
+		width = <128>;
+		height = <32>;
+		segment-offset = <0>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <31>;
+		com-sequential;
+		prechargep = <0x22>;
+	};
+};

--- a/app/boards/shields/snap/snap.keymap
+++ b/app/boards/shields/snap/snap.keymap
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/rgb.h>
+
+/ {
+	sensors {
+		compatible = "zmk,keymap-sensors";
+		sensors = <&left_encoder &right_encoder>;
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+
+		default_layer {
+			label = "Default";
+			sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
+			bindings = <
+             &kp ESC     &kp F1   &kp F2   &kp F3   &kp F4   &kp F5   &kp F6     &kp F7   &kp F8   &kp F9    &kp F10  &kp F11     &kp F12     &kp KP_NUM   &kp PAUSE_BREAK
+&kp C_MUTE   &kp TILDE   &kp N1   &kp N2   &kp N3   &kp N4   &kp N5   &kp N6     &kp N7   &kp N8   &kp N9    &kp N0   &kp MINUS   &kp EQUAL   &kp BSPC     &kp DEL    &kp HOME
+&kp F13      &kp TAB     &kp Q    &kp W    &kp E    &kp R             &kp T      &kp Y    &kp U    &kp I     &kp O    &kp P       &kp LBKT    &kp RBKT     &kp BSLH   &kp END
+&kp F14      &kp CLCK    &kp A    &kp S    &kp D    &kp F             &kp G      &kp H    &kp J    &kp K     &kp L    &kp SEMI    &kp SQT     &kp RET                 &kp PG_UP
+&kp F15      &kp LSHFT   &kp NUHS &kp Z    &kp X    &kp C    &kp V    &kp B      &kp N    &kp M    &kp COMMA &kp DOT  &kp FSLH    &kp RSHFT                &kp UP     &kp PG_DN
+&kp F16      &kp LCTRL   &kp LGUI &kp LALT          &mo 1            &kp SPACE    &kp BSPC                   &mo 1    &kp RALT    &kp RCTRL   &kp LEFT     &kp DOWN   &kp RIGHT
+			>;
+		};
+
+		function_layer {
+			label = "Function";
+			sensor-bindings = <&inc_dec_kp C_NEXT C_PREV &inc_dec_kp C_NEXT C_PREV>;
+			bindings = <
+             &bootloader &trans   &trans   &trans   &trans   &trans   &trans     &trans   &trans   &trans   &trans    &trans      &trans      &trans       &bootloader
+&kp C_PP     &trans      &trans   &trans   &trans   &trans   &trans   &trans     &trans   &trans   &trans   &trans    &trans      &trans      &trans       &trans     &kp C_PP
+&trans       &trans      &trans   &trans   &trans   &trans            &trans     &trans   &trans   &trans   &trans    &trans      &trans      &trans       &trans     &trans 
+&trans       &trans      &trans   &trans   &trans   &trans            &trans     &trans   &trans   &trans   &trans    &trans      &trans                   &trans     &trans
+&trans       &trans      &trans   &trans   &trans   &trans   &trans   &trans     &trans   &trans   &trans   &trans    &trans          &rgb_ug RGB_TOG &rgb_ug RGB_BRI &rgb_ug RGB_EFF
+&trans       &trans      &trans   &trans            &trans           &trans       &trans                    &trans    &trans  &trans  &rgb_ug RGB_HUD &rgb_ug RGB_BRD &rgb_ug RGB_HUI
+			>;
+		};
+	};
+};

--- a/app/boards/shields/snap/snap.zmk.yml
+++ b/app/boards/shields/snap/snap.zmk.yml
@@ -1,0 +1,15 @@
+file_format: "1"
+id: snap
+name: SNAP
+type: shield
+url: https://nullbits.co/snap
+requires: [pro_micro]
+exposes: [i2c_oled]
+features:
+  - keys
+  - display
+  - encoder
+  - underglow
+siblings:
+  - snap_left
+  - snap_right

--- a/app/boards/shields/snap/snap_left.overlay
+++ b/app/boards/shields/snap/snap_left.overlay
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "snap.dtsi"
+
+&kscan_demux {
+	input-gpios
+		= <&pro_micro 4  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 5  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 6  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 8  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 9  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		;
+	output-gpios
+		= <&pro_micro 18 GPIO_ACTIVE_HIGH>
+		, <&pro_micro 19 GPIO_ACTIVE_HIGH>
+		, <&pro_micro 20 GPIO_ACTIVE_HIGH>
+		;
+};
+
+&left_encoder {
+	a-gpios = <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	b-gpios = <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;	
+	status = "okay";
+};
+
+&oled {
+	segment-remap;
+	com-invdir;
+};

--- a/app/boards/shields/snap/snap_right.overlay
+++ b/app/boards/shields/snap/snap_right.overlay
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "snap.dtsi"
+
+/ {
+kscan_direct: kscan_direct {
+	compatible = "zmk,kscan-gpio-direct";
+	label = "DIRECT";
+	input-gpios
+		= <&pro_micro 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		;
+	};
+};
+
+&default_transform {
+	col-offset = <8>;
+};
+
+&kscan_composite {
+		direct {
+			kscan = <&kscan_direct>;
+			row-offset = <1>;
+			column-offset = <8>;
+	};
+};
+
+&kscan_demux {
+	input-gpios
+		= <&pro_micro 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 20 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 19 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 18 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		, <&pro_micro 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+		;
+	output-gpios
+		= <&pro_micro 6 GPIO_ACTIVE_HIGH>
+		, <&pro_micro 5 GPIO_ACTIVE_HIGH>
+		, <&pro_micro 4 GPIO_ACTIVE_HIGH>
+		;
+};
+
+&right_encoder {
+	a-gpios = <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
+	b-gpios = <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;	
+	status = "okay";
+};


### PR DESCRIPTION
PR to add the [nullbits SNAP](https://nullbits.co/snap/) split keyboard. 

Thoroughly tested on real hardware with nice!nano V1s.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
