### PR TITLE
docs: Correction for Japanese charactor

### DIFF
--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -3477,7 +3477,7 @@ export default [
   },
   {
     names: ["INTERNATIONAL_6", "INT6", "INT_KPJPCOMMA"],
-    description: ", [カソマ] (International 6)",
+    description: ", [カンマ] (International 6)",
     context: "Keyboard",
     clarify: false,
     usages: [


### PR DESCRIPTION
I found a typo. 
There is no Japanese word "カソマ". "カンマ" (or "コンマ") is correct. 
"ソ" and "ン" are different characters :)