### PR TITLE
fix(backlight): Improve initial power on behaviour

### DIFF
--- a/app/src/backlight.c
+++ b/app/src/backlight.c
@@ -91,7 +91,9 @@ static int zmk_backlight_init(const struct device *_arg) {
         LOG_ERR("Failed to load backlight settings: %d", rc);
     }
 #endif
-
+#if IS_ENABLED(CONFIG_ZMK_BACKLIGHT_AUTO_OFF_USB)
+    state.on = zmk_usb_is_powered();
+#endif
     return zmk_backlight_update();
 }
 


### PR DESCRIPTION
This is just a minor tweak to address #1361 so that the RGB an backlighting behave the same
