### PR TITLE
fix: Don't exclude segger, needed for DKs.

### DIFF
--- a/app/west.yml
+++ b/app/west.yml
@@ -27,7 +27,6 @@ manifest:
           - mcuboot
           - mcumgr
           - net-tools
-          - segger
           - openthread
           - edtt
           - trusted-firmware-m


### PR DESCRIPTION
Hit this working w/ the nRF52840 DK, it builds expecting an RTT logger output, but fails due to us excluding the `segger` module. Restoring it so we can easily use DKs for developing ZMK.