### PR TITLE
Set bits per pixel and color depth on n!v

### DIFF
--- a/app/boards/shields/nice_view/Kconfig.defconfig
+++ b/app/boards/shields/nice_view/Kconfig.defconfig
@@ -17,6 +17,13 @@ config LS0XX
 config ZMK_WIDGET_WPM_STATUS
 	default y if !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
 
+config LVGL_BITS_PER_PIXEL
+	default 1
+
+choice LVGL_COLOR_DEPTH
+	default LVGL_COLOR_DEPTH_1
+endchoice
+
 endif # ZMK_DISPLAY
 
 endif

--- a/app/boards/shields/nice_view/Kconfig.shield
+++ b/app/boards/shields/nice_view/Kconfig.shield
@@ -3,10 +3,3 @@
 
 config SHIELD_NICE_VIEW
 	def_bool $(shields_list_contains,nice_view)
-
-config LVGL_BITS_PER_PIXEL
-	default 1
-
-choice LVGL_COLOR_DEPTH
-	default LVGL_COLOR_DEPTH_1
-endchoice

--- a/app/boards/shields/nice_view/Kconfig.shield
+++ b/app/boards/shields/nice_view/Kconfig.shield
@@ -3,3 +3,10 @@
 
 config SHIELD_NICE_VIEW
 	def_bool $(shields_list_contains,nice_view)
+
+config LVGL_BITS_PER_PIXEL
+	default 1
+
+choice LVGL_COLOR_DEPTH
+	default LVGL_COLOR_DEPTH_1
+endchoice


### PR DESCRIPTION
The default bit/pixel is 32, as is the default color depth. This results in LVGL sending all zeros to the nice view, which makes for not happy dev times. 😢

Default it to 1x1 in the nice_view shield so no one else has to go though this. 🎉 