### PR TITLE
chore(build): update west.yml syntax

### DIFF
--- a/app/west.yml
+++ b/app/west.yml
@@ -10,8 +10,7 @@ manifest:
       revision: v3.0.0+zmk-fixes
       clone-depth: 1
       import:
-        # TODO: Rename once upstream offers option like `exclude` or `denylist`
-        name-blacklist:
+        name-blocklist:
           - ci-tools
           - hal_altera
           - hal_cypress


### PR DESCRIPTION
West has supported a 'name-blocklist' replacement for 'name-blacklist' since v0.9.

