### PR TITLE
fix(usb): add USB_DC_CLEAR_HALT to supported states

### DIFF
--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -34,6 +34,7 @@ enum zmk_usb_conn_state zmk_usb_get_conn_state() {
     case USB_DC_SUSPEND:
     case USB_DC_CONFIGURED:
     case USB_DC_RESUME:
+    case USB_DC_CLEAR_HALT:
         return ZMK_USB_CONN_HID;
 
     case USB_DC_DISCONNECTED:


### PR DESCRIPTION
See https://manpages.debian.org/testing/linux-manual-4.9/usb_clear_halt.9 for information on halted USB endpoints

Before fix:

```
[24:50:12.712,371] <dbg> zmk: zmk_usb_get_conn_state: state: 9
[24:50:12.712,371] <dbg> zmk: get_selected_endpoint: Only BLE is ready.
```