### PR TITLE
refactor(encoder): use behavior queue to archive key taps for encoder

### DIFF
--- a/app/src/behavior_queue.c
+++ b/app/src/behavior_queue.c
@@ -51,7 +51,7 @@ static void behavior_queue_process_next(struct k_work *work) {
 
 int zmk_behavior_queue_add(uint32_t position, const struct zmk_behavior_binding binding, bool press,
                            uint32_t wait) {
-    struct q_item item = {.press = press, .binding = binding, .wait = wait};
+    struct q_item item = {.position = position, .press = press, .binding = binding, .wait = wait};
 
     const int ret = k_msgq_put(&zmk_behavior_queue_msgq, &item, K_NO_WAIT);
     if (ret < 0) {

--- a/app/src/behaviors/behavior_sensor_rotate_key_press.c
+++ b/app/src/behaviors/behavior_sensor_rotate_key_press.c
@@ -11,6 +11,7 @@
 #include <logging/log.h>
 
 #include <drivers/sensor.h>
+#include <zmk/behavior_queue.h>
 #include <zmk/event_manager.h>
 #include <zmk/events/keycode_state_changed.h>
 
@@ -20,11 +21,47 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 static int behavior_sensor_rotate_key_press_init(const struct device *dev) { return 0; };
 
+static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
+    uint32_t keycode;
+
+    switch (event.position) {
+    case 1:
+        keycode = binding->param1;
+        break;
+    case 2:
+        keycode = binding->param2;
+        break;
+    default:
+        return -ENOTSUP;
+    }
+
+    return ZMK_EVENT_RAISE(zmk_keycode_state_changed_from_encoded(keycode, true, event.timestamp));
+}
+
+static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
+    uint32_t keycode;
+
+    switch (event.position) {
+    case 1:
+        keycode = binding->param1;
+        break;
+    case 2:
+        keycode = binding->param2;
+        break;
+    default:
+        return -ENOTSUP;
+    }
+
+    return ZMK_EVENT_RAISE(zmk_keycode_state_changed_from_encoded(keycode, false, event.timestamp));
+}
+
 static int on_sensor_binding_triggered(struct zmk_behavior_binding *binding,
                                        const struct device *sensor, int64_t timestamp) {
     struct sensor_value value;
     int err;
-    uint32_t keycode;
+    uint32_t keycode_position;
     LOG_DBG("inc keycode 0x%02X dec keycode 0x%02X", binding->param1, binding->param2);
 
     err = sensor_channel_get(sensor, SENSOR_CHAN_ROTATION, &value);
@@ -36,26 +73,22 @@ static int on_sensor_binding_triggered(struct zmk_behavior_binding *binding,
 
     switch (value.val1) {
     case 1:
-        keycode = binding->param1;
+        keycode_position = 1;
         break;
     case -1:
-        keycode = binding->param2;
+        keycode_position = 2;
         break;
     default:
         return -ENOTSUP;
     }
 
-    LOG_DBG("SEND %d", keycode);
-
-    ZMK_EVENT_RAISE(zmk_keycode_state_changed_from_encoded(keycode, true, timestamp));
-
-    // TODO: Better way to do this?
-    k_msleep(5);
-
-    return ZMK_EVENT_RAISE(zmk_keycode_state_changed_from_encoded(keycode, false, timestamp));
+    zmk_behavior_queue_add(keycode_position, *binding, true, 20);
+    return zmk_behavior_queue_add(keycode_position, *binding, false, 20);
 }
 
 static const struct behavior_driver_api behavior_sensor_rotate_key_press_driver_api = {
+    .binding_pressed = on_keymap_binding_pressed,
+    .binding_released = on_keymap_binding_released,
     .sensor_binding_triggered = on_sensor_binding_triggered};
 
 #define KP_INST(n)                                                                                 \


### PR DESCRIPTION
Remove k_msleep() call used in sensor trigger callback that's meant to simulate a key tap (press and release), instead we can use the existing behavior queue mechanism, where a press and a release events are queued up separately. The trick is to add .binging_pressed and .binding_released callbacks for the sensor driver api, which will get called when the queued events are processed accordingly.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [ ] This board/shield is tested working on real hardware
 - [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [ ] `.zmk.yml` metadata file added
 - [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [ ] General consistent formatting of DeviceTree files
 - [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [ ] If split, no name added for the right/peripheral half
 - [ ] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [ ] `.conf` file has optional extra features commented out
 - [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
