### PR TITLE
Fixup nice!view adapters

### DIFF
--- a/app/boards/shields/nice_view_adapter/boards/bluemicro840_v1.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/bluemicro840_v1.overlay
@@ -17,7 +17,7 @@
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
-	pinctrl-0 = &spi0_default;
+	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };

--- a/app/boards/shields/nice_view_adapter/boards/mikoto_520.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/mikoto_520.overlay
@@ -16,7 +16,7 @@
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
-	pinctrl-0 = &spi0_default;
+	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };

--- a/app/boards/shields/nice_view_adapter/boards/nice_nano.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nice_nano.overlay
@@ -16,7 +16,7 @@
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
-	pinctrl-0 = &spi0_default;
+	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };

--- a/app/boards/shields/nice_view_adapter/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nrfmicro_11.overlay
@@ -17,7 +17,7 @@
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
-	pinctrl-0 = &spi0_default;
+	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };

--- a/app/boards/shields/nice_view_adapter/boards/nrfmicro_11_flipped.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nrfmicro_11_flipped.overlay
@@ -16,7 +16,7 @@
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
-	pinctrl-0 = &spi0_default;
+	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };

--- a/app/boards/shields/nice_view_adapter/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nrfmicro_13.overlay
@@ -16,7 +16,7 @@
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
-	pinctrl-0 = &spi0_default;
+	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };

--- a/app/boards/shields/nice_view_adapter/boards/puchi_ble_v1.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/puchi_ble_v1.overlay
@@ -16,7 +16,7 @@
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
-	pinctrl-0 = &spi0_default;
+	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };


### PR DESCRIPTION
`pinctrl-0` setting missing `<>`.

Happened to copy paste from one of these when setting up my test branch. 💥  Fluke discovery.