### PR TITLE
feat(Underglow): Battery state of charge effect

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -323,7 +323,7 @@ config ZMK_RGB_UNDERGLOW_SPD_START
 
 config ZMK_RGB_UNDERGLOW_EFF_START
     int "RGB underglow start effect int value related to the effect enum list"
-    range 0 3
+    range 0 4
 
 config ZMK_RGB_UNDERGLOW_ON_START
     bool "RGB underglow starts on by default"


### PR DESCRIPTION
This adds a state of charge effect to RGB underglow. Potentially a duplicate of #935 however this is significantly different

- I use the battery library to get state of charge instead of the Bluetooth BAS function to handle applications where BAS was disabled 
- Using HSB instead of RGB and inheriting from the state.colour allows the previously set or default brightness to be used in calculating the colour, this has to temporarily override the saturation to show the colours properly though
- Uses the new battery chosen node binding and like the other PR displays blue when no battery is configured. to avoid any ambiguity
- Added the effect to KConfig
