### PR TITLE
fix(boards): unify board I2C configuration, use TWI driver

### DIFF
--- a/app/boards/arm/bluemicro840/bluemicro840_v1.dts
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1.dts
@@ -63,7 +63,7 @@
 };
 
 &i2c0 {
-    compatible = "nordic,nrf-twim";
+    compatible = "nordic,nrf-twi";
     pinctrl-0 = <&i2c0_default>;
     pinctrl-1 = <&i2c0_sleep>;
     pinctrl-names = "default", "sleep";
@@ -71,6 +71,7 @@
 
 &uart0 {
     compatible = "nordic,nrf-uarte";
+    current-speed = <115200>;
     pinctrl-0 = <&uart0_default>;
     pinctrl-1 = <&uart0_sleep>;
     pinctrl-names = "default", "sleep";

--- a/app/boards/arm/nrfmicro/nrfmicro_11.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11.dts
@@ -48,7 +48,7 @@
 };
 
 &i2c0 {
-    compatible = "nordic,nrf-twim";
+    compatible = "nordic,nrf-twi";
     pinctrl-0 = <&i2c0_default>;
     pinctrl-1 = <&i2c0_sleep>;
     pinctrl-names = "default", "sleep";
@@ -56,6 +56,7 @@
 
 &uart0 {
     compatible = "nordic,nrf-uarte";
+    current-speed = <115200>;
     pinctrl-0 = <&uart0_default>;
     pinctrl-1 = <&uart0_sleep>;
     pinctrl-names = "default", "sleep";

--- a/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
@@ -48,7 +48,7 @@
 };
 
 &i2c0 {
-    compatible = "nordic,nrf-twim";
+    compatible = "nordic,nrf-twi";
     pinctrl-0 = <&i2c0_default>;
     pinctrl-1 = <&i2c0_sleep>;
     pinctrl-names = "default", "sleep";
@@ -56,6 +56,7 @@
 
 &uart0 {
     compatible = "nordic,nrf-uarte";
+    current-speed = <115200>;
     pinctrl-0 = <&uart0_default>;
     pinctrl-1 = <&uart0_sleep>;
     pinctrl-names = "default", "sleep";

--- a/app/boards/arm/nrfmicro/nrfmicro_13.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13.dts
@@ -61,7 +61,7 @@
 };
 
 &i2c0 {
-    compatible = "nordic,nrf-twim";
+    compatible = "nordic,nrf-twi";
     pinctrl-0 = <&i2c0_default>;
     pinctrl-1 = <&i2c0_sleep>;
     pinctrl-names = "default", "sleep";
@@ -69,6 +69,7 @@
 
 &uart0 {
     compatible = "nordic,nrf-uarte";
+    current-speed = <115200>;
     pinctrl-0 = <&uart0_default>;
     pinctrl-1 = <&uart0_sleep>;
     pinctrl-names = "default", "sleep";

--- a/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
@@ -61,7 +61,7 @@
 };
 
 &i2c0 {
-    compatible = "nordic,nrf-twim";
+    compatible = "nordic,nrf-twi";
     pinctrl-0 = <&i2c0_default>;
     pinctrl-1 = <&i2c0_sleep>;
     pinctrl-names = "default", "sleep";
@@ -69,6 +69,7 @@
 
 &uart0 {
     compatible = "nordic,nrf-uarte";
+    current-speed = <115200>;
     pinctrl-0 = <&uart0_default>;
     pinctrl-1 = <&uart0_sleep>;
     pinctrl-names = "default", "sleep";


### PR DESCRIPTION
https://github.com/petejohanson/zmk/commit/b74830bec6dab11c4cbf59b16eecb9a62b5ff429 (the commit moving boards to pinctrl) used the `nrf-twim` driver for all `nrfmicro` revisions and the `bluemicro840`.
That driver does not seem to work with ZMK OLED screens for some reason. Both the issue and the fix were observed and tested with `nrfmicro_13_52833` and `nrfmicro_13` with various shields.

Note: the Corne-ish Zen V1 uses the same `nrf-twim` driver for its fuel gauge, that seems to work fine (tested on my Zen). The issue only occurs with the screens.