### PR TITLE
refactor(shields): MurphPad

### DIFF
--- a/app/boards/shields/murphpad/Kconfig.defconfig
+++ b/app/boards/shields/murphpad/Kconfig.defconfig
@@ -6,6 +6,9 @@ if SHIELD_MURPHPAD
 config ZMK_KEYBOARD_NAME
     default "MurphPad"
 
+config ZMK_DISPLAY
+    default y
+
 if ZMK_DISPLAY
 
 config I2C

--- a/app/boards/shields/murphpad/boards/nice_nano.conf
+++ b/app/boards/shields/murphpad/boards/nice_nano.conf
@@ -1,3 +1,0 @@
-# Uncomment both to enable underglow
-CONFIG_ZMK_RGB_UNDERGLOW=y
-CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/murphpad/boards/nice_nano.overlay
+++ b/app/boards/shields/murphpad/boards/nice_nano.overlay
@@ -31,7 +31,7 @@
         spi-max-frequency = <4000000>;
 
         /* WS2812 */
-        chain-length = <10>; /* arbitrary; change at will */
+        chain-length = <8>; /* number of SMD LED footprints on PCB */
         spi-one-frame = <0x70>;
         spi-zero-frame = <0x40>;
 

--- a/app/boards/shields/murphpad/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/murphpad/boards/nice_nano_v2.overlay
@@ -31,7 +31,7 @@
         spi-max-frequency = <4000000>;
 
         /* WS2812 */
-        chain-length = <10>; /* arbitrary; change at will */
+        chain-length = <8>; /* number of SMD LED footprints on PCB */
         spi-one-frame = <0x70>;
         spi-zero-frame = <0x40>;
 

--- a/app/boards/shields/murphpad/murphpad-layout.dtsi
+++ b/app/boards/shields/murphpad/murphpad-layout.dtsi
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <physical_layouts.dtsi>
+
+/ {
+    chosen {
+        zmk,physical-layout = &all_1u_layout;
+    };
+
+    all_1u_layout: keymap_layout_0 {
+        compatible = "zmk,physical-layout";
+        display-name = "Default";
+
+        transform = <&all_1u_transform>;
+
+        keys  //                     w   h    x    y     rot   rx   ry
+            = <&key_physical_attrs 100 100  100    0       0    0    0>
+            , <&key_physical_attrs 100 100  200    0       0    0    0>
+            , <&key_physical_attrs 100 100  300    0       0    0    0>
+            , <&key_physical_attrs 100 100  400    0       0    0    0>
+            , <&key_physical_attrs 100 100  100  100       0    0    0>
+            , <&key_physical_attrs 100 100  200  100       0    0    0>
+            , <&key_physical_attrs 100 100  300  100       0    0    0>
+            , <&key_physical_attrs 100 100  400  100       0    0    0>
+            , <&key_physical_attrs 100 100  100  200       0    0    0>
+            , <&key_physical_attrs 100 100  200  200       0    0    0>
+            , <&key_physical_attrs 100 100  300  200       0    0    0>
+            , <&key_physical_attrs 100 100  400  200       0    0    0>
+            , <&key_physical_attrs 100 100    0  275       0    0    0>
+            , <&key_physical_attrs 100 100  100  300       0    0    0>
+            , <&key_physical_attrs 100 100  200  300       0    0    0>
+            , <&key_physical_attrs 100 100  300  300       0    0    0>
+            , <&key_physical_attrs 100 100  400  300       0    0    0>
+            , <&key_physical_attrs 100 100    0  400       0    0    0>
+            , <&key_physical_attrs 100 100  100  400       0    0    0>
+            , <&key_physical_attrs 100 100  200  400       0    0    0>
+            , <&key_physical_attrs 100 100  300  400       0    0    0>
+            , <&key_physical_attrs 100 100  400  400       0    0    0>
+            , <&key_physical_attrs 100 100    0  500       0    0    0>
+            , <&key_physical_attrs 100 100  100  500       0    0    0>
+            , <&key_physical_attrs 100 100  200  500       0    0    0>
+            , <&key_physical_attrs 100 100  300  500       0    0    0>
+            , <&key_physical_attrs 100 100  400  500       0    0    0>
+            , <&key_physical_attrs 100 100  100  700       0    0    0>
+            , <&key_physical_attrs 100 100  200  700       0    0    0>
+            , <&key_physical_attrs 100 100  300  700       0    0    0>
+            ;
+
+    };
+
+    right_numpad_layout: keymap_layout_1 {
+        compatible = "zmk,physical-layout";
+        display-name = "Right Numpad";
+
+        transform = <&right_numpad_transform>;
+
+        keys  //                     w   h    x    y     rot   rx   ry
+            = <&key_physical_attrs 100 100  100    0       0    0    0>
+            , <&key_physical_attrs 100 100  200    0       0    0    0>
+            , <&key_physical_attrs 100 100  300    0       0    0    0>
+            , <&key_physical_attrs 100 100  400    0       0    0    0>
+            , <&key_physical_attrs 100 100  100  100       0    0    0>
+            , <&key_physical_attrs 100 100  200  100       0    0    0>
+            , <&key_physical_attrs 100 100  300  100       0    0    0>
+            , <&key_physical_attrs 100 100  400  100       0    0    0>
+            , <&key_physical_attrs 100 200  100  200       0    0    0>
+            , <&key_physical_attrs 100 100  200  200       0    0    0>
+            , <&key_physical_attrs 100 100  300  200       0    0    0>
+            , <&key_physical_attrs 100 100  400  200       0    0    0>
+            , <&key_physical_attrs 100 100    0  275       0    0    0>
+            , <&key_physical_attrs 100 100  200  300       0    0    0>
+            , <&key_physical_attrs 100 100  300  300       0    0    0>
+            , <&key_physical_attrs 100 100  400  300       0    0    0>
+            , <&key_physical_attrs 100 100    0  400       0    0    0>
+            , <&key_physical_attrs 100 200  100  400       0    0    0>
+            , <&key_physical_attrs 100 100  200  400       0    0    0>
+            , <&key_physical_attrs 100 100  300  400       0    0    0>
+            , <&key_physical_attrs 100 100  400  400       0    0    0>
+            , <&key_physical_attrs 100 100    0  500       0    0    0>
+            , <&key_physical_attrs 100 100  200  500       0    0    0>
+            , <&key_physical_attrs 200 100  300  500       0    0    0>
+            , <&key_physical_attrs 100 100  100  700       0    0    0>
+            , <&key_physical_attrs 100 100  200  700       0    0    0>
+            , <&key_physical_attrs 100 100  300  700       0    0    0>
+            ;
+
+    };
+
+    left_numpad_layout: keymap_layout_2 {
+        compatible = "zmk,physical-layout";
+        display-name = "Left Numpad";
+
+        transform = <&left_numpad_transform>;
+
+        keys  //                     w   h    x    y     rot   rx   ry
+            = <&key_physical_attrs 100 100  100    0       0    0    0>
+            , <&key_physical_attrs 100 100  200    0       0    0    0>
+            , <&key_physical_attrs 100 100  300    0       0    0    0>
+            , <&key_physical_attrs 100 100  400    0       0    0    0>
+            , <&key_physical_attrs 100 100  100  100       0    0    0>
+            , <&key_physical_attrs 100 100  200  100       0    0    0>
+            , <&key_physical_attrs 100 100  300  100       0    0    0>
+            , <&key_physical_attrs 100 100  400  100       0    0    0>
+            , <&key_physical_attrs 100 100  100  200       0    0    0>
+            , <&key_physical_attrs 100 100  200  200       0    0    0>
+            , <&key_physical_attrs 100 100  300  200       0    0    0>
+            , <&key_physical_attrs 100 200  400  200       0    0    0>
+            , <&key_physical_attrs 100 100    0  275       0    0    0>
+            , <&key_physical_attrs 100 100  100  300       0    0    0>
+            , <&key_physical_attrs 100 100  200  300       0    0    0>
+            , <&key_physical_attrs 100 100  300  300       0    0    0>
+            , <&key_physical_attrs 100 100    0  400       0    0    0>
+            , <&key_physical_attrs 100 100  100  400       0    0    0>
+            , <&key_physical_attrs 100 100  200  400       0    0    0>
+            , <&key_physical_attrs 100 100  300  400       0    0    0>
+            , <&key_physical_attrs 100 200  400  400       0    0    0>
+            , <&key_physical_attrs 100 100    0  500       0    0    0>
+            , <&key_physical_attrs 200 100  100  500       0    0    0>
+            , <&key_physical_attrs 100 100  300  500       0    0    0>
+            , <&key_physical_attrs 100 100  100  700       0    0    0>
+            , <&key_physical_attrs 100 100  200  700       0    0    0>
+            , <&key_physical_attrs 100 100  300  700       0    0    0>
+            ;
+    };
+
+    position_map {
+        compatible = "zmk,physical-layout-position-map";
+        all_1u_map {
+            physical-layout = <&all_1u_layout>;
+            positions
+                = <11 21 23 25 22 17 18 19 20 13 14 15  8  9 10 27>
+                , <28 29 16 26 24>
+                ;
+        };
+
+        right_numpad_map {
+            physical-layout = <&right_numpad_layout>;
+            positions
+                = < 8 17 23 22 21 16 18 19 20 13 14 15  9 10 11 24>
+                , <25 26 27 28 29>
+                ;
+        };
+
+        left_numpad_map {
+            physical-layout = <&left_numpad_layout>;
+            positions
+                = <11 20 22 23 21 16 17 18 19 13 14 15  8  9 10 24>
+                , <25 26 27 28 29>
+                ;
+        };
+    };
+};

--- a/app/boards/shields/murphpad/murphpad.conf
+++ b/app/boards/shields/murphpad/murphpad.conf
@@ -1,9 +1,15 @@
-# Uncomment to turn on logging, and set ZMK logging to debug output
-# CONFIG_ZMK_USB_LOGGING=y
+# To enable logging, use the snippet per the documentation.
+# Delaying log output may help catch issues close to startup. Uncomment and adjust if necessary (default is 1000ms)
+#CONFIG_LOG_PROCESS_THREAD_STARTUP_DELAY_MS=3000
 
-# Uncomment both to enable encoder
+# Uncomment both to enable encoder(s)
 CONFIG_EC11=y
 CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
 
-# Uncomment to enable OLED
-CONFIG_ZMK_DISPLAY=y
+# Uncomment to disable OLED
+#CONFIG_ZMK_DISPLAY=n
+
+# Uncomment both to enable underglow
+# Note that this will only work if an implementation exists for your board; check under the shield folder for board-specific overlays.
+#CONFIG_ZMK_RGB_UNDERGLOW=y
+#CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/murphpad/murphpad.keymap
+++ b/app/boards/shields/murphpad/murphpad.keymap
@@ -7,16 +7,16 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
 #include <dt-bindings/zmk/rgb.h>
-
 
 #define TIMEOUT 300
 
-&encoder_1 {
+&middle_left_encoder {
     status = "okay";
 };
 
-&encoder_2 {
+&top_right_encoder {
     status = "okay";
 };
 
@@ -25,59 +25,56 @@
         compatible = "zmk,combos";
         combo_btclr {
             timeout-ms = <TIMEOUT>;
-            key-positions = <1 6>;
+            key-positions = <0 4>;
             bindings = <&bt BT_CLR>;
         };
         combo_reset {
             timeout-ms = <TIMEOUT>;
-            key-positions = <1 3>;
+            key-positions = <0 2>;
             bindings = <&sys_reset>;
         };
         combo_bootloader {
             timeout-ms = <TIMEOUT>;
-            key-positions = <1 2>;
+            key-positions = <0 1>;
             bindings = <&bootloader>;
         };
         combo_bt_nxt {
             timeout-ms = <TIMEOUT>;
-            key-positions = <1 4>;
+            key-positions = <0 3>;
             bindings = <&bt BT_NXT>;
         };
     };
 
-    sensors: sensors {
-        compatible = "zmk,keymap-sensors";
-        sensors = <&encoder_1 &encoder_2>;
-        triggers-per-rotation = <20>;
-    };
-
-
-    keymap0: keymap {
+    keymap: keymap {
         compatible = "zmk,keymap";
 
         default_layer {
-            display-name = "default layer";
+            display-name = "default";
             bindings = <
-                &bt BT_CLR       &kp TAB      &kp F5          &kp LC(LA(C))     &kp LG(D)
-                &rgb_ug RGB_TOG  &kp ESC      &kp KP_DIVIDE   &kp KP_MULTIPLY   &kp KP_MINUS
-                &rgb_ug RGB_EFF  &kp KP_N7    &kp KP_N8       &kp KP_N9         &kp KP_PLUS
-                &kp C_MUTE       &kp KP_N4    &kp KP_N5       &kp KP_N6         &trans
-                &mo 1            &kp KP_N1    &kp KP_N2       &kp KP_N3         &kp KP_ENTER
-                &kp BSPC         &kp KP_N0    &trans          &kp KP_DOT        &trans
+                            &kp F1       &kp F2          &kp F3            &kp F4
+                            &kp KP_NUM   &kp KP_DIVIDE   &kp KP_MULTIPLY   &kp KP_MINUS
+                            &kp KP_N7    &kp KP_N8       &kp KP_N9         &kp KP_PLUS
+                &kp C_MUTE  &kp KP_N4    &kp KP_N5       &kp KP_N6         &trans
+                &mo 1       &kp KP_N1    &kp KP_N2       &kp KP_N3         &kp KP_ENTER
+                &kp BSPC    &kp KP_N0    &trans          &kp KP_DOT        &trans
+
+                            &bt BT_CLR   &rgb_ug RGB_TOG &rgb_ug RGB_EFF
             >;
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
 
         };
 
         fn_layer {
-            display-name = "fn layer";
+            display-name = "fn";
             bindings = <
-                &trans      &trans     &trans        &trans          &trans
-                &trans      &kp KP_NUM &trans        &trans          &trans
-                &trans      &trans     &trans        &trans             &trans
-                &bt BT_CLR  &trans     &trans        &trans          &trans
-                &trans      &trans     &trans        &trans          &trans
-                &kp DEL        &trans     &trans        &trans          &trans
+                            &out OUT_TOG     &bt BT_PRV       &bt BT_NXT       &trans
+                            &trans           &trans           &trans           &trans
+                            &rgb_ug RGB_HUD  &rgb_ug RGB_SPI  &rgb_ug RGB_HUI  &trans
+                &bt BT_CLR  &rgb_ug RGB_EFR  &rgb_ug RGB_TOG  &rgb_ug RGB_EFF  &trans
+                &trans      &rgb_ug RGB_BRD  &rgb_ug RGB_SPD  &rgb_ug RGB_BRI  &trans
+                &kp DEL     &rgb_ug RGB_SAD  &trans           &rgb_ug RGB_SAI  &trans
+
+                            &trans           &trans           &trans
             >;
             sensor-bindings = <&inc_dec_kp PG_UP PG_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
 

--- a/app/boards/shields/murphpad/murphpad.overlay
+++ b/app/boards/shields/murphpad/murphpad.overlay
@@ -6,35 +6,86 @@
 
 #include <dt-bindings/zmk/matrix_transform.h>
 
+#include "murphpad-layout.dtsi"
+
 / {
     chosen {
         zephyr,display = &oled;
-        zmk,kscan = &kscan0;
+        zmk,kscan = &kscan;
+        zmk,physical-layouts = &all_1u_layout;
     };
 
-    kscan0: kscan {
+    kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
         wakeup-source;
 
         diode-direction = "col2row";
         row-gpios
-            = <&pro_micro 20  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&pro_micro 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-                    , <&pro_micro 18  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-                    , <&pro_micro 19  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
         col-gpios
             = <&pro_micro 9  GPIO_ACTIVE_HIGH>
             , <&pro_micro 6  GPIO_ACTIVE_HIGH>
             , <&pro_micro 5  GPIO_ACTIVE_HIGH>
             , <&pro_micro 4  GPIO_ACTIVE_HIGH>
-                    , <&pro_micro 10 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 10 GPIO_ACTIVE_HIGH>
             ;
     };
 
-    encoder_1: encoder_1 {
+    all_1u_transform: keymap_transform_0 {
+            compatible = "zmk,matrix-transform";
+            columns = <5>;
+            rows = <6>;
+            map = <
+                        RC(0,1) RC(0,2) RC(0,3) RC(0,4)
+                        RC(1,1) RC(1,2) RC(1,3) RC(1,4)
+                        RC(2,1) RC(2,2) RC(2,3) RC(2,4)
+                RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)
+                RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4)
+                RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4)
+
+                        RC(0,0) RC(1,0) RC(2,0)
+        >;
+    };
+
+    right_numpad_transform: keymap_transform_1 {
+            compatible = "zmk,matrix-transform";
+            columns = <5>;
+            rows = <6>;
+            map = <
+                        RC(0,1) RC(0,2) RC(0,3) RC(0,4)
+                        RC(1,1) RC(1,2) RC(1,3) RC(1,4)
+                        RC(2,1) RC(2,2) RC(2,3) RC(2,4)
+                RC(3,0)         RC(3,2) RC(3,3) RC(3,4)
+                RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4)
+                RC(5,0)         RC(5,2)     RC(5,4)
+
+                        RC(0,0) RC(1,0) RC(2,0)
+        >;
+    };
+
+    left_numpad_transform: keymap_transform_2 {
+            compatible = "zmk,matrix-transform";
+            columns = <5>;
+            rows = <6>;
+            map = <
+                        RC(0,1) RC(0,2) RC(0,3) RC(0,4)
+                        RC(1,1) RC(1,2) RC(1,3) RC(1,4)
+                        RC(2,1) RC(2,2) RC(2,3) RC(2,4)
+                RC(3,0) RC(3,1) RC(3,2) RC(3,3)
+                RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4)
+                RC(5,0)     RC(5,1)     RC(5,3)
+
+                        RC(0,0) RC(1,0) RC(2,0)
+        >;
+    };
+
+    middle_left_encoder: encoder_1: encoder_1 {
         compatible = "alps,ec11";
         a-gpios = <&pro_micro 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
@@ -42,12 +93,18 @@
         status = "disabled";
     };
 
-    encoder_2: encoder_2 {
+    top_right_encoder: encoder_2: encoder_2 {
         compatible = "alps,ec11";
         a-gpios = <&pro_micro 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
         status = "disabled";
+    };
+
+    sensors: sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&middle_left_encoder &top_right_encoder>;
+        triggers-per-rotation = <20>;
     };
 
 };


### PR DESCRIPTION
- **Added matrix transforms and physical layouts for three configurations.** This is a numpad, but notably the first three positions of column 0 are actually tact switches on the back of the PCB. I believe the new transforms make this clearer (the keymap appearance matches QMK Configurator now, too)
- Tweaked default keymap:
  - more closely resembles the QMK Configurator default map (reduces confusion for users who are new to ZMK; also generally less niche)
  - more useful OOTB for ZMK (immediate access to output selection, easier BT profile switching).
- Cleaned up formatting a bit.
- Updated encoder configuration to current ZMK standards.
- Avoid forcing RGB on for `nice_nano`.
- Corrected the number of default LEDs. While some users may opt for less or more, there are exactly eight footprints on the PCB for 5050 SMD LEDs.

## Board/Shield Check-list

- [x] This board/shield is tested working on real hardware
- [x] General consistent formatting of DeviceTree files
- [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
