### PR TITLE
feat(docs): Add suggestion to workaround macOS 13 Finder bug

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -21,6 +21,10 @@ Variations of the warnings shown below occur when flashing the `<firmware>.uf2` 
 | :--------------------------------------------------------------------------: |
 |                An example of the file transfer error on MacOS                |
 
+### MacOS Ventura error
+
+MacOS 13.0 (Ventura) Finder running on Apple silicon hardware may report an error code 100093 when copying `<firmware>.uf2` files into microcontrollers. This bug is limited to the operating system's Finder. You can work around it by copying on Terminal command line or use a third party file manager.
+
 ### CMake Error
 
 An error along the lines of `CMake Error at (zmk directory)/zephyr/cmake/generic_toolchain.cmake:64 (include): include could not find load file:` during firmware compilation indicates that the Zephyr Environment Variables are not properly defined.


### PR DESCRIPTION
Copying a UF2 into microcontrollers with macOS 13's Finder will trigger an "error code 100093". This change add a workaround for that error.
