### PR TITLE
fix(boards): Move nice!60 to SPI3 for underglow

### DIFF
--- a/app/boards/arm/nice60/nice60-pinctrl.dtsi
+++ b/app/boards/arm/nice60/nice60-pinctrl.dtsi
@@ -4,7 +4,7 @@
  */
 
 &pinctrl {
-	spi0_default: spi0_default {
+	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_MOSI, 0, 27)>;
 		};

--- a/app/boards/arm/nice60/nice60.dts
+++ b/app/boards/arm/nice60/nice60.dts
@@ -109,10 +109,10 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
 	status = "okay";
 };
 
-&spi0 {
+&spi3 {
 	compatible = "nordic,nrf-spim";
-	/* Cannot be used together with i2c0. */
-	pinctrl-0 = <&spi0_default>;
+
+	pinctrl-0 = <&spi3_default>;
 	pinctrl-names = "default";
 	status = "okay";
 


### PR DESCRIPTION
* Move to SPI3 for underglow peripheral, needed after the
  move to pinctrl.