### PR TITLE
Update pillbug_defconfig to have pinctrl on

### DIFF
--- a/app/boards/arm/pillbug/pillbug_defconfig
+++ b/app/boards/arm/pillbug/pillbug_defconfig
@@ -8,6 +8,9 @@ CONFIG_BOARD_PILLBUG=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
+# Use pinctrl
+CONFIG_PINCTRL=y
+
 # enable GPIO
 CONFIG_GPIO=y
 


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [x] This board/shield is tested working on real hardware
- [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [x] `.zmk.yml` metadata file added
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] General consistent formatting of DeviceTree files
- [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [x] If split, no name added for the right/peripheral half
- [x] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [x] `.conf` file has optional extra features commented out
- [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
