### PR TITLE
Error not exclusive to Apple silicon

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -23,7 +23,7 @@ Variations of the warnings shown below occur when flashing the `<firmware>.uf2` 
 
 ### MacOS Ventura error
 
-MacOS 13.0 (Ventura) Finder running on Apple silicon hardware may report an error code 100093 when copying `<firmware>.uf2` files into microcontrollers. This bug is limited to the operating system's Finder. You can work around it by copying on Terminal command line or use a third party file manager.
+MacOS 13.0 (Ventura) Finder may report an error code 100093 when copying `<firmware>.uf2` files into microcontrollers. This bug is limited to the operating system's Finder. You can work around it by copying on Terminal command line or use a third party file manager.
 
 ### CMake Error
 


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
