### PR TITLE
bugfix: sticky keys held for longer than `release-after-ms` get stuck

### DIFF
--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -167,9 +167,8 @@ static int on_sticky_key_binding_released(struct zmk_behavior_binding *binding,
     sticky_key->release_at = event.timestamp + sticky_key->config->release_after_ms;
     // adjust timer in case this behavior was queued by a hold-tap
     int32_t ms_left = sticky_key->release_at - k_uptime_get();
-    if (ms_left > 0) {
-        k_work_schedule(&sticky_key->release_timer, K_MSEC(ms_left));
-    }
+    ms_left = ms_left > 0 ? ms_left : 1;
+    k_work_schedule(&sticky_key->release_timer, K_MSEC(ms_left));
     return ZMK_BEHAVIOR_OPAQUE;
 }
 


### PR DESCRIPTION
Sticky keys work to modify the next keypress, but also have utility in being held to achieve certain behaviours such as making multiple selections with a mouse. The current implementation of sticky keys does not account for the case where a sticky key is held longer than `release-after-ms`. In this case, the sticky key gets stuck. 

This PR proposes releasing the sticky key 1ms after the key is released if `release-after-ms` has lapsed during the hold, so that the sticky key behaves like a momentary key for long holds. 

I have tested this for the past few days and have found it fixes my use cases.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [ ] This board/shield is tested working on real hardware
 - [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [ ] `.zmk.yml` metadata file added
 - [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [ ] General consistent formatting of DeviceTree files
 - [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [ ] If split, no name added for the right/peripheral half
 - [ ] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [ ] `.conf` file has optional extra features commented out
 - [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
