### PR TITLE
Bug: Layer-tap from higher-number to lower fails

### DIFF
--- a/app/tests/layer-tap/lt-higher-lower-layer/events.patterns
+++ b/app/tests/layer-tap/lt-higher-lower-layer/events.patterns
@@ -1,0 +1,2 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p

--- a/app/tests/layer-tap/lt-higher-lower-layer/keycode_events.snapshot
+++ b/app/tests/layer-tap/lt-higher-lower-layer/keycode_events.snapshot
@@ -1,0 +1,12 @@
+mo_pressed: position 1 layer 2
+kp_pressed: usage_page 0x07 keycode 0x1F implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x1F implicit_mods 0x00 explicit_mods 0x00
+mo_released: position 1 layer 2
+mo_pressed: position 2 layer 2
+kp_pressed: usage_page 0x07 keycode 0x1F implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x1F implicit_mods 0x00 explicit_mods 0x00
+mo_released: position 2 layer 2
+mo_pressed: position 2 layer 2
+kp_pressed: usage_page 0x07 keycode 0x1F implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x1F implicit_mods 0x00 explicit_mods 0x00
+mo_released: position 2 layer 2

--- a/app/tests/layer-tap/lt-higher-lower-layer/native_posix_64.keymap
+++ b/app/tests/layer-tap/lt-higher-lower-layer/native_posix_64.keymap
@@ -1,0 +1,71 @@
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+&lt {
+    flavor = "balanced";
+};
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+        default_layer {
+            bindings = <
+                &kp N0 &lt 2 N0
+                &to 1 &to 3
+            >;
+        };
+        layer_1 {
+            bindings = <
+                &kp N1 &none
+                &lt 2 N1 &to 0
+            >;
+        };
+        layer_2 {
+            bindings = <
+                &kp N2 &none
+                &trans &trans
+            >;
+        };
+        layer_3 {
+            bindings = <
+                &kp N3 &none
+                &lt 2 N3 &to 0
+            >;
+        };
+    };
+};
+
+&kscan {
+  events = <
+    // LT 0->2 and get 2
+    ZMK_MOCK_PRESS(0,1,10)
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    ZMK_MOCK_RELEASE(0,1,10)
+
+    // TO 1
+    ZMK_MOCK_PRESS(1,0,10)
+    ZMK_MOCK_RELEASE(1,0,10)
+
+    // LT 1->2 and get 2
+    ZMK_MOCK_PRESS(1,0,10)
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    ZMK_MOCK_RELEASE(1,0,10)
+
+    // TO 0
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,10)
+
+    // TO 3
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,10)
+
+    // LT 3->2 and get 2
+    ZMK_MOCK_PRESS(1,0,10)
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    ZMK_MOCK_RELEASE(1,0,10)
+    >;
+};


### PR DESCRIPTION
This tests uses `&to` to switch to layer 3 which has a `&lt` for layer 2, but instead the keycodes on layer 3 are still sent. I'm not sure how to fix it, but at least this replicates the bug.

I found this by trying a similar scenario on my own zmk-config.