### PR TITLE
fix(underglow): Fix racing condition where LEDs turn on again after off

### DIFF
--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -332,14 +332,14 @@ int zmk_rgb_underglow_off() {
     }
 #endif
 
+    k_timer_stop(&underglow_tick);
+    state.on = false;
+
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
         pixels[i] = (struct led_rgb){r : 0, g : 0, b : 0};
     }
 
     led_strip_update_rgb(led_strip, pixels, STRIP_NUM_PIXELS);
-
-    k_timer_stop(&underglow_tick);
-    state.on = false;
 
     return zmk_rgb_underglow_save_state();
 }


### PR DESCRIPTION
The timer was not being stopped before updating all LEDs to `#000000`. In boards without a EXT_POWER, this will cause the LEDs being turned on immediately after they get turned off.