### PR TITLE
feat(docs): Add testing related remarks to user setup page

### DIFF
--- a/docs/docs/user-setup.md
+++ b/docs/docs/user-setup.md
@@ -193,13 +193,14 @@ To flash the firmware, first put your board into bootloader mode by double click
 or the one that is part of your keyboard). The controller should appear in your OS as a new USB storage device.
 
 Once this happens, copy the correct UF2 file (e.g. left or right if working on a split), and paste it onto the root of that USB mass
-storage device. Once the flash is complete, the controller should automatically restart, and load your newly flashed firmware.
+storage device. Once the flash is complete, the controller should automatically restart, and load your newly flashed firmware. It is
+recommended that you test your keyboard works over USB first to rule out hardware issues, before trying to connect to it wirelessly.
 
 ## Wirelessly Connecting Your Keyboard
 
-ZMK will automatically advertise itself as connectable if it is not currently connected to a device. You should be able to see your keyboard from the bluetooth scanning view of your laptop or phone / tablet. It is reported by some users that the connections with Android / iOS devices are generally smoother than with laptops, so if you have trouble connecting, you could try to connect from your phone or tablet first to eliminate any potential hardware issues.
+ZMK will automatically advertise itself as connectable if it is not currently connected to a device. You should be able to see your keyboard from the bluetooth scanning view of your computer or phone / tablet. It is reported by some users that the connections with Android / iOS devices are generally smoother than with laptops, so if you have trouble connecting, you could try to connect from your phone or tablet first to eliminate any potential hardware issues with bluetooth receivers.
 
-ZMK supports multiple BLE “profiles”, which allows you to connect to and switch among multiple devices. Please refer to the [Bluetooth behavior](behaviors/bluetooth.md) section for detailed explanations on how to use them.
+ZMK supports multiple BLE “profiles”, which allows you to connect to and switch among multiple devices. Please refer to the [Bluetooth behavior](behaviors/bluetooth.md) section for detailed explanations on how to use them. If you don't make use of the mentioned behaviors you will have issues pairing your keyboard to other devices.
 
 ### Connecting Split Keyboard Halves
 

--- a/docs/docs/user-setup.md
+++ b/docs/docs/user-setup.md
@@ -196,6 +196,14 @@ Once this happens, copy the correct UF2 file (e.g. left or right if working on a
 storage device. Once the flash is complete, the controller should automatically restart, and load your newly flashed firmware. It is
 recommended that you test your keyboard works over USB first to rule out hardware issues, before trying to connect to it wirelessly.
 
+:::caution Split keyboards
+
+For split keyboards, only the central half (typically the left side) will send keyboard outputs over USB or advertise to other devices
+over bluetooth. Peripheral half will only send keystrokes to the central once they are paired and connected. For this reason it is
+recommended to test the left half of a split keyboard first.
+
+:::
+
 ## Wirelessly Connecting Your Keyboard
 
 ZMK will automatically advertise itself as connectable if it is not currently connected to a device. You should be able to see your keyboard from the bluetooth scanning view of your computer or phone / tablet. It is reported by some users that the connections with Android / iOS devices are generally smoother than with laptops, so if you have trouble connecting, you could try to connect from your phone or tablet first to eliminate any potential hardware issues with bluetooth receivers.

--- a/docs/docs/user-setup.md
+++ b/docs/docs/user-setup.md
@@ -213,3 +213,11 @@ ZMK supports multiple BLE “profiles”, which allows you to connect to and swi
 ### Connecting Split Keyboard Halves
 
 For split keyboards, after flashing each half individually you can connect them together by resetting them at the same time. Within a few seconds of resetting, both halves should automatically connect to each other.
+
+:::note
+
+If you have issues connecting the halves, make sure that both sides are getting powered properly through USB or batteries, then follow the
+[recommended troubleshooting procedure](troubleshooting.md#split-keyboard-halves-unable-to-pair). This is typically necessary if you
+swapped firmware sides between controllers, like flashing left side firmware to the same controller after flashing the right, or vice versa.
+
+:::


### PR DESCRIPTION
I added a few improvements to the end of user setup cautioning against common issues that people run into when they are first testing their keyboard. These are related to: (a) encouraging testing over USB before BT, (b) explaining peripherals shouldn't be tested before central for split keyboards, (c) linking to troubleshooting for pairing two halves in case of issues, (d) emphasizing BT profiles' importance a little more.