### PR TITLE
docs: Move BT troubleshooting items and note known issue for Windows

### DIFF
--- a/docs/docs/features/bluetooth.md
+++ b/docs/docs/features/bluetooth.md
@@ -38,6 +38,20 @@ Management of the bluetooth in ZMK is accomplished using the [`&bt` behavior](..
 
 ## Troubleshooting
 
+### Connectivity Issues
+
+Some users may experience a poor connection between the keyboard and the host. This might be due to poor quality BLE hardware, a metal enclosure on the keyboard or host, or the distance between them. Increasing the transmit power of the keyboard's BLE radio may reduce the severity of this problem. To do this, set the `CONFIG_BT_CTLR_TX_PWR_PLUS_8` configuration value in the `.conf` file of your user config directory as such:
+
+```
+CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
+```
+
+For the `nRF52840`, the value `PLUS_8` can be set to any multiple of four between `MINUS_20` and `PLUS_8`. The default value for this config is `0`, but if you are having connection issues it is recommended to set it to `PLUS_8` because the power consumption difference is negligible. For more information on changing the transmit power of your BLE device, please refer to [the Zephyr docs.](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_BT_CTLR_TX_PWR)
+
+### Using bluetooth output with USB power
+
+If you want to test bluetooth output on your keyboard and are powering it through the USB connection rather than a battery, you will be able to pair with a host device but may not see keystrokes sent. In this case you need to use the [output selection behavior](../docs/behaviors/outputs.md) to prefer sending keystrokes over bluetooth rather than USB. This might be necessary even if you are not powering from a device capable of receiving USB inputs, such as a USB charger.
+
 ## Known Issues
 
 There are a few known issues related to BLE and ZMK:

--- a/docs/docs/features/bluetooth.md
+++ b/docs/docs/features/bluetooth.md
@@ -57,3 +57,18 @@ If you attempt to pair a ZMK keyboard from macOS in a way that causes a bonding 
 1. Remove the keyboard from macOS using the Bluetooth control panel.
 1. Invoke `&bt BT_CLR` on the keyboard while the profile associated with the macOS device is active, by pressing the correct keys for your particular keymap.
 1. Try connecting again from macOS.
+
+### Windows Connected But Not Working
+
+Occasionally pairing the keyboard to a Windows device might result in a state where the keyboard is connected but does not send any key strokes.
+If this occurs:
+
+1. Remove the keyboard from Windows using the Bluetooth settings.
+1. Invoke `&bt BT_CLR` on the keyboard while the profile associated with the Windows device is active, by pressing the correct keys for your particular keymap.
+1. Turn off Bluetooth from Windows settings, then turn it back on.
+1. Pair the keyboard to the Windows device.
+
+If this doesn't help, try following the procedure above but replace step 3 with one of the following:
+
+- Restart the Windows device
+- Open "Device Manager," turn on "Show hidden devices" from the "View" menu, then find and delete the keyboard under the "Bluetooth" item

--- a/docs/docs/features/bluetooth.md
+++ b/docs/docs/features/bluetooth.md
@@ -48,6 +48,10 @@ CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
 
 For the `nRF52840`, the value `PLUS_8` can be set to any multiple of four between `MINUS_20` and `PLUS_8`. The default value for this config is `0`, but if you are having connection issues it is recommended to set it to `PLUS_8` because the power consumption difference is negligible. For more information on changing the transmit power of your BLE device, please refer to [the Zephyr docs.](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_BT_CTLR_TX_PWR)
 
+:::info
+This setting can also improve the connection strength between the keyboard halves for split keyboards.
+:::
+
 ### Using bluetooth output with USB power
 
 If you want to test bluetooth output on your keyboard and are powering it through the USB connection rather than a battery, you will be able to pair with a host device but may not see keystrokes sent. In this case you need to use the [output selection behavior](../docs/behaviors/outputs.md) to prefer sending keystrokes over bluetooth rather than USB. This might be necessary even if you are not powering from a device capable of receiving USB inputs, such as a USB charger.

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -5,6 +5,8 @@ sidebar_title: Troubleshooting
 
 The following page provides suggestions for common errors that may occur during firmware compilation or other issues with keyboard usage. If the information provided is insufficient to resolve the issue, feel free to seek out help from the [ZMK Discord](https://zmk.dev/community/discord/invite).
 
+Please also see [the troubleshooting section](features/bluetooth.md#troubleshooting) under the Bluetooth feature page.
+
 ### File Transfer Error
 
 Variations of the warnings shown below occur when flashing the `<firmware>.uf2` onto the microcontroller. This is because the microcontroller resets itself before the OS receives confirmation that the file transfer is complete. Errors like this are normal and can generally be ignored. Verification of a functional board can be done by attempting to pair your newly flashed keyboard to your computer via Bluetooth or plugging in a USB cable if `ZMK_USB` is enabled in your Kconfig.defconfig.

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -5,7 +5,7 @@ sidebar_title: Troubleshooting
 
 The following page provides suggestions for common errors that may occur during firmware compilation or other issues with keyboard usage. If the information provided is insufficient to resolve the issue, feel free to seek out help from the [ZMK Discord](https://zmk.dev/community/discord/invite).
 
-Please also see [the troubleshooting section](features/bluetooth.md#troubleshooting) under the Bluetooth feature page.
+Please also see [the troubleshooting section](features/bluetooth.md#troubleshooting) under the Bluetooth feature page for issues related to bluetooth.
 
 ### File Transfer Error
 
@@ -102,17 +102,3 @@ Perform the following steps to reset both halves of your split keyboard:
 1. Flash the actual image for each half of the split keyboard (e.g `my_board_left.uf2` to the left half, `my_board_right.uf2` to the right half).
 
 After completing these steps, pair the halves of the split keyboard together by resetting them at the same time. Most commonly, this is done by grounding the reset pins for each of your keyboard's microcontrollers or pressing the reset buttons at the same time.
-
-### Connectivity Issues
-
-Some users may experience a poor connection between the keyboard and the host. This might be due to poor quality BLE hardware, a metal enclosure on the keyboard or host, or the distance between them. Increasing the transmit power of the keyboard's BLE radio may reduce the severity of this problem. To do this, set the `CONFIG_BT_CTLR_TX_PWR_PLUS_8` configuration value in the `.conf` file of your user config directory as such:
-
-```
-CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
-```
-
-For the `nRF52840`, the value `PLUS_8` can be set to any multiple of four between `MINUS_20` and `PLUS_8`. The default value for this config is `0`, but if you are having connection issues it is recommended to set it to `PLUS_8` because the power consumption difference is negligible. For more information on changing the transmit power of your BLE device, please refer to [the Zephyr docs.](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_BT_CTLR_TX_PWR)
-
-### Other notes and warnings
-
-- If you want to test bluetooth output on your keyboard and are powering it through the USB connection rather than a battery, you will be able to pair with a host device but may not see keystrokes sent. In this case you need to use the [output selection behavior](../docs/behaviors/outputs.md) to prefer sending keystrokes over bluetooth rather than USB. This might be necessary even if you are not powering from a device capable of receiving USB inputs, such as a USB charger.


### PR DESCRIPTION
Move BT-related items from under troubleshooting page to under the troubleshooting section under new BT feature page, then link to that from the original page.

In addition:
- note the known issue with Windows sometimes not receiving keystrokes and provide a workaround[^1]
- note that TX power config also improves split keyboard inter-half connectivity

[^1]: Recently (after the Zephyr 3.2 upgrade) this issue popped up, where some Windows devices can be properly connected but not receive key strokes from the keyboard. A simple un-pair/re-pair doesn't seem to solve it and other actions detailed here is required. 
I have seen this issue reported a few times and I experienced it myself once, and they were solved with these suggestions.
I think investigating the root cause would be good but meanwhile, we should have it noted since it has a simple but non-obvious fix.