### PR TITLE
feat(shields): Add RGB support to 2% Milk

### DIFF
--- a/app/boards/shields/two_percent_milk/boards/nice_nano.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nice_nano.overlay
@@ -1,0 +1,31 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <9>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <2>;
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/two_percent_milk/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nice_nano_v2.overlay
@@ -1,0 +1,31 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <9>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <2>;
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/two_percent_milk/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nrfmicro_11.overlay
@@ -1,0 +1,32 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <43>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <12>;  // 0.12 is not broken out on the nRFMicro
+	miso-pin = <22>; // 0.22 is not broken out on the nRFMicro
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <2>;
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};
+

--- a/app/boards/shields/two_percent_milk/boards/nrfmicro_11_flipped.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nrfmicro_11_flipped.overlay
@@ -1,0 +1,31 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <38>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <12>;  // 0.12 is not broken out on the nRFMicro
+	miso-pin = <22>; // 0.22 is not broken out on the nRFMicro
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <2>;
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/two_percent_milk/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nrfmicro_13.overlay
@@ -1,0 +1,31 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <43>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <12>;  // 0.12 is not broken out on the nRFMicro
+	miso-pin = <22>; // 0.22 is not broken out on the nRFMicro
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <2>;
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/two_percent_milk/two_percent_milk.conf
+++ b/app/boards/shields/two_percent_milk/two_percent_milk.conf
@@ -1,2 +1,9 @@
 # Copyright (c) 2022 The ZMK Contributors
 # SPDX-License-Identifier: MIT
+
+# Uncomment the following lines to enable RGB Underglow
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y
+
+# Uncomment the following line to turn on logging, and set ZMK logging to debug output
+# CONFIG_ZMK_USB_LOGGING=y


### PR DESCRIPTION
Adds RGB support to the 2% Milk. Tested by @treezoob using the nice!nano V2, working as expected so far. 
