### PR TITLE
feat(display): Add modifiers widget

### DIFF
--- a/app/include/zmk/display/widgets/mods_status.h
+++ b/app/include/zmk/display/widgets/mods_status.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <lvgl.h>
+#include <kernel.h>
+
+struct zmk_widget_mods_status {
+    sys_snode_t node;
+    lv_obj_t *obj;
+};
+
+int zmk_widget_mods_status_init(struct zmk_widget_mods_status *widget, lv_obj_t *parent);
+lv_obj_t *zmk_widget_mods_status_obj(struct zmk_widget_mods_status *widget);

--- a/app/include/zmk/display/widgets/mods_status.h
+++ b/app/include/zmk/display/widgets/mods_status.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <lvgl.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 struct zmk_widget_mods_status {
     sys_snode_t node;

--- a/app/src/display/status_screen.c
+++ b/app/src/display/status_screen.c
@@ -9,6 +9,7 @@
 #include <zmk/display/widgets/battery_status.h>
 #include <zmk/display/widgets/layer_status.h>
 #include <zmk/display/widgets/wpm_status.h>
+#include <zmk/display/widgets/mods_status.h>
 #include <zmk/display/status_screen.h>
 
 #include <zephyr/logging/log.h>
@@ -32,6 +33,10 @@ static struct zmk_widget_layer_status layer_status_widget;
 
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_WPM_STATUS)
 static struct zmk_widget_wpm_status wpm_status_widget;
+#endif
+
+#if IS_ENABLED(CONFIG_ZMK_WIDGET_MODS_STATUS)
+static struct zmk_widget_mods_status mods_status_widget;
 #endif
 
 lv_obj_t *zmk_display_status_screen() {
@@ -64,6 +69,15 @@ lv_obj_t *zmk_display_status_screen() {
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_WPM_STATUS)
     zmk_widget_wpm_status_init(&wpm_status_widget, screen);
     lv_obj_align(zmk_widget_wpm_status_obj(&wpm_status_widget), LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+#endif
+
+#if IS_ENABLED(CONFIG_ZMK_WIDGET_MODS_STATUS)
+    zmk_widget_mods_status_init(&mods_status_widget, screen);
+    lv_obj_set_style_local_text_font(zmk_widget_mods_status_obj(&mods_status_widget),
+                                     LV_LABEL_PART_MAIN, LV_STATE_DEFAULT,
+                                     lv_theme_get_font_small());
+    lv_obj_align(zmk_widget_mods_status_obj(&mods_status_widget), NULL, LV_ALIGN_IN_BOTTOM_RIGHT, 0,
+                 0);
 #endif
     return screen;
 }

--- a/app/src/display/status_screen.c
+++ b/app/src/display/status_screen.c
@@ -73,11 +73,9 @@ lv_obj_t *zmk_display_status_screen() {
 
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_MODS_STATUS)
     zmk_widget_mods_status_init(&mods_status_widget, screen);
-    lv_obj_set_style_local_text_font(zmk_widget_mods_status_obj(&mods_status_widget),
-                                     LV_LABEL_PART_MAIN, LV_STATE_DEFAULT,
-                                     lv_theme_get_font_small());
-    lv_obj_align(zmk_widget_mods_status_obj(&mods_status_widget), NULL, LV_ALIGN_IN_BOTTOM_RIGHT, 0,
-                 0);
+    lv_obj_set_style_text_font(zmk_widget_mods_status_obj(&mods_status_widget),
+                               lv_theme_get_font_small(screen), LV_PART_MAIN);
+    lv_obj_align(zmk_widget_mods_status_obj(&mods_status_widget), LV_ALIGN_BOTTOM_RIGHT, 0, 0);
 #endif
     return screen;
 }

--- a/app/src/display/widgets/CMakeLists.txt
+++ b/app/src/display/widgets/CMakeLists.txt
@@ -6,3 +6,4 @@ target_sources_ifdef(CONFIG_ZMK_WIDGET_OUTPUT_STATUS app PRIVATE output_status.c
 target_sources_ifdef(CONFIG_ZMK_WIDGET_PERIPHERAL_STATUS app PRIVATE peripheral_status.c)
 target_sources_ifdef(CONFIG_ZMK_WIDGET_LAYER_STATUS app PRIVATE layer_status.c)
 target_sources_ifdef(CONFIG_ZMK_WIDGET_WPM_STATUS app PRIVATE wpm_status.c)
+target_sources_ifdef(CONFIG_ZMK_WIDGET_MODS_STATUS app PRIVATE mods_status.c)

--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -36,4 +36,9 @@ config ZMK_WIDGET_WPM_STATUS
     select LV_USE_LABEL
     select ZMK_WPM
 
+config ZMK_WIDGET_MODS_STATUS
+    bool "Widget for displaying active modifiers"
+    depends on !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
+    select LV_USE_LABEL
+
 endmenu

--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -41,4 +41,12 @@ config ZMK_WIDGET_MODS_STATUS
     depends on !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
     select LV_USE_LABEL
 
+if ZMK_WIDGET_MODS_STATUS
+
+config ZMK_WIDGET_MODS_STATUS_CHARACTERS
+    string "Characters to show for each modifier, corresponding to Control/Shift/Alt/GUI respectively"
+    default "CSAG"
+
+endif
+
 endmenu

--- a/app/src/display/widgets/mods_status.c
+++ b/app/src/display/widgets/mods_status.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <logging/log.h>
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+#include <zmk/display.h>
+#include <zmk/display/widgets/mods_status.h>
+#include <zmk/events/keycode_state_changed.h>
+#include <zmk/event_manager.h>
+#include <zmk/endpoints.h>
+#include <zmk/hid.h>
+
+static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
+
+struct mods_status_state {
+    uint8_t mods;
+};
+
+struct mods_status_state mods_status_get_state(const zmk_event_t *eh) {
+    return (struct mods_status_state){.mods = zmk_hid_get_explicit_mods()};
+};
+
+void set_mods_symbol(lv_obj_t *label, struct mods_status_state state) {
+    char text[5] = {};
+
+    LOG_DBG("mods changed to %i", state.mods);
+    if (state.mods & (MOD_LCTL | MOD_RCTL))
+        strcat(text, "C");
+    if (state.mods & (MOD_LSFT | MOD_RSFT))
+        strcat(text, "S");
+    if (state.mods & (MOD_LALT | MOD_RALT))
+        strcat(text, "A");
+    if (state.mods & (MOD_LGUI | MOD_RGUI))
+        strcat(text, "G");
+
+    lv_label_set_text(label, text);
+    lv_obj_align(label, NULL, LV_ALIGN_IN_BOTTOM_RIGHT, -1, 0);
+}
+
+void mods_status_update_cb(struct mods_status_state state) {
+    struct zmk_widget_mods_status *widget;
+    SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { set_mods_symbol(widget->obj, state); }
+}
+
+ZMK_DISPLAY_WIDGET_LISTENER(widget_mods_status, struct mods_status_state, mods_status_update_cb,
+                            mods_status_get_state)
+ZMK_SUBSCRIPTION(widget_mods_status, zmk_keycode_state_changed);
+
+int zmk_widget_mods_status_init(struct zmk_widget_mods_status *widget, lv_obj_t *parent) {
+    widget->obj = lv_label_create(parent, NULL);
+    lv_label_set_align(widget->obj, LV_LABEL_ALIGN_RIGHT);
+
+    lv_obj_set_size(widget->obj, 40, 15);
+
+    sys_slist_append(&widgets, &widget->node);
+
+    widget_mods_status_init();
+    return 0;
+}
+
+lv_obj_t *zmk_widget_mods_status_obj(struct zmk_widget_mods_status *widget) { return widget->obj; }

--- a/app/src/display/widgets/mods_status.c
+++ b/app/src/display/widgets/mods_status.c
@@ -14,6 +14,12 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/endpoints.h>
 #include <zmk/hid.h>
 
+#define MOD_CHARS CONFIG_ZMK_WIDGET_MODS_STATUS_CHARACTERS
+#define MOD_CHARS_LEN (sizeof(MOD_CHARS) - 1)
+
+BUILD_ASSERT(MOD_CHARS_LEN == 4,
+             "ERROR: CONFIG_ZMK_WIDGET_MODS_STATUS_CHARACTERS should have exactly 4 characters");
+
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
 
 struct mods_status_state {
@@ -29,13 +35,13 @@ void set_mods_symbol(lv_obj_t *label, struct mods_status_state state) {
 
     LOG_DBG("mods changed to %i", state.mods);
     if (state.mods & (MOD_LCTL | MOD_RCTL))
-        strcat(text, "C");
+        strncat(text, &MOD_CHARS[0], 1);
     if (state.mods & (MOD_LSFT | MOD_RSFT))
-        strcat(text, "S");
+        strncat(text, &MOD_CHARS[1], 1);
     if (state.mods & (MOD_LALT | MOD_RALT))
-        strcat(text, "A");
+        strncat(text, &MOD_CHARS[2], 1);
     if (state.mods & (MOD_LGUI | MOD_RGUI))
-        strcat(text, "G");
+        strncat(text, &MOD_CHARS[3], 1);
 
     lv_label_set_text(label, text);
     lv_obj_align(label, LV_ALIGN_BOTTOM_RIGHT, -1, 0);

--- a/app/src/display/widgets/mods_status.c
+++ b/app/src/display/widgets/mods_status.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include <zmk/display.h>
@@ -38,7 +38,7 @@ void set_mods_symbol(lv_obj_t *label, struct mods_status_state state) {
         strcat(text, "G");
 
     lv_label_set_text(label, text);
-    lv_obj_align(label, NULL, LV_ALIGN_IN_BOTTOM_RIGHT, -1, 0);
+    lv_obj_align(label, LV_ALIGN_BOTTOM_RIGHT, -1, 0);
 }
 
 void mods_status_update_cb(struct mods_status_state state) {
@@ -51,10 +51,8 @@ ZMK_DISPLAY_WIDGET_LISTENER(widget_mods_status, struct mods_status_state, mods_s
 ZMK_SUBSCRIPTION(widget_mods_status, zmk_keycode_state_changed);
 
 int zmk_widget_mods_status_init(struct zmk_widget_mods_status *widget, lv_obj_t *parent) {
-    widget->obj = lv_label_create(parent, NULL);
-    lv_label_set_align(widget->obj, LV_LABEL_ALIGN_RIGHT);
-
-    lv_obj_set_size(widget->obj, 40, 15);
+    widget->obj = lv_label_create(parent);
+    lv_obj_set_style_text_align(widget->obj, LV_TEXT_ALIGN_RIGHT, 0);
 
     sys_slist_append(&widgets, &widget->node);
 

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -23,6 +23,9 @@ Definition files:
 | `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool | If battery widget is enabled, show percentage instead of icons | n       |
 | `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool | Enable a widget to show the current output (USB/BLE)           | y       |
 | `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool | Enable a widget to show words per minute                       | n       |
+| `CONFIG_ZMK_WIDGET_MODS_STATUS`                    | bool | Enable a widget to show active modifiers                       | n       |
+
+Note that WPM and modifiers widgets are both shown on the bottom right of the display and hence can conflict with each other.
 
 Note that `CONFIG_ZMK_DISPLAY_INVERT` setting might not work as expected with custom status screens that utilize images.
 

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -14,16 +14,17 @@ Definition files:
 - [zmk/app/src/display/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/Kconfig)
 - [zmk/app/src/display/widgets/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/widgets/Kconfig)
 
-| Config                                             | Type | Description                                                    | Default |
-| -------------------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_DISPLAY`                               | bool | Enable support for displays                                    | n       |
-| `CONFIG_ZMK_DISPLAY_INVERT`                        | bool | Invert display colors from black-on-white to white-on-black    | n       |
-| `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool | Enable a widget to show the highest, active layer              | y       |
-| `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool | Enable a widget to show battery charge information             | y       |
-| `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool | If battery widget is enabled, show percentage instead of icons | n       |
-| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool | Enable a widget to show the current output (USB/BLE)           | y       |
-| `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool | Enable a widget to show words per minute                       | n       |
-| `CONFIG_ZMK_WIDGET_MODS_STATUS`                    | bool | Enable a widget to show active modifiers                       | n       |
+| Config                                             | Type   | Description                                                                               | Default |
+| -------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_DISPLAY`                               | bool   | Enable support for displays                                                               | n       |
+| `CONFIG_ZMK_DISPLAY_INVERT`                        | bool   | Invert display colors from black-on-white to white-on-black                               | n       |
+| `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool   | Enable a widget to show the highest, active layer                                         | y       |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool   | Enable a widget to show battery charge information                                        | y       |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool   | If battery widget is enabled, show percentage instead of icons                            | n       |
+| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool   | Enable a widget to show the current output (USB/BLE)                                      | y       |
+| `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool   | Enable a widget to show words per minute                                                  | n       |
+| `CONFIG_ZMK_WIDGET_MODS_STATUS`                    | bool   | Enable a widget to show active modifiers                                                  | n       |
+| `CONFIG_ZMK_WIDGET_MODS_STATUS_CHARACTERS`         | string | Characters to show for each modifier, corresponding to Control/Shift/Alt/GUI respectively | "CSAG"  |
 
 Note that WPM and modifiers widgets are both shown on the bottom right of the display and hence can conflict with each other.
 


### PR DESCRIPTION
This is a barebones modifiers widget for showing the status of active modifiers on the bottom right of the status screen (thus it should not be enabled together with the WPM widget). It only tracks explicit modifiers (is showing implicit modifiers desirable?) but it seems to work well with sticky keys so it should be useful for tracking their state.

The widget can be enabled with `CONFIG_ZMK_WIDGET_MODS_STATUS=y` in your `.conf` file. You can use `CONFIG_ZMK_WIDGET_MODS_STATUS_CHARACTERS` to change the characters displayed for each modifier (one char each, default is `"CSAG"`).

~~Since Zephyr 3.2 has some LVGL changes affecting widgets I'd happy to revisit once it is merged in as well.~~ This has been completed.

Small demo:
![mods](https://user-images.githubusercontent.com/7876996/205185516-81e726a7-5633-4c75-a1d7-459467fcce8d.gif)
