### PR TITLE
fix(boards): Fix XIAO BLE voltage divider config.

### DIFF
--- a/app/boards/seeeduino_xiao_ble.overlay
+++ b/app/boards/seeeduino_xiao_ble.overlay
@@ -16,7 +16,7 @@
 		label = "BATTERY";
 		io-channels = <&adc 7>;
 		power-gpios = <&gpio0 14 (GPIO_OPEN_DRAIN | GPIO_ACTIVE_LOW)>;
-		output-ohms = <1000000>;
+		output-ohms = <510000>;
 		full-ohms = <(1000000 + 510000)>;
 	};
 };


### PR DESCRIPTION
* Use proper resistor value for the `output-ohms` property.

Found this bug in my own testing, and the fix came from `sctanf` [on Discord](https://discord.com/channels/719497620560543766/719909884769992755/1042977575418474586). Reviewing the schematic confirms that's the proper fix.