### PR TITLE
Updated pins arduino_pro_micro_pins.dtsi for nice!nano V2

### DIFF
--- a/app/boards/arm/nice_nano/arduino_pro_micro_pins.dtsi
+++ b/app/boards/arm/nice_nano/arduino_pro_micro_pins.dtsi
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2020 Pete Johanson
  *
+ * Updated by the-kwak 11/6/2022
+ *
  * SPDX-License-Identifier: MIT
  */
 

--- a/app/boards/arm/nice_nano/arduino_pro_micro_pins.dtsi
+++ b/app/boards/arm/nice_nano/arduino_pro_micro_pins.dtsi
@@ -24,6 +24,9 @@
 			, <8 0 &gpio1 4 0>		/* D8/A8 */
 			, <9 0 &gpio1 6 0>		/* D9/A9 */
 			, <10 0 &gpio0 9 0>		/* D10/A10 */
+			, <11 0 &gpio1 1 0>     /* Custom label D11 */
+			, <12 0 &gpio1 2 0>     /* Custom label D12 */
+			, <13 0 &gpio1 7 0>   	/* Custom label D13 */
 			, <16 0 &gpio0 10 0>	/* D16 */
 			, <14 0 &gpio1 11 0>	/* D14 */
 			, <15 0 &gpio1 13 0>	/* D15 */


### PR DESCRIPTION
added missing pins 101,102,107 as D11, D12, D13
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [ ] If split, no name added for the right/peripheral half
 - [ ] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [ ] `.conf` file has optional extra features commented out
 - [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
