### PR TITLE
fix(shields): Fix nice!view for deep sleep

### DIFF
--- a/app/boards/shields/nice_view_adapter/boards/bluemicro840_v1.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/bluemicro840_v1.overlay
@@ -12,13 +12,21 @@
 				<NRF_PSEL(SPIM_MISO, 0, 25)>;
 		};
 	};
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 17)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 15)>,
+				<NRF_PSEL(SPIM_MISO, 0, 25)>;
+			low-power-enable;
+		};
+	};
 };
-
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };
 

--- a/app/boards/shields/nice_view_adapter/boards/mikoto_520.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/mikoto_520.overlay
@@ -12,12 +12,21 @@
 				<NRF_PSEL(SPIM_MISO, 0, 5)>;
 		};
 	};
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 20)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 17)>,
+				<NRF_PSEL(SPIM_MISO, 0, 5)>;
+			low-power-enable;
+		};
+	};
 };
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };
 

--- a/app/boards/shields/nice_view_adapter/boards/nice_nano.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nice_nano.overlay
@@ -12,12 +12,21 @@
 				<NRF_PSEL(SPIM_MISO, 0, 25)>;
 		};
 	};
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 20)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 17)>,
+				<NRF_PSEL(SPIM_MISO, 0, 25)>;
+			low-power-enable;
+		};
+	};
 };
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };
 

--- a/app/boards/shields/nice_view_adapter/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nice_nano_v2.overlay
@@ -12,12 +12,21 @@
 				<NRF_PSEL(SPIM_MISO, 0, 25)>;
 		};
 	};
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 20)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 17)>,
+				<NRF_PSEL(SPIM_MISO, 0, 25)>;
+			low-power-enable;
+		};
+	};
 };
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };
 

--- a/app/boards/shields/nice_view_adapter/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nrfmicro_11.overlay
@@ -12,13 +12,21 @@
 				<NRF_PSEL(SPIM_MISO, 0, 25)>;
 		};
 	};
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 17)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 15)>,
+				<NRF_PSEL(SPIM_MISO, 0, 25)>;
+			low-power-enable;
+		};
+	};
 };
-
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };
 

--- a/app/boards/shields/nice_view_adapter/boards/nrfmicro_11_flipped.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nrfmicro_11_flipped.overlay
@@ -12,12 +12,21 @@
 				<NRF_PSEL(SPIM_MISO, 0, 25)>;
 		};
 	};
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 31)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 30)>,
+				<NRF_PSEL(SPIM_MISO, 0, 25)>;
+			low-power-enable;
+		};
+	};
 };
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };
 

--- a/app/boards/shields/nice_view_adapter/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nrfmicro_13.overlay
@@ -12,12 +12,21 @@
 				<NRF_PSEL(SPIM_MISO, 0, 25)>;
 		};
 	};
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 17)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 15)>,
+				<NRF_PSEL(SPIM_MISO, 0, 25)>;
+			low-power-enable;
+		};
+	};
 };
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };
 

--- a/app/boards/shields/nice_view_adapter/boards/puchi_ble_v1.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/puchi_ble_v1.overlay
@@ -12,12 +12,21 @@
 				<NRF_PSEL(SPIM_MISO, 0, 25)>;
 		};
 	};
+	spi0_sleep: spi0_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 17)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 15)>,
+				<NRF_PSEL(SPIM_MISO, 0, 25)>;
+			low-power-enable;
+		};
+	};
 };
 
 nice_view_spi: &spi0 {
 	compatible = "nordic,nrf-spim";
 	pinctrl-0 = <&spi0_default>;
-	pinctrl-names = "default";
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
 	cs-gpios = <&pro_micro 1 GPIO_ACTIVE_HIGH>;
 };
 


### PR DESCRIPTION
Currently building with `nice_view_adapter` shields isn't working if deep sleep is enabled, e.g. the following fails to build: 
```sh
west build -p -d build/corne_left_nv -b nice_nano -- -DSHIELD="corne_left nice_view_adapter nice_view" -DCONFIG_ZMK_SLEEP=y
```

This seems to be because `spi0_sleep` pinctrl nodes aren't defined and adding those seems to fix the issue. Corne-ish Zen definitions [defines and uses them ](https://github.com/zmkfirmware/zmk/blob/main/app/boards/arm/corneish_zen/corneish_zen_v2_left.dts#L65)in a similar way.