### PR TITLE
fix(setup): Fix conf download path in PS script

### DIFF
--- a/docs/src/templates/setup.ps1.mustache
+++ b/docs/src/templates/setup.ps1.mustache
@@ -217,7 +217,7 @@ if ($keyboard_type -eq "shield") {
 
 Write-Host "Downloading config file (${url_base}/${keyboard}.conf)"
 Try {
-    Invoke-RestMethod -Uri "${config_url}" -OutFile "${keyboard}.conf"
+    Invoke-RestMethod -Uri "${url_base}/${keyboard}.conf" -OutFile "${keyboard}.conf"
 } Catch {
     Try {
         Write-Host "Could not find it, falling back to ${url_base}/${basedir}.conf"


### PR DESCRIPTION
This is a hotfix for a typo in b8fb218a where I forgot to change a variable name.