### PR TITLE
Update link to Zephyr led docs

### DIFF
--- a/docs/docs/config/backlight.md
+++ b/docs/docs/config/backlight.md
@@ -34,7 +34,7 @@ Applies to: [`/chosen` node](https://docs.zephyrproject.org/latest/build/dts/int
 
 See the Zephyr devicetree bindings for LED drivers:
 
-- [gpio-leds](https://docs.zephyrproject.org/latest/build/dts/api/bindings/led/gpio-leds.html)
+- [gpio-leds](https://docs.zephyrproject.org/3.0.0/reference/devicetree/bindings/gpio/gpio-leds.html)
 - [pwm-leds](https://docs.zephyrproject.org/latest/build/dts/api/bindings/led/pwm-leds.html)
 
 See the [backlight feature page](../features/backlight.md) for examples of the properties that must be set to enable backlighting.

--- a/docs/docs/config/backlight.md
+++ b/docs/docs/config/backlight.md
@@ -34,7 +34,7 @@ Applies to: [`/chosen` node](https://docs.zephyrproject.org/latest/build/dts/int
 
 See the Zephyr devicetree bindings for LED drivers:
 
-- [gpio-leds](https://docs.zephyrproject.org/latest/build/dts/api/bindings/gpio/gpio-leds.html)
+- [gpio-leds](https://docs.zephyrproject.org/latest/build/dts/api/bindings/led/gpio-leds.html)
 - [pwm-leds](https://docs.zephyrproject.org/latest/build/dts/api/bindings/led/pwm-leds.html)
 
 See the [backlight feature page](../features/backlight.md) for examples of the properties that must be set to enable backlighting.


### PR DESCRIPTION
The documentation has a broken link. This change updates the link to a relevant page.