### PR TITLE
feat(shields): add atreus62

### DIFF
--- a/app/boards/shields/atreus62/Kconfig.defconfig
+++ b/app/boards/shields/atreus62/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_ATREUS62
+
+config ZMK_KEYBOARD_NAME
+    default "Atreus62BMP"
+
+endif

--- a/app/boards/shields/atreus62/Kconfig.defconfig
+++ b/app/boards/shields/atreus62/Kconfig.defconfig
@@ -3,4 +3,10 @@ if SHIELD_ATREUS62
 config ZMK_KEYBOARD_NAME
     default "Atreus62"
 
+config ZMK_BLE
+    default y
+
+config ZMK_USB
+    default y
+
 endif

--- a/app/boards/shields/atreus62/Kconfig.defconfig
+++ b/app/boards/shields/atreus62/Kconfig.defconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2022 The ZMK Contributors
-# SPDX-License-Identifier: MIT
-
 if SHIELD_ATREUS62
 
 config ZMK_KEYBOARD_NAME
-    default "Atreus62BMP"
+    default "Atreus62"
 
 endif

--- a/app/boards/shields/atreus62/Kconfig.shield
+++ b/app/boards/shields/atreus62/Kconfig.shield
@@ -1,5 +1,2 @@
-# Copyright (c) 2022 The ZMK Contributors
-# SPDX-License-Identifier: MIT
-
 config SHIELD_ATREUS62
     def_bool $(shields_list_contains,atreus62)

--- a/app/boards/shields/atreus62/Kconfig.shield
+++ b/app/boards/shields/atreus62/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_ATREUS62
+    def_bool $(shields_list_contains,atreus62)

--- a/app/boards/shields/atreus62/atreus62.conf
+++ b/app/boards/shields/atreus62/atreus62.conf
@@ -1,0 +1,3 @@
+# Uncomment lines below to enable encoder
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y

--- a/app/boards/shields/atreus62/atreus62.keymap
+++ b/app/boards/shields/atreus62/atreus62.keymap
@@ -9,33 +9,40 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
 
+#define NONE 0
+#define LOWER 1
+#define RAISE 2
+#define SOME_THING 4 // need to update this layer what should this be called??
+#define MEDIA 5
+#define FUNC 6
+
 / {
     keymap {
         compatible = "zmk,keymap";
 
         default_layer {
             // ----------------------------------------------------------------------------------------------------------
-            // |  ESC  |  1   |  2   |  3   |  4   |  5   |-------|-------|   6   |  7    |  8   |  9   |   0   |   |
-            // |  TAB  |  Q   |  W   |  E   |  R   |  T   |-------|-------|   Y   |  U    |  I   |  O   |   P   |  \    |
-            // | BSPC  |  A   |  S   |  D   |  F   |  G   |-------|-------|   H   |  J    |  K   |  L   |   ;   |  '    |
-            // | SHIFT |  Z   |  X   |  C   |  V   |  B   |-------|-------|   N   |  M    |  ,   |  .   |   /   | ENTER |
-            // |  CTRL |  Fn  | LALT | LGUI | RAIS | TAB  | SPACE | ENTER |  LOWR |	 MEH  |      |  -   |   =   |-------|
+            // |  ESC  |  1   |  2   |  3   |  4   |  5     |-------|-------|   6   |  7    |  8   |  9   |   0   |   |
+            // |  TAB  |  Q   |  W   |  E   |  R   |  T     |-------|-------|   Y   |  U    |  I   |  O   |   P   |  \    |
+            // | BSPC  |  A   |  S   |  D   |  F   |  G     |-------|-------|   H   |  J    |  K   |  L   |   ;   |  '    |
+            // | SHIFT |  Z   |  X   |  C   |  V   |  B     |-------|-------|   N   |  M    |  ,   |  .   |   /   | ENTER |
+            // |  CTRL |  Fn  | LALT | LGUI | RAIS | SPACE  | TAB   | ENTER |  LOWR |  MEH  |      |  -   |   =   |-------|
             bindings = <
-                &kp ESC    &kp N1 &kp N2   &kp N3   &kp N4 &kp N5                    &kp N6 &kp N7            &kp N8    &kp N9    &kp N0    &trans
-                &kp GRAVE  &kp Q  &kp W    &kp E    &kp R  &kp T                     &kp Y  &kp U             &kp I     &kp O     &kp P     &kp BSLH
-                &kp BSPC   &kp A  &kp S    &kp D    &kp F  &kp G                     &kp H  &kp J             &kp K     &kp L     &kp SEMI  &kp SQT
-                &kp LSHFT  &kp Z  &kp X    &kp C    &kp V  &kp B                     &kp N  &kp M             &kp COMMA &kp DOT   &kp FSLH  &kp RSHIFT
-                &kp LCTRL  &mo 5  &kp LALT &kp LGUI &mo 1  &kp TAB &kp SPACE &kp RET &mo 2  &kp LA(LC(LSHFT)) &trans    &kp MINUS &kp EQUAL &mo 4
+                &kp ESC    &kp N1 &kp N2   &kp N3   &kp N4     &kp N5                    &kp N6     &kp N7            &kp N8    &kp N9    &kp N0    &trans
+                &kp GRAVE  &kp Q  &kp W    &kp E    &kp R      &kp T                     &kp Y      &kp U             &kp I     &kp O     &kp P     &kp BSLH
+                &kp BSPC   &kp A  &kp S    &kp D    &kp F      &kp G                     &kp H      &kp J             &kp K     &kp L     &kp SEMI  &kp SQT
+                &kp LSHFT  &kp Z  &kp X    &kp C    &kp V      &kp B                     &kp N      &kp M             &kp COMMA &kp DOT   &kp FSLH  &kp RSHIFT
+                &kp LCTRL  &mo 5  &kp LALT &kp LGUI &mo LOWER  &kp SPACE &kp TAB &kp RET &mo RAISE  &kp LA(LC(LSHFT)) &trans    &kp MINUS &kp EQUAL &mo 4
             >;
         };
 
-        raise {
-            // ----------------------------------------------------------------------------------------------------------
-            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|   F7  |  F8   |  F9  | F10  |  F11  |  F12  |
-            // |   ~   |  !   |  @   |  #   |  $   |  %   |-------|-------|   ^   |   &   |  *   |  (   |   )   |  DEL  |
-            // |       |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|   F6  |   _   |  +   |  {   |   }   |   |   |
-            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|   F12 | LS(#) |LS(|) |      |       |       |
-            // |-------|      |      |      |      |      |       |       |       | NEXT  | Vol- | Vol+ | PLAY  |-------|
+        lower {
+            // ----------------------------------------------------------------------------------------------------------------------------
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |  DEL  |        |        |        |        |        |-------|-------|  LEFT  |  DOWN  |  UP    |  RIGHT |        |        |
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |       |       |        |        |        |        |        |        |
             bindings = <
                 &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans     &trans    &trans
                 &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans     &trans    &trans
@@ -45,13 +52,13 @@
             >;
         };
 
-        lower {
-            // ----------------------------------------------------------------------------------------------------------
-            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|  F7   |  F8   |  F9  | F10  |  F11  |  F12  |
-            // |   ~   |  1   |  2   |  3   |  4   |  5   |-------|-------|  6    |   7   |  8   |  9   |   0   |  DEL  |
-            // |  DEL  |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|  F6   |   -   |  =   |  [   |   ]   |   \   |
-            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |
-            // |-------|      |      |      |      |      |       |       |       |       |      |      |       |-------|
+        raise {
+            // ----------------------------------------------------------------------------------------------------------------------------
+            // |       |   F1   |   F2   |   F3   |   F4   |   F5   |-------|-------|   F6   |   F7   |   F8   |   F9   |   F10  |   F11  |
+            // |       |        |        |   {    |   }    |        |-------|-------|        |        |        |        |        |   F12  |
+            // |       |        |        |   (    |   )    |        |-------|-------|  LEFT  |  DOWN  |  UP    |  RIGHT |        |        |
+            // |       |        |        |   [    |   ]    |        |-------|-------|        |        |  PREV  |  NEXT  |        |        |
+            // |       |        |        |        |        |        |       |       |        |        |        |  VOL-  |  VOL+  |  PLAY  |
             bindings = <
                 &trans  &kp F1  &kp F2  &kp F3   &kp F4   &kp F5               &kp F6     &kp F7    &kp F8     &kp F9       &kp F10      &kp F11
                 &trans  &trans  &trans  &kp LBRC &kp RBRC &trans               &trans     &trans    &trans     &trans       &trans       &kp F12
@@ -89,12 +96,12 @@
         };
 /*
         flock {
-            // ----------------------------------------------------------------------------------------------------------
-            // |tog(4) |  F2    |   F3   |   F4   |   F5   |   F6   |-------|-------|  F7  |  F8  |  F9  | F10 | F11 |      |
-            // |out tog|BT_SEL 0|BT_SEL 1|BT_SEL 2|BT_SEL 3|BT_SEL 4|-------|-------|BT_PRV|BT_NXT|BT_CLR|     |     |      |
-            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
-            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
-            // |       |        |        |        |        |        |       |       |      |      |      |     |     |      |
+            // ----------------------------------------------------------------------------------------------------------------------------
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |       |       |        |        |        |        |        |        |
             bindings = <
                 &tog 4       &kp F2       &kp F3       &kp F4       &kp F5       &kp F6                     &kp F7     &kp F8     &kp F9     &kp F10 &kp F11 &trans
                 &out OUT_TOG &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4               &bt BT_PRV &bt BT_NXT &bt BT_CLR &trans  &trans  &trans
@@ -105,3 +112,10 @@
         };*/
     };
 };
+
+            // ----------------------------------------------------------------------------------------------------------------------------
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        |        |        |       |       |        |        |        |        |        |        |

--- a/app/boards/shields/atreus62/atreus62.keymap
+++ b/app/boards/shields/atreus62/atreus62.keymap
@@ -20,19 +20,17 @@
             // |  TAB  |  Q   |  W   |  E   |  R   |  T   |-------|-------|   Y   |  U    |  I   |  O   |   P   |  \    |
             // | BSPC  |  A   |  S   |  D   |  F   |  G   |-------|-------|   H   |  J    |  K   |  L   |   ;   |  '    |
             // | SHIFT |  Z   |  X   |  C   |  V   |  B   |-------|-------|   N   |  M    |  ,   |  .   |   /   | ENTER |
-            // |  CTRL |  Fn  | LALT | LGUI | RAIS |      | SPACE | ENTER |  LOWR |       |      |  -   |   =   |-------|
-
-
+            // |  CTRL |  Fn  | LALT | LGUI | RAIS | TAB  | SPACE | ENTER |  LOWR |       |      |  -   |   =   |-------|
             bindings = <
-                &kp ESC    &kp N1 &kp N2    &kp N3   &kp N4   &kp N5                    &kp N6 &kp N7   &kp N8    &kp N9  &kp N0    &trans
-                &kp GRAVE  &kp Q  &kp W     &kp E    &kp R    &kp T                     &kp Y  &kp U    &kp I     &kp O   &kp P     &kp BSLH
-                &kp BSPC   &kp A  &kp S     &kp D    &kp F    &kp G                     &kp H  &kp J    &kp K     &kp L   &kp SEMI  &kp SQT
-                &kp LSHFT  &kp Z  &kp X     &kp C    &kp V    &kp B                     &kp N  &kp M    &kp COMMA &kp DOT &kp FSLH  &kp RET
-                &kp LCTRL  &mo 4  &kp LALT  &kp LGUI &mo 2 &kp TAB &kp SPACE &kp ENTER  &mo 1  &kp LEFT &kp DOWN  &kp UP  &kp RIGHT &trans
+                &kp ESC    &kp N1 &kp N2   &kp N3   &kp N4 &kp N5                    &kp N6 &kp N7 &kp N8    &kp N9    &kp N0    &trans
+                &kp GRAVE  &kp Q  &kp W    &kp E    &kp R  &kp T                     &kp Y  &kp U  &kp I     &kp O     &kp P     &kp BSLH
+                &kp BSPC   &kp A  &kp S    &kp D    &kp F  &kp G                     &kp H  &kp J  &kp K     &kp L     &kp SEMI  &kp SQT
+                &kp LSHFT  &kp Z  &kp X    &kp C    &kp V  &kp B                     &kp N  &kp M  &kp COMMA &kp DOT   &kp FSLH  &kp RSHIFT
+                &kp LCTRL  &mo 5  &kp LALT &kp LGUI &mo 1  &kp TAB &kp SPACE &kp RET &mo 2  &trans &trans    &kp MINUS &kp EQUAL &mo 4
             >;
         };
 
-        lower {
+        raise {
             // ----------------------------------------------------------------------------------------------------------
             // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|   F7  |  F8   |  F9  | F10  |  F11  |  F12  |
             // |   ~   |  !   |  @   |  #   |  $   |  %   |-------|-------|   ^   |   &   |  *   |  (   |   )   |  DEL  |
@@ -40,15 +38,15 @@
             // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|   F12 | LS(#) |LS(|) |      |       |       |
             // |-------|      |      |      |      |      |       |       |       | NEXT  | Vol- | Vol+ | PLAY  |-------|
             bindings = <
-                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                  &kp F7    &kp F8              &kp F9              &kp F10      &kp F11          &kp F12
-                &kp TILDE &kp EXCL &kp AT   &kp HASH &kp DLLR  &kp PRCNT               &kp CARET &kp AMPS            &kp ASTRK           &kp LPAR     &kp RPAR         &kp DEL
-                &trans    &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                  &kp F6    &kp UNDER           &kp PLUS            &kp LBRC     &kp RBRC         &kp PIPE
-                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11                 &kp F12   &kp LS(NON_US_HASH) &kp LS(NON_US_BSLH) &trans       &trans           &trans
-                &trans    &trans   &trans   &trans   &trans    &trans    &trans &trans &mo 3     &kp C_NEXT          &kp C_VOL_DN        &kp C_VOL_UP &kp C_PLAY_PAUSE &trans
+                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans
+                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans
+                &kp DEL    &trans  &trans  &trans  &trans  &trans                  &kp LEFT  &kp DOWN  &kp UP    &kp RIGHT
+                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans
+                &trans     &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans    &trans    &trans    &trans
             >;
         };
 
-        raise {
+        lower {
             // ----------------------------------------------------------------------------------------------------------
             // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|  F7   |  F8   |  F9  | F10  |  F11  |  F12  |
             // |   ~   |  1   |  2   |  3   |  4   |  5   |-------|-------|  6    |   7   |  8   |  9   |   0   |  DEL  |
@@ -56,15 +54,15 @@
             // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |
             // |-------|      |      |      |      |      |       |       |       |       |      |      |       |-------|
             bindings = <
-                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                &kp F7    &kp F8          &kp F9          &kp F10      &kp F11          &kp F12
-                &kp TILDE &kp N1   &kp N2   &kp N3   &kp N4    &kp N5                &kp N6    &kp N7          &kp N8          &kp N9       &kp N0           &kp DEL
-                &kp DEL   &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                &kp F6    &kp MINUS       &kp EQUAL       &kp LBKT     &kp RBKT         &kp BSLH
-                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11               &kp F12   &kp NON_US_HASH &kp NON_US_BSLH &trans       &trans           &trans
-                &trans    &trans   &trans   &trans   &trans    &mo 3   &trans &trans &trans    &trans          &trans          &trans       &trans           &trans
+                &trans  &kp F1  &kp F2  &kp F3   &kp F4   &kp F5               &kp F6     &kp F7     &kp F8  &kp F9       &kp F10      &kp F11
+                &trans  &trans  &trans  &kp LBRC &kp RBRC &trans               &trans     &trans     &trans  &trans       &trans       &kp F12
+                &trans  &trans  &trans  &kp LPAR &kp RPAR &trans               &kp LEFT   &kp DOWN   &kp UP  &kp RIGHT    &trans       &trans
+                &trans  &trans  &trans  &kp LBKT &kp RBKT &trans               &kp C_PREV &kp C_NEXT &trans  &trans       &trans       &trans
+                &trans  &trans  &trans  &trans   &mo 3    &trans &trans &trans &trans     &trans     &trans  &kp C_VOL_DN &kp C_VOL_UP &kp C_PP
             >;
         };
 
-        adjust {
+        control {
             // ----------------------------------------------------------------------------------------------------------
             // |tog(4)|  F2  |  F3  |  F4  |  F5  |  F6  |------|------|  F7  |  F8  |  F9  |  F10 |  F11 |    F12    |
             // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LALT(PRTSN)|
@@ -80,6 +78,17 @@
             >;
         };
 
+        SOME_THING {
+            bindings = <
+                &bootloader &reset  &trans  &trans  &trans  &trans                  &kp N6  &kp N8  &kp N9  &trans &trans &trans
+                &trans      &trans  &trans  &trans  &trans  &trans                  &kp N4  &kp N5  &kp N6  &trans &trans &trans
+                &trans      &trans  &trans  &trans  &trans  &trans                  &kp N1  &kp N2  &kp N3  &trans &trans &trans
+                &trans      &trans  &trans  &trans  &trans  &trans                  &trans  &kp N0  &trans  &trans &trans &trans
+                &trans      &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans &trans &trans
+
+            >;
+        };
+/*
         flock {
             // ----------------------------------------------------------------------------------------------------------
             // |tog(4) |  F2    |   F3   |   F4   |   F5   |   F6   |-------|-------|  F7  |  F8  |  F9  | F10 | F11 |      |
@@ -94,6 +103,6 @@
                 &trans       &trans       &trans       &trans       &trans       &trans                     &trans     &trans     &trans     &trans  &trans  &trans
                 &trans       &trans       &trans       &trans       &trans       &trans       &trans &trans &trans     &trans     &trans     &trans  &trans  &trans
             >;
-        };
+        };*/
     };
 };

--- a/app/boards/shields/atreus62/atreus62.keymap
+++ b/app/boards/shields/atreus62/atreus62.keymap
@@ -9,7 +9,6 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
 
-
 / {
     keymap {
         compatible = "zmk,keymap";
@@ -38,11 +37,11 @@
             // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|   F12 | LS(#) |LS(|) |      |       |       |
             // |-------|      |      |      |      |      |       |       |       | NEXT  | Vol- | Vol+ | PLAY  |-------|
             bindings = <
-                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans
-                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans
-                &kp DEL    &trans  &trans  &trans  &trans  &trans                  &kp LEFT  &kp DOWN  &kp UP    &kp RIGHT
-                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans
-                &trans     &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans    &trans    &trans    &trans
+                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans     &trans    &trans
+                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans     &trans    &trans
+                &kp DEL    &trans  &trans  &trans  &trans  &trans                  &kp LEFT  &kp DOWN  &kp UP    &kp RIGHT  &trans    &trans
+                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans     &trans    &trans
+                &trans     &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans    &trans    &trans    &trans     &trans    &trans
             >;
         };
 
@@ -51,14 +50,14 @@
             // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|  F7   |  F8   |  F9  | F10  |  F11  |  F12  |
             // |   ~   |  1   |  2   |  3   |  4   |  5   |-------|-------|  6    |   7   |  8   |  9   |   0   |  DEL  |
             // |  DEL  |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|  F6   |   -   |  =   |  [   |   ]   |   \   |
-            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |
+            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |9
             // |-------|      |      |      |      |      |       |       |       |       |      |      |       |-------|
             bindings = <
-                &trans  &kp F1  &kp F2  &kp F3   &kp F4   &kp F5               &kp F6     &kp F7     &kp F8  &kp F9       &kp F10      &kp F11
-                &trans  &trans  &trans  &kp LBRC &kp RBRC &trans               &trans     &trans     &trans  &trans       &trans       &kp F12
-                &trans  &trans  &trans  &kp LPAR &kp RPAR &trans               &kp LEFT   &kp DOWN   &kp UP  &kp RIGHT    &trans       &trans
-                &trans  &trans  &trans  &kp LBKT &kp RBKT &trans               &kp C_PREV &kp C_NEXT &trans  &trans       &trans       &trans
-                &trans  &trans  &trans  &trans   &mo 3    &trans &trans &trans &trans     &trans     &trans  &kp C_VOL_DN &kp C_VOL_UP &kp C_PP
+                &trans  &kp F1  &kp F2  &kp F3   &kp F4   &kp F5               &kp F6     &kp F7    &kp F8     &kp F9       &kp F10      &kp F11
+                &trans  &trans  &trans  &kp LBRC &kp RBRC &trans               &trans     &trans    &trans     &trans       &trans       &kp F12
+                &trans  &trans  &trans  &kp LPAR &kp RPAR &trans               &kp LEFT   &kp DOWN  &kp UP     &kp RIGHT    &trans       &trans
+                &trans  &trans  &trans  &kp LBKT &kp RBKT &trans               &trans     &trans    &kp C_PREV &kp C_NEXT   &trans       &trans
+                &trans  &trans  &trans  &trans   &mo 3    &trans &trans &trans &trans     &trans    &trans     &kp C_VOL_DN &kp C_VOL_UP &kp C_PP
             >;
         };
 

--- a/app/boards/shields/atreus62/atreus62.keymap
+++ b/app/boards/shields/atreus62/atreus62.keymap
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            // ----------------------------------------------------------------------------------------------------------
+            // |  ESC  |  1   |  2   |  3   |  4   |  5   |-------|-------|   6   |  7    |  8   |  9   |   0   | BSPC  |
+            // |  TAB  |  Q   |  W   |  E   |  R   |  T   |-------|-------|   Y   |  U    |  I   |  O   |   P   |  \    |
+            // | SHIFT |  A   |  S   |  D   |  F   |  G   |-------|-------|   H   |  J    |  K   |  L   |   ;   |  '    |
+            // | CTRL  |  Z   |  X   |  C   |  V   |  B   |-------|-------|   N   |  M    |  ,   |  .   |   /   | ENTER |
+            // |-------|ADJUST| LCTL | LALT | LGUI | LOWR | SPACE | SPACE |  RAIS | LARW | DARW | UARW  | RARW  |-------|
+
+
+            bindings = <
+                &kp ESC    &kp N1 &kp N2    &kp N3   &kp N4   &kp N5                    &kp N6 &kp N7   &kp N8    &kp N9  &kp N0    &kp BSPC
+                &kp TAB    &kp Q  &kp W     &kp E    &kp R    &kp T                     &kp Y  &kp U    &kp I     &kp O   &kp P     &kp BSLH
+                &kp LSHFT  &kp A  &kp S     &kp D    &kp F    &kp G                     &kp H  &kp J    &kp K     &kp L   &kp SEMI  &kp SQT
+                &kp LCTRL  &kp Z  &kp X     &kp C    &kp V    &kp B                     &kp N  &kp M    &kp COMMA &kp DOT &kp FSLH  &kp RET
+                &trans     &mo 3  &kp LCTRL &kp LALT &kp LGUI &mo 1 &kp SPACE &kp SPACE &mo 2  &kp LEFT &kp DOWN  &kp UP  &kp RIGHT &trans
+            >;
+        };
+
+        lower {
+            // ----------------------------------------------------------------------------------------------------------
+            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|   F7  |  F8   |  F9  | F10  |  F11  |  F12  |
+            // |   ~   |  !   |  @   |  #   |  $   |  %   |-------|-------|   ^   |   &   |  *   |  (   |   )   |  DEL  |
+            // |       |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|   F6  |   _   |  +   |  {   |   }   |   |   |
+            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|   F12 | LS(#) |LS(|) |      |       |       |
+            // |-------|      |      |      |      |      |       |       |       | NEXT  | Vol- | Vol+ | PLAY  |-------|
+            bindings = <
+                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                  &kp F7    &kp F8              &kp F9              &kp F10      &kp F11          &kp F12
+                &kp TILDE &kp EXCL &kp AT   &kp HASH &kp DLLR  &kp PRCNT               &kp CARET &kp AMPS            &kp ASTRK           &kp LPAR     &kp RPAR         &kp DEL
+                &trans    &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                  &kp F6    &kp UNDER           &kp PLUS            &kp LBRC     &kp RBRC         &kp PIPE
+                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11                 &kp F12   &kp LS(NON_US_HASH) &kp LS(NON_US_BSLH) &trans       &trans           &trans
+                &trans    &trans   &trans   &trans   &trans    &trans    &trans &trans &mo 3     &kp C_NEXT          &kp C_VOL_DN        &kp C_VOL_UP &kp C_PLAY_PAUSE &trans
+            >;
+        };
+
+        raise {
+            // ----------------------------------------------------------------------------------------------------------
+            // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|  F7   |  F8   |  F9  | F10  |  F11  |  F12  |
+            // |   ~   |  1   |  2   |  3   |  4   |  5   |-------|-------|  6    |   7   |  8   |  9   |   0   |  DEL  |
+            // |  DEL  |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|  F6   |   -   |  =   |  [   |   ]   |   \   |
+            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |
+            // |-------|      |      |      |      |      |       |       |       |       |      |      |       |-------|
+            bindings = <
+                &kp ESC   &kp F2   &kp F3   &kp F4   &kp F5    &kp F6                &kp F7    &kp F8          &kp F9          &kp F10      &kp F11          &kp F12
+                &kp TILDE &kp N1   &kp N2   &kp N3   &kp N4    &kp N5                &kp N6    &kp N7          &kp N8          &kp N9       &kp N0           &kp DEL
+                &kp DEL   &kp F1   &kp F2   &kp F3   &kp F4    &kp F5                &kp F6    &kp MINUS       &kp EQUAL       &kp LBKT     &kp RBKT         &kp BSLH
+                &trans    &kp F7   &kp F8   &kp F9   &kp F10   &kp F11               &kp F12   &kp NON_US_HASH &kp NON_US_BSLH &trans       &trans           &trans
+                &trans    &trans   &trans   &trans   &trans    &mo 3   &trans &trans &trans    &trans          &trans          &trans       &trans           &trans
+            >;
+        };
+
+        adjust {
+            // ----------------------------------------------------------------------------------------------------------
+            // |tog(4)|  F2  |  F3  |  F4  |  F5  |  F6  |------|------|  F7  |  F8  |  F9  |  F10 |  F11 |    F12    |
+            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LALT(PRTSN)|
+            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |   PRTSN   |
+            // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LCTRL(DEL) |
+            // |------|      |      |      |      |      |BOOTLD|BOOTLD|      |      |      |      |      |-----------|
+            bindings = <
+                &tog 4 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6                         &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12
+                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp LA(PSCRN)
+                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp PSCRN
+                &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp LC(DEL)
+                &trans &trans &trans &trans &trans &trans &bootloader &bootloader &trans &trans &trans &trans  &trans  &trans
+            >;
+        };
+
+        flock {
+            // ----------------------------------------------------------------------------------------------------------
+            // |tog(4) |  F2    |   F3   |   F4   |   F5   |   F6   |-------|-------|  F7  |  F8  |  F9  | F10 | F11 |      |
+            // |out tog|BT_SEL 0|BT_SEL 1|BT_SEL 2|BT_SEL 3|BT_SEL 4|-------|-------|BT_PRV|BT_NXT|BT_CLR|     |     |      |
+            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
+            // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
+            // |-------|        |        |        |        |        |       |       |      |      |      |     |     |------|
+            bindings = <
+                &tog 4       &kp F2       &kp F3       &kp F4       &kp F5       &kp F6                     &kp F7     &kp F8     &kp F9     &kp F10 &kp F11 &trans
+                &out OUT_TOG &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4               &bt BT_PRV &bt BT_NXT &bt BT_CLR &trans  &trans  &trans
+                &trans       &trans       &trans       &trans       &trans       &trans                     &trans     &trans     &trans     &trans  &trans  &trans
+                &trans       &trans       &trans       &trans       &trans       &trans                     &trans     &trans     &trans     &trans  &trans  &trans
+                &trans       &trans       &trans       &trans       &trans       &trans       &trans &trans &trans     &trans     &trans     &trans  &trans  &trans
+            >;
+        };
+    };
+};

--- a/app/boards/shields/atreus62/atreus62.keymap
+++ b/app/boards/shields/atreus62/atreus62.keymap
@@ -19,13 +19,13 @@
             // |  TAB  |  Q   |  W   |  E   |  R   |  T   |-------|-------|   Y   |  U    |  I   |  O   |   P   |  \    |
             // | BSPC  |  A   |  S   |  D   |  F   |  G   |-------|-------|   H   |  J    |  K   |  L   |   ;   |  '    |
             // | SHIFT |  Z   |  X   |  C   |  V   |  B   |-------|-------|   N   |  M    |  ,   |  .   |   /   | ENTER |
-            // |  CTRL |  Fn  | LALT | LGUI | RAIS | TAB  | SPACE | ENTER |  LOWR |       |      |  -   |   =   |-------|
+            // |  CTRL |  Fn  | LALT | LGUI | RAIS | TAB  | SPACE | ENTER |  LOWR |	 MEH  |      |  -   |   =   |-------|
             bindings = <
-                &kp ESC    &kp N1 &kp N2   &kp N3   &kp N4 &kp N5                    &kp N6 &kp N7 &kp N8    &kp N9    &kp N0    &trans
-                &kp GRAVE  &kp Q  &kp W    &kp E    &kp R  &kp T                     &kp Y  &kp U  &kp I     &kp O     &kp P     &kp BSLH
-                &kp BSPC   &kp A  &kp S    &kp D    &kp F  &kp G                     &kp H  &kp J  &kp K     &kp L     &kp SEMI  &kp SQT
-                &kp LSHFT  &kp Z  &kp X    &kp C    &kp V  &kp B                     &kp N  &kp M  &kp COMMA &kp DOT   &kp FSLH  &kp RSHIFT
-                &kp LCTRL  &mo 5  &kp LALT &kp LGUI &mo 1  &kp TAB &kp SPACE &kp RET &mo 2  &trans &trans    &kp MINUS &kp EQUAL &mo 4
+                &kp ESC    &kp N1 &kp N2   &kp N3   &kp N4 &kp N5                    &kp N6 &kp N7            &kp N8    &kp N9    &kp N0    &trans
+                &kp GRAVE  &kp Q  &kp W    &kp E    &kp R  &kp T                     &kp Y  &kp U             &kp I     &kp O     &kp P     &kp BSLH
+                &kp BSPC   &kp A  &kp S    &kp D    &kp F  &kp G                     &kp H  &kp J             &kp K     &kp L     &kp SEMI  &kp SQT
+                &kp LSHFT  &kp Z  &kp X    &kp C    &kp V  &kp B                     &kp N  &kp M             &kp COMMA &kp DOT   &kp FSLH  &kp RSHIFT
+                &kp LCTRL  &mo 5  &kp LALT &kp LGUI &mo 1  &kp TAB &kp SPACE &kp RET &mo 2  &kp LA(LC(LSHFT)) &trans    &kp MINUS &kp EQUAL &mo 4
             >;
         };
 
@@ -50,7 +50,7 @@
             // |  ESC  |  F2  |  F3  |  F4  |  F5  |  F6  |-------|-------|  F7   |  F8   |  F9  | F10  |  F11  |  F12  |
             // |   ~   |  1   |  2   |  3   |  4   |  5   |-------|-------|  6    |   7   |  8   |  9   |   0   |  DEL  |
             // |  DEL  |  F1  |  F2  |  F3  |  F4  |  F5  |-------|-------|  F6   |   -   |  =   |  [   |   ]   |   \   |
-            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |9
+            // |       |  F7  |  F8  |  F9  |  F10 |  F11 |-------|-------|  F12  |   #   |  |   |      |       |       |
             // |-------|      |      |      |      |      |       |       |       |       |      |      |       |-------|
             bindings = <
                 &trans  &kp F1  &kp F2  &kp F3   &kp F4   &kp F5               &kp F6     &kp F7    &kp F8     &kp F9       &kp F10      &kp F11

--- a/app/boards/shields/atreus62/atreus62.keymap
+++ b/app/boards/shields/atreus62/atreus62.keymap
@@ -16,19 +16,19 @@
 
         default_layer {
             // ----------------------------------------------------------------------------------------------------------
-            // |  ESC  |  1   |  2   |  3   |  4   |  5   |-------|-------|   6   |  7    |  8   |  9   |   0   | BSPC  |
+            // |  ESC  |  1   |  2   |  3   |  4   |  5   |-------|-------|   6   |  7    |  8   |  9   |   0   |   |
             // |  TAB  |  Q   |  W   |  E   |  R   |  T   |-------|-------|   Y   |  U    |  I   |  O   |   P   |  \    |
-            // | SHIFT |  A   |  S   |  D   |  F   |  G   |-------|-------|   H   |  J    |  K   |  L   |   ;   |  '    |
-            // | CTRL  |  Z   |  X   |  C   |  V   |  B   |-------|-------|   N   |  M    |  ,   |  .   |   /   | ENTER |
-            // |-------|ADJUST| LCTL | LALT | LGUI | LOWR | SPACE | SPACE |  RAIS | LARW | DARW | UARW  | RARW  |-------|
+            // | BSPC  |  A   |  S   |  D   |  F   |  G   |-------|-------|   H   |  J    |  K   |  L   |   ;   |  '    |
+            // | SHIFT |  Z   |  X   |  C   |  V   |  B   |-------|-------|   N   |  M    |  ,   |  .   |   /   | ENTER |
+            // |  CTRL |  Fn  | LALT | LGUI | RAIS |      | SPACE | ENTER |  LOWR |       |      |  -   |   =   |-------|
 
 
             bindings = <
-                &kp ESC    &kp N1 &kp N2    &kp N3   &kp N4   &kp N5                    &kp N6 &kp N7   &kp N8    &kp N9  &kp N0    &kp BSPC
-                &kp TAB    &kp Q  &kp W     &kp E    &kp R    &kp T                     &kp Y  &kp U    &kp I     &kp O   &kp P     &kp BSLH
-                &kp LSHFT  &kp A  &kp S     &kp D    &kp F    &kp G                     &kp H  &kp J    &kp K     &kp L   &kp SEMI  &kp SQT
-                &kp LCTRL  &kp Z  &kp X     &kp C    &kp V    &kp B                     &kp N  &kp M    &kp COMMA &kp DOT &kp FSLH  &kp RET
-                &trans     &mo 3  &kp LCTRL &kp LALT &kp LGUI &mo 1 &kp SPACE &kp SPACE &mo 2  &kp LEFT &kp DOWN  &kp UP  &kp RIGHT &trans
+                &kp ESC    &kp N1 &kp N2    &kp N3   &kp N4   &kp N5                    &kp N6 &kp N7   &kp N8    &kp N9  &kp N0    &trans
+                &kp GRAVE  &kp Q  &kp W     &kp E    &kp R    &kp T                     &kp Y  &kp U    &kp I     &kp O   &kp P     &kp BSLH
+                &kp BSPC   &kp A  &kp S     &kp D    &kp F    &kp G                     &kp H  &kp J    &kp K     &kp L   &kp SEMI  &kp SQT
+                &kp LSHFT  &kp Z  &kp X     &kp C    &kp V    &kp B                     &kp N  &kp M    &kp COMMA &kp DOT &kp FSLH  &kp RET
+                &kp LCTRL  &mo 4  &kp LALT  &kp LGUI &mo 2 &kp TAB &kp SPACE &kp ENTER  &mo 1  &kp LEFT &kp DOWN  &kp UP  &kp RIGHT &trans
             >;
         };
 
@@ -70,7 +70,7 @@
             // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LALT(PRTSN)|
             // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |   PRTSN   |
             // |      |  NA  |  NA  |  NA  |  NA  |  NA  |------|------|  NA  |  NA  |  NA  |  NA  |  NA  |LCTRL(DEL) |
-            // |------|      |      |      |      |      |BOOTLD|BOOTLD|      |      |      |      |      |-----------|
+            // |      |      |      |      |      |      |BOOTLD|BOOTLD|      |      |      |      |      |-----------|
             bindings = <
                 &tog 4 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6                         &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12
                 &trans &none  &none  &none  &none  &none                          &none  &none  &none  &none   &none   &kp LA(PSCRN)
@@ -86,7 +86,7 @@
             // |out tog|BT_SEL 0|BT_SEL 1|BT_SEL 2|BT_SEL 3|BT_SEL 4|-------|-------|BT_PRV|BT_NXT|BT_CLR|     |     |      |
             // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
             // |       |        |        |        |        |        |-------|-------|      |      |      |     |     |      |
-            // |-------|        |        |        |        |        |       |       |      |      |      |     |     |------|
+            // |       |        |        |        |        |        |       |       |      |      |      |     |     |      |
             bindings = <
                 &tog 4       &kp F2       &kp F3       &kp F4       &kp F5       &kp F6                     &kp F7     &kp F8     &kp F9     &kp F10 &kp F11 &trans
                 &out OUT_TOG &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4               &bt BT_PRV &bt BT_NXT &bt BT_CLR &trans  &trans  &trans

--- a/app/boards/shields/atreus62/atreus62.keymap
+++ b/app/boards/shields/atreus62/atreus62.keymap
@@ -38,17 +38,17 @@
 
         lower {
             // ----------------------------------------------------------------------------------------------------------------------------
-            // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
+            // |       |        |        |        | SCRSHT |        |-------|-------|  GIFOX |        |        |        |        |        |
             // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
             // |  DEL  |        |        |        |        |        |-------|-------|  LEFT  |  DOWN  |  UP    |  RIGHT |        |        |
             // |       |        |        |        |        |        |-------|-------|        |        |        |        |        |        |
             // |       |        |        |        |        |        |       |       |        |        |        |        |        |        |
             bindings = <
-                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans     &trans    &trans
-                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans     &trans    &trans
-                &kp DEL    &trans  &trans  &trans  &trans  &trans                  &kp LEFT  &kp DOWN  &kp UP    &kp RIGHT  &trans    &trans
-                &trans     &trans  &trans  &trans  &trans  &trans                  &trans    &trans    &trans    &trans     &trans    &trans
-                &trans     &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans    &trans    &trans    &trans     &trans    &trans
+                &trans     &trans  &trans  &trans  &kp LG(LS(N4)) &trans                  &kp LG(LS(N6))  &trans    &trans    &trans     &trans    &trans
+                &trans     &trans  &trans  &trans  &trans         &trans                  &trans          &trans    &trans    &trans     &trans    &trans
+                &kp DEL    &trans  &trans  &trans  &trans         &trans                  &kp LEFT        &kp DOWN  &kp UP    &kp RIGHT  &trans    &trans
+                &trans     &trans  &trans  &trans  &trans         &trans                  &trans          &trans    &trans    &trans     &trans    &trans
+                &trans     &trans  &trans  &trans  &trans         &trans  &trans  &trans  &trans          &trans    &trans    &trans     &trans    &trans
             >;
         };
 

--- a/app/boards/shields/atreus62/atreus62.overlay
+++ b/app/boards/shields/atreus62/atreus62.overlay
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+
 #include <dt-bindings/zmk/matrix_transform.h>
 
 / {
@@ -12,46 +13,49 @@
         zmk,matrix_transform = &default_transform;
     };
 
-
+    /* 
+      Thumb buttons (3,6) and (4,6) sit vertically in the matric, and mapped to the bottom for easier keymapping.
+    */
     default_transform: keymap_transform_0 {
-        compatible = "zmk-matrix-transform"
+        compatible = "zmk,matrix-transform";
         columns = <13>;
         rows = <5>;
         map = <
             RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)                 RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12)
             RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)                 RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12)
             RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)                 RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11) RC(2,12)
-            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)                 RC(3,7) RC(3,8) RC(3,9) RC(3,10)  RC(3,11) RC(3,12)
-            RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(3,6) RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10)  RC(4,11) RC(4,12)
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)                 RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11) RC(3,12)
+            RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(3,6) RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10) RC(4,11) RC(4,12)
         >;
     };
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
         label = "KSCAN";
-        diode-direction = "col2row";
+        diode-direction = "row2col";
 
         col-gpios
-            = <&pro_micro 21 GPIO_ACTIVE_HIGH> // col 0
-            , <&pro_micro 20 GPIO_ACTIVE_HIGH> // col 1
-            , <&pro_micro 19 GPIO_ACTIVE_HIGH> // col 2
-            , <&pro_micro 18 GPIO_ACTIVE_HIGH> // col 3
-            , <&pro_micro 15 GPIO_ACTIVE_HIGH> // col 4
-            , <&pro_micro 14 GPIO_ACTIVE_HIGH> // col 5
-            , <&pro_micro 16 GPIO_ACTIVE_HIGH> // col 6
-            , <&pro_micro 6 GPIO_ACTIVE_HIGH> // col 7
-            , <&pro_micro 7 GPIO_ACTIVE_HIGH> // col 8
-            , <&pro_micro 8 GPIO_ACTIVE_HIGH> // col 9
-            , <&pro_micro 9 GPIO_ACTIVE_HIGH> // col 10
-            , <&pro_micro 1 GPIO_ACTIVE_HIGH> // col 11
+            = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 0
+            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 1
+            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 2
+            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 3
+            , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 4
+            , <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 5
+            , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 6
+            , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 7
+            , <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 8
+            , <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 9
+            , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 10
+            , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 11
+            , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 12
             ;
 
         row-gpios
-            = <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 0
-            , <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 1
-            , <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 2
-            , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 3
-            , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 4
+            = <&pro_micro 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 0
+            , <&pro_micro 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 1
+            , <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 2
+            , <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 3
+            , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 4
             ;
     };
 };

--- a/app/boards/shields/atreus62/atreus62.overlay
+++ b/app/boards/shields/atreus62/atreus62.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+    };
+
+    kscan0: kscan_0 {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "col2row";
+
+        col-gpios
+            = <&pro_micro 21 GPIO_ACTIVE_HIGH> // col 0
+            , <&pro_micro 20 GPIO_ACTIVE_HIGH> // col 1
+            , <&pro_micro 19 GPIO_ACTIVE_HIGH> // col 2
+            , <&pro_micro 18 GPIO_ACTIVE_HIGH> // col 3
+            , <&pro_micro 15 GPIO_ACTIVE_HIGH> // col 4
+            , <&pro_micro 14 GPIO_ACTIVE_HIGH> // col 5
+            , <&pro_micro 16 GPIO_ACTIVE_HIGH> // col 6
+            , <&pro_micro 6 GPIO_ACTIVE_HIGH> // col 7
+            , <&pro_micro 7 GPIO_ACTIVE_HIGH> // col 8
+            , <&pro_micro 8 GPIO_ACTIVE_HIGH> // col 9
+            , <&pro_micro 9 GPIO_ACTIVE_HIGH> // col 10
+            , <&pro_micro 1 GPIO_ACTIVE_HIGH> // col 11
+            ;
+
+        row-gpios
+            = <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 0
+            , <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 1
+            , <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 2
+            , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 3
+            , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 4
+            ;
+    };
+};

--- a/app/boards/shields/atreus62/atreus62.overlay
+++ b/app/boards/shields/atreus62/atreus62.overlay
@@ -51,11 +51,11 @@
             ;
 
         row-gpios
-            = <&pro_micro 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 0
-            , <&pro_micro 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 1
-            , <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 2
-            , <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 3
-            , <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row 4
+            = <&pro_micro 0 GPIO_ACTIVE_HIGH> // row 0
+            , <&pro_micro 1 GPIO_ACTIVE_HIGH> // row 1
+            , <&pro_micro 2 GPIO_ACTIVE_HIGH> // row 2
+            , <&pro_micro 3 GPIO_ACTIVE_HIGH> // row 3
+            , <&pro_micro 4 GPIO_ACTIVE_HIGH> // row 4
             ;
     };
 };

--- a/app/boards/shields/atreus62/atreus62.overlay
+++ b/app/boards/shields/atreus62/atreus62.overlay
@@ -4,9 +4,26 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <dt-bindings/zmk/matrix_transform.h>
+
 / {
     chosen {
         zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk-matrix-transform"
+        columns = <13>;
+        rows = <5>;
+        map = <
+            RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)                 RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12)
+            RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)                 RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12)
+            RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)                 RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11) RC(2,12)
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5)                 RC(3,7) RC(3,8) RC(3,9) RC(3,10)  RC(3,11) RC(3,12)
+            RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(3,6) RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10)  RC(4,11) RC(4,12)
+        >;
     };
 
     kscan0: kscan_0 {

--- a/app/boards/shields/atreus62/atreus62.yml
+++ b/app/boards/shields/atreus62/atreus62.yml
@@ -3,6 +3,6 @@ id: atreus62
 name: Atreus62
 type: shield
 url: https://github.com/profet23/atreus62
-requires: [nice!nano]
+requires: [nice_nano]
 features:
   - keys

--- a/app/boards/shields/atreus62/atreus62.yml
+++ b/app/boards/shields/atreus62/atreus62.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: atreus62
+name: Atreus62
+type: shield
+url: https://github.com/profet23/atreus62
+requires: [nice!nano]
+features:
+  - keys


### PR DESCRIPTION
## Disclaimer ⚠️ 
Self PR to track atreus62 addition. There is zero intention to get this merged into zmk as this is a custom keyboard layout without a standard configuration

## Description
This shield was created to work with the nice_nano_v2 in attempt to support bluetooth for a wireless Atreus62 with the [Profet Keyboards Atreus62 pcb](https://shop.profetkeyboards.com/product/atreus62-keyboard). Almost all of the wireless Atreus62 builds were hand wired and not using the Nice!Nano. Hoping this will allow me to use my Nice!Nano v2 and get this keyboard wireless.