### PR TITLE
feat(docs): Added behavior queue limit section to macros page

### DIFF
--- a/docs/docs/behaviors/macros.md
+++ b/docs/docs/behaviors/macros.md
@@ -138,7 +138,7 @@ bindings
 
 Macros use an internal queue to invoke each behavior in the bindings list when triggered, which has a size of 64 by default. Bindings in "press" and "release" modes correspond to one event in the queue, whereas "tap" mode bindings correspond to two (one for press and one for release). As a result, the effective number of actions processed might be less than 64 and this can cause problems for long macros.
 
-You can change the limit by adding `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE=n` to your `.conf` file. For example, you can add `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE=512` if your macro outputs more than 200 characters.
+To prevent issues with longer macros, you can change the size of this queue via the `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE` setting in your configuration, [typically through your `.conf` file](../config/index.md). For example, `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE=512` would allow your macro to type about 256 characters.
 
 ## Common Patterns
 

--- a/docs/docs/behaviors/macros.md
+++ b/docs/docs/behaviors/macros.md
@@ -136,7 +136,7 @@ bindings
 
 ### Behavior Queue Limit
 
-The default queue limit is 64. However, some actions require multiple events (e.g. `&kp` requires `key press` and `key release` events). As a result, the effective number of actions can be less than 64.
+Macros use an internal queue to invoke each behavior in the bindings list when triggered, which has a size of 64 by default. Bindings in "press" and "release" modes correspond to one event in the queue, whereas "tap" mode bindings correspond to two (one for press and one for release). As a result, the effective number of actions processed might be less than 64 and this can cause problems for long macros.
 
 You can change the limit by adding `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE=n` to your `.conf` file. For example, you can add `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE=512` if your macro outputs more than 200 characters.
 

--- a/docs/docs/behaviors/macros.md
+++ b/docs/docs/behaviors/macros.md
@@ -134,6 +134,12 @@ bindings
     ;
 ```
 
+### Behavior Queue Limit
+
+The default queue limit is 64. However, some actions require multiple events (e.g. `&kp` requires `key press` and `key release` events). As a result, the effective number of actions can be less than 64.
+
+You can change the limit by adding `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE=n` to your `.conf` file. For example, you can add `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE=512` if your macro outputs more than 200 characters.
+
 ## Common Patterns
 
 Below are some examples of how the macro behavior can be used for various useful functionality.

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -11,9 +11,9 @@ See the [zmk/app/dts/behaviors/](https://github.com/zmkfirmware/zmk/tree/main/ap
 
 ## Kconfig
 
-| Config                             | Type | Description                                          | Default |
-| ---------------------------------- | ---- | ---------------------------------------------------- | ------- |
-| `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE`  | int  | The size of the behaviors queue                      | 64      |
+| Config                            | Type | Description                                                                          | Default |
+| --------------------------------- | ---- | ------------------------------------------------------------------------------------ | ------- |
+| `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE` | int  | Maximum number of behaviors to allow queueing from a macro or other complex behavior | 64      |
 
 ## Caps Word
 

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -9,6 +9,12 @@ See [Configuration Overview](index.md) for instructions on how to change these s
 
 See the [zmk/app/dts/behaviors/](https://github.com/zmkfirmware/zmk/tree/main/app/dts/behaviors) folder for all default behaviors.
 
+## Kconfig
+
+| Config                             | Type | Description                                          | Default |
+| ---------------------------------- | ---- | ---------------------------------------------------- | ------- |
+| `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE`  | int  | The size of the behaviors queue                      | 64      |
+
 ## Caps Word
 
 Creates a custom behavior that behaves similar to a caps lock but deactivates when any key not in a continue list is pressed.

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -9,7 +9,9 @@ See [Configuration Overview](index.md) for instructions on how to change these s
 
 See the [zmk/app/dts/behaviors/](https://github.com/zmkfirmware/zmk/tree/main/app/dts/behaviors) folder for all default behaviors.
 
-## Kconfig
+## Common
+
+### Kconfig
 
 | Config                            | Type | Description                                                                          | Default |
 | --------------------------------- | ---- | ------------------------------------------------------------------------------------ | ------- |


### PR DESCRIPTION
Added information about the `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE` config option to the macros page in the docs.