### PR TITLE
fix(shields): Remove uses of deprecated pro_micro_a/d nodes

### DIFF
--- a/app/boards/shields/a_dux/a_dux.dtsi
+++ b/app/boards/shields/a_dux/a_dux.dtsi
@@ -29,23 +29,23 @@
 		compatible = "zmk,kscan-gpio-direct";
 		label = "KSCAN";
 		input-gpios =
-			<&pro_micro_d  5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d  0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_a  0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_a  3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d  6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d  3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_a  1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_a  2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d  7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d  4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d  1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d  8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
-			<&pro_micro_d  9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+			<&pro_micro  5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro  0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro 18 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro  6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro  3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro 19 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro 20 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro  7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro  4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro  1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro  8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
+			<&pro_micro  9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 		;
 	};
 

--- a/app/boards/shields/cradio/README.md
+++ b/app/boards/shields/cradio/README.md
@@ -11,23 +11,23 @@ Some revisions of the aforementioned PCBs have slightly different pin arrangemen
 /* The position of Q and B keys have been swapped */
 &kscan0 {
 	input-gpios
-	= <&pro_micro_d  6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_a  0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_a  1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_a  2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_a  3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d  1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d  2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d  3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d  4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d  5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d  7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d  8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-	, <&pro_micro_d  9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	= <&pro_micro  6 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro 18 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro 19 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro 20 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro  1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro  2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro  3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro  4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro  5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro  7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro  8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+	, <&pro_micro  9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
 	;
 };
 ```


### PR DESCRIPTION
Cleaning up a couple missed instances of old `&pro_micro_d/&pro_micro_a` naming in shields.