### PR TITLE
fix(boards): Proper i2c pinctrl for BlueMicro840

### DIFF
--- a/app/boards/arm/bluemicro840/bluemicro840_v1-pinctrl.dtsi
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1-pinctrl.dtsi
@@ -17,22 +17,22 @@
     uart0_sleep: uart0_sleep {
         group1 {
             psels = <NRF_PSEL(UART_RX, 0, 8)>,
-                <NRF_PSEL(UART_TX, 0, 6)>;
+                    <NRF_PSEL(UART_TX, 0, 6)>;
             low-power-enable;
         };
     };
 
     i2c0_default: i2c0_default {
         group1 {
-            psels = <NRF_PSEL(TWIM_SDA, 0, 17)>,
-                <NRF_PSEL(TWIM_SCL, 0, 20)>;
+            psels = <NRF_PSEL(TWIM_SDA, 0, 15)>,
+                    <NRF_PSEL(TWIM_SCL, 0, 17)>;
         };
     };
 
     i2c0_sleep: i2c0_sleep {
         group1 {
-            psels = <NRF_PSEL(TWIM_SDA, 0, 17)>,
-                <NRF_PSEL(TWIM_SCL, 0, 20)>;
+            psels = <NRF_PSEL(TWIM_SDA, 0, 15)>,
+                    <NRF_PSEL(TWIM_SCL, 0, 17)>;
             low-power-enable;
         };
     };


### PR DESCRIPTION
* Use the proper pin assignmets after the move to pinctrl for the
  Zephyr 3.2 migration.