### PR TITLE
docs(power profiling): add nice!view

### DIFF
--- a/docs/src/data/power.js
+++ b/docs/src/data/power.js
@@ -96,4 +96,10 @@ export const displayPower = {
     active: 10000, // Estimated power draw when about half the pixels are on
     sleep: 7, // Deep sleep power draw (display off)
   },
+  // Based on the nice!view using Sharp's LS011B7DH01
+  NICEVIEW: {
+    activePercent: 0.01, // Estimated two refreshes per second taking five milliseconds each
+    active: 225, // Power draw during refresh
+    sleep: 1, // Idle power draw of the display
+  },
 };

--- a/docs/src/data/power.js
+++ b/docs/src/data/power.js
@@ -99,7 +99,7 @@ export const displayPower = {
   // Based on the nice!view using Sharp's LS011B7DH01
   NICEVIEW: {
     activePercent: 0.01, // Estimated two refreshes per second taking five milliseconds each
-    active: 225, // Power draw during refresh
+    active: 1425, // Power draw during refresh (225uA display + 1200uA SPIM)
     sleep: 1, // Idle power draw of the display
   },
 };

--- a/docs/src/pages/power-profiler.js
+++ b/docs/src/pages/power-profiler.js
@@ -308,6 +308,7 @@ function PowerProfiler() {
                       </option>
                       <option value="EPAPER">ePaper</option>
                       <option value="OLED">OLED</option>
+                      <option value="NICEVIEW">nice!view</option>
                     </select>
                   </div>
                 )}


### PR DESCRIPTION
Adds the nice!view based on my profiling using a Nordic PPK2. Idle is lower than 1uA, but I wrote this originally to use uA as the base unit, so 1 will do.