### PR TITLE
fix(docs): ignore-modifiers clarification

### DIFF
--- a/docs/docs/behaviors/sticky-key.md
+++ b/docs/docs/behaviors/sticky-key.md
@@ -75,7 +75,7 @@ This configuration would apply to all sticky keys. This may not be appropriate i
 };
 ```
 
-If you combine multiple modifiers in a single key, like for example `&skq LS(LALT)`, you might need to add the `ignore-modifiers;` setting because it is not inherited from the default `&sq` behaviour.
+If you combine multiple modifiers in a single key, like for example `&skq LS(LALT)`, you might need to add the `ignore-modifiers;` setting because it is not inherited from the default `&sq` behavior.
 
 ### Advanced usage
 

--- a/docs/docs/behaviors/sticky-key.md
+++ b/docs/docs/behaviors/sticky-key.md
@@ -36,7 +36,7 @@ Some typists may find that using a sticky shift key interspersed with rapid typi
 
 #### `ignore-modifiers`
 
-This setting is enabled by default. It ensures that if a sticky key modifier is pressed before a previously pressed sticky key is released, the modifiers will get combined so you can add more sticky keys or press a regular key to apply the modifiers. This is to accommodate _callum-style mods_ where you are prone to rolling sticky keys. If you want sticky key modifiers to only chain after release, you can disable this setting.
+This setting is enabled by default. It ensures that if a sticky key modifier is pressed before a previously pressed sticky key is released, the modifiers will get combined so you can add more sticky keys or press a regular key to apply the modifiers. This is to accommodate _callum-style mods_ where you are prone to rolling sticky keys. If you want sticky key modifiers to only chain after release, you can disable this setting. Please note that [modifier functions](https://zmk.dev/docs/codes/modifiers#modifier-functions), such as `&sk LS(LALT)`, require `ignore-modifiers` enabled in order to function properly.
 
 #### Example
 
@@ -66,6 +66,7 @@ This configuration would apply to all sticky keys. This may not be appropriate i
         bindings = <&kp>;
         release-after-ms = <1000>;
         quick-release;
+        ignore-modifiers;
       };
     };
 
@@ -74,8 +75,6 @@ This configuration would apply to all sticky keys. This may not be appropriate i
     };
 };
 ```
-
-If you combine multiple modifiers in a single key, like for example `&skq LS(LALT)`, you might need to add the `ignore-modifiers;` setting because it is not inherited from the default `&sk` behavior.
 
 ### Advanced usage
 

--- a/docs/docs/behaviors/sticky-key.md
+++ b/docs/docs/behaviors/sticky-key.md
@@ -36,7 +36,7 @@ Some typists may find that using a sticky shift key interspersed with rapid typi
 
 #### `ignore-modifiers`
 
-This setting is enabled by default. It ensures that if a sticky key modifier is pressed before a previously pressed sticky key is released, the modifiers will get combined so you can add more sticky keys or press a regular key to apply the modifiers. This is to accommodate _callum-style mods_ where you are prone to rolling sticky keys. If you want sticky key modifiers to only chain after release, you can disable this setting. Please note that [modifier functions](https://zmk.dev/docs/codes/modifiers#modifier-functions), such as `&sk LS(LALT)`, require `ignore-modifiers` enabled in order to function properly.
+This setting is enabled by default. It ensures that if a sticky key modifier is pressed before a previously pressed sticky key is released, the modifiers will get combined so you can add more sticky keys or press a regular key to apply the modifiers. This is to accommodate _callum-style mods_ where you are prone to rolling sticky keys. If you want sticky key modifiers to only chain after release, you can disable this setting. Please note that activating multiple modifiers via [modifier functions](https://zmk.dev/docs/codes/modifiers#modifier-functions) such as `&sk LS(LALT)`, require `ignore-modifiers` enabled in order to function properly.
 
 #### Example
 

--- a/docs/docs/behaviors/sticky-key.md
+++ b/docs/docs/behaviors/sticky-key.md
@@ -75,7 +75,7 @@ This configuration would apply to all sticky keys. This may not be appropriate i
 };
 ```
 
-If you combine multiple modifiers in a single key, like for example `&skq LS(LALT)`, you might need to add the `ignore-modifiers;` setting because it is not inherited from the default `&sq` behavior.
+If you combine multiple modifiers in a single key, like for example `&skq LS(LALT)`, you might need to add the `ignore-modifiers;` setting because it is not inherited from the default `&sk` behavior.
 
 ### Advanced usage
 

--- a/docs/docs/behaviors/sticky-key.md
+++ b/docs/docs/behaviors/sticky-key.md
@@ -75,6 +75,8 @@ This configuration would apply to all sticky keys. This may not be appropriate i
 };
 ```
 
+If you combine multiple modifiers in a single key, like for example `&skq LS(LALT)`, you might need to add the `ignore-modifiers;` setting because it is not inherited from the default `&sq` behaviour.
+
 ### Advanced usage
 
 Sticky keys can be combined; if you tap `&sk LCTRL` and then `&sk LSHIFT` and then `&kp A`, the output will be ctrl+shift+a.


### PR DESCRIPTION
Clarify the potential need of adding the `ignore-modifiers;` setting for new sticky key behaviors when combining multiple modifiers into a single key.