### PR TITLE
fix(boards): Move the CDC ACM node under the USBD.

### DIFF
--- a/app/boards/arm/ferris/ferris_rev02.dts
+++ b/app/boards/arm/ferris/ferris_rev02.dts
@@ -116,6 +116,10 @@
 
 &usb {
 	status = "okay";
+	cdc_acm_uart: cdc_acm_uart {
+		compatible = "zephyr,cdc-acm-uart";
+		label = "CDC_ACM_0";
+	};
 };
 
 &clk_hsi {
@@ -139,10 +143,6 @@
 
 &rtc {
 	status = "okay";
-	cdc_acm_uart: cdc_acm_uart {
-		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
-	};
 };
 
 &flash0 {


### PR DESCRIPTION
* Ferris board's CDC ACM node was accidentally nested under the wrong node, causing USB logging builds to fail with cryptic error.
