### PR TITLE
sofle: add underglow support with `&pinctrl` update

### DIFF
--- a/app/boards/shields/sofle/Kconfig.defconfig
+++ b/app/boards/shields/sofle/Kconfig.defconfig
@@ -46,4 +46,10 @@ endchoice
 
 endif # LVGL
 
+if ZMK_RGB_UNDERGLOW
+
+config WS2812_STRIP
+    default y
+endif
+
 endif

--- a/app/boards/shields/sofle/boards/nice_nano.overlay
+++ b/app/boards/shields/sofle/boards/nice_nano.overlay
@@ -1,0 +1,35 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+   compatible = "nordic,nrf-spim";
+   status = "okay";
+   mosi-pin = <6>;
+   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+   sck-pin = <5>;
+   miso-pin = <7>;
+
+   led_strip: ws2812@0 {
+      compatible = "worldsemi,ws2812-spi";
+      label = "WS2812";
+
+      /* SPI */
+      reg = <0>; /* ignored, but necessary for SPI bindings */
+      spi-max-frequency = <4000000>;
+
+      /* WS2812 */
+      chain-length = <29>; /* arbitrary; change at will */
+      spi-one-frame = <0x70>;
+      spi-zero-frame = <0x40>;
+      color-mapping = <
+         LED_COLOR_ID_GREEN
+         LED_COLOR_ID_RED
+         LED_COLOR_ID_BLUE
+      >;
+   };
+};
+
+/ {
+   chosen {
+      zmk,underglow = &led_strip;
+   };
+};

--- a/app/boards/shields/sofle/boards/nice_nano.overlay
+++ b/app/boards/shields/sofle/boards/nice_nano.overlay
@@ -1,35 +1,51 @@
 #include <dt-bindings/led/led.h>
 
-&spi1 {
-   compatible = "nordic,nrf-spim";
-   status = "okay";
-   mosi-pin = <6>;
-   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
-   sck-pin = <5>;
-   miso-pin = <7>;
+&pinctrl {
+    spi3_default: spi3_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+        };
+    };
 
-   led_strip: ws2812@0 {
-      compatible = "worldsemi,ws2812-spi";
-      label = "WS2812";
+    spi3_sleep: spi3_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+            low-power-enable;
+        };
+    };
+};
 
-      /* SPI */
-      reg = <0>; /* ignored, but necessary for SPI bindings */
-      spi-max-frequency = <4000000>;
+&spi3 {
+    compatible = "nordic,nrf-spim";
+    status = "okay";
 
-      /* WS2812 */
-      chain-length = <29>; /* arbitrary; change at will */
-      spi-one-frame = <0x70>;
-      spi-zero-frame = <0x40>;
-      color-mapping = <
-         LED_COLOR_ID_GREEN
-         LED_COLOR_ID_RED
-         LED_COLOR_ID_BLUE
-      >;
-   };
+    pinctrl-0 = <&spi3_default>;
+    pinctrl-1 = <&spi3_sleep>;
+    pinctrl-names = "default", "sleep";
+
+    led_strip: ws2812@0 {
+        compatible = "worldsemi,ws2812-spi";
+        label = "WS2812";
+
+        /* SPI */
+        reg = <0>; /* ignored, but necessary for SPI bindings */
+        spi-max-frequency = <4000000>;
+
+        /* WS2812 */
+        chain-length = <36>; /* arbitrary; change at will */
+        spi-one-frame = <0x70>;
+        spi-zero-frame = <0x40>;
+
+        color-mapping = <
+            LED_COLOR_ID_GREEN
+            LED_COLOR_ID_RED
+            LED_COLOR_ID_BLUE
+        >;
+    };
 };
 
 / {
-   chosen {
-      zmk,underglow = &led_strip;
-   };
+    chosen {
+        zmk,underglow = &led_strip;
+    };
 };

--- a/app/boards/shields/sofle/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/sofle/boards/nice_nano_v2.overlay
@@ -1,0 +1,35 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+   compatible = "nordic,nrf-spim";
+   status = "okay";
+   mosi-pin = <6>;
+   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+   sck-pin = <5>;
+   miso-pin = <7>;
+
+   led_strip: ws2812@0 {
+      compatible = "worldsemi,ws2812-spi";
+      label = "WS2812";
+
+      /* SPI */
+      reg = <0>; /* ignored, but necessary for SPI bindings */
+      spi-max-frequency = <4000000>;
+
+      /* WS2812 */
+      chain-length = <29>; /* arbitrary; change at will */
+      spi-one-frame = <0x70>;
+      spi-zero-frame = <0x40>;
+      color-mapping = <
+         LED_COLOR_ID_GREEN
+         LED_COLOR_ID_RED
+         LED_COLOR_ID_BLUE
+      >;
+   };
+};
+
+/ {
+   chosen {
+      zmk,underglow = &led_strip;
+   };
+};

--- a/app/boards/shields/sofle/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/sofle/boards/nice_nano_v2.overlay
@@ -1,35 +1,51 @@
 #include <dt-bindings/led/led.h>
 
-&spi1 {
-   compatible = "nordic,nrf-spim";
-   status = "okay";
-   mosi-pin = <6>;
-   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
-   sck-pin = <5>;
-   miso-pin = <7>;
+&pinctrl {
+    spi3_default: spi3_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+        };
+    };
 
-   led_strip: ws2812@0 {
-      compatible = "worldsemi,ws2812-spi";
-      label = "WS2812";
+    spi3_sleep: spi3_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+            low-power-enable;
+        };
+    };
+};
 
-      /* SPI */
-      reg = <0>; /* ignored, but necessary for SPI bindings */
-      spi-max-frequency = <4000000>;
+&spi3 {
+    compatible = "nordic,nrf-spim";
+    status = "okay";
 
-      /* WS2812 */
-      chain-length = <29>; /* arbitrary; change at will */
-      spi-one-frame = <0x70>;
-      spi-zero-frame = <0x40>;
-      color-mapping = <
-         LED_COLOR_ID_GREEN
-         LED_COLOR_ID_RED
-         LED_COLOR_ID_BLUE
-      >;
-   };
+    pinctrl-0 = <&spi3_default>;
+    pinctrl-1 = <&spi3_sleep>;
+    pinctrl-names = "default", "sleep";
+
+    led_strip: ws2812@0 {
+        compatible = "worldsemi,ws2812-spi";
+        label = "WS2812";
+
+        /* SPI */
+        reg = <0>; /* ignored, but necessary for SPI bindings */
+        spi-max-frequency = <4000000>;
+
+        /* WS2812 */
+        chain-length = <36>; /* arbitrary; change at will */
+        spi-one-frame = <0x70>;
+        spi-zero-frame = <0x40>;
+
+        color-mapping = <
+            LED_COLOR_ID_GREEN
+            LED_COLOR_ID_RED
+            LED_COLOR_ID_BLUE
+        >;
+    };
 };
 
 / {
-   chosen {
-      zmk,underglow = &led_strip;
-   };
+    chosen {
+        zmk,underglow = &led_strip;
+    };
 };

--- a/app/boards/shields/sofle/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/sofle/boards/nrfmicro_11.overlay
@@ -1,0 +1,35 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+   compatible = "nordic,nrf-spim";
+   status = "okay";
+   mosi-pin = <6>;
+   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+   sck-pin = <5>;
+   miso-pin = <7>;
+
+   led_strip: ws2812@0 {
+      compatible = "worldsemi,ws2812-spi";
+      label = "WS2812";
+
+      /* SPI */
+      reg = <0>; /* ignored, but necessary for SPI bindings */
+      spi-max-frequency = <4000000>;
+
+      /* WS2812 */
+      chain-length = <29>; /* arbitrary; change at will */
+      spi-one-frame = <0x70>;
+      spi-zero-frame = <0x40>;
+      color-mapping = <
+         LED_COLOR_ID_GREEN
+         LED_COLOR_ID_RED
+         LED_COLOR_ID_BLUE
+      >;
+   };
+};
+
+/ {
+   chosen {
+      zmk,underglow = &led_strip;
+   };
+};

--- a/app/boards/shields/sofle/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/sofle/boards/nrfmicro_11.overlay
@@ -1,35 +1,51 @@
 #include <dt-bindings/led/led.h>
 
-&spi1 {
-   compatible = "nordic,nrf-spim";
-   status = "okay";
-   mosi-pin = <6>;
-   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
-   sck-pin = <5>;
-   miso-pin = <7>;
+&pinctrl {
+    spi3_default: spi3_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+        };
+    };
 
-   led_strip: ws2812@0 {
-      compatible = "worldsemi,ws2812-spi";
-      label = "WS2812";
+    spi3_sleep: spi3_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+            low-power-enable;
+        };
+    };
+};
 
-      /* SPI */
-      reg = <0>; /* ignored, but necessary for SPI bindings */
-      spi-max-frequency = <4000000>;
+&spi3 {
+    compatible = "nordic,nrf-spim";
+    status = "okay";
 
-      /* WS2812 */
-      chain-length = <29>; /* arbitrary; change at will */
-      spi-one-frame = <0x70>;
-      spi-zero-frame = <0x40>;
-      color-mapping = <
-         LED_COLOR_ID_GREEN
-         LED_COLOR_ID_RED
-         LED_COLOR_ID_BLUE
-      >;
-   };
+    pinctrl-0 = <&spi3_default>;
+    pinctrl-1 = <&spi3_sleep>;
+    pinctrl-names = "default", "sleep";
+
+    led_strip: ws2812@0 {
+        compatible = "worldsemi,ws2812-spi";
+        label = "WS2812";
+
+        /* SPI */
+        reg = <0>; /* ignored, but necessary for SPI bindings */
+        spi-max-frequency = <4000000>;
+
+        /* WS2812 */
+        chain-length = <36>; /* arbitrary; change at will */
+        spi-one-frame = <0x70>;
+        spi-zero-frame = <0x40>;
+
+        color-mapping = <
+            LED_COLOR_ID_GREEN
+            LED_COLOR_ID_RED
+            LED_COLOR_ID_BLUE
+        >;
+    };
 };
 
 / {
-   chosen {
-      zmk,underglow = &led_strip;
-   };
+    chosen {
+        zmk,underglow = &led_strip;
+    };
 };

--- a/app/boards/shields/sofle/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/sofle/boards/nrfmicro_13.overlay
@@ -1,0 +1,35 @@
+#include <dt-bindings/led/led.h>
+
+&spi1 {
+   compatible = "nordic,nrf-spim";
+   status = "okay";
+   mosi-pin = <6>;
+   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
+   sck-pin = <5>;
+   miso-pin = <7>;
+
+   led_strip: ws2812@0 {
+      compatible = "worldsemi,ws2812-spi";
+      label = "WS2812";
+
+      /* SPI */
+      reg = <0>; /* ignored, but necessary for SPI bindings */
+      spi-max-frequency = <4000000>;
+
+      /* WS2812 */
+      chain-length = <29>; /* arbitrary; change at will */
+      spi-one-frame = <0x70>;
+      spi-zero-frame = <0x40>;
+      color-mapping = <
+         LED_COLOR_ID_GREEN
+         LED_COLOR_ID_RED
+         LED_COLOR_ID_BLUE
+      >;
+   };
+};
+
+/ {
+   chosen {
+      zmk,underglow = &led_strip;
+   };
+};

--- a/app/boards/shields/sofle/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/sofle/boards/nrfmicro_13.overlay
@@ -1,35 +1,51 @@
 #include <dt-bindings/led/led.h>
 
-&spi1 {
-   compatible = "nordic,nrf-spim";
-   status = "okay";
-   mosi-pin = <6>;
-   // Unused pins, needed for SPI definition, but not used by the ws2812 driver itself.
-   sck-pin = <5>;
-   miso-pin = <7>;
+&pinctrl {
+    spi3_default: spi3_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+        };
+    };
 
-   led_strip: ws2812@0 {
-      compatible = "worldsemi,ws2812-spi";
-      label = "WS2812";
+    spi3_sleep: spi3_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+            low-power-enable;
+        };
+    };
+};
 
-      /* SPI */
-      reg = <0>; /* ignored, but necessary for SPI bindings */
-      spi-max-frequency = <4000000>;
+&spi3 {
+    compatible = "nordic,nrf-spim";
+    status = "okay";
 
-      /* WS2812 */
-      chain-length = <29>; /* arbitrary; change at will */
-      spi-one-frame = <0x70>;
-      spi-zero-frame = <0x40>;
-      color-mapping = <
-         LED_COLOR_ID_GREEN
-         LED_COLOR_ID_RED
-         LED_COLOR_ID_BLUE
-      >;
-   };
+    pinctrl-0 = <&spi3_default>;
+    pinctrl-1 = <&spi3_sleep>;
+    pinctrl-names = "default", "sleep";
+
+    led_strip: ws2812@0 {
+        compatible = "worldsemi,ws2812-spi";
+        label = "WS2812";
+
+        /* SPI */
+        reg = <0>; /* ignored, but necessary for SPI bindings */
+        spi-max-frequency = <4000000>;
+
+        /* WS2812 */
+        chain-length = <36>; /* arbitrary; change at will */
+        spi-one-frame = <0x70>;
+        spi-zero-frame = <0x40>;
+
+        color-mapping = <
+            LED_COLOR_ID_GREEN
+            LED_COLOR_ID_RED
+            LED_COLOR_ID_BLUE
+        >;
+    };
 };
 
 / {
-   chosen {
-      zmk,underglow = &led_strip;
-   };
+    chosen {
+        zmk,underglow = &led_strip;
+    };
 };

--- a/app/boards/shields/sofle/sofle.conf
+++ b/app/boards/shields/sofle/sofle.conf
@@ -7,3 +7,11 @@
 # Uncomment these two lines to add support for encoders
 # CONFIG_EC11=y
 # CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Uncomment this line below to add rgb underglow / backlight support
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+
+# Uncomment the line below to disable external power toggling by the underglow.
+# By default toggling the underglow on and off also toggles external power
+# on and off. This also causes the display to turn off.
+# CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER=n

--- a/app/boards/shields/sofle/sofle.keymap
+++ b/app/boards/shields/sofle/sofle.keymap
@@ -7,8 +7,25 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/ext_power.h>
+
+#define BASE 0
+#define LOWER 1
+#define RAISE 2
+#define ADJUST 3
 
 / {
+
+   // Activate ADJUST layer by pressing raise and lower
+    conditional_layers {
+        compatible = "zmk,conditional-layers";
+        adjust_layer {
+            if-layers = <LOWER RAISE>;
+            then-layer = <ADJUST>;
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 
@@ -24,7 +41,7 @@
 &kp ESC   &kp Q  &kp W    &kp E    &kp R     &kp T                       &kp Y  &kp U     &kp I     &kp O    &kp P    &kp BSPC
 &kp TAB   &kp A  &kp S    &kp D    &kp F     &kp G                       &kp H  &kp J     &kp K     &kp L    &kp SEMI &kp SQT
 &kp LSHFT &kp Z  &kp X    &kp C    &kp V     &kp B  &kp C_MUTE &none     &kp N  &kp M     &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-                 &kp LGUI &kp LALT &kp LCTRL &mo 1  &kp RET    &kp SPACE &mo 2  &kp RCTRL &kp RALT  &kp RGUI
+                 &kp LGUI &kp LALT &kp LCTRL &mo LOWER  &kp RET    &kp SPACE &mo RAISE  &kp RCTRL &kp RALT  &kp RGUI
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
@@ -66,5 +83,23 @@
 
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
+
+// ------------------------------------------------------------------------------------------------------------
+// |BTCLR | BT1   | BT2   |  BT3  |  BT4  |  BT5  |                |      |      |       |      |       |       |
+// |EXTPWR|RGB_HUD|RGB_HUI|RGB_SAD|RGB_SAI|RGB_EFF|                |      |      |       |      |       |       |
+// |      |RGB_BRD|RGB_BRI|       |       |       |                |      |      |       |      |       |       |
+// |      |       |       |       |       |       |RGB_TOG| |      |      |      |       |      |       |       |
+//                |       |       |       |       |       | |      |      |      |       |      |
+
+        Adjust_layer {
+        bindings = <
+&bt BT_CLR                      &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                    &none &none &none &none &none &none
+&ext_power EXT_POWER_TOGGLE_CMD &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                                 &none &none &none &none &none &none
+&none                           &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                           &none &none &none &none &none &none
+&none                           &none           &none           &none           &none           &none               &rgb_ug RGB_TOG  &none      &none &none &none &none &none &none
+                                                &none           &none           &none           &none               &none            &none      &none &none &none &none
+        >;
+        };
+
     };
 };

--- a/app/boards/shields/sofle/sofle.keymap
+++ b/app/boards/shields/sofle/sofle.keymap
@@ -30,28 +30,30 @@
         compatible = "zmk,keymap";
 
         default_layer {
+            label = "default";
 // ------------------------------------------------------------------------------------------------------------
-// |  `    |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |       |
+// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |       |
 // |  ESC  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   | BKSPC |
 // |  TAB  |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   |   '   |
 // | SHIFT |  Z  |  X  |  C   |  V   |  B   |  MUTE  |  |       |  N   |  M    |  ,    |  .   |   /   | SHIFT |
 //               | GUI | ALT  | CTRL | LOWER|  ENTER |  | SPACE | RAISE| CTRL  | ALT   | GUI  |
             bindings = <
-&kp GRAVE &kp N1 &kp N2   &kp N3   &kp N4    &kp N5                      &kp N6 &kp N7    &kp N8    &kp N9   &kp N0   &none
-&kp ESC   &kp Q  &kp W    &kp E    &kp R     &kp T                       &kp Y  &kp U     &kp I     &kp O    &kp P    &kp BSPC
-&kp TAB   &kp A  &kp S    &kp D    &kp F     &kp G                       &kp H  &kp J     &kp K     &kp L    &kp SEMI &kp SQT
-&kp LSHFT &kp Z  &kp X    &kp C    &kp V     &kp B  &kp C_MUTE &none     &kp N  &kp M     &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-                 &kp LGUI &kp LALT &kp LCTRL &mo LOWER  &kp RET    &kp SPACE &mo RAISE  &kp RCTRL &kp RALT  &kp RGUI
+&kp GRAVE &kp N1 &kp N2   &kp N3   &kp N4    &kp N5                           &kp N6 &kp N7    &kp N8    &kp N9   &kp N0   &none
+&kp ESC   &kp Q  &kp W    &kp E    &kp R     &kp T                            &kp Y  &kp U     &kp I     &kp O    &kp P    &kp BSPC
+&kp TAB   &kp A  &kp S    &kp D    &kp F     &kp G                            &kp H  &kp J     &kp K     &kp L    &kp SEMI &kp SQT
+&kp LSHFT &kp Z  &kp X    &kp C    &kp V     &kp B      &kp C_MUTE &none      &kp N  &kp M     &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
+                 &kp LGUI &kp LALT &kp LCTRL &mo LOWER  &kp RET    &kp SPACE  &mo RAISE  &kp RCTRL &kp RALT  &kp RGUI
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         lower_layer {
+            label = "lower";
 // TODO: Some binds are waiting for shifted keycode support.
 // ------------------------------------------------------------------------------------------------------------
 // |       |  F1 |  F2 |  F3  |  F4  |  F5  |                   |  F6  |  F7   |  F8   |  F9  |  F10  |  F11  |
-// | `     |   1 |   2 |   3  |   4  |   5  |                   |   6  |   7   |   8   |   9  |    0  |  F12  |
+// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |  F12  |
 // |       |  !  |  @  |  #   |  $   |  %   |                   |  ^   |  &    |  *    |  (   |   )   |   |   |
 // |       |  =  |  -  |  +   |  {   |  }   |        |  |       |  [   |  ]    |  ;    |  :   |   \   |       |
 //               |     |      |      |      |        |  |       |      |       |       |      |
@@ -59,46 +61,47 @@
 &trans    &kp F1    &kp F2    &kp F3      &kp F4    &kp F5                    &kp F6    &kp F7   &kp F8          &kp F9    &kp F10   &kp F11
 &kp GRAVE &kp N1    &kp N2    &kp N3      &kp N4    &kp N5                    &kp N6    &kp N7   &kp N8          &kp N9    &kp N0    &kp F12
 &trans    &kp EXCL  &kp AT    &kp HASH    &kp DLLR  &kp PRCNT                 &kp CARET &kp AMPS &kp KP_MULTIPLY &kp LPAR  &kp RPAR  &kp PIPE
-&trans    &kp EQUAL &kp MINUS &kp KP_PLUS &kp LBRC  &kp RBRC  &trans   &trans &kp LBKT  &kp RBKT &kp SEMI        &kp COLON &kp BSLH  &trans
-                    &trans    &trans      &trans    &trans    &trans   &trans &trans    &trans   &trans          &trans
+&trans    &kp EQUAL &kp MINUS &kp KP_PLUS &kp LBRC  &kp RBRC   &trans &trans  &kp LBKT  &kp RBKT &kp SEMI        &kp COLON &kp BSLH  &trans
+                    &trans    &trans      &trans    &trans     &trans &trans  &trans    &trans   &trans          &trans
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
         raise_layer {
+            label = "raise";
 // ------------------------------------------------------------------------------------------------------------
-// |BTCLR| BT1  | BT2  |  BT3  |  BT4  |  BT5 |                |      |      |       |      |       |       |
-// |     | INS  | PSCR | GUI   |       |      |                | PGUP |      |   ^   |      |       |       |
-// |     | ALT  | CTRL | SHIFT |       | CAPS |                | PGDN |   <- |   v   |  ->  |  DEL  | BKSPC |
-// |     | UNDO | CUT  | COPY  | PASTE |      |      |  |      |      |      |       |      |       |       |
-//              |      |       |       |      |      |  |      |      |      |       |      |
+// | BTCLR | BT1  | BT2  |  BT3  |  BT4  |  BT5 |                |      |      |       |      |       |       |
+// |       | INS  | PSCR | GUI   |       |      |                | PGUP |      |   ^   |      |       |       |
+// |       | ALT  | CTRL | SHIFT |       | CAPS |                | PGDN |   <- |   v   |  ->  |  DEL  | BKSPC |
+// |       | UNDO | CUT  | COPY  | PASTE |      |      |  |      |      |      |       |      |       |       |
+//                |      |       |       |      |      |  |      |      |      |       |      |
             bindings = <
-&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4             &trans    &trans    &trans   &trans    &trans  &trans
-&trans     &kp INS      &kp PSCRN    &kp K_CMENU  &trans       &trans                   &kp PG_UP &trans    &kp UP   &trans    &kp N0  &trans
-&trans     &kp LALT     &kp LCTRL    &kp LSHFT    &trans       &kp CLCK                 &kp PG_DN &kp LEFT  &kp DOWN &kp RIGHT &kp DEL &kp BSPC
-&trans     &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &trans  &trans   &trans  &trans    &trans    &trans   &trans    &trans  &trans
-                        &trans       &trans       &trans       &trans  &trans   &trans  &trans    &trans    &trans   &trans
+&bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                  &trans    &trans    &trans   &trans    &trans  &trans
+&trans     &kp INS      &kp PSCRN    &kp K_CMENU  &trans       &trans                        &kp PG_UP &trans    &kp UP   &trans    &kp N0  &trans
+&trans     &kp LALT     &kp LCTRL    &kp LSHFT    &trans       &kp CLCK                      &kp PG_DN &kp LEFT  &kp DOWN &kp RIGHT &kp DEL &kp BSPC
+&trans     &kp K_UNDO   &kp K_CUT    &kp K_COPY   &kp K_PASTE  &trans        &trans  &trans  &trans    &trans    &trans   &trans    &trans  &trans
+                        &trans       &trans       &trans       &trans        &trans  &trans  &trans    &trans    &trans   &trans
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp PG_UP PG_DN>;
         };
 
-// ------------------------------------------------------------------------------------------------------------
-// |BTCLR | BT1   | BT2   |  BT3  |  BT4  |  BT5  |                |      |      |       |      |       |       |
-// |EXTPWR|RGB_HUD|RGB_HUI|RGB_SAD|RGB_SAI|RGB_EFF|                |      |      |       |      |       |       |
-// |      |RGB_BRD|RGB_BRI|       |       |       |                |      |      |       |      |       |       |
-// |      |       |       |       |       |       |RGB_TOG| |      |      |      |       |      |       |       |
-//                |       |       |       |       |       | |      |      |      |       |      |
-
-        Adjust_layer {
-        bindings = <
-&bt BT_CLR                      &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                                    &none &none &none &none &none &none
-&ext_power EXT_POWER_TOGGLE_CMD &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                                 &none &none &none &none &none &none
-&none                           &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                           &none &none &none &none &none &none
-&none                           &none           &none           &none           &none           &none               &rgb_ug RGB_TOG  &none      &none &none &none &none &none &none
-                                                &none           &none           &none           &none               &none            &none      &none &none &none &none
-        >;
+        adjust_layer {
+// ----------------------------------------------------------------------------------------------------------------------------
+// | BTCLR  |  BT1    |  BT2    |   BT3   |   BT4   |   BT5   |                  |      |      |       |      |       |       |
+// | EXTPWR | RGB_HUD | RGB_HUI | RGB_SAD | RGB_SAI | RGB_EFF |                  |      |      |       |      |       |       |
+// |        | RGB_BRD | RGB_BRI |         |         |         |                  |      |      |       |      |       |       |
+// |        |         |         |         |         |         | RGB_TOG | |      |      |      |       |      |       |       |
+//                    |         |         |         |         |         | |      |      |      |       |      |
+            label = "adjust";
+            bindings = <
+&bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                            &none &none &none &none &none &none
+&ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                         &none &none &none &none &none &none
+&none             &rgb_ug RGB_BRD &rgb_ug RGB_BRI &none           &none           &none                                   &none &none &none &none &none &none
+&none             &none           &none           &none           &none           &none            &rgb_ug RGB_TOG &none  &none &none &none &none &none &none
+                                  &none           &none           &none           &none            &none           &none  &none &none &none &none
+            >;
         };
 
     };

--- a/app/boards/shields/sofle/sofle.zmk.yml
+++ b/app/boards/shields/sofle/sofle.zmk.yml
@@ -9,6 +9,7 @@ features:
   - keys
   - display
   - encoder
+  - underglow
 siblings:
   - sofle_left
   - sofle_right


### PR DESCRIPTION
Multiple folks on the ZMK Discord server have recently run into difficulties trying to get RGB underglow working on their Sofle, as a result of mainline Sofle not having `&led_strip` defined. This `nice_nano_v2.overlay`—similar to overlays for other boards (differing only in default `chain-length`)—should be sufficient to remove this hurdle for others.