### PR TITLE
On-release option for positional-hold-taps

### DIFF
--- a/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
@@ -37,3 +37,5 @@ properties:
     type: array
     required: false
     default: []
+  hold-trigger-on-release:
+    type: boolean

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -60,6 +60,7 @@ struct behavior_hold_tap_config {
     bool global_quick_tap;
     enum flavor flavor;
     bool retro_tap;
+    bool hold_trigger_on_release;
     int32_t hold_trigger_key_positions_len;
     int32_t hold_trigger_key_positions[];
 };
@@ -587,9 +588,10 @@ static int position_state_changed_listener(const zmk_event_t *eh) {
     }
 
     // Store the position of pressed key for positional hold-tap purposes.
-    if ((ev->state) // i.e. key pressed (not released)
+    if (((!undecided_hold_tap->config->hold_trigger_on_release && ev->state)     // key pressed
+         || (undecided_hold_tap->config->hold_trigger_on_release && !ev->state)) // key released
         && (undecided_hold_tap->position_of_first_other_key_pressed ==
-            -1) // i.e. no other key has been pressed yet
+            -1) // no other key has been pressed yet
     ) {
         undecided_hold_tap->position_of_first_other_key_pressed = ev->position;
     }
@@ -703,6 +705,7 @@ static int behavior_hold_tap_init(const struct device *dev) {
         .global_quick_tap = DT_INST_PROP(n, global_quick_tap),                                     \
         .flavor = DT_ENUM_IDX(DT_DRV_INST(n), flavor),                                             \
         .retro_tap = DT_INST_PROP(n, retro_tap),                                                   \
+        .hold_trigger_on_release = DT_INST_PROP(n, hold_trigger_on_release),                       \
         .hold_trigger_key_positions = DT_INST_PROP(n, hold_trigger_key_positions),                 \
         .hold_trigger_key_positions_len = DT_INST_PROP_LEN(n, hold_trigger_key_positions),         \
     };                                                                                             \

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -588,8 +588,9 @@ static int position_state_changed_listener(const zmk_event_t *eh) {
     }
 
     // Store the position of pressed key for positional hold-tap purposes.
-    if (((!undecided_hold_tap->config->hold_trigger_on_release && ev->state)     // key pressed
-         || (undecided_hold_tap->config->hold_trigger_on_release && !ev->state)) // key released
+    if ((undecided_hold_tap->config->hold_trigger_on_release !=
+         ev->state) // key has been pressed and hold_trigger_on_release is not set, or key
+                    // has been released and hold_trigger_on_release is set
         && (undecided_hold_tap->position_of_first_other_key_pressed ==
             -1) // no other key has been pressed yet
     ) {

--- a/app/tests/hold-tap/balanced/7-positional/on-release-no-trigger/events.patterns
+++ b/app/tests/hold-tap/balanced/7-positional/on-release-no-trigger/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/balanced/7-positional/on-release-no-trigger/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced/7-positional/on-release-no-trigger/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_decide: 0 decided hold-interrupt (balanced decision moment other-key-up)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided tap (balanced decision moment key-up)
+kp_pressed: usage_page 0x07 keycode 0x0D implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x0D implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced/7-positional/on-release-no-trigger/native_posix_64.keymap
+++ b/app/tests/hold-tap/balanced/7-positional/on-release-no-trigger/native_posix_64.keymap
@@ -1,0 +1,17 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&ht_bal { hold-trigger-on-release; };
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10)  // mod 1
+		ZMK_MOCK_PRESS(0,1,10)  // mod 2
+		ZMK_MOCK_PRESS(1,1,10)  // not trigger position
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/app/tests/hold-tap/balanced/7-positional/on-release-trigger/events.patterns
+++ b/app/tests/hold-tap/balanced/7-positional/on-release-trigger/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/balanced/7-positional/on-release-trigger/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced/7-positional/on-release-trigger/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-interrupt (balanced decision moment other-key-up)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided hold-interrupt (balanced decision moment other-key-up)
+kp_pressed: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced/7-positional/on-release-trigger/native_posix_64.keymap
+++ b/app/tests/hold-tap/balanced/7-positional/on-release-trigger/native_posix_64.keymap
@@ -1,0 +1,17 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&ht_bal { hold-trigger-on-release; };
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10)  // mod 1
+		ZMK_MOCK_PRESS(0,1,10)  // mod 2
+		ZMK_MOCK_PRESS(1,0,10)  // trigger position
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/app/tests/hold-tap/hold-preferred/7-positional/on-release-no-trigger/events.patterns
+++ b/app/tests/hold-tap/hold-preferred/7-positional/on-release-no-trigger/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/hold-preferred/7-positional/on-release-no-trigger/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred/7-positional/on-release-no-trigger/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-interrupt (hold-preferred decision moment other-key-down)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided hold-interrupt (hold-preferred decision moment other-key-down)
+kp_pressed: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred/7-positional/on-release-no-trigger/native_posix_64.keymap
+++ b/app/tests/hold-tap/hold-preferred/7-positional/on-release-no-trigger/native_posix_64.keymap
@@ -1,0 +1,17 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&ht_hold { hold-trigger-on-release; };
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10)  // mod 1
+		ZMK_MOCK_PRESS(0,1,10)  // mod 2
+		ZMK_MOCK_PRESS(1,1,10)  // not trigger position
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/app/tests/hold-tap/hold-preferred/7-positional/on-release-trigger/events.patterns
+++ b/app/tests/hold-tap/hold-preferred/7-positional/on-release-trigger/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/hold-preferred/7-positional/on-release-trigger/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred/7-positional/on-release-trigger/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-interrupt (hold-preferred decision moment other-key-down)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided hold-interrupt (hold-preferred decision moment other-key-down)
+kp_pressed: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred/7-positional/on-release-trigger/native_posix_64.keymap
+++ b/app/tests/hold-tap/hold-preferred/7-positional/on-release-trigger/native_posix_64.keymap
@@ -1,0 +1,17 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&ht_hold { hold-trigger-on-release; };
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10)  // mod 1
+		ZMK_MOCK_PRESS(0,1,10)  // mod 2
+		ZMK_MOCK_PRESS(1,0,10)  // trigger position
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/app/tests/hold-tap/tap-preferred/7-positional/on-release-no-trigger/events.patterns
+++ b/app/tests/hold-tap/tap-preferred/7-positional/on-release-no-trigger/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/tap-preferred/7-positional/on-release-no-trigger/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-preferred/7-positional/on-release-no-trigger/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_decide: 0 decided tap (tap-preferred decision moment key-up)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided tap (tap-preferred decision moment key-up)
+kp_pressed: usage_page 0x07 keycode 0x0D implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x0D implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-preferred/7-positional/on-release-no-trigger/native_posix_64.keymap
+++ b/app/tests/hold-tap/tap-preferred/7-positional/on-release-no-trigger/native_posix_64.keymap
@@ -1,0 +1,17 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&tp { hold-trigger-on-release; };
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10)  // mod 1
+		ZMK_MOCK_PRESS(0,1,10)  // mod 2
+		ZMK_MOCK_PRESS(1,1,10)  // not trigger position
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/app/tests/hold-tap/tap-preferred/7-positional/on-release-trigger/events.patterns
+++ b/app/tests/hold-tap/tap-preferred/7-positional/on-release-trigger/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p

--- a/app/tests/hold-tap/tap-preferred/7-positional/on-release-trigger/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-preferred/7-positional/on-release-trigger/keycode_events.snapshot
@@ -1,0 +1,12 @@
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-preferred decision moment key-up)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided tap (tap-preferred decision moment key-up)
+kp_pressed: usage_page 0x07 keycode 0x0D implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x0D implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-preferred/7-positional/on-release-trigger/native_posix_64.keymap
+++ b/app/tests/hold-tap/tap-preferred/7-positional/on-release-trigger/native_posix_64.keymap
@@ -1,0 +1,17 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&tp { hold-trigger-on-release; };
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10)  // mod 1
+		ZMK_MOCK_PRESS(0,1,10)  // mod 2
+		ZMK_MOCK_PRESS(1,0,10)  // trigger position
+		ZMK_MOCK_RELEASE(1,0,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+		ZMK_MOCK_RELEASE(0,0,10)
+	>;
+};

--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -132,6 +132,9 @@ See the following example, which uses a hold-tap behavior definition, configured
 - The sequence `(pht_down, W_down, W_up, pht_up)` produces `W`. The normal hold behavior (LEFT_SHIFT) **is NOT** modified into a tap behavior (Q) by positional hold-tap because the first key pressed after the hold-tap key is the `W key`, which is in position 1, which **IS** included in `hold-trigger-key-positions`.
 - If the `LEFT_SHIFT / Q key` is held by itself for longer than `tapping-term-ms`, a hold behavior is produced. This is because positional hold-tap only modifies the behavior of a hold-tap if another key is pressed before the `tapping-term-ms` period expires.
 
+By default, `hold-trigger-key-positions` are evaluated upon the first _key press_ after
+the hold-tap. For homerow mods, this is not always ideal, because it prevents combining multiple modifiers unless they are included in `hold-trigger-key-positions`. To overwrite this behavior, one can set `hold-trigger-on-release`. If set to true, the evaluation of `hold-trigger-key-positions` gets delayed until _key release_. This allows combining multiple modifiers when the next key is _held_, while still deciding the hold-tap in favor of a tap when the next key is _tapped_.
+
 ### Example Use-Cases
 
 <Tabs


### PR DESCRIPTION
This fixes https://github.com/zmkfirmware/zmk/issues/1363 by adding a `hold-trigger-on-release` option to positional hold-taps. 

When `hold-trigger-on-release` is set to `true`, it delays the evaluation of `hold-trigger-key-position` until the next key's *release*. This is in contrast to the current behavior, which evaluates `hold-trigger-key-positions` upon the next key *press*. The current behavior is not always ideal, for example for homerow mods, because it prevents combining multiple modifiers on the same hand. 

The new `hold-trigger-on-release` configuration allows combining multiple modifiers when held, while still forcing a tap-decision when the next key is tapped.

Note: Due to the delay of the position-check until key *release*, the property has no effect when using the `hold-preferred` flavor (which triggers mods when another key is *pressed*). The property is most useful when combined with the `balanced` or `tap-preferred` flavor.

Example configuration:
```
// 36 keys layout
#define LEFT_KEYS 0 1 2 3 4 10 11 12 13 14 20 21 22 23 24  // left-hand keys
#define RIGHT_KEYS 5 6 7 8 9 15 16 17 18 19 25 26 27 28 29  // right-hand keys

/ {
    behaviors {
        hrm_l: left_homerow_mods {
            compatible = "zmk,behavior-hold-tap";
            label = "HOMEROW_MODS_LEFT";
            #binding-cells = <2>;
            flavor = "balanced";
            tapping-term-ms = <200>;
            hold-trigger-key-positions = <RIGHT_KEYS>;
            hold-trigger-on-release;
            bindings = <&kp>, <&kp>;
        };

        hrm_r: right_homerow_mods {
            compatible = "zmk,behavior-hold-tap";
            label = "HOMEROW_MODS_RIGHT";
            #binding-cells = <2>;
            flavor = "balanced";
            tapping-term-ms = <200>;
            hold-trigger-key-positions = <LEFT_KEYS>;
            hold-trigger-on-release;
            bindings = <&kp>, <&kp>;
        };
    };
};
```






