### PR TITLE
feat(ble): Default a few configs for DIS GATT svc.

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -25,6 +25,18 @@ config USB_DEVICE_PID
 config USB_DEVICE_MANUFACTURER
 	default "ZMK Project"
 
+config BT_DIS_PNP_VID
+	default 0x1D50
+
+config BT_DIS_PNP_PID
+	default 0x615E
+
+config BT_DIS_MODEL
+	default ZMK_KEYBOARD_NAME
+
+config BT_DIS_MANUF
+	default "ZMK Project"
+
 menu "HID"
 
 choice ZMK_HID_REPORT_TYPE


### PR DESCRIPTION
Default values for DIS GATT characteristics for:

* Vendor ID
* Product ID
* Manufacturer
* Model

This should help our ZMK keebs show properly in more places on various hosts, and hopefully help with identification for programs like Karabiner Elements on macOS.