### PR TITLE
fix(docs): Correct syntax in capsword mods

### DIFF
--- a/docs/docs/behaviors/caps-word.md
+++ b/docs/docs/behaviors/caps-word.md
@@ -43,7 +43,7 @@ In addition, if you would like _multiple_ modifiers, instead of just `MOD_LSFT`,
 
 ```
 &caps_word {
-    mods = <MOD_LSFT | MOD_LALT>;
+    mods = <(MOD_LSFT | MOD_LALT)>;
 };
 
 / {


### PR DESCRIPTION
Update the example for the `mods` property for `&caps_word` per the devicetree spec

> values may be represented as arithmetic, bitwise, or logical expressions within parenthesis.

This is also in line with the usage in the mod-morph documentation as well.