### PR TITLE
feat(shields): Add splitkb.com Aurora Corne.

### DIFF
--- a/app/boards/shields/splitkb_aurora_corne/Kconfig.defconfig
+++ b/app/boards/shields/splitkb_aurora_corne/Kconfig.defconfig
@@ -1,0 +1,55 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_SPLITKB_AURORA_CORNE_LEFT
+
+config ZMK_KEYBOARD_NAME
+	default "Aurora Corne"
+
+config ZMK_SPLIT_ROLE_CENTRAL
+	default y
+
+endif # SHIELD_SPLITKB_AURORA_CORNE_LEFT
+
+if SHIELD_SPLITKB_AURORA_CORNE_LEFT || SHIELD_SPLITKB_AURORA_CORNE_RIGHT
+
+config ZMK_SPLIT
+	default y
+
+config ZMK_RGB_UNDERGLOW
+	select WS2812_STRIP
+	select SPI
+
+config ZMK_DISPLAY
+	
+if ZMK_DISPLAY
+
+config SSD1306
+	default y
+
+config I2C
+	default y
+
+config SSD1306_REVERSE_MODE
+	default y
+
+endif # ZMK_DISPLAY
+
+if LVGL
+
+config LVGL_VDB_SIZE
+	default 64
+
+config LVGL_DPI
+	default 148
+
+config LVGL_BITS_PER_PIXEL
+	default 1
+
+choice LVGL_COLOR_DEPTH
+	default LVGL_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL
+
+endif # SHIELD_SPLITKB_AURORA_CORNE_LEFT || SHIELD_SPLITKB_AURORA_CORNE_RIGHT

--- a/app/boards/shields/splitkb_aurora_corne/Kconfig.shield
+++ b/app/boards/shields/splitkb_aurora_corne/Kconfig.shield
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_SPLITKB_AURORA_CORNE_LEFT
+	def_bool $(shields_list_contains,splitkb_aurora_corne_left)
+
+config SHIELD_SPLITKB_AURORA_CORNE_RIGHT
+	def_bool $(shields_list_contains,splitkb_aurora_corne_right)

--- a/app/boards/shields/splitkb_aurora_corne/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/boards/nice_nano.overlay
@@ -1,0 +1,31 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <6>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/splitkb_aurora_corne/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/boards/nice_nano_v2.overlay
@@ -1,0 +1,31 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	mosi-pin = <6>;
+	// Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+	sck-pin = <5>;
+	miso-pin = <7>;
+
+	led_strip: ws2812@0 {
+		compatible = "worldsemi,ws2812-spi";
+		label = "WS2812";
+
+		/* SPI */
+		reg = <0>; /* ignored, but necessary for SPI bindings */
+		spi-max-frequency = <4000000>;
+
+		/* WS2812 */
+		chain-length = <6>; /* arbitrary; change at will */
+		spi-one-frame = <0x70>;
+		spi-zero-frame = <0x40>;
+		color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+	};
+};
+
+/ {
+	chosen {
+		zmk,underglow = &led_strip;
+	};
+};

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.conf
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.conf
@@ -1,0 +1,9 @@
+# Uncomment these two line to add support for encoders to your firmware
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Uncomment the following line to enable the Kyria OLED Display
+# CONFIG_ZMK_DISPLAY=y
+
+# Uncomment the following lines to enable RGB underglow
+# CONFIG_ZMK_RGB_UNDERGLOW=y

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.dtsi
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.dtsi
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+
+	chosen {
+		zephyr,display = &oled;
+		zmk,matrix_transform = &default_transform;
+	};
+
+	default_transform: keymap_transform_0 {
+		compatible = "zmk,matrix-transform";
+		columns = <12>;
+		rows = <4>;
+// | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  |   | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |
+// | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 |   | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |
+// | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 |   | SW18 | SW17 | SW16 | SW15 | SW14 | SW13 |
+//                      | SW19 | SW20 | SW21 |   | SW21 | SW20 | SW19 |
+		map = <
+RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)  RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11)
+RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)  RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11)
+RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11)
+                        RC(3,3) RC(3,4) RC(3,5)  RC(3,6) RC(3,7) RC(3,8)
+		>;
+	};
+
+	five_column_transform: keymap_transform_1 {
+		compatible = "zmk,matrix-transform";
+		columns = <10>;
+		rows = <4>;
+// | SW2  | SW3  | SW4  | SW5  | SW6  |   | SW6  | SW5  | SW4  | SW3  | SW2  |
+// | SW8  | SW9  | SW10 | SW11 | SW12 |   | SW12 | SW11 | SW10 | SW9  | SW8  |
+// | SW14 | SW15 | SW16 | SW17 | SW18 |   | SW18 | SW17 | SW16 | SW15 | SW14 |
+//               | SW19 | SW20 | SW21 |   | SW21 | SW20 | SW19 |
+		map = <
+RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)  RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10)
+RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)  RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10)
+RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10)
+                RC(3,3) RC(3,4) RC(3,5)  RC(3,6) RC(3,7) RC(3,8)
+		>;
+	};
+
+	left_encoder: left_encoder {
+		compatible = "alps,ec11";
+		label = "L_ENCODER";
+		resolution = <4>;
+		status = "disabled";
+
+		a-gpios = <&pro_micro 4 GPIO_PULL_UP>;
+		b-gpios = <&pro_micro 5 GPIO_PULL_UP>;
+	};
+
+	right_encoder: right_encoder {
+		compatible = "alps,ec11";
+		label = "R_ENCODER";
+		resolution = <4>;
+		status = "disabled";
+
+		a-gpios = <&pro_micro 19 GPIO_PULL_UP>;
+		b-gpios = <&pro_micro 18 GPIO_PULL_UP>;
+	};
+
+	sensors {
+		compatible = "zmk,keymap-sensors";
+		sensors = <&left_encoder &right_encoder>;
+	};
+};
+
+&pro_micro_i2c {
+	status = "okay";
+
+	oled: ssd1306@3c {
+		compatible = "solomon,ssd1306fb";
+		reg = <0x3c>;
+		label = "DISPLAY";
+		width = <128>;
+		height = <32>;
+		segment-offset = <0>;
+		page-offset = <0>;
+		display-offset = <0>;
+		multiplex-ratio = <31>;
+		segment-remap;
+		com-invdir;
+		com-sequential;
+		prechargep = <0x22>;
+	};
+};

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.keymap
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.keymap
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+/ {
+        keymap {
+                compatible = "zmk,keymap";
+
+                default_layer {
+// -----------------------------------------------------------------------------------------
+// |  TAB |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  | BKSP |
+// | CTRL |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |  '   |
+// | SHFT |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | ESC  |
+//                    | GUI | LWR | SPC |   | ENT | RSE  | ALT |
+                        bindings = <
+   &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
+   &kp LCTRL &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
+   &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp ESC
+                  &kp LGUI &mo 1 &kp SPACE   &kp RET &mo 2 &kp RALT
+                        >;
+                };
+                lower_layer {
+// -----------------------------------------------------------------------------------------
+// |  TAB |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  | BKSP |
+// | BTCLR| BT1 | BT2 | BT3 | BT4 | BT5 |   | LFT | DWN |  UP | RGT |     |      |
+// | SHFT |     |     |     |     |     |   |     |     |     |     |     |      |
+//                    | GUI |     | SPC |   | ENT |     | ALT |
+                        bindings = <
+   &kp TAB    &kp N1       &kp N2       &kp N3       &kp N4       &kp N5         &kp N6   &kp N7   &kp N8 &kp N9    &kp N0 &kp BSPC
+   &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4   &kp LEFT &kp DOWN &kp UP &kp RIGHT &trans &trans
+   &kp LSHFT  &trans       &trans       &trans       &trans       &trans         &trans   &trans   &trans &trans    &trans &trans
+                          	        &kp LGUI     &trans       &kp SPACE      &kp RET  &trans   &kp RALT
+                        >;
+                };
+
+                raise_layer {
+// -----------------------------------------------------------------------------------------
+// |  TAB |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  (  |  )  | BKSP |
+// | CTRL |     |     |     |     |     |   |  -  |  =  |  [  |  ]  |  \  |  `   |
+// | SHFT |     |     |     |     |     |   |  _  |  +  |  {  |  }  | "|" |  ~   |
+//                    | GUI |     | SPC |   | ENT |     | ALT |
+                        bindings = <
+   &kp  TAB  &kp EXCL &kp AT &kp HASH &kp DLLR &kp PRCNT   &kp CARET &kp AMPS  &kp KP_MULTIPLY &kp LPAR &kp RPAR &kp BSPC
+   &kp LCTRL &trans   &trans &trans   &trans   &trans      &kp MINUS &kp EQUAL &kp LBKT        &kp RBKT &kp BSLH &kp GRAVE
+   &kp LSHFT &trans   &trans &trans   &trans   &trans      &kp UNDER &kp PLUS  &kp LBRC        &kp RBRC &kp PIPE &kp TILDE
+                    	     &kp LGUI &trans   &kp SPACE   &kp RET   &trans    &kp RALT
+                        >;
+                };
+        };
+};

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.zmk.yml
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.zmk.yml
@@ -1,0 +1,12 @@
+file_format: "1"
+id: splitkb_aurora_corne
+name: splitkb.com Aurora Corne
+type: shield
+url: https://splitkb.com/products/aurora-corne-pcb-kit
+requires: [pro_micro]
+exposes: [i2c_oled]
+features:
+  - keys
+siblings:
+  - splitkb_aurora_corne_left
+  - splitkb_aurora_corne_right

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_left.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_left.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "splitkb_aurora_corne.dtsi"
+
+/ {
+	chosen {
+		zmk,kscan = &kscan;
+	};
+
+	kscan: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+
+		label = "KSCAN";
+		diode-direction = "col2row";
+
+		row-gpios
+			= <&pro_micro 6 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 7 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 8 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 9 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			;
+
+		col-gpios 
+			= <&pro_micro 16 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 10 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 14 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 15 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 18 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 19 GPIO_ACTIVE_HIGH>
+			;
+	};
+};
+
+&left_encoder {
+	status = "okay";
+};
+
+

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_right.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_right.overlay
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "splitkb_aurora_corne.dtsi"
+
+/ {
+	chosen {
+		zmk,kscan = &kscan;
+	};
+
+	kscan: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+
+		label = "KSCAN";
+		diode-direction = "col2row";
+
+		row-gpios
+			= <&pro_micro 15 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 14 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 16 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			, <&pro_micro 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+			;
+
+		col-gpios 
+			= <&pro_micro 9 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 8 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 7 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 6 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 5 GPIO_ACTIVE_HIGH>
+			, <&pro_micro 4 GPIO_ACTIVE_HIGH>
+			;
+	};
+};
+
+&right_encoder {
+	status = "okay";
+};
+
+&default_transform {
+	col-offset = <5>;
+};
+
+&five_column_transform {
+	col-offset = <6>;
+};


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [ ] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
