### PR TITLE
feat(behaviors): Smart-layers (e.g., num-word) and caps-word enhancements

### DIFF
--- a/app/dts/behaviors/caps_word.dtsi
+++ b/app/dts/behaviors/caps_word.dtsi
@@ -12,6 +12,7 @@
 			compatible = "zmk,behavior-caps-word";
 			label = "CAPS_WORD";
 			#binding-cells = <0>;
+            mods = <MOD_LSFT>;
 			continue-list = <UNDERSCORE BACKSPACE DELETE>;
             ignore-alphas;
             ignore-numbers;
@@ -24,7 +25,6 @@
 			compatible = "zmk,behavior-caps-word";
 			label = "NUM_WORD";
 			#binding-cells = <0>;
-            mods = <0>;
             // layers = <xxx>;  // to be specified in user config using &num_word {}
 			continue-list = <BACKSPACE DELETE>;
             ignore-numbers;

--- a/app/dts/behaviors/caps_word.dtsi
+++ b/app/dts/behaviors/caps_word.dtsi
@@ -12,22 +12,22 @@
 			compatible = "zmk,behavior-caps-word";
 			label = "CAPS_WORD";
 			#binding-cells = <0>;
-            mods = <MOD_LSFT>;
+			mods = <MOD_LSFT>;
 			continue-list = <UNDERSCORE BACKSPACE DELETE>;
-            ignore-alphas;
-            ignore-numbers;
-            ignore-modifiers;
+			ignore-alphas;
+			ignore-numbers;
+			ignore-modifiers;
 		};
 	};
 
-    behaviors {
+	behaviors {
 		/omit-if-no-ref/ num_word: behavior_num_word {
 			compatible = "zmk,behavior-caps-word";
 			label = "NUM_WORD";
 			#binding-cells = <0>;
-            // layers = <xxx>;  // to be specified in user config using &num_word {}
-			continue-list = <BACKSPACE DELETE>;
-            ignore-numbers;
+			// layers = <xx>; // to be specified in user config using "&num_word { layers = <xx>; };"
+			continue-list = <BACKSPACE DELETE DOT COMMA>;
+			ignore-numbers;
 		};
 	};
 };

--- a/app/dts/behaviors/caps_word.dtsi
+++ b/app/dts/behaviors/caps_word.dtsi
@@ -13,6 +13,7 @@
 			label = "CAPS_WORD";
 			#binding-cells = <0>;
 			continue-list = <UNDERSCORE BACKSPACE DELETE>;
+            ignore-modifiers;
 		};
 	};
 };

--- a/app/dts/behaviors/caps_word.dtsi
+++ b/app/dts/behaviors/caps_word.dtsi
@@ -13,7 +13,21 @@
 			label = "CAPS_WORD";
 			#binding-cells = <0>;
 			continue-list = <UNDERSCORE BACKSPACE DELETE>;
+            ignore-alphas;
+            ignore-numbers;
             ignore-modifiers;
+		};
+	};
+
+    behaviors {
+		/omit-if-no-ref/ num_word: behavior_num_word {
+			compatible = "zmk,behavior-caps-word";
+			label = "NUM_WORD";
+			#binding-cells = <0>;
+            mods = <0>;
+            // layers = <xxx>;  // to be specified in user config using &num_word {}
+			continue-list = <BACKSPACE DELETE>;
+            ignore-numbers;
 		};
 	};
 };

--- a/app/dts/bindings/behaviors/zmk,behavior-caps-word.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-caps-word.yaml
@@ -13,3 +13,5 @@ properties:
     required: true
   mods:
     type: int
+  ignore-modifiers:
+    type: boolean

--- a/app/dts/bindings/behaviors/zmk,behavior-caps-word.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-caps-word.yaml
@@ -13,5 +13,11 @@ properties:
     required: true
   mods:
     type: int
+  layers:
+    type: int
+  ignore-alphas:
+    type: boolean
+  ignore-numbers:
+    type: boolean
   ignore-modifiers:
     type: boolean

--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -32,6 +32,7 @@ struct caps_word_continue_item {
 
 struct behavior_caps_word_config {
     zmk_mod_flags_t mods;
+    bool ignore_modifiers;
     uint8_t index;
     uint8_t continuations_count;
     struct caps_word_continue_item continuations[];
@@ -146,7 +147,7 @@ static int caps_word_keycode_state_changed_listener(const zmk_event_t *eh) {
         caps_word_enhance_usage(config, ev);
 
         if (!caps_word_is_alpha(ev->keycode) && !caps_word_is_numeric(ev->keycode) &&
-            !is_mod(ev->usage_page, ev->keycode) &&
+            (!is_mod(ev->usage_page, ev->keycode) || !(config->ignore_modifiers)) &&
             !caps_word_is_caps_includelist(config, ev->usage_page, ev->keycode,
                                            ev->implicit_modifiers)) {
             LOG_DBG("Deactivating caps_word for 0x%02X - 0x%02X", ev->usage_page, ev->keycode);
@@ -178,6 +179,7 @@ static int behavior_caps_word_init(const struct device *dev) {
     static struct behavior_caps_word_config behavior_caps_word_config_##n = {                      \
         .index = n,                                                                                \
         .mods = DT_INST_PROP_OR(n, mods, MOD_LSFT),                                                \
+        .ignore_modifiers = DT_INST_PROP(n, ignore_modifiers),                                     \
         .continuations = {LISTIFY(DT_INST_PROP_LEN(n, continue_list), BREAK_ITEM, (, ), n)},       \
         .continuations_count = DT_INST_PROP_LEN(n, continue_list),                                 \
     };                                                                                             \

--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -138,7 +138,6 @@ static void caps_word_enhance_usage(const struct behavior_caps_word_config *conf
     if (config->mods != 0) {
         ev->implicit_modifiers |= config->mods;
     }
-
 }
 
 static int caps_word_keycode_state_changed_listener(const zmk_event_t *eh) {
@@ -162,7 +161,8 @@ static int caps_word_keycode_state_changed_listener(const zmk_event_t *eh) {
 
         caps_word_enhance_usage(config, ev);
 
-        if ((!caps_word_is_alpha(ev->keycode) || !config->ignore_alphas) && (!caps_word_is_numeric(ev->keycode) || !config->ignore_numbers) &&
+        if ((!caps_word_is_alpha(ev->keycode) || !config->ignore_alphas) &&
+            (!caps_word_is_numeric(ev->keycode) || !config->ignore_numbers) &&
             (!is_mod(ev->usage_page, ev->keycode) || !config->ignore_modifiers) &&
             !caps_word_is_caps_includelist(config, ev->usage_page, ev->keycode,
                                            ev->implicit_modifiers)) {
@@ -195,9 +195,9 @@ static int behavior_caps_word_init(const struct device *dev) {
     static struct behavior_caps_word_config behavior_caps_word_config_##n = {                      \
         .index = n,                                                                                \
         .mods = DT_INST_PROP_OR(n, mods, MOD_LSFT),                                                \
-        .layers = DT_INST_PROP_OR(n, layers, -1),                                                \
-        .ignore_alphas = DT_INST_PROP(n, ignore_alphas),                                     \
-        .ignore_numbers = DT_INST_PROP(n, ignore_numbers),                                     \
+        .layers = DT_INST_PROP_OR(n, layers, -1),                                                  \
+        .ignore_alphas = DT_INST_PROP(n, ignore_alphas),                                           \
+        .ignore_numbers = DT_INST_PROP(n, ignore_numbers),                                         \
         .ignore_modifiers = DT_INST_PROP(n, ignore_modifiers),                                     \
         .continuations = {LISTIFY(DT_INST_PROP_LEN(n, continue_list), BREAK_ITEM, (, ), n)},       \
         .continuations_count = DT_INST_PROP_LEN(n, continue_list),                                 \

--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -32,6 +32,9 @@ struct caps_word_continue_item {
 
 struct behavior_caps_word_config {
     zmk_mod_flags_t mods;
+    int8_t layers;
+    bool ignore_alphas;
+    bool ignore_numbers;
     bool ignore_modifiers;
     uint8_t index;
     uint8_t continuations_count;
@@ -45,12 +48,22 @@ struct behavior_caps_word_data {
 static void activate_caps_word(const struct device *dev) {
     struct behavior_caps_word_data *data = dev->data;
 
+    const struct behavior_caps_word_config *config = dev->config;
+
+    if (config->layers > -1) {
+        zmk_keymap_layer_activate(config->layers);
+    }
     data->active = true;
 }
 
 static void deactivate_caps_word(const struct device *dev) {
     struct behavior_caps_word_data *data = dev->data;
 
+    const struct behavior_caps_word_config *config = dev->config;
+
+    if (config->layers > -1) {
+        zmk_keymap_layer_deactivate(config->layers);
+    }
     data->active = false;
 }
 
@@ -122,7 +135,10 @@ static void caps_word_enhance_usage(const struct behavior_caps_word_config *conf
     }
 
     LOG_DBG("Enhancing usage 0x%02X with modifiers: 0x%02X", ev->keycode, config->mods);
-    ev->implicit_modifiers |= config->mods;
+    if (config->mods != 0) {
+        ev->implicit_modifiers |= config->mods;
+    }
+
 }
 
 static int caps_word_keycode_state_changed_listener(const zmk_event_t *eh) {
@@ -146,8 +162,8 @@ static int caps_word_keycode_state_changed_listener(const zmk_event_t *eh) {
 
         caps_word_enhance_usage(config, ev);
 
-        if (!caps_word_is_alpha(ev->keycode) && !caps_word_is_numeric(ev->keycode) &&
-            (!is_mod(ev->usage_page, ev->keycode) || !(config->ignore_modifiers)) &&
+        if ((!caps_word_is_alpha(ev->keycode) || !config->ignore_alphas) && (!caps_word_is_numeric(ev->keycode) || !config->ignore_numbers) &&
+            (!is_mod(ev->usage_page, ev->keycode) || !config->ignore_modifiers) &&
             !caps_word_is_caps_includelist(config, ev->usage_page, ev->keycode,
                                            ev->implicit_modifiers)) {
             LOG_DBG("Deactivating caps_word for 0x%02X - 0x%02X", ev->usage_page, ev->keycode);
@@ -179,6 +195,9 @@ static int behavior_caps_word_init(const struct device *dev) {
     static struct behavior_caps_word_config behavior_caps_word_config_##n = {                      \
         .index = n,                                                                                \
         .mods = DT_INST_PROP_OR(n, mods, MOD_LSFT),                                                \
+        .layers = DT_INST_PROP_OR(n, layers, -1),                                                \
+        .ignore_alphas = DT_INST_PROP(n, ignore_alphas),                                     \
+        .ignore_numbers = DT_INST_PROP(n, ignore_numbers),                                     \
         .ignore_modifiers = DT_INST_PROP(n, ignore_modifiers),                                     \
         .continuations = {LISTIFY(DT_INST_PROP_LEN(n, continue_list), BREAK_ITEM, (, ), n)},       \
         .continuations_count = DT_INST_PROP_LEN(n, continue_list),                                 \

--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -194,7 +194,7 @@ static int behavior_caps_word_init(const struct device *dev) {
     static struct behavior_caps_word_data behavior_caps_word_data_##n = {.active = false};         \
     static struct behavior_caps_word_config behavior_caps_word_config_##n = {                      \
         .index = n,                                                                                \
-        .mods = DT_INST_PROP_OR(n, mods, MOD_LSFT),                                                \
+        .mods = DT_INST_PROP_OR(n, mods, 0),                                                       \
         .layers = DT_INST_PROP_OR(n, layers, -1),                                                  \
         .ignore_alphas = DT_INST_PROP(n, ignore_alphas),                                           \
         .ignore_numbers = DT_INST_PROP(n, ignore_numbers),                                         \

--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -134,8 +134,8 @@ static void caps_word_enhance_usage(const struct behavior_caps_word_config *conf
         return;
     }
 
-    LOG_DBG("Enhancing usage 0x%02X with modifiers: 0x%02X", ev->keycode, config->mods);
     if (config->mods != 0) {
+        LOG_DBG("Enhancing usage 0x%02X with modifiers: 0x%02X", ev->keycode, config->mods);
         ev->implicit_modifiers |= config->mods;
     }
 }

--- a/app/tests/caps-word/deactivate-by-mod/events.patterns
+++ b/app/tests/caps-word/deactivate-by-mod/events.patterns
@@ -1,0 +1,3 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_implicit_modifiers_//p
+s/.*caps_word_enhance_usage/enhance_usage/p

--- a/app/tests/caps-word/deactivate-by-mod/keycode_events.snapshot
+++ b/app/tests/caps-word/deactivate-by-mod/keycode_events.snapshot
@@ -1,0 +1,13 @@
+enhance_usage: Enhancing usage 0x04 with modifiers: 0x02
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x02 explicit_mods 0x00
+press: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00

--- a/app/tests/caps-word/deactivate-by-mod/native_posix_64.keymap
+++ b/app/tests/caps-word/deactivate-by-mod/native_posix_64.keymap
@@ -1,0 +1,35 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+&caps_word {
+    /delete-property/ ignore-modifiers;
+};
+
+/ {
+	keymap {
+		compatible = "zmk,keymap";
+		label = "Default keymap";
+
+		default_layer {
+			bindings = <
+				&caps_word &kp A
+				&kp LSHFT &none
+			>;
+		};
+	};
+};
+
+
+&kscan {
+	events = <
+	ZMK_MOCK_PRESS(0,0,10)
+	ZMK_MOCK_RELEASE(0,0,10)
+	ZMK_MOCK_PRESS(0,1,10)
+	ZMK_MOCK_RELEASE(0,1,10)
+	ZMK_MOCK_PRESS(1,0,10)
+	ZMK_MOCK_RELEASE(1,0,10)
+	ZMK_MOCK_PRESS(0,1,10)
+	ZMK_MOCK_RELEASE(0,1,10)
+	>;
+};

--- a/docs/docs/behaviors/caps-word.md
+++ b/docs/docs/behaviors/caps-word.md
@@ -37,6 +37,18 @@ By default, the caps word will remain active when any alphanumeric character or 
 };
 ```
 
+#### Continue on modifiers
+
+By default, the caps word will remain active when any modifiers are pressed. If you
+would like to deactivate caps word when modifiers are pressed, you can delete the
+`ignored-modifiers` property in your keymap:
+
+```
+&caps_word {
+    /delete-property/ ignore-modifiers;
+};
+```
+
 #### Applied Modifier(s)
 
 In addition, if you would like _multiple_ modifiers, instead of just `MOD_LSFT`, you can override the `mods` property:


### PR DESCRIPTION
**EDIT**: The PR is somewhat outdated. An updated version focusing on the auto-layer functions is available as [ZMK module](https://github.com/urob/zmk-auto-layer)

---

This PR contains a number of enhancements for the caps-word behavior. Most importantly it adds a smart-layer option that activates a layer until a key not in `continue-list` is pressed. The PR supersedes https://github.com/zmkfirmware/zmk/pull/1422

### New/updated backend-properties:

The backend behavior `zmk,behavior-caps-word` (not to be confused with the frontend `&caps_word`) now supports the following config options:

- **[updated]** `mods`: Specifies the mods that get activated when smart-word is active. New default: `0` (none).
- **[new]** int `layers`: Specifies the layer that gets activated when smart-word is active. Default: `-1` (none)
- **[new]** bool `ignore-alphas`: If true, alphas do *not* cancel the smart-word behavior
- **[new]** bool `ignore-numbers`: If true, numbers do *not* cancel the smart-word behavior
- **[new]** bool `ignore-modifiers`: If true, modifiers do *not* cancel the smart-word behavior

The new `layers` property is used to configure the new smart-layers capabilities. The new `ignore-*` flags can be used to configure whether smart-word continues on alphas, numbers or modifiers (the original caps-word would always continue on all of these regardless of the value of `continue-list`)

### Smart-layer example: Num-word

For instance, to set up a "numword", one can define a new behavior as follows:

```
\ {
    behaviors {
		        num_word: behavior_num_word {
			compatible = "zmk,behavior-caps-word";
			label = "NUM_WORD";
			#binding-cells = <0>;
                        layers = <NUM>;                                // insert location of numbers layer here
			continue-list = <BACKSPACE DELETE DOT COMMA>;  // adjust as desired
                        ignore-numbers;                                // numbers don't deactivate the layer
		};
	};
};

```

Pressing `&num_word` will activate the number-layer and keep it active for as long as only numbers, backspace, space, dot or comma are pressed. After any other key is pressed, say, "space", the layer is automatically deactivated. This works well if the number-layer is mostly transparent, so that one can just continue typing normally after finishing with the numbers without having to actively release the number-layer.

For convenience, the PR also adds a pre-defined `&num_word` behavior. To use it, one only needs to specify the correct layer specification in the user config:
```
&num_word {
    layers = <NUM>;  // replace NUM by the location of numbers layer
};
```

### Caps-word

The pre-defined caps-word definition has been adjusted to yield the old behavior using the new configuration-flags:
```
/ {
	behaviors {
		/omit-if-no-ref/ caps_word: behavior_caps_word {
			compatible = "zmk,behavior-caps-word";
			label = "CAPS_WORD";
			#binding-cells = <0>;
                        mods = <MOD_LSFT>;
			continue-list = <UNDERSCORE BACKSPACE DELETE>;
                        ignore-alphas;
                        ignore-numbers;
                        ignore-modifiers;
		};
	};
};
```
On the user-side nothing changes when using `&caps_word`.

### Using ignore-flags to tweak caps-word

For backwards-compatibility, the frontend implementation of `&caps_word` continues on all alphas, numbers and modifiers. This can be overwritten using `/delete-property/`. For instance, to cancel caps-word when numbers and modifiers are pressed, one can add the following to the user config:
```
&caps_word {
    /delete-property/ ignore-numbers;
    /delete-property/ ignore-modifiers;
};
```
This is useful, for example, for people who activate caps-word with somewhat complex key combos or tap dances and who wish to be able to deactivate it by simply pressing LEFT_SHIFT (of course, it still deactivates automatically with any other key not specified in `continue-list`). This fixes https://github.com/zmkfirmware/zmk/issues/1410.

If one wants more fine-grained control over which modifiers or numbers cancel caps-word, one can use `continue-list` to do so.  For example, if one wants to continue caps-word on shift but cancel it with all other modifiers, one can do so by adding the following to the user-config:
```
&caps_word {
    /delete-property/ ignore-modifiers;
    continue-list = <UNDERSCORE BACKSPACE DELETE LSHFT RSHFT>;
};
```

### Discussion

Would it make sense to rename the backend-behavior from `zmk,behavior-caps-word` to something like `zmk,behavior-smart-word`? It might be a bit confusing that the `zmk,behavior-caps-word` backend (which can be used to implement any smart-modifier or smart-layer) has almost exactly the same name as the `&caps_word` frontend that sets `mods` to `MOD_LSFT` and `layers` to `-1` (none).