### PR TITLE
fix(boards): Fix Corne-ish Zen logo alignment

### DIFF
--- a/app/boards/arm/corneish_zen/custom_status_screen.c
+++ b/app/boards/arm/corneish_zen/custom_status_screen.c
@@ -70,7 +70,7 @@ lv_obj_t *zmk_display_status_screen() {
     lv_obj_t *zenlogo_icon;
     zenlogo_icon = lv_img_create(screen);
     lv_img_set_src(zenlogo_icon, &zenlogo);
-    lv_obj_align(zenlogo_icon, LV_ALIGN_BOTTOM_MID, 2, -5);
+    lv_obj_align(zenlogo_icon, LV_ALIGN_BOTTOM_MID, 0, -5);
 #endif
 
     return screen;


### PR DESCRIPTION
The Corne-ish Zen logo on the peripheral was slightly misaligned, which I am guessing causes the black bar at the bottom to appear. Moving it slightly so it doesn't go off-screen fixes this issue, see pictures below:

Before:
![image](https://user-images.githubusercontent.com/7876996/232157524-3e9b7833-72fc-4ed2-b7d7-80724b68c38b.png)

After:
![image](https://user-images.githubusercontent.com/7876996/232157633-6a2a3133-697d-4e60-af6b-313f7d020703.png)

