### PR TITLE
feat(kscan): Kconfig for optional scan delay.

### DIFF
--- a/app/drivers/kscan/Kconfig
+++ b/app/drivers/kscan/Kconfig
@@ -30,6 +30,20 @@ config ZMK_KSCAN_GPIO_MATRIX
 	default $(dt_compat_enabled,$(DT_COMPAT_ZMK_KSCAN_GPIO_MATRIX))
 	select ZMK_KSCAN_GPIO_DRIVER
 
+if ZMK_KSCAN_GPIO_MATRIX
+
+config ZMK_KSCAN_MATRIX_WAIT_BETWEEN_OUTPUTS
+    int "Ticks to wait between each output when scanning"
+	default 0
+	help
+	    When iterating over each output to drive it active, read inputs, then set
+		inactive again, some boards may take time for the previous output to
+		"settle" before reading inputs for the next active output column. In that
+		scenario, set this value to a positive value to configure the number of
+		usecs to wait after reading each column of keys.
+
+endif # ZMK_KSCAN_GPIO_MATRIX
+
 config ZMK_KSCAN_MOCK_DRIVER
 	bool
 	default $(dt_compat_enabled,$(DT_COMPAT_ZMK_KSCAN_MOCK))

--- a/app/drivers/kscan/kscan_gpio_matrix.c
+++ b/app/drivers/kscan/kscan_gpio_matrix.c
@@ -250,6 +250,10 @@ static int kscan_matrix_read(const struct device *dev) {
             LOG_ERR("Failed to set output %i inactive: %i", o, err);
             return err;
         }
+
+#if CONFIG_ZMK_KSCAN_MATRIX_WAIT_BETWEEN_OUTPUTS > 0
+        k_busy_wait(CONFIG_ZMK_KSCAN_MATRIX_WAIT_BETWEEN_OUTPUTS);
+#endif
     }
 
     // Process the new state.


### PR DESCRIPTION
Add optional Kconfig setting to delay scanning after each
output column is set, and inputs are read, to allow inputs
to "settle" after the last column is set back to inactive.

This was found during work on the RP2040 hardware, but this was also encountered by jmnw on Discord for an stm32 build recently.

Without a delay, on some platforms we need to have a small delay after disabling the previous output column to prevent it from causing a "false positive" detected on an input for the next column.