### PR TITLE
fix(shields): Fix indentation in two_percent_milk.keymap

### DIFF
--- a/app/boards/shields/two_percent_milk/two_percent_milk.keymap
+++ b/app/boards/shields/two_percent_milk/two_percent_milk.keymap
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: MIT
  */
 
- #include <behaviors.dtsi>
- #include <dt-bindings/zmk/keys.h>
- #include <dt-bindings/zmk/bt.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
  
- / {
-     keymap {
-         compatible = "zmk,keymap";
+/ {
+    keymap {
+        compatible = "zmk,keymap";
  
-         default_layer {
-             bindings = <
-              &kp X
-              &kp Z
-             >;
-         };
-     };
- };
+        default_layer {
+            bindings = <
+                &kp X
+                &kp Z
+            >;
+        };
+    };
+};


### PR DESCRIPTION
A very minor nitpick to improve the indentation styling for the 2% Milk keymap. Removes the leading space for each affected line.