### PR TITLE
fix(docs): Fix broken link in BT troubleshooting

### DIFF
--- a/docs/docs/features/bluetooth.md
+++ b/docs/docs/features/bluetooth.md
@@ -54,7 +54,7 @@ This setting can also improve the connection strength between the keyboard halve
 
 ### Using bluetooth output with USB power
 
-If you want to test bluetooth output on your keyboard and are powering it through the USB connection rather than a battery, you will be able to pair with a host device but may not see keystrokes sent. In this case you need to use the [output selection behavior](../docs/behaviors/outputs.md) to prefer sending keystrokes over bluetooth rather than USB. This might be necessary even if you are not powering from a device capable of receiving USB inputs, such as a USB charger.
+If you want to test bluetooth output on your keyboard and are powering it through the USB connection rather than a battery, you will be able to pair with a host device but may not see keystrokes sent. In this case you need to use the [output selection behavior](../behaviors/outputs.md) to prefer sending keystrokes over bluetooth rather than USB. This might be necessary even if you are not powering from a device capable of receiving USB inputs, such as a USB charger.
 
 ## Known Issues
 


### PR DESCRIPTION
Missed updating a link target while moving BT troubleshooting items in #1818.