### PR TITLE
fix(hold-tap binding) Mark tapping-term-ms as required

### DIFF
--- a/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
@@ -13,6 +13,7 @@ properties:
     required: true
   tapping-term-ms:
     type: int
+    required: true
   tapping_term_ms: # deprecated
     type: int
   quick-tap-ms:


### PR DESCRIPTION
I think this is the last instance of a behavior property being required but not marked as such.

Looking through the other yaml files the only other instances of properties not marked as required and not specifying a default in the definition are:

- caps word's `mods` so the modifiers can be referenced by identifier, and
- macros (where the defaults can come from kconfig)