### PR TITLE
feat(docs): Fix ambigous tap-preferred documentation

### DIFF
--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -28,7 +28,7 @@ We call this the 'hold-preferred' flavor of hold-taps. While this flavor may wor
 
 - The 'hold-preferred' flavor triggers the hold behavior when the `tapping-term-ms` has expired or another key is pressed.
 - The 'balanced' flavor will trigger the hold behavior when the `tapping-term-ms` has expired or another key is pressed and released.
-- The 'tap-preferred' flavor triggers the hold behavior when the `tapping-term-ms` has expired. It triggers the tap behavior when another key is pressed.
+- The 'tap-preferred' flavor triggers the hold behavior when the `tapping-term-ms` has expired. Pressing another key within `tapping-term-ms` does not affect the decision.
 - The 'tap-unless-interrupted' flavor triggers a hold behavior only when another key is pressed before `tapping-term-ms` has expired. It triggers the tap behavior in all other situations.
 
 When the hold-tap key is released and the hold behavior has not been triggered, the tap behavior will trigger.


### PR DESCRIPTION
Having misinterpreted the tap-preferred documentation myself and seeing other people on discord doing the same mistake, I suggest rewording it slightly. The current wording ("It triggers the tap behavior when another key is pressed") may falsely be interpreted as "tap-preferred" being the mirror of "hold-preferred": i.e., that it resolves all interrupts within the tapping-term as tap.

(As an aside, if one wants to implement the mirror of "hold-preferred", one can do so using positional hold taps with `hold-trigger-key-positions` set to a dummy key (setting it all empty is interpreted as all keys)).