### PR TITLE
Typo: tap => hold

### DIFF
--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -159,7 +159,7 @@ The following are suggested hold-tap configurations that work well with home row
 			label = "LEFT_POSITIONAL_HOLD_TAP";
 			#binding-cells = <2>;
 			flavor = "tap-unless-interrupted";
-			tapping-term-ms = <100>;                        // <---[[produces tap if held longer than tapping-term-ms]]
+			tapping-term-ms = <100>;                        // <---[[produces hold if held longer than tapping-term-ms]]
 			quick-tap-ms = <200>;
 			bindings = <&kp>, <&kp>;
 			hold-trigger-key-positions = <5 6 7 8 9 10>;    // <---[[right-hand keys]]


### PR DESCRIPTION
This PR contains a fix to a little typo in the documentation.

In the Hold-Tap section, one of the examples states:

```
tapping-term-ms = <100>;                        // <---[[produces tap if held longer than tapping-term-ms]]
```

I believe this is incorrect: if a key is held longer than `tapping-term-ms`, it has the "hold" behavior, not the tap. 