### PR TITLE
fix(tests): Fix line endings causing tests to fail in Docker on Windows

### DIFF
--- a/app/run-test.sh
+++ b/app/run-test.sh
@@ -33,7 +33,7 @@ if [ $? -gt 0 ]; then
 fi
 
 ./build/$testcase/zephyr/zmk.exe | sed -e "s/.*> //" | tee build/$testcase/keycode_events_full.log | sed -n -f $testcase/events.patterns > build/$testcase/keycode_events.log
-diff -au $testcase/keycode_events.snapshot build/$testcase/keycode_events.log
+diff -auZ $testcase/keycode_events.snapshot build/$testcase/keycode_events.log
 if [ $? -gt 0 ]; then
 	if [ -f $testcase/pending ]; then
 		echo "PENDING: $testcase" | tee -a ./build/tests/pass-fail.log


### PR DESCRIPTION
Running tests from within Docker on Windows results in failed tests due to mismatched line endings:

```lang=bash
Running tests/backlight/basic:
--- tests/backlight/basic/keycode_events.snapshot       2023-03-07 13:24:03.103769000 +0000
+++ build/tests/backlight/basic/keycode_events.log      2023-03-07 13:45:21.258707000 +0000
@@ -1,9 +1,9 @@
-Update backlight brightness: 40%
-Update backlight brightness: 60%
-Update backlight brightness: 80%
-Update backlight brightness: 60%
-Update backlight brightness: 40%
-Update backlight brightness: 0%
-Update backlight brightness: 0%
-Update backlight brightness: 40%
-Update backlight brightness: 40%
+Update backlight brightness: 40%
+Update backlight brightness: 60%
+Update backlight brightness: 80%
+Update backlight brightness: 60%
+Update backlight brightness: 40%
+Update backlight brightness: 0%
+Update backlight brightness: 0%
+Update backlight brightness: 40%
+Update backlight brightness: 40%
FAILED: tests/backlight/basic
```

Forcing unix line endings on all snapshot files in the tests directory fixes the issue.

```lang=bash
Running tests/backlight/basic:
PASS: tests/backlight/basic
```