### PR TITLE
feat(shields): Added Atreus 42

### DIFF
--- a/app/boards/shields/atreus42/Kconfig.defconfig
+++ b/app/boards/shields/atreus42/Kconfig.defconfig
@@ -1,0 +1,6 @@
+if SHIELD_ATREUS42
+
+config ZMK_KEYBOARD_NAME
+	default "RAH-Atreus42-SS"
+
+endif

--- a/app/boards/shields/atreus42/Kconfig.defconfig
+++ b/app/boards/shields/atreus42/Kconfig.defconfig
@@ -4,6 +4,6 @@
 if SHIELD_ATREUS42
 
 config ZMK_KEYBOARD_NAME
-	default "Atreus42"
+    default "RAH-Atreus42-SS"
 
 endif

--- a/app/boards/shields/atreus42/Kconfig.defconfig
+++ b/app/boards/shields/atreus42/Kconfig.defconfig
@@ -1,6 +1,9 @@
+# Copyright (c) 2023 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
 if SHIELD_ATREUS42
 
 config ZMK_KEYBOARD_NAME
-	default "RAH-Atreus42-SS"
+	default "Atreus42"
 
 endif

--- a/app/boards/shields/atreus42/Kconfig.shield
+++ b/app/boards/shields/atreus42/Kconfig.shield
@@ -1,0 +1,2 @@
+config SHIELD_ATREUS42
+  def_bool $(shields_list_contains,atreus42)

--- a/app/boards/shields/atreus42/Kconfig.shield
+++ b/app/boards/shields/atreus42/Kconfig.shield
@@ -1,2 +1,5 @@
+# Copyright (c) 2023 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
 config SHIELD_ATREUS42
   def_bool $(shields_list_contains,atreus42)

--- a/app/boards/shields/atreus42/Kconfig.shield
+++ b/app/boards/shields/atreus42/Kconfig.shield
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT
 
 config SHIELD_ATREUS42
-  def_bool $(shields_list_contains,atreus42)
+    def_bool $(shields_list_contains,atreus42)

--- a/app/boards/shields/atreus42/atreus42.dtsi
+++ b/app/boards/shields/atreus42/atreus42.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The ZMK Contributors
+ * Copyright (c) 2023 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/boards/shields/atreus42/atreus42.dtsi
+++ b/app/boards/shields/atreus42/atreus42.dtsi
@@ -36,10 +36,10 @@
 
         diode-direction = "col2row";
         row-gpios
-            = <&pro_micro_a 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D8/A8 */
-            , <&pro_micro_a 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D9/A9 */
-            , <&pro_micro_a 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D10/A10 */
-            , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D16 */
+            = <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
 
     };

--- a/app/boards/shields/atreus42/atreus42.dtsi
+++ b/app/boards/shields/atreus42/atreus42.dtsi
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+	chosen {
+		zmk,kscan = &kscan0;
+		zmk,matrix_transform = &default_transform;
+	};
+
+	default_transform: keymap_transform_0 {
+		compatible = "zmk,matrix-transform";
+		columns = <11>;
+		rows = <4>;
+
+// |   MX1   |   MX2   |   MX3   |   MX4   |   MX5   |                   |   MX6   |   MX7   |   MX8   |   MX9   |   MX10  |
+// |   MX11  |   MX12  |   MX13  |   MX14  |   MX15  |                   |   MX16  |   MX17  |   MX18  |   MX19  |   MX20  |
+// |   MX21  |   MX22  |   MX23  |   MX24  |   MX25  |                   |   MX26  |   MX27  |   MX28  |   MX29  |   MX30  |
+// |   MX31  |   MX32  |   MX33  |   MX34  |   MX35  |   MX36  |   MX37  |   MX38  |   MX39  |   MX40  |   MX41  |   MX42  |
+
+	  map = <
+    RC(0,0)   RC(0,1)   RC(0,2)   RC(0,3)   RC(0,4)                       RC(0,6)   RC(0,7)   RC(0,8)   RC(0,9)   RC(0,10)
+    RC(1,0)   RC(1,1)   RC(1,2)   RC(1,3)   RC(1,4)                       RC(1,6)   RC(1,7)   RC(1,8)   RC(1,9)   RC(1,10)
+    RC(2,0)   RC(2,1)   RC(2,2)   RC(2,3)   RC(2,4)                       RC(2,6)   RC(2,7)   RC(2,8)   RC(2,9)   RC(2,10)
+    RC(3,0)   RC(3,1)   RC(3,2)   RC(3,3)   RC(3,4)   RC(3,5)   RC(2,5)   RC(3,6)   RC(3,7)   RC(3,8)   RC(3,9)   RC(3,10)
+		>;
+	};
+
+	kscan0: kscan {
+		compatible = "zmk,kscan-gpio-matrix";
+		label = "KSCAN";
+
+		diode-direction = "col2row";
+    row-gpios
+      = <&pro_micro_a 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D8/A8 */
+      , <&pro_micro_a 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D9/A9 */
+      , <&pro_micro_a 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D10/A10 */
+      , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D16 */
+      ;
+
+	};
+};

--- a/app/boards/shields/atreus42/atreus42.dtsi
+++ b/app/boards/shields/atreus42/atreus42.dtsi
@@ -7,40 +7,40 @@
 #include <dt-bindings/zmk/matrix_transform.h>
 
 / {
-	chosen {
-		zmk,kscan = &kscan0;
-		zmk,matrix_transform = &default_transform;
-	};
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
 
-	default_transform: keymap_transform_0 {
-		compatible = "zmk,matrix-transform";
-		columns = <11>;
-		rows = <4>;
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <11>;
+        rows = <4>;
 
-// |   MX1   |   MX2   |   MX3   |   MX4   |   MX5   |                   |   MX6   |   MX7   |   MX8   |   MX9   |   MX10  |
-// |   MX11  |   MX12  |   MX13  |   MX14  |   MX15  |                   |   MX16  |   MX17  |   MX18  |   MX19  |   MX20  |
-// |   MX21  |   MX22  |   MX23  |   MX24  |   MX25  |                   |   MX26  |   MX27  |   MX28  |   MX29  |   MX30  |
-// |   MX31  |   MX32  |   MX33  |   MX34  |   MX35  |   MX36  |   MX37  |   MX38  |   MX39  |   MX40  |   MX41  |   MX42  |
+        //|   MX1   |   MX2   |   MX3   |   MX4   |   MX5   |                   |   MX6   |   MX7   |   MX8   |   MX9   |   MX10  |
+        //|   MX11  |   MX12  |   MX13  |   MX14  |   MX15  |                   |   MX16  |   MX17  |   MX18  |   MX19  |   MX20  |
+        //|   MX21  |   MX22  |   MX23  |   MX24  |   MX25  |                   |   MX26  |   MX27  |   MX28  |   MX29  |   MX30  |
+        //|   MX31  |   MX32  |   MX33  |   MX34  |   MX35  |   MX36  |   MX37  |   MX38  |   MX39  |   MX40  |   MX41  |   MX42  |
 
-	  map = <
-    RC(0,0)   RC(0,1)   RC(0,2)   RC(0,3)   RC(0,4)                       RC(0,6)   RC(0,7)   RC(0,8)   RC(0,9)   RC(0,10)
-    RC(1,0)   RC(1,1)   RC(1,2)   RC(1,3)   RC(1,4)                       RC(1,6)   RC(1,7)   RC(1,8)   RC(1,9)   RC(1,10)
-    RC(2,0)   RC(2,1)   RC(2,2)   RC(2,3)   RC(2,4)                       RC(2,6)   RC(2,7)   RC(2,8)   RC(2,9)   RC(2,10)
-    RC(3,0)   RC(3,1)   RC(3,2)   RC(3,3)   RC(3,4)   RC(3,5)   RC(2,5)   RC(3,6)   RC(3,7)   RC(3,8)   RC(3,9)   RC(3,10)
-		>;
-	};
+        map = <
+            RC(0,0)   RC(0,1)   RC(0,2)   RC(0,3)   RC(0,4)                       RC(0,6)   RC(0,7)   RC(0,8)   RC(0,9)   RC(0,10)
+            RC(1,0)   RC(1,1)   RC(1,2)   RC(1,3)   RC(1,4)                       RC(1,6)   RC(1,7)   RC(1,8)   RC(1,9)   RC(1,10)
+            RC(2,0)   RC(2,1)   RC(2,2)   RC(2,3)   RC(2,4)                       RC(2,6)   RC(2,7)   RC(2,8)   RC(2,9)   RC(2,10)
+            RC(3,0)   RC(3,1)   RC(3,2)   RC(3,3)   RC(3,4)   RC(3,5)   RC(2,5)   RC(3,6)   RC(3,7)   RC(3,8)   RC(3,9)   RC(3,10)
+        >;
+    };
 
-	kscan0: kscan {
-		compatible = "zmk,kscan-gpio-matrix";
-		label = "KSCAN";
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
 
-		diode-direction = "col2row";
-    row-gpios
-      = <&pro_micro_a 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D8/A8 */
-      , <&pro_micro_a 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D9/A9 */
-      , <&pro_micro_a 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D10/A10 */
-      , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D16 */
-      ;
+        diode-direction = "col2row";
+        row-gpios
+            = <&pro_micro_a 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D8/A8 */
+            , <&pro_micro_a 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D9/A9 */
+            , <&pro_micro_a 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D10/A10 */
+            , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D16 */
+            ;
 
-	};
+    };
 };

--- a/app/boards/shields/atreus42/atreus42.dtsi
+++ b/app/boards/shields/atreus42/atreus42.dtsi
@@ -36,10 +36,10 @@
 
 		diode-direction = "col2row";
     row-gpios
-      = <&pro_micro_a 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D8/A8 */
-      , <&pro_micro_a 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D9/A9 */
-      , <&pro_micro_a 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D10/A10 */
-      , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D16 */
+      = <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D8/A8 */
+      , <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D9/A9 */
+      , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D10/A10 */
+      , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D16 */
       ;
 
 	};

--- a/app/boards/shields/atreus42/atreus42.dtsi
+++ b/app/boards/shields/atreus42/atreus42.dtsi
@@ -36,10 +36,10 @@
 
 		diode-direction = "col2row";
     row-gpios
-      = <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D8/A8 */
-      , <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D9/A9 */
-      , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D10/A10 */
-      , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D16 */
+      = <&pro_micro_a 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D8/A8 */
+      , <&pro_micro_a 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>     /* D9/A9 */
+      , <&pro_micro_a 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D10/A10 */
+      , <&pro_micro_d 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>    /* D16 */
       ;
 
 	};

--- a/app/boards/shields/atreus42/atreus42.keymap
+++ b/app/boards/shields/atreus42/atreus42.keymap
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>

--- a/app/boards/shields/atreus42/atreus42.keymap
+++ b/app/boards/shields/atreus42/atreus42.keymap
@@ -15,48 +15,48 @@
 
 / {
     keymap {
-      compatible = "zmk,keymap";
+        compatible = "zmk,keymap";
 
-      default_layer {
-// --------------------------------------------------------------------------------------------------------------------------------------------------------------------
-// |     Q     |     W     |     E     |     R     |     T     |                       |     Y     |    U      |     I     |     O     |     P     |
-// |     A     |     S     |     D     |     F     |     G     |                       |     H     |    J      |     K     |     L     |     ;     |
-// |     Z     |     X     |     C     |     V     |     B     |                       |     N     |    M      |     ,     |     .     |  SHIFT(/) |
-// |   LSHFT   | LAY2(TAB) |   SUPER   |   LAY1    |    BSPC   |    CTL    |  ALT(ESC) |   SPACE   |   LAY1    |   SUPER   |   LAY2    |    ENT    |
-        bindings = <
-    &kp Q       &kp W       &kp E       &kp R       &kp T                               &kp Y       &kp U       &kp I       &kp O       &kp P
-    &kp A       &kp S       &kp D       &kp F       &kp G                               &kp H       &kp J       &kp K       &kp L       &kp SEMI
-    &kp Z       &kp X       &kp C       &kp V       &kp B                               &kp N       &kp M       &kp COMMA   &kp DOT     &mt RSHFT FSLH
-    &kp LSHFT   &lt FUN TAB &kp LGUI    &mo NAV     &kp BSPC    &kp LCTRL  &mt RALT ESC &kp SPACE   &mo NAV     &kp RGUI    &mo FUN     &kp RET
-        >;
-      };
+        default_layer {
+            // -------------------------------------------------------------------------------------------------------------------------------------------------
+            // |     Q     |     W     |     E     |     R     |     T     |                       |     Y     |    U      |     I     |     O     |     P     |
+            // |     A     |     S     |     D     |     F     |     G     |                       |     H     |    J      |     K     |     L     |     ;     |
+            // |     Z     |     X     |     C     |     V     |     B     |                       |     N     |    M      |     ,     |     .     |  SHIFT(/) |
+            // |   LSHFT   | LAY2(TAB) |   SUPER   |   LAY1    |    BSPC   |    CTL    |  ALT(ESC) |   SPACE   |   LAY1    |   SUPER   |   LAY2    |    ENT    |
+            bindings = <
+                &kp Q       &kp W       &kp E       &kp R       &kp T                               &kp Y       &kp U       &kp I       &kp O       &kp P
+                &kp A       &kp S       &kp D       &kp F       &kp G                               &kp H       &kp J       &kp K       &kp L       &kp SEMI
+                &kp Z       &kp X       &kp C       &kp V       &kp B                               &kp N       &kp M       &kp COMMA   &kp DOT     &mt RSHFT FSLH
+                &kp LSHFT   &lt FUN TAB &kp LGUI    &mo NAV     &kp BSPC    &kp LCTRL  &mt RALT ESC &kp SPACE   &mo NAV     &kp RGUI    &mo FUN     &kp RET
+            >;
+        };
 
-      nav_layer {
-// --------------------------------------------------------------------------------------------------------------------------------------------------------------------
-// |     1     |    2      |    3      |     4     |    5      |                       |    6      |    7      |     8     |     9     |     0     |
-// |    TAB    |    `      |    UP     |     \     |    =/+    |                       |   LEFT    |   DOWN    |    UP     |   RIGHT   |     '     |
-// |   SUPER   |   LEFT    |   DOWN    |   RIGHT   |    -/_    |                       |     [     |     ]     |     ,     |     .     |  SHIFT(/) |
-// |___________|___________|___________|___________|___________|___________|___________|___________|___________|   HOME    |    END    |    ENT    |
-        bindings = <
-    &kp N1      &kp N2      &kp N3      &kp N4      &kp N5                              &kp N6      &kp N7      &kp N8      &kp N9      &kp N0
-    &kp TAB     &kp GRAVE   &kp UP      &kp BSLH    &kp EQUAL                           &kp LEFT    &kp DOWN    &kp UP      &kp RIGHT   &kp SQT
-    &kp LGUI    &kp LEFT    &kp DOWN    &kp RIGHT   &kp MINUS                           &kp LBKT    &kp RBKT    &kp COMMA   &kp DOT     &mt RSHFT FSLH
-    &trans      &trans      &trans      &trans      &trans      &trans       &trans     &trans      &trans      &kp HOME    &kp END     &trans
-        >;
-      };
+        nav_layer {
+            // -------------------------------------------------------------------------------------------------------------------------------------------------
+            // |     1     |    2      |    3      |     4     |    5      |                       |    6      |    7      |     8     |     9     |     0     |
+            // |    TAB    |    `      |    UP     |     \     |    =/+    |                       |   LEFT    |   DOWN    |    UP     |   RIGHT   |     '     |
+            // |   SUPER   |   LEFT    |   DOWN    |   RIGHT   |    -/_    |                       |     [     |     ]     |     ,     |     .     |  SHIFT(/) |
+            // |___________|___________|___________|___________|___________|___________|___________|___________|___________|   HOME    |    END    |    ENT    |
+            bindings = <
+                &kp N1      &kp N2      &kp N3      &kp N4      &kp N5                              &kp N6      &kp N7      &kp N8      &kp N9      &kp N0
+                &kp TAB     &kp GRAVE   &kp UP      &kp BSLH    &kp EQUAL                           &kp LEFT    &kp DOWN    &kp UP      &kp RIGHT   &kp SQT
+                &kp LGUI    &kp LEFT    &kp DOWN    &kp RIGHT   &kp MINUS                           &kp LBKT    &kp RBKT    &kp COMMA   &kp DOT     &mt RSHFT FSLH
+                &trans      &trans      &trans      &trans      &trans      &trans       &trans     &trans      &trans      &kp HOME    &kp END     &trans
+            >;
+        };
 
-      fun_layer {
-// --------------------------------------------------------------------------------------------------------------------------------------------------------------------
-// |    F1     |    F2     |    F3     |    F4     |    F5     |                       |    F6     |    F7     |    F8     |    F9     |    F10    |
-// |           |           |           |           |           |                       |   PREV    |   NEXT    |  VOL_UP   |  VOL_DN   |    F11    |
-// |BOOTLOADER |   RESET   |  BT_PRV   |  BT_NXT   |  BT_CLR   |                       |PLAY/PAUSE |    CTL    |   PG_UP   |   PG_DN   |    F12    |
-// |___________|___________|___________|___________|    DEL    |___________|___________|___________|           |           |___________|    ENT    |
-        bindings = <
-    &kp F1      &kp F2      &kp F3      &kp F4      &kp F5                              &kp F6      &kp F7      &kp F8      &kp F9      &kp F10
-    &none       &none       &none       &none       &none                               &kp C_PREV &kp C_NEXT &kp C_VOL_UP &kp C_VOL_DN &kp F11
-    &bootloader &sys_reset  &bt BT_PRV  &bt BT_NXT  &bt BT_CLR                          &kp C_PP    &kp RCTRL   &kp PG_UP   &kp PG_DN   &kp F12
-    &trans      &trans      &trans      &trans      &kp DEL     &trans       &trans     &trans      &none       &none       &trans      &trans
-        >;
-      };
+        fun_layer {
+            // -------------------------------------------------------------------------------------------------------------------------------------------------
+            // |    F1     |    F2     |    F3     |    F4     |    F5     |                       |    F6     |    F7     |    F8     |    F9     |    F10    |
+            // |           |           |           |           |           |                       |   PREV    |   NEXT    |  VOL_UP   |  VOL_DN   |    F11    |
+            // |BOOTLOADER |   RESET   |  BT_PRV   |  BT_NXT   |  BT_CLR   |                       |PLAY/PAUSE |    CTL    |   PG_UP   |   PG_DN   |    F12    |
+            // |___________|___________|___________|___________|    DEL    |___________|___________|___________|           |           |___________|    ENT    |
+            bindings = <
+                &kp F1      &kp F2      &kp F3      &kp F4      &kp F5                              &kp F6      &kp F7      &kp F8      &kp F9      &kp F10
+                &none       &none       &none       &none       &none                               &kp C_PREV &kp C_NEXT &kp C_VOL_UP &kp C_VOL_DN &kp F11
+                &bootloader &sys_reset  &bt BT_PRV  &bt BT_NXT  &bt BT_CLR                          &kp C_PP    &kp RCTRL   &kp PG_UP   &kp PG_DN   &kp F12
+                &trans      &trans      &trans      &trans      &kp DEL     &trans       &trans     &trans      &none       &none       &trans      &trans
+            >;
+        };
     };
 };

--- a/app/boards/shields/atreus42/atreus42.keymap
+++ b/app/boards/shields/atreus42/atreus42.keymap
@@ -1,0 +1,56 @@
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+#define DEFAULT 0
+#define NAV    1
+#define FUN    2
+
+/ {
+    keymap {
+      compatible = "zmk,keymap";
+
+      default_layer {
+// --------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// |     Q     |     W     |     E     |     R     |     T     |                       |     Y     |    U      |     I     |     O     |     P     |
+// |     A     |     S     |     D     |     F     |     G     |                       |     H     |    J      |     K     |     L     |     ;     |
+// |     Z     |     X     |     C     |     V     |     B     |                       |     N     |    M      |     ,     |     .     |  SHIFT(/) |
+// |   LSHFT   | LAY2(TAB) |   SUPER   |   LAY1    |    BSPC   |    CTL    |  ALT(ESC) |   SPACE   |   LAY1    |   SUPER   |   LAY2    |    ENT    |
+        bindings = <
+    &kp Q       &kp W       &kp E       &kp R       &kp T                               &kp Y       &kp U       &kp I       &kp O       &kp P
+    &kp A       &kp S       &kp D       &kp F       &kp G                               &kp H       &kp J       &kp K       &kp L       &kp SEMI
+    &kp Z       &kp X       &kp C       &kp V       &kp B                               &kp N       &kp M       &kp COMMA   &kp DOT     &mt RSHFT FSLH
+    &kp LSHFT   &lt FUN TAB &kp LGUI    &mo NAV     &kp BSPC    &kp LCTRL  &mt RALT ESC &kp SPACE   &mo NAV     &kp RGUI    &mo FUN     &kp RET
+        >;
+      };
+
+      nav_layer {
+// --------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// |     1     |    2      |    3      |     4     |    5      |                       |    6      |    7      |     8     |     9     |     0     |
+// |    TAB    |    `      |    UP     |     \     |    =/+    |                       |   LEFT    |   DOWN    |    UP     |   RIGHT   |     '     |
+// |   SUPER   |   LEFT    |   DOWN    |   RIGHT   |    -/_    |                       |     [     |     ]     |     ,     |     .     |  SHIFT(/) |
+// |___________|___________|___________|___________|___________|___________|___________|___________|___________|   HOME    |    END    |    ENT    |
+        bindings = <
+    &kp N1      &kp N2      &kp N3      &kp N4      &kp N5                              &kp N6      &kp N7      &kp N8      &kp N9      &kp N0
+    &kp TAB     &kp GRAVE   &kp UP      &kp BSLH    &kp EQUAL                           &kp LEFT    &kp DOWN    &kp UP      &kp RIGHT   &kp SQT
+    &kp LGUI    &kp LEFT    &kp DOWN    &kp RIGHT   &kp MINUS                           &kp LBKT    &kp RBKT    &kp COMMA   &kp DOT     &mt RSHFT FSLH
+    &trans      &trans      &trans      &trans      &trans      &trans       &trans     &trans      &trans      &kp HOME    &kp END     &trans
+        >;
+      };
+
+      fun_layer {
+// --------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// |    F1     |    F2     |    F3     |    F4     |    F5     |                       |    F6     |    F7     |    F8     |    F9     |    F10    |
+// |           |           |           |           |           |                       |   PREV    |   NEXT    |  VOL_UP   |  VOL_DN   |    F11    |
+// |BOOTLOADER |   RESET   |  BT_PRV   |  BT_NXT   |  BT_CLR   |                       |PLAY/PAUSE |    CTL    |   PG_UP   |   PG_DN   |    F12    |
+// |___________|___________|___________|___________|    DEL    |___________|___________|___________|           |           |___________|    ENT    |
+        bindings = <
+    &kp F1      &kp F2      &kp F3      &kp F4      &kp F5                              &kp F6      &kp F7      &kp F8      &kp F9      &kp F10
+    &none       &none       &none       &none       &none                               &kp C_PREV &kp C_NEXT &kp C_VOL_UP &kp C_VOL_DN &kp F11
+    &bootloader &sys_reset  &bt BT_PRV  &bt BT_NXT  &bt BT_CLR                          &kp C_PP    &kp RCTRL   &kp PG_UP   &kp PG_DN   &kp F12
+    &trans      &trans      &trans      &trans      &kp DEL     &trans       &trans     &trans      &none       &none       &trans      &trans
+        >;
+      };
+    };
+};

--- a/app/boards/shields/atreus42/atreus42.overlay
+++ b/app/boards/shields/atreus42/atreus42.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The ZMK Contributors
+ * Copyright (c) 2023 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/boards/shields/atreus42/atreus42.overlay
+++ b/app/boards/shields/atreus42/atreus42.overlay
@@ -7,17 +7,17 @@
 #include "atreus42.dtsi"
 
 &kscan0{
-  col-gpios
-    = <&pro_micro_a 3 GPIO_ACTIVE_HIGH>     /* A3 */
-    , <&pro_micro_a 2 GPIO_ACTIVE_HIGH>     /* A2 */
-    , <&pro_micro_a 1 GPIO_ACTIVE_HIGH>     /* A1 */
-    , <&pro_micro_a 0 GPIO_ACTIVE_HIGH>     /* A0 */
-    , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>    /* D15 */
-    , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>    /* D14 */
-    , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>     /* D6/A7 */
-    , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>     /* D5 */
-    , <&pro_micro_d 4 GPIO_ACTIVE_HIGH>     /* D4/A6 */
-    , <&pro_micro_d 3 GPIO_ACTIVE_HIGH>     /* D3 */
-    , <&pro_micro_d 2 GPIO_ACTIVE_HIGH>     /* D2 */
-    ;
+    col-gpios
+        = <&pro_micro_a 3 GPIO_ACTIVE_HIGH>     /* A3 */
+        , <&pro_micro_a 2 GPIO_ACTIVE_HIGH>     /* A2 */
+        , <&pro_micro_a 1 GPIO_ACTIVE_HIGH>     /* A1 */
+        , <&pro_micro_a 0 GPIO_ACTIVE_HIGH>     /* A0 */
+        , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>    /* D15 */
+        , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>    /* D14 */
+        , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>     /* D6/A7 */
+        , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>     /* D5 */
+        , <&pro_micro_d 4 GPIO_ACTIVE_HIGH>     /* D4/A6 */
+        , <&pro_micro_d 3 GPIO_ACTIVE_HIGH>     /* D3 */
+        , <&pro_micro_d 2 GPIO_ACTIVE_HIGH>     /* D2 */
+        ;
 };

--- a/app/boards/shields/atreus42/atreus42.overlay
+++ b/app/boards/shields/atreus42/atreus42.overlay
@@ -8,16 +8,16 @@
 
 &kscan0{
     col-gpios
-        = <&pro_micro_a 3 GPIO_ACTIVE_HIGH>     /* A3 */
-        , <&pro_micro_a 2 GPIO_ACTIVE_HIGH>     /* A2 */
-        , <&pro_micro_a 1 GPIO_ACTIVE_HIGH>     /* A1 */
-        , <&pro_micro_a 0 GPIO_ACTIVE_HIGH>     /* A0 */
-        , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>    /* D15 */
-        , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>    /* D14 */
-        , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>     /* D6/A7 */
-        , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>     /* D5 */
-        , <&pro_micro_d 4 GPIO_ACTIVE_HIGH>     /* D4/A6 */
-        , <&pro_micro_d 3 GPIO_ACTIVE_HIGH>     /* D3 */
-        , <&pro_micro_d 2 GPIO_ACTIVE_HIGH>     /* D2 */
+        = <&pro_micro 21 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 20 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 19 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 18 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 15 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 14 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 6 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 5 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 4 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 3 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 2 GPIO_ACTIVE_HIGH>
         ;
 };

--- a/app/boards/shields/atreus42/atreus42.overlay
+++ b/app/boards/shields/atreus42/atreus42.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "atreus42.dtsi"
+
+&kscan0{
+  col-gpios
+    = <&pro_micro_a 3 GPIO_ACTIVE_HIGH>     /* A3 */
+    , <&pro_micro_a 2 GPIO_ACTIVE_HIGH>     /* A2 */
+    , <&pro_micro_a 1 GPIO_ACTIVE_HIGH>     /* A1 */
+    , <&pro_micro_a 0 GPIO_ACTIVE_HIGH>     /* A0 */
+    , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>    /* D15 */
+    , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>    /* D14 */
+    , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>     /* D6/A7 */
+    , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>     /* D5 */
+    , <&pro_micro_d 4 GPIO_ACTIVE_HIGH>     /* D4/A6 */
+    , <&pro_micro_d 3 GPIO_ACTIVE_HIGH>     /* D3 */
+    , <&pro_micro_d 2 GPIO_ACTIVE_HIGH>     /* D2 */
+    ;
+};

--- a/app/boards/shields/atreus42/atreus42.overlay
+++ b/app/boards/shields/atreus42/atreus42.overlay
@@ -8,16 +8,16 @@
 
 &kscan0{
   col-gpios
-    = <&pro_micro 3 GPIO_ACTIVE_HIGH>     /* A3 */
-    , <&pro_micro 2 GPIO_ACTIVE_HIGH>     /* A2 */
-    , <&pro_micro 1 GPIO_ACTIVE_HIGH>     /* A1 */
-    , <&pro_micro 0 GPIO_ACTIVE_HIGH>     /* A0 */
-    , <&pro_micro 15 GPIO_ACTIVE_HIGH>    /* D15 */
-    , <&pro_micro 14 GPIO_ACTIVE_HIGH>    /* D14 */
-    , <&pro_micro 6 GPIO_ACTIVE_HIGH>     /* D6/A7 */
-    , <&pro_micro 5 GPIO_ACTIVE_HIGH>     /* D5 */
-    , <&pro_micro 4 GPIO_ACTIVE_HIGH>     /* D4/A6 */
-    , <&pro_micro 3 GPIO_ACTIVE_HIGH>     /* D3 */
-    , <&pro_micro 2 GPIO_ACTIVE_HIGH>     /* D2 */
+    = <&pro_micro_a 3 GPIO_ACTIVE_HIGH>     /* A3 */
+    , <&pro_micro_a 2 GPIO_ACTIVE_HIGH>     /* A2 */
+    , <&pro_micro_a 1 GPIO_ACTIVE_HIGH>     /* A1 */
+    , <&pro_micro_a 0 GPIO_ACTIVE_HIGH>     /* A0 */
+    , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>    /* D15 */
+    , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>    /* D14 */
+    , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>     /* D6/A7 */
+    , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>     /* D5 */
+    , <&pro_micro_d 4 GPIO_ACTIVE_HIGH>     /* D4/A6 */
+    , <&pro_micro_d 3 GPIO_ACTIVE_HIGH>     /* D3 */
+    , <&pro_micro_d 2 GPIO_ACTIVE_HIGH>     /* D2 */
     ;
 };

--- a/app/boards/shields/atreus42/atreus42.overlay
+++ b/app/boards/shields/atreus42/atreus42.overlay
@@ -8,16 +8,16 @@
 
 &kscan0{
   col-gpios
-    = <&pro_micro_a 3 GPIO_ACTIVE_HIGH>     /* A3 */
-    , <&pro_micro_a 2 GPIO_ACTIVE_HIGH>     /* A2 */
-    , <&pro_micro_a 1 GPIO_ACTIVE_HIGH>     /* A1 */
-    , <&pro_micro_a 0 GPIO_ACTIVE_HIGH>     /* A0 */
-    , <&pro_micro_d 15 GPIO_ACTIVE_HIGH>    /* D15 */
-    , <&pro_micro_d 14 GPIO_ACTIVE_HIGH>    /* D14 */
-    , <&pro_micro_d 6 GPIO_ACTIVE_HIGH>     /* D6/A7 */
-    , <&pro_micro_d 5 GPIO_ACTIVE_HIGH>     /* D5 */
-    , <&pro_micro_d 4 GPIO_ACTIVE_HIGH>     /* D4/A6 */
-    , <&pro_micro_d 3 GPIO_ACTIVE_HIGH>     /* D3 */
-    , <&pro_micro_d 2 GPIO_ACTIVE_HIGH>     /* D2 */
+    = <&pro_micro 3 GPIO_ACTIVE_HIGH>     /* A3 */
+    , <&pro_micro 2 GPIO_ACTIVE_HIGH>     /* A2 */
+    , <&pro_micro 1 GPIO_ACTIVE_HIGH>     /* A1 */
+    , <&pro_micro 0 GPIO_ACTIVE_HIGH>     /* A0 */
+    , <&pro_micro 15 GPIO_ACTIVE_HIGH>    /* D15 */
+    , <&pro_micro 14 GPIO_ACTIVE_HIGH>    /* D14 */
+    , <&pro_micro 6 GPIO_ACTIVE_HIGH>     /* D6/A7 */
+    , <&pro_micro 5 GPIO_ACTIVE_HIGH>     /* D5 */
+    , <&pro_micro 4 GPIO_ACTIVE_HIGH>     /* D4/A6 */
+    , <&pro_micro 3 GPIO_ACTIVE_HIGH>     /* D3 */
+    , <&pro_micro 2 GPIO_ACTIVE_HIGH>     /* D2 */
     ;
 };

--- a/app/boards/shields/atreus42/atreus42.zmk.yml
+++ b/app/boards/shields/atreus42/atreus42.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: atreus42
+name: Atreus42
+type: shield
+url: https://github.com/ralphie02/zmk-config/tree/master/config/boards/shields/atreus42
+requires: [pro_micro]
+features:
+  - keys

--- a/app/boards/shields/atreus42/atreus42.zmk.yml
+++ b/app/boards/shields/atreus42/atreus42.zmk.yml
@@ -2,7 +2,7 @@ file_format: "1"
 id: atreus42
 name: Atreus42
 type: shield
-url: https://github.com/ralphie02/zmk-config/tree/master/config/boards/shields/atreus42
+url: https://atreus.technomancy.us/
 requires: [pro_micro]
 features:
   - keys


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [x] This board/shield is tested working on real hardware
- [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [x] `.zmk.yml` metadata file added
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] General consistent formatting of DeviceTree files
- [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [x] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
