### PR TITLE
fix(display): Re-default to blank on idle for OLEDs

### DIFF
--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -6,13 +6,14 @@ menuconfig ZMK_DISPLAY
     default n
     select DISPLAY
     select LVGL
-	select LVGL_THEMES
-	select LVGL_THEME_MONO
+    select LVGL_THEMES
+    select LVGL_THEME_MONO
 
 if ZMK_DISPLAY
 
 config ZMK_DISPLAY_BLANK_ON_IDLE
     bool "Blank display on idle"
+    default y if SSD1306
 
 choice LVGL_TXT_ENC
     default LVGL_TXT_ENC_UTF8


### PR DESCRIPTION
Default to blanking displays on idle like before https://github.com/zmkfirmware/zmk/commit/4a3e783f3212e584e86494db2af8e30f362ecace#diff-1b9b4413fe6b7fbc88f0437fdd6b38c3717f2dede8faa249a16bbd1ae04cb4cb for OLED displays. See [user question on Discord](https://discord.com/channels/719497620560543766/1053852659842547762) where this came up.

Also there is a tiny tab-to-spaces consistency fix in the same file.

Let me know if there is a better way to do this. One other way would be to add it to all the shield Kconfigs that use OLEDs (but not sure if that would interfere with `nice_view` being able to disable it). Another way might be to default to `y` as before but disable it in `corneish_zen_*_defconfig` (rather than `Kconfig.defconfig` -- I don't know why that wasn't initially preferred and haven't tried if that would work).

I tested this on `corneish_zen_v2_left` board (no change), `corne_left` with `CONFIG_ZMK_DISPLAY=y` (correctly enabled) `corne_left nice_view_adapter nice_view` shield (no change).