### PR TITLE
refactor: Add format on save for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "ms-python.python",
+    "ms-vscode.cpptools",
+    "plorefice.devicetree",
+    "twxs.cmake"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,21 @@
     "*.overlay": "dts",
     "*.keymap": "dts"
   },
-  "python.formatting.provider": "black"
+  "python.formatting.provider": "black",
+  "[c]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "ms-vscode.cpptools"
+  },
+  "[javascript][javascriptreact][typescript][typescriptreact]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "ms-python.python"
+  },
+  "[css][json][jsonc][html][markdown][yaml]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,7 @@
   },
   "python.formatting.provider": "black",
   "[c]": {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "ms-vscode.cpptools"
+    "editor.formatOnSave": true
   },
   "[javascript][javascriptreact][typescript][typescriptreact]": {
     "editor.formatOnSave": true,


### PR DESCRIPTION
Added settings to format various file types on save in VS Code.

Added some recommended VS Code extensions:

- Prettier for formatting various file types
- Python for formatting Python files
- C/C++ for formatting C files
- Devicetree for syntax highlighting
- CMake for syntax highlighting
