### PR TITLE
fix(setup): Fix issues for using Corne-ish Zen with the setup scripts

### DIFF
--- a/app/boards/arm/corneish_zen/corneish_zen.conf
+++ b/app/boards/arm/corneish_zen/corneish_zen.conf
@@ -1,0 +1,5 @@
+# Go to sleep after one hour (1*60*60*1000ms)
+CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=3600000
+
+# Turn on logging, and set ZMK logging to debug output
+# CONFIG_ZMK_USB_LOGGING=y

--- a/docs/src/templates/setup.ps1.mustache
+++ b/docs/src/templates/setup.ps1.mustache
@@ -209,27 +209,36 @@ Set-Location "$repo_name"
 
 Push-Location config
 
-$config_file = "${keyboard}.conf"
-$keymap_file = "${keyboard}.keymap"
-
 if ($keyboard_type -eq "shield") {
-    $config_url = "https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/shields/${basedir}/${keyboard}.conf"
-    $keymap_url = "https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/shields/${basedir}/${keyboard}.keymap"
+    $url_base = "https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/shields/${basedir}"
 } else {
-    $config_url = "https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/${keyboard_arch}/${basedir}/${keyboard}.conf"
-    $keymap_url = "https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/${keyboard_arch}/${basedir}/${keyboard}.keymap"
+    $url_base = "https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/${keyboard_arch}/${basedir}"
 }
 
-Write-Host "Downloading config file (${config_url})"
+Write-Host "Downloading config file (${url_base}/${keyboard}.conf)"
 Try {
-    Invoke-RestMethod -Uri "${config_url}" -OutFile "${config_file}"
+    Invoke-RestMethod -Uri "${config_url}" -OutFile "${keyboard}.conf"
 } Catch {
-    Set-Content -Path $config_file "# Place configuration items here"
+    Try {
+        Write-Host "Could not find it, falling back to ${url_base}/${basedir}.conf"
+        Invoke-RestMethod -Uri "${url_base}/${basedir}.conf" -OutFile "${basedir}.conf"
+    } Catch {
+        Set-Content -Path "${keyboard}.conf" "# Put configuration options here"
+    }
 }
 
 if ($copy_keymap -eq "yes") {
-    Write-Host "Downloading keymap file (${keymap_url})"
-    Invoke-RestMethod -Uri "${keymap_url}" -OutFile "${keymap_file}"
+    Write-Host "Downloading keymap file (${url_base}/${keyboard}.keymap)"
+    Try {
+        Invoke-RestMethod -Uri "${url_base}/${keyboard}.keymap" -OutFile "${keyboard}.keymap"
+    } Catch {
+        Write-Host "Could not find it, falling back to ${url_base}/${basedir}.keymap"
+        Try {
+            Invoke-RestMethod -Uri "${url_base}/${basedir}.keymap" -OutFile "${basedir}.keymap"
+        } Catch {
+            Write-Host "Warning: Could not find a keymap file to download!"
+        }
+    }
 }
 
 Pop-Location
@@ -264,7 +273,7 @@ if ($github_repo -ne "") {
         Write-Host "    git remote rm origin"
         Write-Host "    git remote add origin FIXED_URL"
         Write-Host "    git push --set-upstream origin $(git symbolic-ref --short HEAD)"
-        Write-Host "Once pushed, your firmware should be availalbe from GitHub Actions at: $actions"
+        Write-Host "Once pushed, your firmware should be available from GitHub Actions at: $actions"
         exit 1
     }
 

--- a/docs/src/templates/setup.sh.mustache
+++ b/docs/src/templates/setup.sh.mustache
@@ -205,19 +205,23 @@ cd ${repo_name}
 pushd config
 
 if [ "$keyboard_shield" == "y" ]; then
-    config_file="https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/shields/${keyboard_basedir}/${shield}.conf"
-    
-    keymap_file="https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/shields/${keyboard_basedir}/${shield}.keymap"
+    url_base="https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/shields/${keyboard_basedir}"
 else
-    config_file="https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/${keyboard_arch}/${keyboard_basedir}/${board}.conf"
-    keymap_file="https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/${keyboard_arch}/${keyboard_basedir}/${board}.keymap"
+    url_base="https://raw.githubusercontent.com/zmkfirmware/zmk/main/app/boards/${keyboard_arch}/${keyboard_basedir}"
 fi
 
-echo "Downloading config file (${config_file})"
-$download_command "${config_file}" || echo "# Put configuration options here" > "${keyboard}.conf"
+echo "Downloading config file (${url_base}/${keyboard}.conf)"
+if ! $download_command "${url_base}/${keyboard}.conf"; then
+    echo "Could not find it, falling back to ${url_base}/${keyboard_basedir}.conf"
+    $download_command "${url_base}/${keyboard_basedir}.conf" || echo "# Put configuration options here" > "${keyboard}.conf"
+fi
+
 if [ "$copy_keymap" == "yes" ]; then
-    echo "Downloading keymap file (${keymap_file})"
-    $download_command "${keymap_file}"
+    echo "Downloading keymap file (${url_base}/${keyboard}.keymap)"
+    if ! $download_command "${url_base}/${keyboard}.keymap"; then
+        echo "Could not find it, falling back to ${url_base}/${keyboard_basedir}.keymap"
+        $download_command "${url_base}/${keyboard_basedir}.keymap" || echo "Warning: Could not find a keymap file to download!"
+    fi
 fi
 
 popd
@@ -254,7 +258,7 @@ if [ -n "$github_repo" ]; then
         echo "    git remote rm origin"
         echo "    git remote add origin FIXED_URL"
         echo "    git push --set-upstream origin $(git symbolic-ref --short HEAD)"
-        echo "Once pushed, your firmware should be availalbe from GitHub Actions at: ${github_repo%.git}/actions"
+        echo "Once pushed, your firmware should be available from GitHub Actions at: ${github_repo%.git}/actions"
         exit 1
     fi
 


### PR DESCRIPTION
- Add the `.conf` file from the [official config repo](https://github.com/LOWPROKB/zmk-config-zen-2/blob/main/config/corneish_zen.conf) so that the ZMK setup script can copy it to the user config folder and the produced repo can match the official config repo
- Make setup scripts also look for `keyboard_dir.{keymap,conf}` files, so that for revisioned board/shields like `corneish_zen_v2` we can retrieve `corneish_zen.keymap` and `corneish_zen.conf` files if the versioned filenames don't exist