### PR TITLE
fix(behaviors): Mark sticky key release-after-ms required

### DIFF
--- a/app/dts/bindings/behaviors/zmk,behavior-sticky-key.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-sticky-key.yaml
@@ -13,6 +13,7 @@ properties:
     required: true
   release-after-ms:
     type: int
+    required: true
   quick-release:
     type: boolean
   ignore-modifiers:


### PR DESCRIPTION
While experimenting with custom behaviors based on `zmk,behavior-sticky-key` I noticed that `release-after-ms` is required, and its absence will cause the build to fail.