### PR TITLE
fix (#1701) combo not interrupting tap-dance (and maybe more)

### DIFF
--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -271,6 +271,14 @@ static inline int press_combo_behavior(struct combo_cfg *combo, int32_t timestam
         .timestamp = timestamp,
     };
 
+    last_combo_timestamp = timestamp;
+
+    ZMK_EVENT_RAISE(new_zmk_position_state_changed(
+        (struct zmk_position_state_changed){.source = 0, // not ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
+                                            .state = true,
+                                            .position = -1, // not combo->virtual_key_position,
+                                            .timestamp = timestamp}));
+
     return behavior_keymap_binding_pressed(&combo->behavior, event);
 }
 
@@ -279,6 +287,12 @@ static inline int release_combo_behavior(struct combo_cfg *combo, int32_t timest
         .position = combo->virtual_key_position,
         .timestamp = timestamp,
     };
+
+    ZMK_EVENT_RAISE(new_zmk_position_state_changed(
+        (struct zmk_position_state_changed){.source = 0, // not ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
+                                            .state = false,
+                                            .position = -1, // not combo->virtual_key_position,
+                                            .timestamp = timestamp}));
 
     return behavior_keymap_binding_released(&combo->behavior, event);
 }


### PR DESCRIPTION
Combos do not interrupt tap-dance. This is due to their order relative to tap-dance in CMakeList.
Changing that order would solve the issue but break doing tap-dance with combos.
This PR fixes the issue by raising an event from the combo to interrupt the tap-dance.