### PR TITLE
fix(underglow): Move to spi3 for underglow bus.

### DIFF
--- a/app/boards/shields/chalice/boards/nice_nano.overlay
+++ b/app/boards/shields/chalice/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/chalice/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/chalice/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/corne/boards/nice_nano.overlay
+++ b/app/boards/shields/corne/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/corne/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/corne/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/elephant42/boards/nice_nano.overlay
+++ b/app/boards/shields/elephant42/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/elephant42/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/elephant42/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/eternal_keypad/boards/nice_nano.overlay
+++ b/app/boards/shields/eternal_keypad/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/eternal_keypad/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/eternal_keypad/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/helix/boards/nice_nano.overlay
+++ b/app/boards/shields/helix/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/helix/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/helix/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/jorne/boards/nice_nano.overlay
+++ b/app/boards/shields/jorne/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/jorne/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/jorne/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/kyria/boards/nice_nano.overlay
+++ b/app/boards/shields/kyria/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/kyria/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/kyria/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/lily58/boards/nice_nano.overlay
+++ b/app/boards/shields/lily58/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/lily58/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/lily58/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/microdox/boards/nice_nano.overlay
+++ b/app/boards/shields/microdox/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/microdox/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/microdox/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/murphpad/boards/nice_nano.overlay
+++ b/app/boards/shields/murphpad/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 31)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 31)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/murphpad/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/murphpad/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 31)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 31)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/nibble/boards/nice_nano.overlay
+++ b/app/boards/shields/nibble/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 11)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 11)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/nibble/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/nibble/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 11)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 11)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/redox/boards/nice_nano.overlay
+++ b/app/boards/shields/redox/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/redox/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/redox/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/reviung41/boards/nice_nano.overlay
+++ b/app/boards/shields/reviung41/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {
@@ -32,7 +32,7 @@
 		spi-max-frequency = <4000000>;
 
 		/* WS2812 */
-		chain-length = <10>; /* arbitrary; change at will */
+		chain-length = <11>;
 		spi-one-frame = <0x70>;
 		spi-zero-frame = <0x40>;
 

--- a/app/boards/shields/reviung41/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/reviung41/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {
@@ -32,7 +32,7 @@
 		spi-max-frequency = <4000000>;
 
 		/* WS2812 */
-		chain-length = <10>; /* arbitrary; change at will */
+		chain-length = <11>;
 		spi-one-frame = <0x70>;
 		spi-zero-frame = <0x40>;
 

--- a/app/boards/shields/romac_plus/boards/nice_nano.overlay
+++ b/app/boards/shields/romac_plus/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/romac_plus/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/romac_plus/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/snap/boards/nice_nano.overlay
+++ b/app/boards/shields/snap/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 10)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 10)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/snap/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/snap/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 10)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 10)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/splitkb_aurora_corne/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/splitkb_aurora_corne/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/splitkb_aurora_lily58/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_lily58/boards/nice_nano.overlay
@@ -2,13 +2,13 @@
 
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -16,12 +16,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/splitkb_aurora_lily58/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_lily58/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/tg4x/boards/nice_nano.overlay
+++ b/app/boards/shields/tg4x/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 8)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 8)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/tg4x/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/tg4x/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 8)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 8)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/tidbit/boards/nice_nano.overlay
+++ b/app/boards/shields/tidbit/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 9)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 9)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/tidbit/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/tidbit/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 9)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 9)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/two_percent_milk/boards/nice_nano.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nice_nano.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 9)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 9)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/app/boards/shields/two_percent_milk/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nice_nano_v2.overlay
@@ -1,13 +1,13 @@
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 9)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 9)>;
 			low-power-enable;
@@ -15,12 +15,12 @@
 	};
 };
 
-&spi1 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
 
 	led_strip: ws2812@0 {

--- a/docs/docs/features/underglow.md
+++ b/docs/docs/features/underglow.md
@@ -52,7 +52,7 @@ For example, the Kyria shield has a `boards/nice_nano.overlay` file that defines
 
 ### nRF52-based boards
 
-With nRF52 boards, you can just use `&spi1` and define the pins you want to use.
+With nRF52 boards, you can just use `&spi3` and define the pins you want to use.
 
 Here's an example on a definition that uses P0.06:
 
@@ -60,13 +60,13 @@ Here's an example on a definition that uses P0.06:
 #include <dt-bindings/led/led.h>
 
 &pinctrl {
-	spi1_default: spi1_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 		};
 	};
 
-	spi1_sleep: spi1_sleep {
+	spi3_sleep: spi3_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
 			low-power-enable;
@@ -74,12 +74,12 @@ Here's an example on a definition that uses P0.06:
 	};
 };
 
-&spi1 {
+&spi3 {
   compatible = "nordic,nrf-spim";
   status = "okay";
 
-  pinctrl-0 = <&spi1_default>;
-  pinctrl-1 = <&spi1_sleep>;
+  pinctrl-0 = <&spi3_default>;
+  pinctrl-1 = <&spi3_sleep>;
   pinctrl-names = "default", "sleep";
 
   led_strip: ws2812@0 {
@@ -119,12 +119,12 @@ If your board/shield uses LEDs that require the data sent in a different order, 
 
 For other boards, you must select an SPI definition that has the `MOSI` pin as your data pin going to your LED strip.
 
-Here's another example for a non-nRF52 board on `spi1`:
+Here's another example for a non-nRF52 board on `spi3`:
 
 ```
 #include <dt-bindings/led/led.h>
 
-&spi1 {
+&spi3 {
 
   led_strip: ws2812@0 {
     compatible = "worldsemi,ws2812-spi";


### PR DESCRIPTION
* Workaround Zephyr bug for Nordic SPI(M) driver after the
  pinctrl refactor by using spi3 peripheral for the SPI bus for
  the WS2812 led_strip driver.
