### PR TITLE
refactor(shields): Remove res max Kconfigs

### DIFF
--- a/app/boards/shields/corne/Kconfig.defconfig
+++ b/app/boards/shields/corne/Kconfig.defconfig
@@ -28,12 +28,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/elephant42/Kconfig.defconfig
+++ b/app/boards/shields/elephant42/Kconfig.defconfig
@@ -31,12 +31,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/jorne/Kconfig.defconfig
+++ b/app/boards/shields/jorne/Kconfig.defconfig
@@ -29,12 +29,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/knob_goblin/Kconfig.defconfig
+++ b/app/boards/shields/knob_goblin/Kconfig.defconfig
@@ -21,12 +21,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-  default 128
-
-config LVGL_VER_RES_MAX
-  default 32
-
 config LVGL_VDB_SIZE
   default 64
 

--- a/app/boards/shields/kyria/Kconfig.defconfig
+++ b/app/boards/shields/kyria/Kconfig.defconfig
@@ -29,12 +29,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 64
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/leeloo/Kconfig.defconfig
+++ b/app/boards/shields/leeloo/Kconfig.defconfig
@@ -31,11 +31,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
 
 config LVGL_VDB_SIZE
 	default 64

--- a/app/boards/shields/lily58/Kconfig.defconfig
+++ b/app/boards/shields/lily58/Kconfig.defconfig
@@ -29,12 +29,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/lotus58/Kconfig.defconfig
+++ b/app/boards/shields/lotus58/Kconfig.defconfig
@@ -31,12 +31,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/microdox/Kconfig.defconfig
+++ b/app/boards/shields/microdox/Kconfig.defconfig
@@ -31,12 +31,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/murphpad/Kconfig.defconfig
+++ b/app/boards/shields/murphpad/Kconfig.defconfig
@@ -21,12 +21,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/nibble/Kconfig.defconfig
+++ b/app/boards/shields/nibble/Kconfig.defconfig
@@ -25,12 +25,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/sofle/Kconfig.defconfig
+++ b/app/boards/shields/sofle/Kconfig.defconfig
@@ -31,12 +31,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/tidbit/Kconfig.defconfig
+++ b/app/boards/shields/tidbit/Kconfig.defconfig
@@ -22,12 +22,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 32
-
 config LVGL_VDB_SIZE
 	default 64
 

--- a/app/boards/shields/zodiark/Kconfig.defconfig
+++ b/app/boards/shields/zodiark/Kconfig.defconfig
@@ -31,12 +31,6 @@ endif # ZMK_DISPLAY
 
 if LVGL
 
-config LVGL_HOR_RES_MAX
-	default 128
-
-config LVGL_VER_RES_MAX
-	default 64
-
 config LVGL_VDB_SIZE
 	default 64
 


### PR DESCRIPTION
* Horizontal/Vertical resolution max is now defaulted
  from the DTS chosen display automatically, so
  remove the duplication in our shield Kconfig.

Found this while helping on Discord, sinze Zephyr 3.0, the Kconfig settings for this is now defaulted from the DTS, so no need to set in the shield Kconfig code.