### PR TITLE
Combo + hold tap fixes (take 3)

### DIFF
--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -612,6 +612,10 @@ static int position_state_changed_listener(const zmk_event_t *eh) {
         decide_hold_tap(undecided_hold_tap, HT_TIMER_EVENT);
     }
 
+    if (undecided_hold_tap == NULL) {
+        return ZMK_EV_EVENT_BUBBLE;
+    }
+
     if (!ev->state && find_captured_keydown_event(ev->position) == NULL) {
         // no keydown event has been captured, let it bubble.
         // we'll catch modifiers later in modifier_state_changed_listener

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -211,7 +211,7 @@ static int filter_timed_out_candidates(int64_t timestamp) {
         if (candidate->timeout_at > timestamp) {
             // reorder candidates so they're contiguous
             candidates[num_candidates].combo = candidate->combo;
-            candidates[num_candidates].timeout_at = candidates->timeout_at;
+            candidates[num_candidates].timeout_at = candidate->timeout_at;
             num_candidates++;
         } else {
             candidate->combo = NULL;

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -253,7 +253,7 @@ static int release_pressed_keys() {
         if (i == 0) {
             LOG_DBG("combo: releasing position event %d",
                     as_zmk_position_state_changed(captured_event)->position);
-            ZMK_EVENT_RELEASE(captured_event)
+            ZMK_EVENT_RAISE_AFTER(captured_event, combo);
         } else {
             // reprocess events (see tests/combo/fully-overlapping-combos-3 for why this is needed)
             LOG_DBG("combo: reraising position event %d",

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -253,7 +253,7 @@ static int release_pressed_keys() {
         if (i == 0) {
             LOG_DBG("combo: releasing position event %d",
                     as_zmk_position_state_changed(captured_event)->position);
-            ZMK_EVENT_RAISE_AFTER(captured_event, combo);
+            ZMK_EVENT_RELEASE(captured_event)
         } else {
             // reprocess events (see tests/combo/fully-overlapping-combos-3 for why this is needed)
             LOG_DBG("combo: reraising position event %d",

--- a/app/src/event_manager.c
+++ b/app/src/event_manager.c
@@ -25,6 +25,7 @@ int zmk_event_manager_handle_from(zmk_event_t *event, uint8_t start_index) {
         if (ev_sub->event_type != event->event) {
             continue;
         }
+        event->last_listener_index = i;
         ret = ev_sub->listener->callback(event);
         switch (ret) {
         case ZMK_EV_EVENT_BUBBLE:
@@ -35,7 +36,6 @@ int zmk_event_manager_handle_from(zmk_event_t *event, uint8_t start_index) {
             goto release;
         case ZMK_EV_EVENT_CAPTURED:
             LOG_DBG("Listener captured the event");
-            event->last_listener_index = i;
             // Listeners are expected to free events they capture
             return 0;
         default:

--- a/app/tests/combo/combos-and-holdtaps-3/events.patterns
+++ b/app/tests/combo/combos-and-holdtaps-3/events.patterns
@@ -1,0 +1,1 @@
+s/.*hid_listener_keycode_//p

--- a/app/tests/combo/combos-and-holdtaps-3/keycode_events.snapshot
+++ b/app/tests/combo/combos-and-holdtaps-3/keycode_events.snapshot
@@ -1,0 +1,5 @@
+pressed: usage_page 0x07 keycode 0xE5 implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/combo/combos-and-holdtaps-3/native_posix_64.keymap
+++ b/app/tests/combo/combos-and-holdtaps-3/native_posix_64.keymap
@@ -1,0 +1,40 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+
+&mt {
+	flavor = "hold-preferred";
+};
+
+/ {
+	combos {
+		compatible = "zmk,combos";
+		combo_one {
+			timeout-ms = <40>;
+			key-positions = <0 1>;
+			bindings = <&kp X>;
+		};
+	};
+
+	keymap {
+		compatible = "zmk,keymap";
+		label = "Default keymap";
+
+		default_layer {
+			bindings = <
+			&kp A         &kp B
+			&mt RSHFT RET &kp C
+			>;
+		};
+	};
+};
+
+&kscan {
+	events = <
+	ZMK_MOCK_PRESS(1,0,10)
+	ZMK_MOCK_PRESS(0,1,10)
+	ZMK_MOCK_PRESS(1,1,10)
+	ZMK_MOCK_RELEASE(0,1,50)
+	ZMK_MOCK_RELEASE(1,1,50)
+	>;
+};

--- a/app/tests/combo/combos-and-holdtaps-4/events.patterns
+++ b/app/tests/combo/combos-and-holdtaps-4/events.patterns
@@ -1,0 +1,1 @@
+s/.*hid_listener_keycode_//p

--- a/app/tests/combo/combos-and-holdtaps-4/keycode_events.snapshot
+++ b/app/tests/combo/combos-and-holdtaps-4/keycode_events.snapshot
@@ -1,0 +1,4 @@
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/combo/combos-and-holdtaps-4/native_posix_64.keymap
+++ b/app/tests/combo/combos-and-holdtaps-4/native_posix_64.keymap
@@ -1,0 +1,46 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan-mock.h>
+
+
+#define ZMK_COMBO(name, combo_bindings, keypos, combo_term) \
+/ { \
+	combos { \
+		compatible = "zmk,combos"; \
+		combo_ ## name { \
+			key-positions = <keypos>; \
+			bindings = <combo_bindings>; \
+			timeout-ms = <combo_term>; \
+		}; \
+	}; \
+};
+
+ZMK_COMBO(qmark, &kp QMARK,     0 3, 30)
+ZMK_COMBO(dllr,  &kp DLLR,      1 3, 50)
+ZMK_COMBO(tilde, &kp TILDE,     3 4, 50)
+
+/ {
+	keymap {
+		compatible = "zmk,keymap";
+		label = "Default keymap";
+
+		default_layer {
+			bindings = <
+			&none         &none
+			&kp A         &mt LSHFT T
+			&none
+			>;
+		};
+	};
+};
+
+&kscan {
+	rows = <3>;
+	columns = <2>;
+	events = <
+	ZMK_MOCK_PRESS(1,1,500)
+	ZMK_MOCK_PRESS(1,0,100)
+	ZMK_MOCK_RELEASE(1,0,500)
+	ZMK_MOCK_RELEASE(1,1,0)
+	>;
+};


### PR DESCRIPTION
Continuing on the work in #1405 this adds another fix in the hold tap event handler clean up code.

Hopefully fixes #986 as part of this.