### PR TITLE
Add 'chosen' node reference for OLEDs to leeloo.dtsi, and a correction to README.md.

### DIFF
--- a/app/boards/shields/leeloo/README.md
+++ b/app/boards/shields/leeloo/README.md
@@ -32,8 +32,8 @@ Build command for the default keymap of Leeloo:
 
 Build command for your custom keymap of Leeloo:
 
-    west build -d build/right -p -b nice_nano_v2 -- -DSHIELD=leeloo_right -DZMK_CONFIG="C:\dev\zmk\[yourNmae]\leeloo\config"
-    west build -d build/left -p -b nice_nano_v2 -- -DSHIELD=leeloo_left -DZMK_CONFIG="C:\dev\zmk\[yourName]\leeloo\config"
+    west build -d build/right -p -b nice_nano_v2 -- -DSHIELD=leeloo_right -DZMK_CONFIG="C:/dev/zmk/[yourNmae]/leeloo/config"
+    west build -d build/left -p -b nice_nano_v2 -- -DSHIELD=leeloo_left -DZMK_CONFIG="C:/dev/zmk/[yourName]/leeloo/config"
 
 # Support
 If you have any questions with regards to Leeloo, please [Contact Us](https://clicketysplit.ca/pages/contact-us).

--- a/app/boards/shields/leeloo/leeloo.dtsi
+++ b/app/boards/shields/leeloo/leeloo.dtsi
@@ -7,6 +7,7 @@
 
 / {
     chosen {
+        zephyr,display = &oled;
         zmk,kscan = &kscan0;
         zmk,matrix_transform = &default_transform;
     };


### PR DESCRIPTION
A quick update to the leeloo.dtsi file to ensure OLEDs are properly supported with the 'chosen' node reference; and, a correction to the README.md file to adjust the direction of the folder separators.