### PR TITLE
fix: Disable battery sensors if reporting is off

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -500,7 +500,7 @@ config ZMK_SETTINGS_SAVE_DEBOUNCE
 endif
 
 config ZMK_BATTERY_REPORT_INTERVAL
-    depends on ZMK_BLE
+    depends on ZMK_BATTERY_REPORTING
     int "Battery level report interval in seconds"
     default 60
 

--- a/app/drivers/sensor/battery/Kconfig
+++ b/app/drivers/sensor/battery/Kconfig
@@ -6,6 +6,7 @@ DT_COMPAT_ZMK_BATTERY_VOLTAGE_DIVIDER := zmk,battery-voltage-divider
 
 config ZMK_BATTERY
     bool "ZMK battery monitoring"
+    depends on ZMK_BATTERY_REPORTING
     help
         Enable battery monitoring
 
@@ -13,7 +14,7 @@ config ZMK_BATTERY_NRF_VDDH
     bool
     default $(dt_compat_enabled,$(DT_COMPAT_ZMK_BATTERY_NRF_VDDH))
     select ADC
-    select ZMK_BATTERY
+    imply ZMK_BATTERY
     help
         Enable ZMK nRF VDDH voltage driver for battery monitoring.
 
@@ -21,6 +22,6 @@ config ZMK_BATTERY_VOLTAGE_DIVIDER
     bool
     default $(dt_compat_enabled,$(DT_COMPAT_ZMK_BATTERY_VOLTAGE_DIVIDER))
     select ADC
-    select ZMK_BATTERY
+    imply ZMK_BATTERY
     help
         Enable ZMK battery voltage divider driver for battery monitoring.

--- a/app/drivers/sensor/battery/Kconfig
+++ b/app/drivers/sensor/battery/Kconfig
@@ -6,7 +6,6 @@ DT_COMPAT_ZMK_BATTERY_VOLTAGE_DIVIDER := zmk,battery-voltage-divider
 
 config ZMK_BATTERY
     bool "ZMK battery monitoring"
-    depends on ZMK_BATTERY_REPORTING
     help
         Enable battery monitoring
 
@@ -14,7 +13,8 @@ config ZMK_BATTERY_NRF_VDDH
     bool
     default $(dt_compat_enabled,$(DT_COMPAT_ZMK_BATTERY_NRF_VDDH))
     select ADC
-    imply ZMK_BATTERY
+    select ZMK_BATTERY
+    depends on SENSOR
     help
         Enable ZMK nRF VDDH voltage driver for battery monitoring.
 
@@ -22,6 +22,7 @@ config ZMK_BATTERY_VOLTAGE_DIVIDER
     bool
     default $(dt_compat_enabled,$(DT_COMPAT_ZMK_BATTERY_VOLTAGE_DIVIDER))
     select ADC
-    imply ZMK_BATTERY
+    select ZMK_BATTERY
+    depends on SENSOR
     help
         Enable ZMK battery voltage divider driver for battery monitoring.


### PR DESCRIPTION
Currenly when `ZMK_BATTERY_REPORTING` is turned off, builds with battery sensors fail due to a kernel init priority missing (ex. [1](https://github.com/KLingO-MS/zmk-config-KgO-Sweep/actions/runs/5553387397/jobs/10141875080#step:9:417), [2](https://github.com/tsndr/zmk-config/actions/runs/5536781382/jobs/10104891126#step:9:400)), which I think is due to `SENSOR` Kconfig not getting selected.

Ideally the sensors wouldn't be enabled at all if battery level reporting is disabled but having them in the DT automatically enables them. This change disables them (in a bit of a roundabout way) through disabling `ZMK_BATTERY`: https://github.com/zmkfirmware/zmk/blob/bbb27ac02769c7bf5f20b76605f2b4e0f811e6e0/app/drivers/sensor/CMakeLists.txt#L4

Another option to directly disable the symbols would be to add `depends on ZMK_BATTERY_REPORTING` on each sensor, but this seemed slightly better to me. Let me know if that makes more sense.

Alternatively, maybe there is a more direct way to fix the kernel init priority warning, in which case the sensors would get compiled but not have an effect if reporting is disabled.