### PR TITLE
fix(behaviors): allow saving sticky keys with the same position

### DIFF
--- a/app/tests/sticky-keys/11-sl-sk-macro/events.patterns
+++ b/app/tests/sticky-keys/11-sl-sk-macro/events.patterns
@@ -1,0 +1,1 @@
+s/.*hid_listener_keycode_//p

--- a/app/tests/sticky-keys/11-sl-sk-macro/keycode_events.snapshot
+++ b/app/tests/sticky-keys/11-sl-sk-macro/keycode_events.snapshot
@@ -1,0 +1,4 @@
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/sticky-keys/11-sl-sk-macro/native_posix_64.keymap
+++ b/app/tests/sticky-keys/11-sl-sk-macro/native_posix_64.keymap
@@ -1,0 +1,54 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+&sl {
+    ignore-modifiers;
+};
+
+/ {
+    macros {
+        sls: sls {
+            label = "sticky_layer_shift";
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <1>;
+            bindings
+                = <&sl 1 &sk LSHFT>;
+        };
+    };
+
+	keymap {
+		compatible = "zmk,keymap";
+		label ="Default keymap";
+
+		default_layer {
+			bindings = <
+				&sls  &kp A
+				&sl 1 &sk LSHFT
+            >;
+		};
+
+		second_layer {
+			bindings = <
+				&trans &kp B
+				&trans &trans
+            >;
+		};
+	};
+};
+
+
+&kscan {
+	events = <
+		ZMK_MOCK_PRESS(0,0,10)  // macro should produce same as sl followd by sk
+		ZMK_MOCK_RELEASE(0,0,10)
+//		ZMK_MOCK_PRESS(1,0,10)
+//		ZMK_MOCK_RELEASE(1,0,10)
+//		ZMK_MOCK_PRESS(1,1,10)
+//		ZMK_MOCK_RELEASE(1,1,10)
+		ZMK_MOCK_PRESS(0,1,10)
+		ZMK_MOCK_RELEASE(0,1,10)
+	>;
+};


### PR DESCRIPTION
When a sticky key is pressed, a duplicated sticky key will be searched for and released. However, currently only `position` is used to search for a sticky key, which causes issues because keys with different layers may have the same position.

Adding checks on both `position` and `layer` is not enough because key events generated by macro have the same position and layer.
7a4f3a261d0c0f6816553727acb45f6ac05d15ad

I have been considering that two sticky keys `&sk LEFT_SHIFT` at different positions should be treated as the same sticky key. The use of `position` or `layer` is not necessary because `param1` has keycode, usage page, and mods, which are sufficient to identify sticky keys.

Fix #1421 
