### PR TITLE
feat(display): Add config to show battery level in percentage

### DIFF
--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -15,6 +15,13 @@ config ZMK_WIDGET_BATTERY_STATUS
     default y if BT
     select LVGL_USE_LABEL
 
+if ZMK_WIDGET_BATTERY_STATUS
+
+config ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE
+    bool "Show battery level percentage in text"
+
+endif
+
 config ZMK_WIDGET_OUTPUT_STATUS
     bool "Widget for keyboard output status icons"
     depends on BT && (!ZMK_SPLIT_BLE || ZMK_SPLIT_ROLE_CENTRAL)

--- a/app/src/display/widgets/battery_status.c
+++ b/app/src/display/widgets/battery_status.c
@@ -27,7 +27,7 @@ struct battery_status_state {
 };
 
 static void set_battery_symbol(lv_obj_t *label, struct battery_status_state state) {
-    char text[8] = {};
+    char text[9] = {};
 
     uint8_t level = state.level;
 
@@ -37,6 +37,11 @@ static void set_battery_symbol(lv_obj_t *label, struct battery_status_state stat
     }
 #endif /* IS_ENABLED(CONFIG_USB_DEVICE_STACK) */
 
+#if IS_ENABLED(CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE)
+    char perc[5] = {};
+    snprintf(perc, sizeof(perc), "%3u%%", level);
+    strcat(text, perc);
+#else
     if (level > 95) {
         strcat(text, LV_SYMBOL_BATTERY_FULL);
     } else if (level > 65) {
@@ -48,6 +53,7 @@ static void set_battery_symbol(lv_obj_t *label, struct battery_status_state stat
     } else {
         strcat(text, LV_SYMBOL_BATTERY_EMPTY);
     }
+#endif
     lv_label_set_text(label, text);
     lv_obj_align(label, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
 }

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -14,13 +14,14 @@ Definition files:
 - [zmk/app/src/display/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/Kconfig)
 - [zmk/app/src/display/widgets/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/widgets/Kconfig)
 
-| Config                             | Type | Description                                          | Default |
-| ---------------------------------- | ---- | ---------------------------------------------------- | ------- |
-| `CONFIG_ZMK_DISPLAY`               | bool | Enable support for displays                          | n       |
-| `CONFIG_ZMK_WIDGET_LAYER_STATUS`   | bool | Enable a widget to show the highest, active layer    | y       |
-| `CONFIG_ZMK_WIDGET_BATTERY_STATUS` | bool | Enable a widget to show battery charge information   | y       |
-| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`  | bool | Enable a widget to show the current output (USB/BLE) | y       |
-| `CONFIG_ZMK_WIDGET_WPM_STATUS`     | bool | Enable a widget to show words per minute             | n       |
+| Config                                             | Type | Description                                                    | Default |
+| -------------------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_DISPLAY`                               | bool | Enable support for displays                                    | n       |
+| `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool | Enable a widget to show the highest, active layer              | y       |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool | Enable a widget to show battery charge information             | y       |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool | If battery widget is enabled, show percentage instead of icons | n       |
+| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool | Enable a widget to show the current output (USB/BLE)           | y       |
+| `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool | Enable a widget to show words per minute                       | n       |
 
 If `CONFIG_ZMK_DISPLAY` is enabled, exactly zero or one of the following options must be set to `y`. The first option is used if none are set.
 


### PR DESCRIPTION
Add a new Kconfig `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` for battery status widget. When set, show battery level in percentage text instead of using battery icons.

Unfortunately it looks to me there can be issues with widgets overlapping while charging with nice!view resolution and font sizes. This is an emulation, haven't tested on the actual shield yet:
![image](https://user-images.githubusercontent.com/7876996/205182396-e74aaf79-99e9-449f-8be7-a3ce1531a277.png)
