### PR TITLE
fix(docs): added property to disable status of encoder in dtsi for a new shield.

### DIFF
--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -461,6 +461,7 @@ left_encoder: encoder_left {
 		a-gpios = <PIN_A (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
 		b-gpios = <PIN_B (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
 		resolution = <4>;
+		status = "disabled";
 	};
 ```
 


### PR DESCRIPTION
**Documentation update**: added property to disable status of encoder in dtsi for a new shield. Per my experience of creating a new shield, encoders wouldn't work unless disabled in dtsi and then enabled through config.