### PR TITLE
feat(docs): additional note on bug fixed in macOS v13.1

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -23,7 +23,7 @@ Variations of the warnings shown below occur when flashing the `<firmware>.uf2` 
 
 ### macOS Ventura error
 
-macOS 13.0 (Ventura) Finder may report an error code 100093 when copying `<firmware>.uf2` files into microcontrollers. This bug is limited to the operating system's Finder. You can work around it by copying on Terminal command line or use a third party file manager.
+macOS 13.0 (Ventura) Finder may report an error code 100093 when copying `<firmware>.uf2` files into microcontrollers. This bug is limited to the operating system's Finder. You can work around it by copying on Terminal command line or use a third party file manager. Issue is fixed in macOS version 13.1.
 
 ### CMake Error
 


### PR DESCRIPTION
Add a note to indicate that the Ventura uf2 bug is fixed in version 13.1
