### PR TITLE
Begin adding Pinky4

### DIFF
--- a/app/boards/shields/pinky4/Kconfig.defconfig
+++ b/app/boards/shields/pinky4/Kconfig.defconfig
@@ -1,0 +1,49 @@
+# Copyright (c) 2022 Shawn Rutledge
+# SPDX-License-Identifier: MIT
+
+if SHIELD_PINKY4_LEFT
+
+config ZMK_KEYBOARD_NAME
+	default "Pinky4"
+
+config ZMK_SPLIT_ROLE_CENTRAL
+	default y
+
+endif
+
+if SHIELD_PINKY4_LEFT || SHIELD_PINKY4_RIGHT
+
+config ZMK_SPLIT
+	default y
+
+if ZMK_DISPLAY
+
+config I2C
+	default y
+
+config SSD1306
+	default y
+
+config SSD1306_REVERSE_MODE
+	default y
+
+endif # ZMK_DISPLAY
+
+if LVGL
+
+config LVGL_VDB_SIZE
+	default 64
+
+config LVGL_DPI
+	default 148
+
+config LVGL_BITS_PER_PIXEL
+	default 1
+
+choice LVGL_COLOR_DEPTH
+	default LVGL_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL
+
+endif # SHIELD_PINKY4_LEFT || SHIELD_PINKY4_RIGHT

--- a/app/boards/shields/pinky4/Kconfig.shield
+++ b/app/boards/shields/pinky4/Kconfig.shield
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Shawn Rutledge
+# SPDX-License-Identifier: MIT
+
+config SHIELD_PINKY4_LEFT
+	def_bool $(shields_list_contains,pinky4_left)
+
+config SHIELD_PINKY4_RIGHT
+	def_bool $(shields_list_contains,pinky4_right)

--- a/app/boards/shields/pinky4/pinky4.conf
+++ b/app/boards/shields/pinky4/pinky4.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2022 Shawn Rutledge
+# SPDX-License-Identifier: MIT
+
+# Uncomment the following line to enable the Pinky4 OLED Display
+# CONFIG_ZMK_DISPLAY=y

--- a/app/boards/shields/pinky4/pinky4.dtsi
+++ b/app/boards/shields/pinky4/pinky4.dtsi
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 Pete Johanson, Ryan Cross
+ * Copyright (c) 2022 Shawn Rutledge
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zephyr,display = &oled;
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <16>;
+        rows = <5>;
+// | SW29 | SW24 | SW19 | SW14 | SW10 | SW6  | SW2  |  | SW2  | SW6  | SW10 | SW14 | SW19 | SW24 | SW29 |
+// | SW30 | SW25 | SW20 | SW15 | SW11 | SW7  | SW3  |  | SW3  | SW7  | SW11 | SW15 | SW20 | SW25 | SW30 |
+// | SW31 | SW26 | SW21 | SW16 | SW12 | SW8  | SW4  |  | SW4  | SW8  | SW12 | SW16 | SW21 | SW26 | SW31 |
+// | SW32 | SW27 | SW22 | SW17 | SW13 | SW9  | SW5  |  | SW5  | SW9  | SW13 | SW17 | SW22 | SW27 | SW32 |
+//                      | SW33 | SW28 | SW23 | SW18 |  | SW18 | SW23 | SW28 | SW33 |
+        map = <
+RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6)  RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12) RC(0,13)
+RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6)  RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12) RC(1,13)
+RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6)  RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11) RC(2,12) RC(2,13)
+RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6)  RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11) RC(3,12) RC(3,13)
+                        RC(4,3) RC(4,4) RC(4,5) RC(4,6)  RC(4,7) RC(4,8) RC(4,9) RC(4,10)
+        >;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+
+        diode-direction = "col2row";
+        row-gpios
+            = <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row 0 from the schematic
+            , <&pro_micro 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row 1
+            , <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row 2
+            , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row 3
+            , <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row 4
+            ;
+    };
+};
+
+&pro_micro_i2c {
+    status = "okay";
+
+    oled: ssd1306@3c {
+        compatible = "solomon,ssd1306fb";
+        reg = <0x3c>;
+        label = "DISPLAY";
+        width = <128>;
+        height = <32>;
+        segment-offset = <0>;
+        page-offset = <0>;
+        display-offset = <0>;
+        multiplex-ratio = <31>;
+        segment-remap;
+        com-invdir;
+        com-sequential;
+        prechargep = <0x22>;
+    };
+};

--- a/app/boards/shields/pinky4/pinky4.keymap
+++ b/app/boards/shields/pinky4/pinky4.keymap
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+// ----------------------------------------------------------------------------------------------------
+// |  ESC  |  1  |  2  |  3   |  4   |  5   |  (   |   |  )   |  6  |  7   |  8  |  9  |   0  | BKSPC |
+// |  TAB  |  Q  |  W  |  E   |  R   |  T   |  [   |   |  ]   |  Y  |  U   |  I  |  O  |   P  |   \   |
+// |  CTRL |  A  |  S  |  D   |  F   |  G   |  {   |   |  }   |  H  |  J   |  K  |  L  |   ;  |   '   |
+// | SHIFT |  Z  |  X  |  C   |  V   |  B   |  ADJ |   |  ADJ |  N  |  M   |  ,  |  .  |   /  | ENTER |
+//                     | ALT  | LOWER| GUI  | SPACE|   | SPACE| GUI | RAISE| ALT |
+            bindings = <
+&kp GRAVE &kp N1 &kp N2   &kp N3   &kp N4  &kp N5   &kp LPAR   &kp RPAR  &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp BSPC
+&kp ESC   &kp Q  &kp W    &kp E    &kp R   &kp T    &kp LBKT   &kp RBKT  &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
+&kp TAB   &kp A  &kp S    &kp D    &kp F   &kp G    &kp LBRC   &kp RBRC  &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
+&kp LSHFT &kp Z  &kp X    &kp C    &kp V   &kp B    &mo 1      &mo 1     &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp ENTER
+                          &kp LALT &mo 2   &kp LGUI &kp SPACE  &kp SPACE &kp RGUI &mo 1 &kp RALT
+            >;
+        };
+
+// ADJ layer is temporary RAISE
+        raise_layer {
+// ---------------------------------------------------------------------------------------------------
+// |     |  F1 |  F2 |  F3  |  F4  |  F5  |     |   |     |  F6  |  F7   |  F8  |  F9  |  F10 |      |
+// |     |     |     |      |      |      |     |   |     |      |       |      |  F11 |  F12 |      |
+// |     |     |     |      |      |      |     |   |     | HOME | PGDN  | PGUP | END  |      |      |
+// |     |     |     |      |      |      |     |   |     |      |       |      |      |      |      |
+//                   |      |      |      |     |   |     |      |       |      |
+            bindings = <
+&trans    &kp F1    &kp F2    &kp F3   &kp F4    &kp F5    &trans     &trans &kp F6    &kp F7   &kp F8     &kp F9    &kp F10 &trans
+&trans    &trans    &trans    &trans   &trans    &trans    &trans     &trans &trans    &trans   &trans     &kp F11   &kp F12 &trans
+&trans    &trans    &trans    &trans   &trans    &trans    &trans     &trans &kp HOME  &kp PG_DN &kp PG_UP &kp END   &trans  &trans
+&trans    &trans    &trans    &trans   &trans    &trans    &trans     &trans &trans    &trans   &trans     &trans    &trans  &trans
+                              &trans   &trans    &trans    &trans     &trans &trans    &trans   &trans
+            >;
+        };
+
+        lower_layer {
+// ------------------------------------------------------------------------------------------------------------
+// |GRAVE| BT1  | BT2  |  BT3  |  BT4  |  BT5 | BTCLR|   |      |      |       |      | MINUS | EQUAL |       |
+// |     |      |      |       |       |      |      |   |      |      |       |      |       |       |       |
+// |     |      |      |       |       |      |      |   |      |      |       |      |       |       |       |
+// |     |      |      |       |       |      |      |   |      |      |       |      |       |       |       |
+//              |      |       |       |      |      |   |      |      |       |      |
+            bindings = <
+&kp GRAVE &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &bt BT_CLR    &trans   &trans   &trans   &trans &kp MINUS &kp EQUAL &trans
+&trans   &trans       &trans       &trans       &trans       &trans       &trans         &trans   &trans   &trans   &trans   &trans  &trans    &trans
+&trans   &trans       &trans       &trans       &trans       &trans       &trans         &trans   &trans   &trans   &trans   &trans  &trans    &trans
+&trans   &trans       &trans       &trans       &trans       &trans       &trans         &trans   &trans   &trans   &trans   &trans  &trans    &trans
+                                   &trans       &trans       &trans       &trans         &trans   &trans   &trans   &trans
+            >;
+        };
+    };
+};

--- a/app/boards/shields/pinky4/pinky4.zmk.yml
+++ b/app/boards/shields/pinky4/pinky4.zmk.yml
@@ -1,0 +1,13 @@
+file_format: "1"
+id: pinky4
+name: Pinky4
+type: shield
+url: https://github.com/tamanishi/Pinky4
+requires: [pro_micro]
+exposes: [i2c_oled]
+features:
+  - keys
+  - display
+siblings:
+  - pinky4_left
+  - pinky4_right

--- a/app/boards/shields/pinky4/pinky4_left.conf
+++ b/app/boards/shields/pinky4/pinky4_left.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2022 Shawn Rutledge
+# SPDX-License-Identifier: MIT

--- a/app/boards/shields/pinky4/pinky4_left.overlay
+++ b/app/boards/shields/pinky4/pinky4_left.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Shawn Rutledge
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "pinky4.dtsi"
+
+&kscan0 {
+	col-gpios
+		= <&pro_micro 21 GPIO_ACTIVE_HIGH> // col0 in the schematic
+		, <&pro_micro 20 GPIO_ACTIVE_HIGH> // col1
+		, <&pro_micro 19 GPIO_ACTIVE_HIGH> // col2
+		, <&pro_micro 18 GPIO_ACTIVE_HIGH> // col3
+		, <&pro_micro 15 GPIO_ACTIVE_HIGH> // col4
+		, <&pro_micro 14 GPIO_ACTIVE_HIGH> // col5
+		, <&pro_micro 16 GPIO_ACTIVE_HIGH> // col6
+		;
+};

--- a/app/boards/shields/pinky4/pinky4_right.conf
+++ b/app/boards/shields/pinky4/pinky4_right.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2022 Shawn Rutledge
+# SPDX-License-Identifier: MIT

--- a/app/boards/shields/pinky4/pinky4_right.overlay
+++ b/app/boards/shields/pinky4/pinky4_right.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Shawn Rutledge
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "pinky4.dtsi"
+
+&default_transform {
+	col-offset = <7>;
+};
+
+&kscan0 {
+	col-gpios
+		= <&pro_micro 16 GPIO_ACTIVE_HIGH> // col6 in the schematic
+		, <&pro_micro 14 GPIO_ACTIVE_HIGH> // col5
+		, <&pro_micro 15 GPIO_ACTIVE_HIGH> // col4
+		, <&pro_micro 18 GPIO_ACTIVE_HIGH> // col3
+		, <&pro_micro 19 GPIO_ACTIVE_HIGH> // col2
+		, <&pro_micro 20 GPIO_ACTIVE_HIGH> // col1
+		, <&pro_micro 21 GPIO_ACTIVE_HIGH> // col0
+		;
+};


### PR DESCRIPTION
Copied Sofle and modified.

I left the code for display features intact, because I suspect an OLED will work if wired in manually, but I didn't test that.

Default keymap like that of QMK to the extent that I understand (not a keymap I want to use though).  Customization recommended.

Fixes #1604

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [x] If split, no name added for the right/peripheral half
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
