### PR TITLE
chore(build): replace workflow set-output with environment variables

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -18,8 +18,8 @@ on:
         default: "bin"
         required: false
         type: string
-      artifact_name:
-        description: 'Artifact output file name'
+      archive_name:
+        description: 'Archive output file name'
         default: 'firmware'
         required: false
         type: string
@@ -29,21 +29,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Fetch Build Keyboards
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      build_matrix: ${{ env.build_matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Install yaml2json
         run: python3 -m pip install remarshal
 
       - name: Fetch Build Matrix
-        id: set-matrix
         run: |
-          set -x
-          matrix=$(yaml2json ${{ inputs.build_matrix_path }} | jq -c .)
-          yaml2json ${{ inputs.build_matrix_path }}
-          echo "::set-output name=matrix::${matrix}"
+          echo "build_matrix=$(yaml2json ${{ inputs.build_matrix_path }} | jq -c .)" >> $GITHUB_ENV
+          yaml2json ${{ inputs.build_matrix_path }} | jq
 
   build:
     runs-on: ubuntu-latest
@@ -53,35 +50,31 @@ jobs:
     name: Build
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.matrix.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.matrix.outputs.build_matrix) }}
     steps:
       - name: Prepare variables
-        id: variables
+        shell: sh -x {0}
         run: |
-          set -x
           if [ -n "${{ matrix.shield }}" ]
           then
-            EXTRA_CMAKE_ARGS="-DSHIELD=\"${{ matrix.shield }}\""
-            ARTIFACT_NAME="${{ matrix.shield }}-${{ matrix.board }}-zmk"
-            DISPLAY_NAME="${{ matrix.shield }} - ${{ matrix.board }}"
+            echo "extra_cmake_args=-DSHIELD=\"${{ matrix.shield }}\"" >> $GITHUB_ENV
+            echo "artifact_name=${{ matrix.shield }}-${{ matrix.board }}-zmk" >> $GITHUB_ENV
+            echo "display_name=${{ matrix.shield }} - ${{ matrix.board }}" >> $GITHUB_ENV
           else
-            EXTRA_CMAKE_ARGS=
-            DISPLAY_NAME="${{ matrix.board }}"
-            ARTIFACT_NAME="${{ matrix.board }}-zmk"
+            echo "extra_cmake_args=" >> $GITHUB_ENV
+            echo "artifact_name=${{ matrix.board }}-zmk" >> $GITHUB_ENV
+            echo "display_name=${{ matrix.board }}" >> $GITHUB_ENV
           fi
-          echo ::set-output name=extra-cmake-args::${EXTRA_CMAKE_ARGS}
-          echo ::set-output name=artifact-name::${ARTIFACT_NAME}
-          echo ::set-output name=display-name::${DISPLAY_NAME}
-          echo ::set-output name=zephyr-version::${ZEPHYR_VERSION}
+          echo "zephyr_version=${ZEPHYR_VERSION}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Cache west modules
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3.0.11
         continue-on-error: true
         env:
-          cache-name: cache-zephyr-${{ steps.variables.outputs.zephyr-version }}-modules
+          cache_name: cache-zephyr-${{ env.zephyr_version }}-modules
         with:
           path: |
             modules/
@@ -89,9 +82,9 @@ jobs:
             zephyr/
             bootloader/
             zmk/
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/west.yml', '**/build.yaml') }}
+          key: ${{ runner.os }}-build-${{ env.cache_name }}-${{ hashFiles('**/west.yml', '**/build.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-${{ env.cache_name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
@@ -104,28 +97,28 @@ jobs:
       - name: West Zephyr export
         run: west zephyr-export
 
-      - name: West Build (${{ steps.variables.outputs.display-name }})
+      - name: West Build (${{ env.display_name }})
+        shell: sh -x {0}
         run: |
-          set -x
-          west build -s zmk/app -b ${{ matrix.board }} -- -DZMK_CONFIG=${GITHUB_WORKSPACE}/${{ inputs.config_path }} ${{ steps.variables.outputs.extra-cmake-args }} ${{ matrix.cmake-args }}
+          west build -s zmk/app -b ${{ matrix.board }} -- -DZMK_CONFIG=${GITHUB_WORKSPACE}/${{ inputs.config_path }} ${{ env.extra_cmake_args }} ${{ matrix.cmake-args }}
 
-      - name: ${{ steps.variables.outputs.display-name }} Kconfig file
+      - name: ${{ env.display_name }} Kconfig file
         run: grep -v -e "^#" -e "^$" build/zephyr/.config | sort
 
       - name: Rename artifacts
+        shell: sh -x {0}
         run: |
-          set -x
           mkdir build/artifacts
           if [ -f build/zephyr/zmk.uf2 ]
           then
-            cp build/zephyr/zmk.uf2 "build/artifacts/${{ steps.variables.outputs.artifact-name }}.uf2"
+            cp build/zephyr/zmk.uf2 "build/artifacts/${{ env.artifact_name }}.uf2"
           elif [ -f build/zephyr/zmk.${{ inputs.fallback_binary }} ]
           then
-            cp build/zephyr/zmk.${{ inputs.fallback_binary }} "build/artifacts/${{ steps.variables.outputs.artifact-name }}.${{ inputs.fallback_binary }}"
+            cp build/zephyr/zmk.${{ inputs.fallback_binary }} "build/artifacts/${{ env.artifact_name }}.${{ inputs.fallback_binary }}"
           fi
 
-      - name: Archive (${{ steps.variables.outputs.display-name }})
-        uses: actions/upload-artifact@v2
+      - name: Archive (${{ env.display_name }})
+        uses: actions/upload-artifact@v3
         with:
-          name: ${{ inputs.artifact_name }}
+          name: ${{ inputs.archive_name }}
           path: build/artifacts


### PR DESCRIPTION
The use of `set-output` will be [deprecated by GitHub](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This change replaces it with [environment variables](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files) to share data between jobs and steps.
