### PR TITLE
LEDs to show status of different states

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -236,7 +236,7 @@ config ZMK_RGB_UNDERGLOW_SPD_START
 
 config ZMK_RGB_UNDERGLOW_EFF_START
 	int "RGB underglow start effect int value related to the effect enum list"
-	range 0 3
+	range 0 4
 	default 0
 
 config ZMK_RGB_UNDERGLOW_ON_START
@@ -249,6 +249,26 @@ config ZMK_RGB_UNDERGLOW_AUTO_OFF_IDLE
 config ZMK_RGB_UNDERGLOW_AUTO_OFF_USB
 	bool "Turn off RGB underglow when USB is disconnected"
 	depends on USB_DEVICE_STACK
+
+config ZMK_RGB_UNDERGLOW_STATUS_BATTERY
+	bool "Shows battery status on a LED"
+	default y
+
+config ZMK_RGB_UNDERGLOW_STATUS_BATTERY_N
+	int "LED number to show the battery status"
+	range 0 26
+	default 0
+	depends on ZMK_RGB_UNDERGLOW_STATUS_BATTERY
+
+config ZMK_RGB_UNDERGLOW_STATUS_LAYER
+	bool "Shows layer status on a LED"
+	default y
+
+config ZMK_RGB_UNDERGLOW_STATUS_LAYER_N
+	int "LED number to show the layer status"
+	range 0 26
+	default 1
+	depends on ZMK_RGB_UNDERGLOW_STATUS_LAYER
 
 #ZMK_RGB_UNDERGLOW
 endif

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -270,6 +270,26 @@ config ZMK_RGB_UNDERGLOW_STATUS_LAYER_N
 	default 1
 	depends on ZMK_RGB_UNDERGLOW_STATUS_LAYER
 
+config ZMK_RGB_UNDERGLOW_STATUS_OUTPUT
+	bool "Shows output status on a LED"
+	default y
+
+config ZMK_RGB_UNDERGLOW_STATUS_OUTPUT_N
+	int "LED number to show the output status"
+	range 0 26
+	default 2
+	depends on ZMK_RGB_UNDERGLOW_STATUS_OUTPUT
+
+config ZMK_RGB_UNDERGLOW_STATUS_BLE
+	bool "Shows on a LED the status of the selected ble device."
+	default y
+
+config ZMK_RGB_UNDERGLOW_STATUS_BLE_N
+	int "LED number to show the selected ble"
+	range 0 26
+	default 3
+	depends on ZMK_RGB_UNDERGLOW_STATUS_BLE
+
 #ZMK_RGB_UNDERGLOW
 endif
 

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -250,15 +250,30 @@ config ZMK_RGB_UNDERGLOW_AUTO_OFF_USB
 	bool "Turn off RGB underglow when USB is disconnected"
 	depends on USB_DEVICE_STACK
 
+config ZMK_RGB_UNDERGLOW_NUM_LEDS
+	int "Numer of leds on the pcb"
+	range 0 100
+	default 100
+
 config ZMK_RGB_UNDERGLOW_STATUS_BATTERY
 	bool "Shows battery status on a LED"
 	default y
 
 config ZMK_RGB_UNDERGLOW_STATUS_BATTERY_N
 	int "LED number to show the battery status"
-	range 0 26
+	range 0 ZMK_RGB_UNDERGLOW_NUM_LEDS
 	default 0
 	depends on ZMK_RGB_UNDERGLOW_STATUS_BATTERY
+
+config ZMK_RGB_UNDERGLOW_STATUS_BATTERY_COLOR_MIN
+	int "Color when battery is at 0%"
+	range 0 359
+	default 0
+
+config ZMK_RGB_UNDERGLOW_STATUS_BATTERY_COLOR_MAX
+	int "Color when battery is at 100%"
+	range 0 359
+	default 100
 
 config ZMK_RGB_UNDERGLOW_STATUS_LAYER
 	bool "Shows layer status on a LED"
@@ -266,7 +281,7 @@ config ZMK_RGB_UNDERGLOW_STATUS_LAYER
 
 config ZMK_RGB_UNDERGLOW_STATUS_LAYER_N
 	int "LED number to show the layer status"
-	range 0 26
+	range 0 ZMK_RGB_UNDERGLOW_NUM_LEDS
 	default 1
 	depends on ZMK_RGB_UNDERGLOW_STATUS_LAYER
 
@@ -276,7 +291,7 @@ config ZMK_RGB_UNDERGLOW_STATUS_OUTPUT
 
 config ZMK_RGB_UNDERGLOW_STATUS_OUTPUT_N
 	int "LED number to show the output status"
-	range 0 26
+	range 0 ZMK_RGB_UNDERGLOW_NUM_LEDS
 	default 2
 	depends on ZMK_RGB_UNDERGLOW_STATUS_OUTPUT
 
@@ -286,7 +301,7 @@ config ZMK_RGB_UNDERGLOW_STATUS_BLE
 
 config ZMK_RGB_UNDERGLOW_STATUS_BLE_N
 	int "LED number to show the selected ble"
-	range 0 26
+	range 0 ZMK_RGB_UNDERGLOW_NUM_LEDS
 	default 3
 	depends on ZMK_RGB_UNDERGLOW_STATUS_BLE
 


### PR DESCRIPTION
Hi guys. I started to write this code this pass week. with this code i can have an underglow effect that show the status of: keyboard output (ble or usb), ble device selected, layer selected, and most important the battery status of each device (both devices if you have a split keyboard).

I just find out that someone else is doing something similar but the code has not make it to the main. If this code does not make it to the main, its fine, but, I would give it a try :)

If someone give this the green light then ill make the documentation page.

Thanks.

