### PR TITLE
Ignore-modifiers property for capsword

### DIFF
--- a/app/dts/behaviors/caps_word.dtsi
+++ b/app/dts/behaviors/caps_word.dtsi
@@ -13,6 +13,7 @@
 			label = "CAPS_WORD";
 			#binding-cells = <0>;
 			continue-list = <UNDERSCORE BACKSPACE DELETE>;
+            ignore-modifiers;
 		};
 	};
 };

--- a/app/dts/bindings/behaviors/zmk,behavior-caps-word.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-caps-word.yaml
@@ -13,3 +13,5 @@ properties:
     required: true
   mods:
     type: int
+  ignore-modifiers:
+    type: boolean

--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -32,6 +32,7 @@ struct caps_word_continue_item {
 
 struct behavior_caps_word_config {
     zmk_mod_flags_t mods;
+    bool ignore_modifiers;
     uint8_t index;
     uint8_t continuations_count;
     struct caps_word_continue_item continuations[];
@@ -146,7 +147,7 @@ static int caps_word_keycode_state_changed_listener(const zmk_event_t *eh) {
         caps_word_enhance_usage(config, ev);
 
         if (!caps_word_is_alpha(ev->keycode) && !caps_word_is_numeric(ev->keycode) &&
-            !is_mod(ev->usage_page, ev->keycode) &&
+            (!is_mod(ev->usage_page, ev->keycode) || !config->ignore_modifiers) &&
             !caps_word_is_caps_includelist(config, ev->usage_page, ev->keycode,
                                            ev->implicit_modifiers)) {
             LOG_DBG("Deactivating caps_word for 0x%02X - 0x%02X", ev->usage_page, ev->keycode);
@@ -177,6 +178,7 @@ static int behavior_caps_word_init(const struct device *dev) {
     static struct behavior_caps_word_config behavior_caps_word_config_##n = {                      \
         .index = n,                                                                                \
         .mods = DT_INST_PROP_OR(n, mods, MOD_LSFT),                                                \
+        .ignore_modifiers = DT_INST_PROP(n, ignore_modifiers),                                     \
         .continuations = {UTIL_LISTIFY(DT_INST_PROP_LEN(n, continue_list), BREAK_ITEM, n)},        \
         .continuations_count = DT_INST_PROP_LEN(n, continue_list),                                 \
     };                                                                                             \

--- a/app/tests/caps-word/deactivate-by-mod/events.patterns
+++ b/app/tests/caps-word/deactivate-by-mod/events.patterns
@@ -1,0 +1,3 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_implicit_modifiers_//p
+s/.*caps_word_enhance_usage/enhance_usage/p

--- a/app/tests/caps-word/deactivate-by-mod/keycode_events.snapshot
+++ b/app/tests/caps-word/deactivate-by-mod/keycode_events.snapshot
@@ -1,0 +1,13 @@
+enhance_usage: Enhancing usage 0x04 with modifiers: 0x02
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x02 explicit_mods 0x00
+press: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00

--- a/app/tests/caps-word/deactivate-by-mod/native_posix_64.keymap
+++ b/app/tests/caps-word/deactivate-by-mod/native_posix_64.keymap
@@ -1,0 +1,35 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+&caps_word {
+    /delete-property/ ignore-modifiers;
+};
+
+/ {
+	keymap {
+		compatible = "zmk,keymap";
+		label = "Default keymap";
+
+		default_layer {
+			bindings = <
+				&caps_word &kp A
+				&kp LSHFT &none
+			>;
+		};
+	};
+};
+
+
+&kscan {
+	events = <
+	ZMK_MOCK_PRESS(0,0,10)
+	ZMK_MOCK_RELEASE(0,0,10)
+	ZMK_MOCK_PRESS(0,1,10)
+	ZMK_MOCK_RELEASE(0,1,10)
+	ZMK_MOCK_PRESS(1,0,10)
+	ZMK_MOCK_RELEASE(1,0,10)
+	ZMK_MOCK_PRESS(0,1,10)
+	ZMK_MOCK_RELEASE(0,1,10)
+	>;
+};

--- a/docs/docs/behaviors/caps-word.md
+++ b/docs/docs/behaviors/caps-word.md
@@ -37,6 +37,18 @@ By default, the caps word will remain active when any alphanumeric character or 
 };
 ```
 
+#### Continue on modifiers
+
+By default, the caps word will remain active when any modifiers are pressed. If you
+would like to deactivate caps word when modifiers are pressed, you can delete the
+`ignored-modifiers` property in your keymap:
+
+```
+&caps_word {
+    /delete-property/ ignore-modifiers;
+};
+```
+
 #### Applied Modifier(s)
 
 In addition, if you would like _multiple_ modifiers, instead of just `MOD_LSFT`, you can override the `mods` property:


### PR DESCRIPTION
**EDIT: This PR is now superseded by https://github.com/zmkfirmware/zmk/pull/1451**

This adds an `ignore-modifiers` property to `caps_word`. If set to `true` (the default), caps word will remain active when any modifiers are pressed. This is the current behavior.

This PR allows the user to overwrite the behavior by deleting the (new) `ignore-modifiers` property in their keymap:
```
&caps_word {
    /delete-property/ ignore-modifiers;
};
```

When the property is deleted, pressing a modifier will deactivate caps word. This is useful, for example, for people who activate caps word with somewhat complex key combos or tap dances and who wish to deactivate it by simply pressing `LEFT_SHIFT`.

----
Discussion: for now, the new `ignore-modifiers` property is set to `true` by default. This is in order to ensure backwards-compatibility. My personal feeling is, however, that setting it to `false` would be a more sensible default. But I didn't want to do it without discussion.