### PR TITLE
fix(drivers): Avoid build failures for GPIO driver

### DIFF
--- a/app/drivers/CMakeLists.txt
+++ b/app/drivers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
-add_subdirectory(gpio)
+add_subdirectory_ifdef(CONFIG_ZMK_DRIVERS_GPIO gpio)
 add_subdirectory(kscan)
 add_subdirectory(sensor)
 add_subdirectory(display)

--- a/app/drivers/gpio/Kconfig
+++ b/app/drivers/gpio/Kconfig
@@ -1,2 +1,5 @@
+menuconfig ZMK_DRIVERS_GPIO
+    bool "GPIO"
+
 rsource "Kconfig.mcp23017"
 rsource "Kconfig.595"

--- a/app/drivers/gpio/Kconfig.595
+++ b/app/drivers/gpio/Kconfig.595
@@ -10,6 +10,7 @@ menuconfig GPIO_595
 	default $(dt_compat_enabled,$(DT_COMPAT_ZMK_GPIO_595))
 	depends on SPI
 	select HAS_DTS_GPIO
+	select ZMK_DRIVERS_GPIO
 	help
 	  Enable driver for 595 shift register chip using SPI.
 

--- a/app/drivers/gpio/Kconfig.mcp23017
+++ b/app/drivers/gpio/Kconfig.mcp23017
@@ -7,6 +7,7 @@ menuconfig GPIO_MCP23017
 	bool "MCP23017 I2C-based GPIO chip"
 	depends on I2C
 	select HAS_DTS_GPIO
+	select ZMK_DRIVERS_GPIO
 	help
 	  Enable driver for MCP23017 I2C-based GPIO chip.
 


### PR DESCRIPTION
* Avoid defining the ZMK GPIO drivers lib if none of the drivers  are
  selected.
