### PR TITLE
feat(shields): Add splitkb.com Aurora Sweep.

### DIFF
--- a/app/boards/shields/splitkb_aurora_sweep/Kconfig.defconfig
+++ b/app/boards/shields/splitkb_aurora_sweep/Kconfig.defconfig
@@ -1,0 +1,55 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_SPLITKB_AURORA_SWEEP_LEFT
+
+config ZMK_KEYBOARD_NAME
+	default "Aurora Sweep"
+
+config ZMK_SPLIT_ROLE_CENTRAL
+	default y
+
+endif # SHIELD_SPLITKB_AURORA_SWEEP_LEFT
+
+if SHIELD_SPLITKB_AURORA_SWEEP_LEFT || SHIELD_SPLITKB_AURORA_SWEEP_RIGHT
+
+config ZMK_SPLIT
+	default y
+
+config ZMK_RGB_UNDERGLOW
+	select WS2812_STRIP
+	select SPI
+
+config ZMK_DISPLAY
+	
+if ZMK_DISPLAY
+
+config SSD1306
+	default y
+
+config I2C
+	default y
+
+config SSD1306_REVERSE_MODE
+	default y
+
+endif # ZMK_DISPLAY
+
+if LVGL
+
+config LVGL_VDB_SIZE
+	default 64
+
+config LVGL_DPI
+	default 148
+
+config LVGL_BITS_PER_PIXEL
+	default 1
+
+choice LVGL_COLOR_DEPTH
+	default LVGL_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL
+
+endif # SHIELD_SPLITKB_AURORA_SWEEP_LEFT || SHIELD_SPLITKB_AURORA_SWEEP_RIGHT

--- a/app/boards/shields/splitkb_aurora_sweep/Kconfig.shield
+++ b/app/boards/shields/splitkb_aurora_sweep/Kconfig.shield
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_SPLITKB_AURORA_SWEEP_LEFT
+	def_bool $(shields_list_contains,splitkb_aurora_sweep_left)
+
+config SHIELD_SPLITKB_AURORA_SWEEP_RIGHT
+	def_bool $(shields_list_contains,splitkb_aurora_sweep_right)

--- a/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano.overlay
@@ -1,0 +1,31 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <6>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano_v2.overlay
@@ -1,0 +1,31 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <6>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.conf
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.conf
@@ -1,0 +1,9 @@
+# Uncomment these two line to add support for encoders to your firmware
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Uncomment the following line to enable the Kyria OLED Display
+# CONFIG_ZMK_DISPLAY=y
+
+# Uncomment the following lines to enable RGB underglow
+# CONFIG_ZMK_RGB_UNDERGLOW=y

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.dtsi
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.dtsi
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+
+	chosen {
+		zephyr,display = &oled;
+		zmk,matrix_transform = &default_transform;
+	};
+
+	default_transform: keymap_transform_0 {
+		compatible = "zmk,matrix-transform";
+		columns = <10>;
+		rows = <4>;
+		map = <
+		RC(0,4)  RC(0,3)  RC(0,2)  RC(0,1)  RC(0,0)  RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9)
+		RC(1,4)  RC(1,3)  RC(1,2)  RC(1,1)  RC(1,0)  RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9)
+		RC(2,4)  RC(2,3)  RC(2,2)  RC(2,1)  RC(2,0)  RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9)
+		                           RC(3,1)  RC(3,0)  RC(3,5) RC(3,6)
+		>;
+	};
+
+	left_encoder1: left_encoder1 {
+		compatible = "alps,ec11";
+		label = "L_ENCODER1";
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	left_encoder2: left_encoder2 {
+		compatible = "alps,ec11";
+		label = "L_ENCODER2";
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	right_encoder1: right_encoder1 {
+		compatible = "alps,ec11";
+		label = "R_ENCODER1";
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	right_encoder2: right_encoder2 {
+		compatible = "alps,ec11";
+		label = "R_ENCODER2";
+		resolution = <4>;
+		status = "disabled";
+	};
+
+	sensors {
+		compatible = "zmk,keymap-sensors";
+		sensors = <&left_encoder1 &right_encoder1>;
+	};
+};
+
+&pro_micro_i2c {
+	status = "okay";
+
+	oled: ssd1306@3c {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3c>;
+		label = "DISPLAY";
+		width = <128>;
+		height = <32>;
+		segment-offset = <0>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <31>;
+		segment-remap;
+		com-invdir;
+		com-sequential;
+		prechargep = <0x22>;
+	};
+};

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.keymap
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.keymap
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+
+&mt {
+  //  flavor = "tap-preferred";
+   // tapping_term_ms = <200>;
+};
+
+/ { 
+
+    combos {
+        compatible = "zmk,combos";
+        combo_esc {
+            timeout-ms = <50>;
+            key-positions = <0 1>;
+            bindings = <&kp ESC>;
+        };
+        
+         combo_tab {
+            timeout-ms = <50>;
+            key-positions = <10 11>;
+            bindings = <&kp TAB>;
+        };
+        
+            combo_ralt {
+            timeout-ms = <50>;
+            key-positions = <17 16>;
+            bindings = <&kp RALT>;
+        };
+        
+                    combo_lalt {
+            timeout-ms = <50>;
+            key-positions = <11 12>;
+            bindings = <&kp LALT>;
+        };
+        
+                           combo_lgui {
+            timeout-ms = <50>;
+            key-positions = <12 13>;
+            bindings = <&kp LGUI>;
+        };
+        
+        
+       combo_rgui {
+            timeout-ms = <50>;
+            key-positions = <17 18>;
+            bindings = <&kp RGUI>;
+        };
+        
+
+        
+    };
+
+        keymap {
+                compatible = "zmk,keymap";
+                
+       		default_layer {
+		bindings = <
+		&kp Q &kp W &kp E &kp R &kp T 						&kp Y &kp U  &kp I    &kp O   &kp P 
+		&kp A &kp S &kp D &kp F &kp G 			        	        &kp H &kp J &kp K &kp L &kp QUOT
+		&mt LSFT Z &kp X &kp C &kp V &kp B				        &kp N &kp M  &kp CMMA &kp DOT &mt LSFT RET
+          				&mo 1 &kp LCTL  				&kp SPC &mo 2 
+		>;
+		};
+
+       		left_layer {
+		bindings = <
+		&kp NUM_1  &kp NUM_2    &kp NUM_3    &kp NUM_4    &kp NUM_5		&kp NUM_6 &kp NUM_7 &kp NUM_8 &kp NUM_9 &kp NUM_0 
+		&kp TAB    &kp LC(S)    &kp DQT      &kp PIPE2     &kp HASH 		&kp MINUS &kp EQL  &kp LBKT &kp RBKT  &kp DEL 
+		&kp ESC    &kp TILDE 	&kp NON_US_BSLH &kp NON_US_HASH  &kp TILDE2 	&kp MINUS &kp GRAVE &kp LBKT &kp RBKT  &kp DEL 
+					    &mo 1  &kp LGUI  					&kp RGUI &mo 2 
+		>;
+		};
+		
+		right_layer {
+		bindings = <
+		&kp BANG  &kp ATSN &kp HASH  &kp DLLR  &kp PRCT    			&kp CRRT  &kp AMPS &kp KMLT &kp LPRN &kp RPRN 
+		&kp HASH  &kp QMARK  &kp FSLH  &kp COLN  &kp SCLN 			&kp MINUS &kp KP_EQUAL  &kp LBRC  &kp RBRC   &kp BKSP
+		&kp LSFT  &kp KPLS &kp LBKT &kp RBKT   &kp BSLH    			&kp UNDER &kp LEFT &kp DOWN &kp UP  &kp RIGHT
+					  &mo 3 &kp LCTL  				&kp SPC  &mo 2 
+		>;
+		};	
+		
+		tri_layer {
+		bindings = <
+		&kp NUM_1  &kp NUM_2    &kp NUM_3    &kp NUM_4    &kp NUM_5 			&trans &trans   &trans   &trans  &trans
+		&kp F1 &kp F2 &kp F3 &kp F4 &kp F5  						&trans &kp PG_UP  &kp K_VOL_UP &kp K_MUTE &trans 
+		&bt BT_CLR  &bt BT_NXT &bt BT_PRV &kp F6 &kp F7   				&trans &kp PG_DN  &kp K_VOL_DN  &trans &trans   
+					 &trans &trans  					&trans &trans 
+		>;
+		};	
+        
+	};
+};

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.zmk.yml
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.zmk.yml
@@ -1,0 +1,12 @@
+file_format: "1"
+id: splitkb_aurora_sweep
+name: splitkb.com Aurora Sweep
+type: shield
+url: https://splitkb.com/products/aurora-sweep-pcb-kit
+requires: [pro_micro]
+exposes: [i2c_oled]
+features:
+  - keys
+siblings:
+  - splitkb_aurora_sweep_left
+  - splitkb_aurora_sweep_right

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep_left.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep_left.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "splitkb_aurora_sweep.dtsi"
+
+/ {
+	chosen {
+		zmk,kscan = &kscan;
+	};
+
+	kscan: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+
+		label = "KSCAN";
+		diode-direction = "row2col";
+
+		row-gpios
+			= <&pro_micro 19 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 20 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 18 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 15 GPIO_ACTIVE_HIGH>
+			;
+
+		col-gpios 
+			= <&pro_micro 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 4  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 5  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 6  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 7  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			;
+	};
+};
+
+&left_encoder1 {
+	status = "okay";
+	a-gpios = <&pro_micro 9 GPIO_PULL_UP>;
+	b-gpios = <&pro_micro 8 GPIO_PULL_UP>;
+};
+
+&left_encoder2 {
+	status = "okay";
+	a-gpios = <&pro_micro 14 GPIO_PULL_UP>;
+	b-gpios = <&pro_micro 16 GPIO_PULL_UP>;
+};
+

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep_right.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep_right.overlay
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "splitkb_aurora_sweep.dtsi"
+
+/ {
+	chosen {
+		zmk,kscan = &kscan;
+	};
+
+	kscan: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+
+		label = "KSCAN";
+		diode-direction = "row2col";
+
+		row-gpios
+			= <&pro_micro 15 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 18 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 19 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 14 GPIO_ACTIVE_HIGH>
+			;
+
+		col-gpios 
+			= <&pro_micro 9 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 8  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 7  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 6  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 5  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			;
+	};
+};
+
+&right_encoder1 {
+	status = "okay";
+	a-gpios = <&pro_micro 16 GPIO_PULL_UP>;
+	b-gpios = <&pro_micro 10 GPIO_PULL_UP>;
+};
+
+&right_encoder2 {
+	status = "okay";
+	a-gpios = <&pro_micro 20 GPIO_PULL_UP>;
+	b-gpios = <&pro_micro 4  GPIO_PULL_UP>;
+};
+
+&default_transform {
+	col-offset = <5>;
+};


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
