### PR TITLE
fix(underglow): Do not save on/off state during auto state change

### DIFF
--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -299,7 +299,7 @@ int zmk_rgb_underglow_get_state(bool *on_off) {
     return 0;
 }
 
-int zmk_rgb_underglow_on() {
+static int zmk_rgb_underglow_on_immediate() {
     if (!led_strip)
         return -ENODEV;
 
@@ -316,10 +316,15 @@ int zmk_rgb_underglow_on() {
     state.animation_step = 0;
     k_timer_start(&underglow_tick, K_NO_WAIT, K_MSEC(50));
 
+    return 0;
+}
+
+int zmk_rgb_underglow_on() {
+    zmk_rgb_underglow_on_immediate();
     return zmk_rgb_underglow_save_state();
 }
 
-int zmk_rgb_underglow_off() {
+static int zmk_rgb_underglow_off_immediate() {
     if (!led_strip)
         return -ENODEV;
 
@@ -341,6 +346,11 @@ int zmk_rgb_underglow_off() {
     k_timer_stop(&underglow_tick);
     state.on = false;
 
+    return 0;
+}
+
+int zmk_rgb_underglow_off() {
+    zmk_rgb_underglow_off_immediate();
     return zmk_rgb_underglow_save_state();
 }
 
@@ -465,11 +475,11 @@ static int rgb_underglow_auto_state(bool *prev_state, bool new_state) {
     if (new_state) {
         state.on = *prev_state;
         *prev_state = false;
-        return zmk_rgb_underglow_on();
+        return zmk_rgb_underglow_on_immediate();
     } else {
         state.on = false;
         *prev_state = true;
-        return zmk_rgb_underglow_off();
+        return zmk_rgb_underglow_off_immediate();
     }
 }
 


### PR DESCRIPTION
When CONFIG_ZMK_RGB_UNDERGLOW_AUTO_OFF_IDLE is enabled, the RGB underglow turns off and on every time the keyboard goes idle or becomes active. However, this causes the on/off state of the underglow to be saved to the storage frequently, which can lead to unnecessary write operations.

To address this issue, this commit separates `zmk_rgb_underglow_on` and `zmk_rgb_underglow_off` into non-persistent versions that can be used in `rgb_underglow_auto_state`.