### PR TITLE
Add NUHS/NUBS alias for Non-US-Backslash/Non-US-Hash

### DIFF
--- a/app/include/dt-bindings/zmk/keys.h
+++ b/app/include/dt-bindings/zmk/keys.h
@@ -263,6 +263,7 @@
 
 /* Keyboard Non-US # and ~ (Non-US Hash/Number and Tilde) */
 #define NON_US_HASH (ZMK_HID_USAGE(HID_USAGE_KEY, HID_USAGE_KEY_KEYBOARD_NON_US_HASH_AND_TILDE))
+#define NUHS (NON_US_HASH)
 
 /* Keyboard ~ (Tilde) */
 #define TILDE2 (LS(ZMK_HID_USAGE(HID_USAGE_KEY, HID_USAGE_KEY_KEYBOARD_NON_US_HASH_AND_TILDE)))
@@ -499,6 +500,7 @@
 #define NON_US_BACKSLASH                                                                           \
     (ZMK_HID_USAGE(HID_USAGE_KEY, HID_USAGE_KEY_KEYBOARD_NON_US_BACKSLASH_AND_PIPE))
 #define NON_US_BSLH (NON_US_BACKSLASH)
+#define NUBS (NON_US_BACKSLASH)
 
 /* Keyboard Pipe */
 #define PIPE2 (LS(ZMK_HID_USAGE(HID_USAGE_KEY, HID_USAGE_KEY_KEYBOARD_NON_US_BACKSLASH_AND_PIPE)))

--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -1356,7 +1356,7 @@ export default [
     footnotes: {},
   },
   {
-    names: ["NON_US_HASH"],
+    names: ["NON_US_HASH", "NUHS"],
     description: "Non-US # [Hash/Pound] and ~ [Tilde]",
     context: "Keyboard",
     clarify: false,
@@ -2606,7 +2606,7 @@ export default [
     footnotes: {},
   },
   {
-    names: ["NON_US_BACKSLASH", "NON_US_BSLH"],
+    names: ["NON_US_BACKSLASH", "NON_US_BSLH", "NUBS"],
     description: "Non-US \\ [Backslash] and | [Pipe]",
     context: "Keyboard",
     clarify: false,


### PR DESCRIPTION
This PR adds additional aliases to NON_US_BACKSLASH (NUBS) and NON_US_HASH (NUHS), as the full length keycode name causes keymaps to look confusing for ISO boards. 

The aliases are still unique and easy to understand in a keymap, while being short enough to be the same length as most regular keycodes.