### PR TITLE
feat(display): Set mono theme and add invert config

### DIFF
--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -9,6 +9,7 @@ menuconfig ZMK_DISPLAY
     select LV_THEMES
     select LV_THEME_MONO
     select LV_CONF_MINIMAL
+    imply LV_USE_THEME_MONO
 
 if ZMK_DISPLAY
 

--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -15,6 +15,13 @@ config ZMK_DISPLAY_BLANK_ON_IDLE
     bool "Blank display on idle"
     default y if SSD1306
 
+if LV_USE_THEME_MONO
+
+config ZMK_DISPLAY_INVERT
+    bool "Invert display colors"
+
+endif
+
 choice LV_TXT_ENC
     default LV_TXT_ENC_UTF8
 

--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -6,8 +6,6 @@ menuconfig ZMK_DISPLAY
     default n
     select DISPLAY
     select LVGL
-    select LV_THEMES
-    select LV_THEME_MONO
     select LV_CONF_MINIMAL
     imply LV_USE_THEME_MONO
 

--- a/app/src/display/main.c
+++ b/app/src/display/main.c
@@ -91,7 +91,8 @@ int zmk_display_is_initialized() { return initialized; }
 static void initialize_theme() {
 #if IS_ENABLED(CONFIG_LV_USE_THEME_MONO)
     lv_disp_t *disp = lv_disp_get_default();
-    lv_theme_t *theme = lv_theme_mono_init(disp, false, CONFIG_LV_FONT_DEFAULT);
+    lv_theme_t *theme =
+        lv_theme_mono_init(disp, IS_ENABLED(CONFIG_ZMK_DISPLAY_INVERT), CONFIG_LV_FONT_DEFAULT);
     theme->font_small = CONFIG_ZMK_LV_FONT_DEFAULT_SMALL;
 
     disp->theme = theme;

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -17,11 +17,14 @@ Definition files:
 | Config                                             | Type | Description                                                    | Default |
 | -------------------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
 | `CONFIG_ZMK_DISPLAY`                               | bool | Enable support for displays                                    | n       |
+| `CONFIG_ZMK_DISPLAY_INVERT`                        | bool | Invert display colors from black-on-white to white-on-black    | n       |
 | `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool | Enable a widget to show the highest, active layer              | y       |
 | `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool | Enable a widget to show battery charge information             | y       |
 | `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool | If battery widget is enabled, show percentage instead of icons | n       |
 | `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool | Enable a widget to show the current output (USB/BLE)           | y       |
 | `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool | Enable a widget to show words per minute                       | n       |
+
+Note that `CONFIG_ZMK_DISPLAY_INVERT` setting might not work as expected with custom status screens that utilize images.
 
 If `CONFIG_ZMK_DISPLAY` is enabled, exactly zero or one of the following options must be set to `y`. The first option is used if none are set.
 


### PR DESCRIPTION
# Update

This PR sets `CONFIG_LV_USE_THEME_MONO` by default when `ZMK_DISPLAY` is enabled, so that small font selection used in the built-in status screen widgets is no longer ineffective.

It also adds a new Kconfig `ZMK_DISPLAY_INVERT` to invert the colors used in the display from black-on-white to white-on-black, by setting the appropriate value in mono theme initialization.

# Original
LVGL mono theme was getting selected by `ZMK_DISPLAY` but not actually used outside of the `corneish_zen` configuration. This change sets it by default if OLEDs or ls0xx memory displays like nice!view are used. This change could use some testing to make sure it doesn't break on OLEDs, nice!views, Adafruit memory displays etc. (Unfortunately I don't have any at the moment, tested on native_posix+SDL setup.)

Given that the theme is set correctly, we can also add an invert option by setting the `dark_bg` parameter of `lv_theme_mono_init` accordingly. The config is currently named `CONFIG_ZMK_DISPLAY_INVERT` but maybe it should be `CONFIG_ZMK_MONO_THEME_INVERT` or something else? Also it is possible that there is a better way to make this change.