### PR TITLE
Checkout submodules when building user config

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+            submodules: recursive
 
       - name: Install yaml2json
         run: python3 -m pip install remarshal
@@ -69,6 +71,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+            submodules: recursive
 
       - name: Cache west modules
         uses: actions/cache@v3.0.11


### PR DESCRIPTION
This modifies the `build-user-config.yml` called by Github Actions to checkout submodules of the user's `zmk-config`. This allows users to build their config in a modular fashion. For instance, instead of adding a shield subdirectory, they can just keep all the hardware related stuff in a separate repo and include that (or someone else's repo) as a submodule.

For anyone who wants to try this out, you can do so by replacing the contents of `.github/workflow/build.yml` in your `zmk-config` repo with the following contents:
```
on: [push, pull_request, workflow_dispatch]

jobs:
  build:
    uses: urob/zmk/.github/workflows/build-user-config.yml@build-with-submodules
```