### PR TITLE
feat(core): Adding pre-release for keys that were already pressed.

### DIFF
--- a/app/src/hid_listener.c
+++ b/app/src/hid_listener.c
@@ -19,7 +19,8 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 static int hid_listener_keycode_pressed(const struct zmk_keycode_state_changed *ev) {
     int err, explicit_mods_changed, implicit_mods_changed;
 
-    if (zmk_hid_is_pressed(ZMK_HID_USAGE(ev->usage_page, ev->keycode))) {
+    if (!is_mod(ev->usage_page, ev->keycode) &&
+        zmk_hid_is_pressed(ZMK_HID_USAGE(ev->usage_page, ev->keycode))) {
         LOG_DBG("unregistering usage_page 0x%02X keycode 0x%02X since it was already pressed",
                 ev->usage_page, ev->keycode);
         err = zmk_hid_release(ZMK_HID_USAGE(ev->usage_page, ev->keycode));

--- a/app/src/hid_listener.c
+++ b/app/src/hid_listener.c
@@ -19,6 +19,20 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 static int hid_listener_keycode_pressed(const struct zmk_keycode_state_changed *ev) {
     int err, explicit_mods_changed, implicit_mods_changed;
 
+    if (zmk_hid_is_pressed(ZMK_HID_USAGE(ev->usage_page, ev->keycode))) {
+        LOG_DBG("unregistering usage_page 0x%02X keycode 0x%02X since it was already pressed",
+                ev->usage_page, ev->keycode);
+        err = zmk_hid_release(ZMK_HID_USAGE(ev->usage_page, ev->keycode));
+        if (err < 0) {
+            LOG_DBG("Unable to pre-release keycode (%d)", err);
+            return err;
+        }
+        err = zmk_endpoints_send_report(ev->usage_page);
+        if (err < 0) {
+            LOG_ERR("Failed to send key report for pre-releasing keycode (%d)", err);
+        }
+    }
+
     LOG_DBG("usage_page 0x%02X keycode 0x%02X implicit_mods 0x%02X explicit_mods 0x%02X",
             ev->usage_page, ev->keycode, ev->implicit_modifiers, ev->explicit_modifiers);
     err = zmk_hid_press(ZMK_HID_USAGE(ev->usage_page, ev->keycode));

--- a/app/tests/key-repeat/tap-when-rolling/events.patterns
+++ b/app/tests/key-repeat/tap-when-rolling/events.patterns
@@ -1,0 +1,2 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_implicit_modifiers_//p

--- a/app/tests/key-repeat/tap-when-rolling/keycode_events.snapshot
+++ b/app/tests/key-repeat/tap-when-rolling/keycode_events.snapshot
@@ -1,0 +1,9 @@
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x00
+pressed: unregistering usage_page 0x07 keycode 0x04 since it was already pressed
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00

--- a/app/tests/key-repeat/tap-when-rolling/native_posix.keymap
+++ b/app/tests/key-repeat/tap-when-rolling/native_posix.keymap
@@ -1,0 +1,13 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+    ZMK_MOCK_PRESS(0,1,10)
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,1,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};

--- a/app/tests/key-repeat/tap-when-rolling/native_posix_64.keymap
+++ b/app/tests/key-repeat/tap-when-rolling/native_posix_64.keymap
@@ -1,0 +1,13 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+    ZMK_MOCK_PRESS(0,1,9000)
+    ZMK_MOCK_PRESS(0,0,30)
+    ZMK_MOCK_RELEASE(0,1,30)
+    ZMK_MOCK_RELEASE(0,0,3000)
+    >;
+};

--- a/app/tests/modifiers/implicit/kp-rolling-symbols-same-key/events.patterns
+++ b/app/tests/modifiers/implicit/kp-rolling-symbols-same-key/events.patterns
@@ -1,0 +1,4 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_register_mod/reg/p
+s/.*hid_unregister_mod/unreg/p
+s/.*zmk_hid_.*Modifiers set to /mods: Modifiers set to /p

--- a/app/tests/modifiers/implicit/kp-rolling-symbols-same-key/keycode_events.snapshot
+++ b/app/tests/modifiers/implicit/kp-rolling-symbols-same-key/keycode_events.snapshot
@@ -1,0 +1,9 @@
+pressed: usage_page 0x07 keycode 0x2E implicit_mods 0x02 explicit_mods 0x00
+mods: Modifiers set to 0x02
+pressed: unregistering usage_page 0x07 keycode 0x2E since it was already pressed
+pressed: usage_page 0x07 keycode 0x2E implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x2E implicit_mods 0x02 explicit_mods 0x00
+mods: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x2E implicit_mods 0x00 explicit_mods 0x00
+mods: Modifiers set to 0x00

--- a/app/tests/modifiers/implicit/kp-rolling-symbols-same-key/native_posix_64.keymap
+++ b/app/tests/modifiers/implicit/kp-rolling-symbols-same-key/native_posix_64.keymap
@@ -1,0 +1,27 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+
+&kscan {
+    events = <
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_PRESS(0,1,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+        ZMK_MOCK_RELEASE(0,1,10)
+    >;
+};
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+        label ="Default keymap";
+
+        default_layer {
+            bindings = <
+                &kp PLUS &kp EQUAL
+                &none &none
+            >;
+        };
+    };
+};


### PR DESCRIPTION
There are a couple of cases where a user may end up rolling two physical keys that happen to map to the same keycode. When this happens, we register a second key press, but this does nothing at the OS level, meaning only one key press will be registered by the computer.

The two cases I'm aware of are:
 1. Rolling the key-repeat behavior (#1207)
 2. Rolling symbols that map to the same keycode (#1076)

This PR solves both of these issues by simply releasing the keycode before it is pressed again.

I've also added some test suites to cover this behavior, though they rely on the new print out when pre-releasing keys in order to be effective.

This requires further testing, currently I'm running this without issue, but more users testing on different setups is needed. I'm curious if we're going to need larger delay between the releases and presses for some setups (remote desktops typically are sensitive to this kind of thing).