### PR TITLE
fix(boards): Bump nRF5340 DK I2C buffer size

### DIFF
--- a/app/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/app/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -6,5 +6,5 @@
 
 &arduino_i2c {
     // Default buffer size is too small for use with displays.
-    zephyr,concat-buf-size = <512>;
+    zephyr,concat-buf-size = <1024>;
 };


### PR DESCRIPTION
Increased the I2C buffer size again, since it needs to be at least 641 to support 128x64 displays.