### PR TITLE
add new shield: new horizons

### DIFF
--- a/app/boards/shields/newhorizons/Kconfig.defconfig
+++ b/app/boards/shields/newhorizons/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_NEWHORIZONS
+
+config ZMK_KEYBOARD_NAME
+    default "New Horizons"
+
+endif

--- a/app/boards/shields/newhorizons/Kconfig.defconfig
+++ b/app/boards/shields/newhorizons/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The ZMK Contributors
+# Copyright (c) 2023 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
 if SHIELD_NEWHORIZONS

--- a/app/boards/shields/newhorizons/Kconfig.shield
+++ b/app/boards/shields/newhorizons/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_NEWHORIZONS
+    def_bool $(shields_list_contains,newhorizons)

--- a/app/boards/shields/newhorizons/Kconfig.shield
+++ b/app/boards/shields/newhorizons/Kconfig.shield
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The ZMK Contributors
+# Copyright (c) 2023 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
 config SHIELD_NEWHORIZONS

--- a/app/boards/shields/newhorizons/newhorizons.conf
+++ b/app/boards/shields/newhorizons/newhorizons.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2020 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+CONFIG_BT_CTLR_TX_PWR_PLUS_8=y

--- a/app/boards/shields/newhorizons/newhorizons.conf
+++ b/app/boards/shields/newhorizons/newhorizons.conf
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The ZMK Contributors
+# Copyright (c) 2023 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y

--- a/app/boards/shields/newhorizons/newhorizons.keymap
+++ b/app/boards/shields/newhorizons/newhorizons.keymap
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The ZMK Contributors
+ * Copyright (c) 2023 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/boards/shields/newhorizons/newhorizons.keymap
+++ b/app/boards/shields/newhorizons/newhorizons.keymap
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+/ {
+	keymap {
+		compatible = "zmk,keymap";
+
+		default_layer {
+			bindings = <
+                                &kp ESC   &kp N1    &kp N2    &kp N3    &kp N4    &kp N5    &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp MINUS &kp EQUAL &kp BSPC  &kp BSPC  &kp DEL
+                                &kp TAB     &kp Q     &kp W     &kp E     &kp R     &kp T     &kp Y     &kp U     &kp I     &kp O     &kp P     &kp LBKT  &kp RBKT    &kp BSLH    &kp HOME
+                                &kp CLCK     &kp A     &kp S     &kp D     &kp F     &kp G     &kp H     &kp J     &kp K     &kp L     &kp SEMI  &kp SQT          &kp RET        &kp PG_UP
+                                &kp LSHFT   &kp LSHFT &kp Z     &kp X     &kp C     &kp V     &kp B     &kp N     &kp M     &kp COMMA &kp DOT   &kp FSLH      &kp RSHFT     &kp UP    &kp PG_DN
+                                &kp LCTRL  &kp LGUI   &kp LALT        &kp SPACE       &kp SPACE       &kp SPACE                     &kp RALT  &mo 1     &kp RCTRL &kp LEFT  &kp DOWN  &kp RIGHT 
+			>;
+		};
+
+		fn_layer {
+			bindings = <
+                                &kp GRAVE &kp F1    &kp F2    &kp F3    &kp F4    &kp F5    &kp F6    &kp F7    &kp F8    &kp F9    &kp F10    &kp F11   &kp F12  &trans    &trans    &bootloader
+                                &out OUT_USB &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans      &trans      &trans
+                                &out OUT_BLE &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &trans &trans &trans &trans    &trans     &trans        &trans
+                                &trans      &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans        &trans        &trans    &trans
+                                &trans     &trans     &trans          &trans          &trans          &trans                        &trans    &trans    &trans    &trans    &trans    &trans
+			>;
+		};
+	};
+};

--- a/app/boards/shields/newhorizons/newhorizons.overlay
+++ b/app/boards/shields/newhorizons/newhorizons.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The ZMK Contributors
+ * Copyright (c) 2023 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/boards/shields/newhorizons/newhorizons.overlay
+++ b/app/boards/shields/newhorizons/newhorizons.overlay
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        rows = <5>;
+        columns = <16>;
+
+        map = <
+            RC(0,0) RC(1,0) RC(0,1) RC(1,1) RC(0,2) RC(1,2) RC(0,3) RC(1,3) RC(0,4) RC(1,4) RC(0,5) RC(1,5) RC(0,6) RC(1,6) RC(0,7) RC(1,7)
+              RC(2,0)  RC(3,0) RC(2,1) RC(3,1) RC(2,2) RC(3,2) RC(2,3) RC(3,3) RC(2,4) RC(3,4) RC(2,5) RC(3,5) RC(2,6)   RC(3,6)    RC(3,7)
+               RC(4,0)  RC(5,0) RC(4,1) RC(5,1) RC(4,2) RC(5,2) RC(4,3) RC(5,3) RC(4,4) RC(5,4) RC(4,5) RC(5,5)       RC(4,7)       RC(5,7)
+             RC(6,0)  RC(7,0) RC(6,1) RC(7,1) RC(6,2) RC(7,2) RC(6,3) RC(7,3) RC(6,4) RC(7,4) RC(6,5) RC(7,5)    RC(6,6)    RC(6,7) RC(7,7)
+            RC(8,0)  RC(9,0)  RC(8,1)          RC(9,1)         RC(8,3)        RC(9,3)       RC(8,5) RC(9,5) RC(8,6) RC(9,6) RC(8,7) RC(9,7)
+        >;
+    };
+
+
+    kscan0: kscan_0 {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "row2col";
+
+        row-gpios
+            = <&pro_micro 1 GPIO_ACTIVE_HIGH> // row 0
+            , <&pro_micro 0 GPIO_ACTIVE_HIGH> // row 1
+            , <&pro_micro 2 GPIO_ACTIVE_HIGH> // row 2
+            , <&pro_micro 3 GPIO_ACTIVE_HIGH> // row 3
+            , <&pro_micro 9 GPIO_ACTIVE_HIGH> // row 4
+            , <&pro_micro 8 GPIO_ACTIVE_HIGH> // row 5
+            , <&pro_micro 7 GPIO_ACTIVE_HIGH> // row 6
+            , <&pro_micro 6 GPIO_ACTIVE_HIGH> // row 7
+            , <&pro_micro 5 GPIO_ACTIVE_HIGH> // row 8
+            , <&pro_micro 4 GPIO_ACTIVE_HIGH> // row 9
+            ;
+
+        col-gpios
+            = <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 0
+            , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 1
+            , <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 2
+            , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 3
+            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 4
+            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 5
+            , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 6
+            , <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col 7
+            ;
+    };
+};

--- a/app/boards/shields/newhorizons/newhorizons.zmk.yml
+++ b/app/boards/shields/newhorizons/newhorizons.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: newhorizons
+name: New Horizons
+type: shield
+url: https://keeb.supply/products/0xcb-new-horizons
+requires: [pro_micro]
+features:
+  - keys


### PR DESCRIPTION
adding a shield config for the 0xCB New Horizons - it is a 65% stacked FR4 kit.
Available [here](https://keeb.supply/products/0xcb-new-horizons)
![](https://keeb.supply/assets/nh-full__preview.webp?preset=full)

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [x] This board/shield is tested working on real hardware
 - [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [x] `.zmk.yml` metadata file added
 - [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [x] General consistent formatting of DeviceTree files
 - [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [x] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [x] `.conf` file has optional extra features commented out
 - [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
