### PR TITLE
fix(docs): Add key to interconnect tabs

### DIFF
--- a/docs/src/components/interconnect-tabs.tsx
+++ b/docs/src/components/interconnect-tabs.tsx
@@ -15,7 +15,7 @@ function mapInterconnect(interconnect: Interconnect) {
   let imageUrl = require(`@site/docs/assets/interconnects/${interconnect.id}/pinout.png`);
 
   return (
-    <TabItem value={interconnect.id}>
+    <TabItem value={interconnect.id} key={interconnect.id}>
       <img src={imageUrl.default} />
 
       <content.default />


### PR DESCRIPTION
Added a `key` property to interconnect tabs list items to fix a React warning.
