### PR TITLE
refactor(kscan): batch GPIO reads by port

### DIFF
--- a/app/drivers/kscan/CMakeLists.txt
+++ b/app/drivers/kscan/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_library_named(zmk__drivers__kscan)
 zephyr_library_include_directories(${CMAKE_SOURCE_DIR}/include)
 
 zephyr_library_sources_ifdef(CONFIG_ZMK_KSCAN_GPIO_DRIVER debounce.c)
+zephyr_library_sources_ifdef(CONFIG_ZMK_KSCAN_GPIO_DRIVER kscan_gpio.c)
 zephyr_library_sources_ifdef(CONFIG_ZMK_KSCAN_GPIO_MATRIX kscan_gpio_matrix.c)
 zephyr_library_sources_ifdef(CONFIG_ZMK_KSCAN_GPIO_DIRECT kscan_gpio_direct.c)
 zephyr_library_sources_ifdef(CONFIG_ZMK_KSCAN_GPIO_DEMUX kscan_gpio_demux.c)

--- a/app/drivers/kscan/kscan_gpio.c
+++ b/app/drivers/kscan/kscan_gpio.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "kscan_gpio.h"
+
+#include <stdlib.h>
+
+static int compare_ports(const void *a, const void *b) {
+    const struct kscan_gpio *gpio_a = a;
+    const struct kscan_gpio *gpio_b = b;
+
+    return gpio_a->spec.port - gpio_b->spec.port;
+}
+
+void kscan_gpio_list_sort_by_port(struct kscan_gpio_list *list) {
+    qsort(list->gpios, list->len, sizeof(list->gpios[0]), compare_ports);
+}
+
+int kscan_gpio_pin_get(const struct kscan_gpio *gpio, struct kscan_gpio_port_state *state) {
+    if (gpio->spec.port != state->port) {
+        state->port = gpio->spec.port;
+
+        const int err = gpio_port_get(state->port, &state->value);
+        if (err) {
+            return err;
+        }
+    }
+
+    return (state->value & BIT(gpio->spec.pin)) != 0;
+}

--- a/app/drivers/kscan/kscan_gpio.h
+++ b/app/drivers/kscan/kscan_gpio.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/sys/util.h>
+
+struct kscan_gpio {
+    struct gpio_dt_spec spec;
+    /** The index of the GPIO in the devicetree *-gpios array. */
+    size_t index;
+};
+
+/** GPIO_DT_SPEC_GET_BY_IDX(), but for a struct kscan_gpio. */
+#define KSCAN_GPIO_GET_BY_IDX(node_id, prop, idx)                                                  \
+    ((struct kscan_gpio){.spec = GPIO_DT_SPEC_GET_BY_IDX(node_id, prop, idx), .index = idx})
+
+struct kscan_gpio_list {
+    struct kscan_gpio *gpios;
+    size_t len;
+};
+
+/** Define a kscan_gpio_list from a compile-time GPIO array. */
+#define KSCAN_GPIO_LIST(gpio_array)                                                                \
+    ((struct kscan_gpio_list){.gpios = gpio_array, .len = ARRAY_SIZE(gpio_array)})
+
+struct kscan_gpio_port_state {
+    const struct device *port;
+    gpio_port_value_t value;
+};
+
+/**
+ * Sorts a GPIO list by port so it can be used with kscan_gpio_pin_get().
+ */
+void kscan_gpio_list_sort_by_port(struct kscan_gpio_list *list);
+
+/**
+ * Get logical level of an input pin.
+ *
+ * This is equivalent to gpio_pin_get() except that, when iterating through the
+ * pins in a list which is sorted by kscan_gpio_list_sort_by_port(), it only
+ * performs one read per port instead of one read per pin.
+ *
+ * @param gpio The input pin to read.
+ * @param state An object to track state between reads. Must be zero-initialized before the first
+ * use.
+ *
+ * @retval 1 If pin logical value is 1 / active.
+ * @retval 0 If pin logical value is 0 / inactive.
+ * @retval -EIO I/O error when accessing an external GPIO chip.
+ * @retval -EWOULDBLOCK if operation would block.
+ */
+int kscan_gpio_pin_get(const struct kscan_gpio *gpio, struct kscan_gpio_port_state *state);


### PR DESCRIPTION
This is an alternative solution to #1567 which does not require any dynamic memory.

Changed the GPIO matrix and direct GPIO key scan drivers to do a single read per port instead of one read per pin. This is much more efficient for some types of GPIO drivers, such as I2C GPIO expanders.

To accomplish this with minimal overhead, we now sort input pins by port at driver init. if we iterate through the pins in the sorted order, all pins on the same port are consecutive, so we only need to read each port once the first time we see it.

