### PR TITLE
Change wording in RGB_COLOR_HSB description

### DIFF
--- a/docs/docs/behaviors/underglow.md
+++ b/docs/docs/behaviors/underglow.md
@@ -41,11 +41,11 @@ Here is a table describing the action for each define:
 
 - Reference: `&rgb_ug`
 - Parameter #1: The RGB action define, e.g. `RGB_TOG` or `RGB_BRI`
-- Parameter #2: Only applies to `RGB_COLOR_HSB` and is the HSB values of the color to set within parenthesis and separated by a common (see below for an example)
+- Parameter #2: Only applies to `RGB_COLOR_HSB` and is the HSB representation of the color to set (see below for an example)
 
 :::note HSB Values
 
-When specifying HSB values you'll need to use `RGB_COLOR_HSB(h, s, b)` in your keymap file. See below for an example.
+When specifying HSB values you'll need to use `RGB_COLOR_HSB(h, s, b)` in your keymap file.
 
 Value Limits:
 


### PR DESCRIPTION
Some minor spelling/grammar issues were bugging me but when I fixed them the sentence still felt awkward so I went for something more concise since it's already pointing the reader towards the syntax example.

I also removed the second "See below for an example" since the examples are in the very next section with a big heading to advertise them.