### PR TITLE
fix(shields): Fix col-offset for splitkb.com corne

### DIFF
--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_right.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_right.overlay
@@ -40,7 +40,7 @@
 };
 
 &default_transform {
-	col-offset = <5>;
+	col-offset = <6>;
 };
 
 &five_column_transform {


### PR DESCRIPTION
Same column offset for both transforms, since we use the same pins for both, just apply a different transform.

Fixes: 1570
