### PR TITLE
feat: Add global macro timing configs

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -355,6 +355,14 @@ config ZMK_BEHAVIOR_KEY_TOGGLE
         bool
         default $(dt_compat_enabled,$(DT_COMPAT_ZMK_BEHAVIOR_KEY_TOGGLE))
 
+config ZMK_MACRO_DEFAULT_WAIT_MS
+	int "Default time to wait (in milliseconds) before triggering the next behavior in macros"
+	default 15
+
+config ZMK_MACRO_DEFAULT_TAP_MS
+	int "Default time to wait (in milliseconds) between the press and release events of a tapped behavior in macros"
+	default 30
+
 endmenu
 
 menu "Advanced"

--- a/app/dts/bindings/behaviors/zmk,behavior-macro.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-macro.yaml
@@ -13,9 +13,7 @@ properties:
     required: true
   wait-ms:
     type: int
-    default: 100
     description: The default time to wait (in milliseconds) before triggering the next behavior in the macro bindings list.
   tap-ms:
     type: int
-    default: 100
     description: The default time to wait (in milliseconds) between the press and release events on a tapped macro behavior binding

--- a/app/src/behaviors/behavior_macro.c
+++ b/app/src/behaviors/behavior_macro.c
@@ -174,8 +174,8 @@ static const struct behavior_driver_api behavior_macro_driver_api = {
 #define MACRO_INST(n)                                                                              \
     static struct behavior_macro_state behavior_macro_state_##n = {};                              \
     static struct behavior_macro_config behavior_macro_config_##n = {                              \
-        .default_wait_ms = DT_INST_PROP_OR(n, wait_ms, 100),                                       \
-        .default_tap_ms = DT_INST_PROP_OR(n, tap_ms, 100),                                         \
+        .default_wait_ms = DT_INST_PROP_OR(n, wait_ms, CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS),          \
+        .default_tap_ms = DT_INST_PROP_OR(n, tap_ms, CONFIG_ZMK_MACRO_DEFAULT_TAP_MS),             \
         .count = DT_INST_PROP_LEN(n, bindings),                                                    \
         .bindings = TRANSFORMED_BEHAVIORS(n)};                                                     \
     DEVICE_DT_INST_DEFINE(n, behavior_macro_init, NULL, &behavior_macro_state_##n,                 \

--- a/app/tests/macros/timing-override/keycode_events.snapshot
+++ b/app/tests/macros/timing-override/keycode_events.snapshot
@@ -1,6 +1,6 @@
 queue_process_next: Invoking KEY_PRESS: 0x70004 0x00
 kp_pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-queue_process_next: Processing next queued behavior in 100ms
+queue_process_next: Processing next queued behavior in 30ms
 queue_process_next: Invoking KEY_PRESS: 0x70004 0x00
 kp_released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 50ms

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -120,19 +120,26 @@ Creates a custom behavior which triggers a sequence of other behaviors.
 
 See the [macro behavior](../behaviors/macros.md) documentation for more details and examples.
 
+### Kconfig
+
+| Config                             | Type | Description                            | Default |
+| ---------------------------------- | ---- | -------------------------------------- | ------- |
+| `CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS` | int  | Default value for `wait-ms` in macros. | 15      |
+| `CONFIG_ZMK_MACRO_DEFAULT_TAP_MS`  | int  | Default value for `tap-ms` in macros.  | 30      |
+
 ### Devicetree
 
 Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-macro.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-macro.yaml)
 
 Applies to: `compatible = "zmk,behavior-macro"`
 
-| Property         | Type          | Description                                                                                           | Default |
-| ---------------- | ------------- | ----------------------------------------------------------------------------------------------------- | ------- |
-| `label`          | string        | Unique label for the node                                                                             |         |
-| `#binding-cells` | int           | Must be `<0>`                                                                                         |         |
-| `bindings`       | phandle array | List of behaviors to trigger                                                                          |         |
-| `wait-ms`        | int           | The default time to wait (in milliseconds) before triggering the next behavior.                       | 100     |
-| `tap-ms`         | int           | The default time to wait (in milliseconds) between the press and release events of a tapped behavior. | 100     |
+| Property         | Type          | Description                                                                                           | Default                            |
+| ---------------- | ------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `label`          | string        | Unique label for the node                                                                             |                                    |
+| `#binding-cells` | int           | Must be `<0>`                                                                                         |                                    |
+| `bindings`       | phandle array | List of behaviors to trigger                                                                          |                                    |
+| `wait-ms`        | int           | The default time to wait (in milliseconds) before triggering the next behavior.                       | `CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS` |
+| `tap-ms`         | int           | The default time to wait (in milliseconds) between the press and release events of a tapped behavior. | `CONFIG_ZMK_MACRO_DEFAULT_TAP_MS`  |
 
 The following macro-specific behaviors can be added at any point in the `bindings` list to change how the macro triggers subsequent behaviors.
 


### PR DESCRIPTION
Added `CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS` and `CONFIG_ZMK_MACRO_DEFAULT_TAP_MS` to set global defaults for the wait-ms and tap-ms properties of macros.

Also reduced the default timings for macros, since it's been reported many times that 100 ms is too slow.