### PR TITLE
fix(shields) correct chosen property name for matrix transform

### DIFF
--- a/app/boards/shields/zmk_uno/zmk_uno.overlay
+++ b/app/boards/shields/zmk_uno/zmk_uno.overlay
@@ -36,7 +36,7 @@
 		zmk,kscan = &kscan_matrix_comp;
 		zmk,backlight = &backlight;
 		zmk,underglow = &led_strip;
-		zmk,matrix-transform = &matrix_transform;
+		zmk,matrix_transform = &matrix_transform;
 	};
 
 	// Commented out until we add more powerful power domain support


### PR DESCRIPTION
I've noticed some users experiencing confusing behaviors that come down to typos in chosen node property names or in compatible property values so I wrote a script to find unrecognized names/values beginning with the ZMK vendor prefix.

I'm not sure how best to incorporate it into the ZMK repo but just running it against existing boards and shields I found this issue. The build is still successful without a matrix transform selected and may even map correctly, but in my use case the selected matrix transform is parsed to generate a graphical layout so I get very different results.

Edit: I'm actually not positive whether this is an issue from ZMK's perspective. Does Zephyr automatically map `zmk_matrix_transform` to `zmk,matrix-transform`/`zmk,matrix_transform`? If that's the case then this PR would just be a question of consistency as all other boards (and the ZMK documentation) use the underscore version.