### PR TITLE
fix(usb): add USB_DC_RESUME to supported states

### DIFF
--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -33,6 +33,7 @@ enum zmk_usb_conn_state zmk_usb_get_conn_state() {
     switch (usb_status) {
     case USB_DC_SUSPEND:
     case USB_DC_CONFIGURED:
+    case USB_DC_RESUME:
         return ZMK_USB_CONN_HID;
 
     case USB_DC_DISCONNECTED:


### PR DESCRIPTION
All credit for this one goes to @xudongzheng (thanks for helping debug this!). Should fix the issue where keyboards go unresponsive after their host machine wakes from sleep due to the USB driver entering an error state. I was able to both reliably reproduce the issue before the patch goes in and confirmed it no longer occurs post patch.

The `USB_DC_RESUME` state indicates the host event has resumed the connection. Adding it to the list of valid connection states to prevent the error when waking from sleep.

Zephyr API Link:
https://docs.zephyrproject.org/apidoc/latest/group____usb__device__controller__api.html#gac09e3e0af1a2b41a5bfbad91f900baf7

fixes #1372

See below for logs both before and after the patch. After the fix goes in the `FAILED TO SEND OVER USB: -11` error being generated by the USB driver no long occurs and the USB connection resumes as expected. With this patch applied I was able to maintain connection after both sleeping and waking the host computer several times in a row.

Old logs with error:
[20220909_zmk_win10_error_wake_log.txt](https://github.com/zmkfirmware/zmk/files/9541989/20220909_zmk_win10_error_wake_log.txt)

New logs with fix:
[20220909_zmk_win10_fixed_wake_log.txt](https://github.com/zmkfirmware/zmk/files/9541990/20220909_zmk_win10_fixed_wake_log.txt)

