### PR TITLE
docs: add llcp setting to troubleshooting guide

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -111,6 +111,14 @@ CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
 
 For the `nRF52840`, the value `PLUS_8` can be set to any multiple of four between `MINUS_20` and `PLUS_8`. The default value for this config is `0`, but if you are having connection issues it is recommended to set it to `PLUS_8` because the power consumption difference is negligible. For more information on changing the transmit power of your BLE device, please refer to [the Zephyr docs.](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_BT_CTLR_TX_PWR)
 
+#### Frequent Disconnects
+
+If you recently rebuilt and flashed your firmware and now notice your keyboard disconnecting frequently, it might be due to the change of the default LLCP in Zephyr 3.2. The following setting might alleviate the problem: 
+
+```
+CONFIG_BT_LL_SW_LLCP_LEGACY=y
+```
+
 ### Other notes and warnings
 
 - If you want to test bluetooth output on your keyboard and are powering it through the USB connection rather than a battery, you will be able to pair with a host device but may not see keystrokes sent. In this case you need to use the [output selection behavior](../docs/behaviors/outputs.md) to prefer sending keystrokes over bluetooth rather than USB. This might be necessary even if you are not powering from a device capable of receiving USB inputs, such as a USB charger.


### PR DESCRIPTION
I added a section to the troubleshooting guide regarding the frequent disconnects caused by the new Zephyr default llcp.
I think it is worthwhile mentioning it there.

I am in no position to phrase the explanation correctly, so any help is appreciated. 

I just prepared this PR to make this quick and easy :)


