### PR TITLE
fix(bluetooth): Revert to Legacy LLCP

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -120,6 +120,11 @@ menuconfig ZMK_BLE
 
 if ZMK_BLE
 
+choice BT_LL_SW_LLCP_IMPL
+	default BT_LL_SW_LLCP_LEGACY
+
+endchoice
+
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	default 4096 if SOC_RP2040
 	default 2048


### PR DESCRIPTION
* Reports of constant/frequent disconnects, with HCI err 0x28, "instant passed", seem linked to newer LLCP that became default in Zephyr 3.2, so revert to the Legacy LLCP for now until a proper fix for new LLCP can be found.

This needs a decent amount of testing, since it switches a core BT building block that hasn't been as well tested on the Zephyr 3.2 work.