### PR TITLE
fix(driver): Fix potentially buggy read/write routines for max7318 driver

### DIFF
--- a/app/drivers/gpio/gpio_max7318.c
+++ b/app/drivers/gpio/gpio_max7318.c
@@ -72,17 +72,19 @@ struct max7318_drv_data {
 static int read_registers(const struct device *dev, uint8_t reg, uint16_t *buf) {
     const struct max7318_config *config = dev->config;
 
-    uint16_t data = 0;
-    int ret = i2c_burst_read_dt(&config->i2c_bus, reg, (uint8_t *)&data, sizeof(data));
+    uint8_t data[2] = { 0 };
+    int ret = i2c_burst_read_dt(&config->i2c_bus, reg, &data[0], sizeof(data));
     if (ret) {
-        LOG_DBG("i2c_write_read FAIL %d\n", ret);
+        LOG_DBG("i2c_burst_read FAIL %d\n", ret);
         return ret;
     }
 
-    *buf = sys_le16_to_cpu(data);
+    // the first register is data[0], the second one is data[1]
+    // since we only ever read the PORTA registers here, it's effectively little endian.
+    *buf = sys_get_le16(data);
 
-    LOG_DBG("max7318: read: reg[0x%X] = 0x%X, reg[0x%X] = 0x%X", reg, (*buf & 0xFF), (reg + 1),
-            (*buf >> 8));
+    LOG_DBG("max7318: read: reg[0x%X] = 0x%X, reg[0x%X] = 0x%X", reg, data[0], (reg + 1),
+            data[1]);
 
     return 0;
 }
@@ -105,9 +107,13 @@ static int write_registers(const struct device *dev, uint8_t reg, uint16_t value
     LOG_DBG("max7318: write: reg[0x%X] = 0x%X, reg[0x%X] = 0x%X", reg, (value & 0xFF), (reg + 1),
             (value >> 8));
 
-    uint16_t data = sys_cpu_to_le16(value);
+    uint8_t data[2] = { 0 };
 
-    return i2c_burst_write_dt(&config->i2c_bus, reg, (uint8_t *)&data, sizeof(data));
+    // bits 0..7 are port A, 8..15 are port B, so we should write bits 0..7 first
+    // -- ie. this is little endian also.
+    sys_put_le16(value, &data[0]);
+
+    return i2c_burst_write_dt(&config->i2c_bus, reg, &data[0], sizeof(data));
 }
 
 /**

--- a/app/drivers/gpio/gpio_max7318.c
+++ b/app/drivers/gpio/gpio_max7318.c
@@ -72,7 +72,7 @@ struct max7318_drv_data {
 static int read_registers(const struct device *dev, uint8_t reg, uint16_t *buf) {
     const struct max7318_config *config = dev->config;
 
-    uint8_t data[2] = { 0 };
+    uint8_t data[2] = {0};
     int ret = i2c_burst_read_dt(&config->i2c_bus, reg, &data[0], sizeof(data));
     if (ret) {
         LOG_DBG("i2c_burst_read FAIL %d\n", ret);
@@ -83,8 +83,7 @@ static int read_registers(const struct device *dev, uint8_t reg, uint16_t *buf) 
     // since we only ever read the PORTA registers here, it's effectively little endian.
     *buf = sys_get_le16(data);
 
-    LOG_DBG("max7318: read: reg[0x%X] = 0x%X, reg[0x%X] = 0x%X", reg, data[0], (reg + 1),
-            data[1]);
+    LOG_DBG("max7318: read: reg[0x%X] = 0x%X, reg[0x%X] = 0x%X", reg, data[0], (reg + 1), data[1]);
 
     return 0;
 }
@@ -107,7 +106,7 @@ static int write_registers(const struct device *dev, uint8_t reg, uint16_t value
     LOG_DBG("max7318: write: reg[0x%X] = 0x%X, reg[0x%X] = 0x%X", reg, (value & 0xFF), (reg + 1),
             (value >> 8));
 
-    uint8_t data[2] = { 0 };
+    uint8_t data[2] = {0};
 
     // bits 0..7 are port A, 8..15 are port B, so we should write bits 0..7 first
     // -- ie. this is little endian also.


### PR DESCRIPTION
Fix the potentially buggy implementation in I2C read/write routines in the MAX7318 driver. It used the same style of read/write as #1301, which was identified as buggy.

While nobody has yet raised an issue about it, this PR changes the register read/write functions to use the same (correct) style as the fix in #1301.