### PR TITLE
feature(drivers): Option for read wait on matrix.

### DIFF
--- a/app/drivers/kscan/Kconfig
+++ b/app/drivers/kscan/Kconfig
@@ -32,6 +32,16 @@ config ZMK_KSCAN_GPIO_MATRIX
 
 if ZMK_KSCAN_GPIO_MATRIX
 
+config ZMK_KSCAN_MATRIX_WAIT_BEFORE_INPUTS
+	int "Ticks to wait before reading inputs after an output set active"
+	default 0
+	help
+	    When iterating over each output to drive it active, read inputs, then set
+		inactive again, some boards may take time for output to propagate to the
+		inputs. In that scenario, set this value to a positive value to configure
+		the number of ticks to wait after setting an output active before reading
+		the inputs for their active state.
+
 config ZMK_KSCAN_MATRIX_WAIT_BETWEEN_OUTPUTS
     int "Ticks to wait between each output when scanning"
 	default 0
@@ -40,7 +50,7 @@ config ZMK_KSCAN_MATRIX_WAIT_BETWEEN_OUTPUTS
 		inactive again, some boards may take time for the previous output to
 		"settle" before reading inputs for the next active output column. In that
 		scenario, set this value to a positive value to configure the number of
-		usecs to wait after reading each column of keys.
+		ticks to wait after reading each column of keys.
 
 endif # ZMK_KSCAN_GPIO_MATRIX
 

--- a/app/drivers/kscan/kscan_gpio_matrix.c
+++ b/app/drivers/kscan/kscan_gpio_matrix.c
@@ -235,6 +235,10 @@ static int kscan_matrix_read(const struct device *dev) {
             return err;
         }
 
+#if CONFIG_ZMK_KSCAN_MATRIX_WAIT_BEFORE_INPUTS > 0
+        k_busy_wait(CONFIG_ZMK_KSCAN_MATRIX_WAIT_BEFORE_INPUTS);
+#endif
+
         for (int i = 0; i < config->inputs.len; i++) {
             const struct gpio_dt_spec *in_gpio = &config->inputs.gpios[i];
 

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -93,9 +93,11 @@ Keyboard scan driver where keys are arranged on a matrix with one GPIO per row a
 
 Definition file: [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/kscan/Kconfig)
 
-| Config                            | Type | Description                                      | Default |
-| --------------------------------- | ---- | ------------------------------------------------ | ------- |
-| `CONFIG_ZMK_KSCAN_MATRIX_POLLING` | bool | Poll for key presses instead of using interrupts | n       |
+| Config                                         | Type        | Description                                                               | Default |
+| ---------------------------------------------- | ----------- | ------------------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_KSCAN_MATRIX_POLLING`              | bool        | Poll for key presses instead of using interrupts                          | n       |
+| `CONFIG_ZMK_KSCAN_MATRIX_WAIT_BEFORE_INPUTS`   | int (ticks) | How long to wait before reading input pins after setting output active    | 0       |
+| `CONFIG_ZMK_KSCAN_MATRIX_WAIT_BETWEEN_OUTPUTS` | int (ticks) | How long to wait between each output to allow previous output to "settle" | 0       |
 
 ### Devicetree
 


### PR DESCRIPTION
* Add a new Kconfig option, `ZMK_KSCAN_MATRIX_WAIT_BEFORE_INPUTS` to delay reading inputs after setting an output active.
