### PR TITLE
fix(displays): Adjust alignment and spacing

### DIFF
--- a/app/src/display/status_screen.c
+++ b/app/src/display/status_screen.c
@@ -68,7 +68,7 @@ lv_obj_t *zmk_display_status_screen() {
 
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_WPM_STATUS)
     zmk_widget_wpm_status_init(&wpm_status_widget, screen);
-    lv_obj_align(zmk_widget_wpm_status_obj(&wpm_status_widget), NULL, LV_ALIGN_IN_BOTTOM_RIGHT, -12,
+    lv_obj_align(zmk_widget_wpm_status_obj(&wpm_status_widget), NULL, LV_ALIGN_IN_BOTTOM_RIGHT, 0,
                  0);
 #endif
     return screen;

--- a/app/src/display/widgets/battery_status.c
+++ b/app/src/display/widgets/battery_status.c
@@ -27,13 +27,13 @@ struct battery_status_state {
 };
 
 static void set_battery_symbol(lv_obj_t *label, struct battery_status_state state) {
-    char text[2] = "  ";
+    char text[3] = {};
 
     uint8_t level = state.level;
 
 #if IS_ENABLED(CONFIG_USB_DEVICE_STACK)
     if (state.usb_present) {
-        strcpy(text, LV_SYMBOL_CHARGE);
+        strcpy(text, LV_SYMBOL_CHARGE " ");
     }
 #endif /* IS_ENABLED(CONFIG_USB_DEVICE_STACK) */
 
@@ -49,6 +49,7 @@ static void set_battery_symbol(lv_obj_t *label, struct battery_status_state stat
         strcat(text, LV_SYMBOL_BATTERY_EMPTY);
     }
     lv_label_set_text(label, text);
+    lv_obj_align(label, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
 }
 
 void battery_status_update_cb(struct battery_status_state state) {

--- a/app/src/display/widgets/battery_status.c
+++ b/app/src/display/widgets/battery_status.c
@@ -27,7 +27,7 @@ struct battery_status_state {
 };
 
 static void set_battery_symbol(lv_obj_t *label, struct battery_status_state state) {
-    char text[3] = {};
+    char text[8] = {};
 
     uint8_t level = state.level;
 

--- a/app/src/display/widgets/layer_status.c
+++ b/app/src/display/widgets/layer_status.c
@@ -26,13 +26,13 @@ static void set_layer_symbol(lv_obj_t *label, struct layer_status_state state) {
     if (state.label == NULL) {
         char text[6] = {};
 
-        sprintf(text, LV_SYMBOL_KEYBOARD "%i", state.index);
+        sprintf(text, LV_SYMBOL_KEYBOARD " %i", state.index);
 
         lv_label_set_text(label, text);
     } else {
         char text[12] = {};
 
-        snprintf(text, 12, LV_SYMBOL_KEYBOARD "%s", state.label);
+        snprintf(text, 12, LV_SYMBOL_KEYBOARD " %s", state.label);
 
         lv_label_set_text(label, text);
     }

--- a/app/src/display/widgets/layer_status.c
+++ b/app/src/display/widgets/layer_status.c
@@ -24,15 +24,15 @@ struct layer_status_state {
 
 static void set_layer_symbol(lv_obj_t *label, struct layer_status_state state) {
     if (state.label == NULL) {
-        char text[6] = {};
+        char text[7] = {};
 
         sprintf(text, LV_SYMBOL_KEYBOARD " %i", state.index);
 
         lv_label_set_text(label, text);
     } else {
-        char text[12] = {};
+        char text[13] = {};
 
-        snprintf(text, 12, LV_SYMBOL_KEYBOARD " %s", state.label);
+        snprintf(text, sizeof(text), LV_SYMBOL_KEYBOARD " %s", state.label);
 
         lv_label_set_text(label, text);
     }

--- a/app/src/display/widgets/output_status.c
+++ b/app/src/display/widgets/output_status.c
@@ -39,24 +39,24 @@ static struct output_status_state get_state(const zmk_event_t *_eh) {
 }
 
 static void set_status_symbol(lv_obj_t *label, struct output_status_state state) {
-    char text[9] = {};
+    char text[10] = {};
 
     switch (state.selected_endpoint) {
     case ZMK_ENDPOINT_USB:
-        strcat(text, LV_SYMBOL_USB "   ");
+        strcat(text, LV_SYMBOL_USB);
         break;
     case ZMK_ENDPOINT_BLE:
         if (state.active_profile_bonded) {
             if (state.active_profile_connected) {
-                snprintf(text, sizeof(text), LV_SYMBOL_WIFI "%i " LV_SYMBOL_OK,
-                         state.active_profile_index);
+                snprintf(text, sizeof(text), LV_SYMBOL_WIFI " %i " LV_SYMBOL_OK,
+                         state.active_profile_index + 1);
             } else {
-                snprintf(text, sizeof(text), LV_SYMBOL_WIFI "%i " LV_SYMBOL_CLOSE,
-                         state.active_profile_index);
+                snprintf(text, sizeof(text), LV_SYMBOL_WIFI " %i " LV_SYMBOL_CLOSE,
+                         state.active_profile_index + 1);
             }
         } else {
-            snprintf(text, sizeof(text), LV_SYMBOL_WIFI "%i " LV_SYMBOL_SETTINGS,
-                     state.active_profile_index);
+            snprintf(text, sizeof(text), LV_SYMBOL_WIFI " %i " LV_SYMBOL_SETTINGS,
+                     state.active_profile_index + 1);
         }
         break;
     }

--- a/app/src/display/widgets/wpm_status.c
+++ b/app/src/display/widgets/wpm_status.c
@@ -28,9 +28,10 @@ void set_wpm_symbol(lv_obj_t *label, struct wpm_status_state state) {
     char text[4] = {};
 
     LOG_DBG("WPM changed to %i", state.wpm);
-    snprintf(text, sizeof(text), "%i ", state.wpm);
+    snprintf(text, sizeof(text), "%i", state.wpm);
 
     lv_label_set_text(label, text);
+    lv_obj_align(label, NULL, LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
 }
 
 void wpm_status_update_cb(struct wpm_status_state state) {


### PR DESCRIPTION
This fixes and improves a few things. I think a couple of these are subjective.

- Fix right aligned widgets (battery and WPM) by realigning every time the text is updated (maybe `lv_realign` could be used? Didn't work when I tried)
- Add spacing between text elements to make things less cramped
- Add one to the profile index, which is better understood in the non-programming world