### PR TITLE
Refactor events API to avoid heap/dynamic allocations

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -595,7 +595,7 @@ endmenu
 endmenu
 
 config HEAP_MEM_POOL_SIZE
-    default 8192
+    default 8192 if ZMK_DISPLAY
 
 config KERNEL_BIN_NAME
     default "zmk"

--- a/app/include/zmk/event_manager.h
+++ b/app/include/zmk/event_manager.h
@@ -38,7 +38,8 @@ struct zmk_event_subscription {
         zmk_event_t header;                                                                        \
         struct event_type data;                                                                    \
     };                                                                                             \
-    struct event_type##_event *new_##event_type(struct event_type);                                \
+    struct event_type##_event copy_raised_##event_type(const struct event_type *ev);               \
+    int raise_##event_type(struct event_type);                                                     \
     struct event_type *as_##event_type(const zmk_event_t *eh);                                     \
     extern const struct zmk_event_type zmk_event_##event_type;
 
@@ -46,12 +47,14 @@ struct zmk_event_subscription {
     const struct zmk_event_type zmk_event_##event_type = {.name = STRINGIFY(event_type)};          \
     const struct zmk_event_type *zmk_event_ref_##event_type __used                                 \
         __attribute__((__section__(".event_type"))) = &zmk_event_##event_type;                     \
-    struct event_type##_event *new_##event_type(struct event_type data) {                          \
-        struct event_type##_event *ev =                                                            \
-            (struct event_type##_event *)k_malloc(sizeof(struct event_type##_event));              \
-        ev->header.event = &zmk_event_##event_type;                                                \
-        ev->data = data;                                                                           \
-        return ev;                                                                                 \
+    struct event_type##_event copy_raised_##event_type(const struct event_type *ev) {              \
+        struct event_type##_event *outer = CONTAINER_OF(ev, struct event_type##_event, data);      \
+        return *outer;                                                                             \
+    };                                                                                             \
+    int raise_##event_type(struct event_type data) {                                               \
+        struct event_type##_event ev = {.data = data};                                             \
+        ev.header.event = &zmk_event_##event_type;                                                 \
+        return ZMK_EVENT_RAISE(ev);                                                                \
     };                                                                                             \
     struct event_type *as_##event_type(const zmk_event_t *eh) {                                    \
         return (eh->event == &zmk_event_##event_type) ? &((struct event_type##_event *)eh)->data   \
@@ -68,17 +71,15 @@ struct zmk_event_subscription {
             .listener = &zmk_listener_##mod,                                                       \
     };
 
-#define ZMK_EVENT_RAISE(ev) zmk_event_manager_raise((zmk_event_t *)ev);
+#define ZMK_EVENT_RAISE(ev) zmk_event_manager_raise((zmk_event_t *)&ev);
 
 #define ZMK_EVENT_RAISE_AFTER(ev, mod)                                                             \
-    zmk_event_manager_raise_after((zmk_event_t *)ev, &zmk_listener_##mod);
+    zmk_event_manager_raise_after((zmk_event_t *)&ev, &zmk_listener_##mod);
 
 #define ZMK_EVENT_RAISE_AT(ev, mod)                                                                \
-    zmk_event_manager_raise_at((zmk_event_t *)ev, &zmk_listener_##mod);
+    zmk_event_manager_raise_at((zmk_event_t *)&ev, &zmk_listener_##mod);
 
-#define ZMK_EVENT_RELEASE(ev) zmk_event_manager_release((zmk_event_t *)ev);
-
-#define ZMK_EVENT_FREE(ev) k_free((void *)ev);
+#define ZMK_EVENT_RELEASE(ev) zmk_event_manager_release((zmk_event_t *)&ev);
 
 int zmk_event_manager_raise(zmk_event_t *event);
 int zmk_event_manager_raise_after(zmk_event_t *event, const struct zmk_listener *listener);

--- a/app/include/zmk/events/keycode_state_changed.h
+++ b/app/include/zmk/events/keycode_state_changed.h
@@ -21,7 +21,7 @@ struct zmk_keycode_state_changed {
 
 ZMK_EVENT_DECLARE(zmk_keycode_state_changed);
 
-static inline struct zmk_keycode_state_changed_event *
+static inline struct zmk_keycode_state_changed
 zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t timestamp) {
     uint16_t page = ZMK_HID_USAGE_PAGE(encoded);
     uint16_t id = ZMK_HID_USAGE_ID(encoded);
@@ -38,11 +38,10 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
         implicit_modifiers = SELECT_MODS(encoded);
     }
 
-    return new_zmk_keycode_state_changed(
-        (struct zmk_keycode_state_changed){.usage_page = page,
-                                           .keycode = id,
-                                           .implicit_modifiers = implicit_modifiers,
-                                           .explicit_modifiers = explicit_modifiers,
-                                           .state = pressed,
-                                           .timestamp = timestamp});
+    return (struct zmk_keycode_state_changed){.usage_page = page,
+                                              .keycode = id,
+                                              .implicit_modifiers = implicit_modifiers,
+                                              .explicit_modifiers = explicit_modifiers,
+                                              .state = pressed,
+                                              .timestamp = timestamp};
 }

--- a/app/include/zmk/events/keycode_state_changed.h
+++ b/app/include/zmk/events/keycode_state_changed.h
@@ -45,3 +45,9 @@ zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t t
                                               .state = pressed,
                                               .timestamp = timestamp};
 }
+
+static inline int raise_zmk_keycode_state_changed_from_encoded(uint32_t encoded, bool pressed,
+                                                               int64_t timestamp) {
+    return raise_zmk_keycode_state_changed(
+        zmk_keycode_state_changed_from_encoded(encoded, pressed, timestamp));
+}

--- a/app/include/zmk/events/layer_state_changed.h
+++ b/app/include/zmk/events/layer_state_changed.h
@@ -17,8 +17,7 @@ struct zmk_layer_state_changed {
 
 ZMK_EVENT_DECLARE(zmk_layer_state_changed);
 
-static inline struct zmk_layer_state_changed_event *create_layer_state_changed(uint8_t layer,
-                                                                               bool state) {
-    return new_zmk_layer_state_changed((struct zmk_layer_state_changed){
+static inline int raise_layer_state_changed(uint8_t layer, bool state) {
+    return raise_zmk_layer_state_changed((struct zmk_layer_state_changed){
         .layer = layer, .state = state, .timestamp = k_uptime_get()});
 }

--- a/app/include/zmk/events/mouse_button_state_changed.h
+++ b/app/include/zmk/events/mouse_button_state_changed.h
@@ -19,8 +19,8 @@ struct zmk_mouse_button_state_changed {
 
 ZMK_EVENT_DECLARE(zmk_mouse_button_state_changed);
 
-static inline struct zmk_mouse_button_state_changed_event *
-zmk_mouse_button_state_changed_from_encoded(uint32_t encoded, bool pressed, int64_t timestamp) {
-    return new_zmk_mouse_button_state_changed((struct zmk_mouse_button_state_changed){
+static inline int raise_zmk_mouse_button_state_changed_from_encoded(uint32_t encoded, bool pressed,
+                                                                    int64_t timestamp) {
+    return raise_zmk_mouse_button_state_changed((struct zmk_mouse_button_state_changed){
         .buttons = ZMK_HID_USAGE_ID(encoded), .state = pressed, .timestamp = timestamp});
 }

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -43,8 +43,8 @@ static uint32_t activity_last_uptime;
 #endif
 
 int raise_event(void) {
-    return ZMK_EVENT_RAISE(new_zmk_activity_state_changed(
-        (struct zmk_activity_state_changed){.state = activity_state}));
+    return raise_zmk_activity_state_changed(
+        (struct zmk_activity_state_changed){.state = activity_state});
 }
 
 int set_state(enum zmk_activity_state state) {

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -63,8 +63,8 @@ static int zmk_battery_update(const struct device *battery) {
             return rc;
         }
 #endif
-        rc = ZMK_EVENT_RAISE(new_zmk_battery_state_changed(
-            (struct zmk_battery_state_changed){.state_of_charge = last_state_of_charge}));
+        rc = raise_zmk_battery_state_changed(
+            (struct zmk_battery_state_changed){.state_of_charge = last_state_of_charge});
     }
 
     return rc;

--- a/app/src/behaviors/behavior_key_press.c
+++ b/app/src/behaviors/behavior_key_press.c
@@ -21,14 +21,14 @@ static int behavior_key_press_init(const struct device *dev) { return 0; };
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
-    return ZMK_EVENT_RAISE(
+    return raise_zmk_keycode_state_changed(
         zmk_keycode_state_changed_from_encoded(binding->param1, true, event.timestamp));
 }
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
-    return ZMK_EVENT_RAISE(
+    return raise_zmk_keycode_state_changed(
         zmk_keycode_state_changed_from_encoded(binding->param1, false, event.timestamp));
 }
 

--- a/app/src/behaviors/behavior_key_press.c
+++ b/app/src/behaviors/behavior_key_press.c
@@ -21,15 +21,13 @@ static int behavior_key_press_init(const struct device *dev) { return 0; };
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
-    return raise_zmk_keycode_state_changed(
-        zmk_keycode_state_changed_from_encoded(binding->param1, true, event.timestamp));
+    return raise_zmk_keycode_state_changed_from_encoded(binding->param1, true, event.timestamp);
 }
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
-    return raise_zmk_keycode_state_changed(
-        zmk_keycode_state_changed_from_encoded(binding->param1, false, event.timestamp));
+    return raise_zmk_keycode_state_changed_from_encoded(binding->param1, false, event.timestamp);
 }
 
 static const struct behavior_driver_api behavior_key_press_driver_api = {

--- a/app/src/behaviors/behavior_key_repeat.c
+++ b/app/src/behaviors/behavior_key_repeat.c
@@ -43,7 +43,7 @@ static int on_key_repeat_binding_pressed(struct zmk_behavior_binding *binding,
            sizeof(struct zmk_keycode_state_changed));
     data->current_keycode_pressed.timestamp = k_uptime_get();
 
-    ZMK_EVENT_RAISE(new_zmk_keycode_state_changed(data->current_keycode_pressed));
+    raise_zmk_keycode_state_changed(data->current_keycode_pressed);
 
     return ZMK_BEHAVIOR_OPAQUE;
 }
@@ -60,7 +60,7 @@ static int on_key_repeat_binding_released(struct zmk_behavior_binding *binding,
     data->current_keycode_pressed.timestamp = k_uptime_get();
     data->current_keycode_pressed.state = false;
 
-    ZMK_EVENT_RAISE(new_zmk_keycode_state_changed(data->current_keycode_pressed));
+    raise_zmk_keycode_state_changed(data->current_keycode_pressed);
     return ZMK_BEHAVIOR_OPAQUE;
 }
 

--- a/app/src/behaviors/behavior_key_toggle.c
+++ b/app/src/behaviors/behavior_key_toggle.c
@@ -23,7 +23,7 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
     bool pressed = zmk_hid_is_pressed(binding->param1);
-    return ZMK_EVENT_RAISE(
+    return raise_zmk_keycode_state_changed(
         zmk_keycode_state_changed_from_encoded(binding->param1, !pressed, event.timestamp));
 }
 

--- a/app/src/behaviors/behavior_key_toggle.c
+++ b/app/src/behaviors/behavior_key_toggle.c
@@ -23,8 +23,7 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
     bool pressed = zmk_hid_is_pressed(binding->param1);
-    return raise_zmk_keycode_state_changed(
-        zmk_keycode_state_changed_from_encoded(binding->param1, !pressed, event.timestamp));
+    return raise_zmk_keycode_state_changed_from_encoded(binding->param1, !pressed, event.timestamp);
 }
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,

--- a/app/src/behaviors/behavior_mouse_key_press.c
+++ b/app/src/behaviors/behavior_mouse_key_press.c
@@ -24,15 +24,15 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
 
-    return ZMK_EVENT_RAISE(
-        zmk_mouse_button_state_changed_from_encoded(binding->param1, true, event.timestamp));
+    return raise_zmk_mouse_button_state_changed_from_encoded(binding->param1, true,
+                                                             event.timestamp);
 }
 
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
-    return ZMK_EVENT_RAISE(
-        zmk_mouse_button_state_changed_from_encoded(binding->param1, false, event.timestamp));
+    return raise_zmk_mouse_button_state_changed_from_encoded(binding->param1, false,
+                                                             event.timestamp);
 }
 
 static const struct behavior_driver_api behavior_mouse_key_press_driver_api = {

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -236,7 +236,9 @@ static int sticky_key_keycode_state_changed_listener(const zmk_event_t *eh) {
                 if (sticky_key->config->quick_release) {
                     // immediately release the sticky key after the key press is handled.
                     if (!event_reraised) {
-                        ZMK_EVENT_RAISE_AFTER(eh, behavior_sticky_key);
+                        struct zmk_keycode_state_changed_event dupe_ev;
+                        memcpy(&dupe_ev, eh, sizeof(struct zmk_keycode_state_changed_event));
+                        ZMK_EVENT_RAISE_AFTER(dupe_ev, behavior_sticky_key);
                         event_reraised = true;
                     }
                     release_sticky_key_behavior(sticky_key, ev_copy.timestamp);

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -236,8 +236,8 @@ static int sticky_key_keycode_state_changed_listener(const zmk_event_t *eh) {
                 if (sticky_key->config->quick_release) {
                     // immediately release the sticky key after the key press is handled.
                     if (!event_reraised) {
-                        struct zmk_keycode_state_changed_event dupe_ev;
-                        memcpy(&dupe_ev, eh, sizeof(struct zmk_keycode_state_changed_event));
+                        struct zmk_keycode_state_changed_event dupe_ev =
+                            copy_raised_zmk_keycode_state_changed(ev);
                         ZMK_EVENT_RAISE_AFTER(dupe_ev, behavior_sticky_key);
                         event_reraised = true;
                     }

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -83,8 +83,8 @@ static bt_addr_le_t peripheral_addrs[ZMK_SPLIT_BLE_PERIPHERAL_COUNT];
 #endif /* IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL) */
 
 static void raise_profile_changed_event(void) {
-    ZMK_EVENT_RAISE(new_zmk_ble_active_profile_changed((struct zmk_ble_active_profile_changed){
-        .index = active_profile, .profile = &profiles[active_profile]}));
+    raise_zmk_ble_active_profile_changed((struct zmk_ble_active_profile_changed){
+        .index = active_profile, .profile = &profiles[active_profile]});
 }
 
 static void raise_profile_changed_event_callback(struct k_work *work) {

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -47,7 +47,9 @@ struct active_combo {
     // key_positions_pressed is filled with key_positions when the combo is pressed.
     // The keys are removed from this array when they are released.
     // Once this array is empty, the behavior is released.
-    const zmk_event_t *key_positions_pressed[CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO];
+    uint32_t key_positions_pressed_count;
+    struct zmk_position_state_changed_event
+        key_positions_pressed[CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO];
 };
 
 struct combo_candidate {
@@ -58,8 +60,9 @@ struct combo_candidate {
     int64_t timeout_at;
 };
 
+uint32_t pressed_keys_count = 0;
 // set of keys pressed
-const zmk_event_t *pressed_keys[CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO] = {NULL};
+struct zmk_position_state_changed_event pressed_keys[CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO] = {};
 // the set of candidate combos based on the currently pressed_keys
 struct combo_candidate candidates[CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY];
 // the last candidate that was completely pressed
@@ -210,12 +213,7 @@ static inline bool candidate_is_completely_pressed(struct combo_cfg *candidate) 
     // since events may have been reraised after clearing one or more slots at
     // the start of pressed_keys (see: release_pressed_keys), we have to check
     // that each key needed to trigger the combo was pressed, not just the last.
-    for (int i = 0; i < candidate->key_position_len; i++) {
-        if (pressed_keys[i] == NULL) {
-            return false;
-        }
-    }
-    return true;
+    return candidate->key_position_len == pressed_keys_count;
 }
 
 static int cleanup();
@@ -261,38 +259,33 @@ static int clear_candidates() {
     return CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY;
 }
 
-static int capture_pressed_key(const zmk_event_t *ev) {
-    for (int i = 0; i < CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO; i++) {
-        if (pressed_keys[i] != NULL) {
-            continue;
-        }
-        pressed_keys[i] = ev;
-        return ZMK_EV_EVENT_CAPTURED;
+static int capture_pressed_key(const struct zmk_position_state_changed *ev) {
+    if (pressed_keys_count == CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY) {
+        return ZMK_EV_EVENT_BUBBLE;
     }
-    return ZMK_EV_EVENT_BUBBLE;
+
+    pressed_keys[pressed_keys_count++] = copy_raised_zmk_position_state_changed(ev);
+    return ZMK_EV_EVENT_CAPTURED;
 }
 
 const struct zmk_listener zmk_listener_combo;
 
 static int release_pressed_keys() {
-    for (int i = 0; i < CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO; i++) {
-        const zmk_event_t *captured_event = pressed_keys[i];
-        if (pressed_keys[i] == NULL) {
-            return i;
-        }
-        pressed_keys[i] = NULL;
+    uint32_t count = pressed_keys_count;
+    pressed_keys_count = 0;
+    for (int i = 0; i < count; i++) {
+        struct zmk_position_state_changed_event ev = pressed_keys[i];
         if (i == 0) {
-            LOG_DBG("combo: releasing position event %d",
-                    as_zmk_position_state_changed(captured_event)->position);
-            ZMK_EVENT_RELEASE(captured_event)
+            LOG_DBG("combo: releasing position event %d", ev.data.position);
+            ZMK_EVENT_RELEASE(ev)
         } else {
             // reprocess events (see tests/combo/fully-overlapping-combos-3 for why this is needed)
-            LOG_DBG("combo: reraising position event %d",
-                    as_zmk_position_state_changed(captured_event)->position);
-            ZMK_EVENT_RAISE(captured_event);
+            LOG_DBG("combo: reraising position event %d", ev.data.position);
+            ZMK_EVENT_RAISE(ev);
         }
     }
-    return CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO;
+
+    return count;
 }
 
 static inline int press_combo_behavior(struct combo_cfg *combo, int32_t timestamp) {
@@ -316,19 +309,19 @@ static inline int release_combo_behavior(struct combo_cfg *combo, int32_t timest
 }
 
 static void move_pressed_keys_to_active_combo(struct active_combo *active_combo) {
-    int combo_length = active_combo->combo->key_position_len;
+
+    int combo_length = MIN(pressed_keys_count, active_combo->combo->key_position_len);
     for (int i = 0; i < combo_length; i++) {
         active_combo->key_positions_pressed[i] = pressed_keys[i];
-        pressed_keys[i] = NULL;
     }
+    active_combo->key_positions_pressed_count = combo_length;
+
     // move any other pressed keys up
-    for (int i = 0; i + combo_length < CONFIG_ZMK_COMBO_MAX_KEYS_PER_COMBO; i++) {
-        if (pressed_keys[i + combo_length] == NULL) {
-            return;
-        }
+    for (int i = 0; i + combo_length < pressed_keys_count; i++) {
         pressed_keys[i] = pressed_keys[i + combo_length];
-        pressed_keys[i + combo_length] = NULL;
     }
+
+    pressed_keys_count -= combo_length;
 }
 
 static struct active_combo *store_active_combo(struct combo_cfg *combo) {
@@ -353,8 +346,7 @@ static void activate_combo(struct combo_cfg *combo) {
         return;
     }
     move_pressed_keys_to_active_combo(active_combo);
-    press_combo_behavior(
-        combo, as_zmk_position_state_changed(active_combo->key_positions_pressed[0])->timestamp);
+    press_combo_behavior(combo, active_combo->key_positions_pressed[0].data.timestamp);
 }
 
 static void deactivate_combo(int active_combo_index) {
@@ -373,22 +365,22 @@ static bool release_combo_key(int32_t position, int64_t timestamp) {
         struct active_combo *active_combo = &active_combos[combo_idx];
 
         bool key_released = false;
-        bool all_keys_pressed = true;
+        bool all_keys_pressed =
+            active_combo->key_positions_pressed_count == active_combo->combo->key_position_len;
         bool all_keys_released = true;
-        for (int i = 0; i < active_combo->combo->key_position_len; i++) {
-            if (active_combo->key_positions_pressed[i] == NULL) {
-                all_keys_pressed = false;
-            } else if (as_zmk_position_state_changed(active_combo->key_positions_pressed[i])
-                           ->position != position) {
+        for (int i = 0; i < active_combo->key_positions_pressed_count; i++) {
+            if (key_released) {
+                active_combo->key_positions_pressed[i - 1] = active_combo->key_positions_pressed[i];
                 all_keys_released = false;
-            } else { // not null and position matches
-                ZMK_EVENT_FREE(active_combo->key_positions_pressed[i]);
-                active_combo->key_positions_pressed[i] = NULL;
+            } else if (active_combo->key_positions_pressed[i].data.position != position) {
+                all_keys_released = false;
+            } else { // position matches
                 key_released = true;
             }
         }
 
         if (key_released) {
+            active_combo->key_positions_pressed_count--;
             if ((active_combo->combo->slow_release && all_keys_released) ||
                 (!active_combo->combo->slow_release && all_keys_pressed)) {
                 release_combo_behavior(active_combo->combo, timestamp);
@@ -442,7 +434,7 @@ static int position_state_down(const zmk_event_t *ev, struct zmk_position_state_
 
     struct combo_cfg *candidate_combo = candidates[0].combo;
     LOG_DBG("combo: capturing position event %d", data->position);
-    int ret = capture_pressed_key(ev);
+    int ret = capture_pressed_key(data);
     switch (num_candidates) {
     case 0:
         cleanup();
@@ -469,7 +461,9 @@ static int position_state_up(const zmk_event_t *ev, struct zmk_position_state_ch
     if (released_keys > 1) {
         // The second and further key down events are re-raised. To preserve
         // correct order for e.g. hold-taps, reraise the key up event too.
-        ZMK_EVENT_RAISE(ev);
+        struct zmk_position_state_changed_event dupe_ev =
+            copy_raised_zmk_position_state_changed(data);
+        ZMK_EVENT_RAISE(dupe_ev);
         return ZMK_EV_EVENT_CAPTURED;
     }
     return ZMK_EV_EVENT_BUBBLE;

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -274,14 +274,14 @@ static int release_pressed_keys() {
     uint32_t count = pressed_keys_count;
     pressed_keys_count = 0;
     for (int i = 0; i < count; i++) {
-        struct zmk_position_state_changed_event ev = pressed_keys[i];
+        struct zmk_position_state_changed_event *ev = &pressed_keys[i];
         if (i == 0) {
-            LOG_DBG("combo: releasing position event %d", ev.data.position);
-            ZMK_EVENT_RELEASE(ev)
+            LOG_DBG("combo: releasing position event %d", ev->data.position);
+            ZMK_EVENT_RELEASE(*ev);
         } else {
             // reprocess events (see tests/combo/fully-overlapping-combos-3 for why this is needed)
-            LOG_DBG("combo: reraising position event %d", ev.data.position);
-            ZMK_EVENT_RAISE(ev);
+            LOG_DBG("combo: reraising position event %d", ev->data.position);
+            ZMK_EVENT_RAISE(*ev);
         }
     }
 

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -346,8 +346,7 @@ static void update_current_endpoint(void) {
         zmk_endpoint_instance_to_str(current_instance, endpoint_str, sizeof(endpoint_str));
         LOG_INF("Endpoint changed: %s", endpoint_str);
 
-        ZMK_EVENT_RAISE(
-            new_zmk_endpoint_changed((struct zmk_endpoint_changed){.endpoint = current_instance}));
+        raise_zmk_endpoint_changed((struct zmk_endpoint_changed){.endpoint = current_instance});
     }
 }
 

--- a/app/src/event_manager.c
+++ b/app/src/event_manager.c
@@ -32,21 +32,17 @@ int zmk_event_manager_handle_from(zmk_event_t *event, uint8_t start_index) {
             continue;
         case ZMK_EV_EVENT_HANDLED:
             LOG_DBG("Listener handled the event");
-            ret = 0;
-            goto release;
+            return 0;
         case ZMK_EV_EVENT_CAPTURED:
             LOG_DBG("Listener captured the event");
-            // Listeners are expected to free events they capture
             return 0;
         default:
             LOG_DBG("Listener returned an error: %d", ret);
-            goto release;
+            return ret;
         }
     }
 
-release:
-    k_free(event);
-    return ret;
+    return 0;
 }
 
 int zmk_event_manager_raise(zmk_event_t *event) { return zmk_event_manager_handle_from(event, 0); }

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -76,6 +76,7 @@ static struct zmk_behavior_binding
 #endif /* ZMK_KEYMAP_HAS_SENSORS */
 
 static inline int set_layer_state(uint8_t layer, bool state) {
+    int ret = 0;
     if (layer >= ZMK_KEYMAP_LAYERS_LEN) {
         return -EINVAL;
     }
@@ -90,10 +91,13 @@ static inline int set_layer_state(uint8_t layer, bool state) {
     // Don't send state changes unless there was an actual change
     if (old_state != _zmk_keymap_layer_state) {
         LOG_DBG("layer_changed: layer %d state %d", layer, state);
-        ZMK_EVENT_RAISE(create_layer_state_changed(layer, state));
+        ret = raise_layer_state_changed(layer, state);
+        if (ret < 0) {
+            LOG_WRN("Failed to raise layer state changed (%d)", ret);
+        }
     }
 
-    return 0;
+    return ret;
 }
 
 uint8_t zmk_keymap_layer_default(void) { return _zmk_keymap_layer_default; }

--- a/app/src/kscan.c
+++ b/app/src/kscan.c
@@ -57,11 +57,11 @@ void zmk_kscan_process_msgq(struct k_work *item) {
 
         LOG_DBG("Row: %d, col: %d, position: %d, pressed: %s", ev.row, ev.column, position,
                 (pressed ? "true" : "false"));
-        ZMK_EVENT_RAISE(new_zmk_position_state_changed(
+        raise_zmk_position_state_changed(
             (struct zmk_position_state_changed){.source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
                                                 .state = pressed,
                                                 .position = position,
-                                                .timestamp = k_uptime_get()}));
+                                                .timestamp = k_uptime_get()});
     }
 }
 

--- a/app/src/sensors.c
+++ b/app/src/sensors.c
@@ -87,12 +87,12 @@ static void trigger_sensor_data_for_position(uint32_t sensor_index) {
         return;
     }
 
-    ZMK_EVENT_RAISE(new_zmk_sensor_event(
+    raise_zmk_sensor_event(
         (struct zmk_sensor_event){.sensor_index = item->sensor_index,
                                   .channel_data_size = 1,
                                   .channel_data = {(struct zmk_sensor_channel_data){
                                       .value = value, .channel = item->trigger.chan}},
-                                  .timestamp = k_uptime_get()}));
+                                  .timestamp = k_uptime_get()});
 }
 
 static void run_sensors_data_trigger(struct k_work *work) {

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -72,7 +72,7 @@ void peripheral_event_work_callback(struct k_work *work) {
     struct zmk_position_state_changed ev;
     while (k_msgq_get(&peripheral_event_msgq, &ev, K_NO_WAIT) == 0) {
         LOG_DBG("Trigger key position state change for %d", ev.position);
-        ZMK_EVENT_RAISE(new_zmk_position_state_changed(ev));
+        raise_zmk_position_state_changed(ev);
     }
 }
 
@@ -188,7 +188,7 @@ void peripheral_sensor_event_work_callback(struct k_work *work) {
     struct zmk_sensor_event ev;
     while (k_msgq_get(&peripheral_sensor_event_msgq, &ev, K_NO_WAIT) == 0) {
         LOG_DBG("Trigger sensor change for %d", ev.sensor_index);
-        ZMK_EVENT_RAISE(new_zmk_sensor_event(ev));
+        raise_zmk_sensor_event(ev);
     }
 }
 

--- a/app/src/split/bluetooth/peripheral.c
+++ b/app/src/split/bluetooth/peripheral.c
@@ -83,8 +83,8 @@ K_WORK_DEFINE(advertising_work, advertising_cb);
 static void connected(struct bt_conn *conn, uint8_t err) {
     is_connected = (err == 0);
 
-    ZMK_EVENT_RAISE(new_zmk_split_peripheral_status_changed(
-        (struct zmk_split_peripheral_status_changed){.connected = is_connected}));
+    raise_zmk_split_peripheral_status_changed(
+        (struct zmk_split_peripheral_status_changed){.connected = is_connected});
 
     if (err == BT_HCI_ERR_ADV_TIMEOUT) {
         low_duty_advertising = true;
@@ -101,8 +101,8 @@ static void disconnected(struct bt_conn *conn, uint8_t reason) {
 
     is_connected = false;
 
-    ZMK_EVENT_RAISE(new_zmk_split_peripheral_status_changed(
-        (struct zmk_split_peripheral_status_changed){.connected = is_connected}));
+    raise_zmk_split_peripheral_status_changed(
+        (struct zmk_split_peripheral_status_changed){.connected = is_connected});
 
     low_duty_advertising = false;
     k_work_submit(&advertising_work);

--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -22,8 +22,8 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 static enum usb_dc_status_code usb_status = USB_DC_UNKNOWN;
 
 static void raise_usb_status_changed_event(struct k_work *_work) {
-    ZMK_EVENT_RAISE(new_zmk_usb_conn_state_changed(
-        (struct zmk_usb_conn_state_changed){.conn_state = zmk_usb_get_conn_state()}));
+    raise_zmk_usb_conn_state_changed(
+        (struct zmk_usb_conn_state_changed){.conn_state = zmk_usb_get_conn_state()});
 }
 
 K_WORK_DEFINE(usb_status_notifier_work, raise_usb_status_changed_event);

--- a/app/src/wpm.c
+++ b/app/src/wpm.c
@@ -54,8 +54,7 @@ void wpm_work_handler(struct k_work *work) {
     if (last_wpm_state != wpm_state) {
         LOG_DBG("Raised WPM state changed %d wpm_update_counter %d", wpm_state, wpm_update_counter);
 
-        ZMK_EVENT_RAISE(
-            new_zmk_wpm_state_changed((struct zmk_wpm_state_changed){.state = wpm_state}));
+        raise_zmk_wpm_state_changed((struct zmk_wpm_state_changed){.state = wpm_state});
 
         last_wpm_state = wpm_state;
     }


### PR DESCRIPTION
Ok, this is a semi-major core refactor to address one of the major nits I had with the initial design for the event manager API I added to ZMK, mainly that it depending on dynamic memory allocation for alloc/free of the event structs. As a result, we need to use some large, arbitrary heap pool in ZMK to be sure we have enough allocated for whatever odd combination of events get raised/captured in the system.

This PR moves to stack allocated event structures, and change the expectation that anyone wanting to capture an even should copy it into a locally allocated storage for it's use as needed. See updates to hold-tap, combos, etc that demonstrate this kind of change.

This potentially disrupts any open behavior PRs, so need to consider the *timing* of the merge of this, but want to get this reviewed for the general approach now, since this I believe is ready, after I found and fixed the final bug in combos I'd introduced.