### PR TITLE
refactor: use low priority workqueue for underglow and battery reporting

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -87,6 +87,7 @@ target_sources_ifdef(CONFIG_USB_DEVICE_STACK app PRIVATE src/usb.c)
 target_sources_ifdef(CONFIG_ZMK_USB app PRIVATE src/usb_hid.c)
 target_sources_ifdef(CONFIG_ZMK_RGB_UNDERGLOW app PRIVATE src/rgb_underglow.c)
 target_sources_ifdef(CONFIG_ZMK_BACKLIGHT app PRIVATE src/backlight.c)
+target_sources(app PRIVATE src/workqueue.c)
 target_sources(app PRIVATE src/main.c)
 
 add_subdirectory(src/display/)

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -504,6 +504,14 @@ config ZMK_BATTERY_REPORT_INTERVAL
     int "Battery level report interval in seconds"
     default 60
 
+config ZMK_LOW_PRIORITY_THREAD_STACK_SIZE
+    int "Low priority thread stack size"
+    default 768
+
+config ZMK_LOW_PRIORITY_THREAD_PRIORITY
+    int "Low priority thread priority"
+    default 10
+
 #Advanced
 endmenu
 

--- a/app/include/zmk/workqueue.h
+++ b/app/include/zmk/workqueue.h
@@ -1,0 +1,1 @@
+struct k_work_q *zmk_workqueue_lowprio_work_q();

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -24,6 +24,7 @@
 #include <zmk/event_manager.h>
 #include <zmk/events/activity_state_changed.h>
 #include <zmk/events/usb_conn_state_changed.h>
+#include <zmk/workqueue.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
@@ -203,7 +204,7 @@ static void zmk_rgb_underglow_tick_handler(struct k_timer *timer) {
         return;
     }
 
-    k_work_submit(&underglow_work);
+    k_work_submit_to_queue(zmk_workqueue_lowprio_work_q(), &underglow_work);
 }
 
 K_TIMER_DEFINE(underglow_tick, zmk_rgb_underglow_tick_handler, NULL);

--- a/app/src/workqueue.c
+++ b/app/src/workqueue.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+
+#include <zmk/workqueue.h>
+
+K_THREAD_STACK_DEFINE(lowprio_q_stack, CONFIG_ZMK_LOW_PRIORITY_THREAD_STACK_SIZE);
+
+static struct k_work_q lowprio_work_q;
+
+struct k_work_q *zmk_workqueue_lowprio_work_q() {
+    return &lowprio_work_q;
+}
+
+static int workqueue_init() {
+    static const struct k_work_queue_config queue_config = {.name = "Low Priority Work Queue"};
+    k_work_queue_start(&lowprio_work_q, lowprio_q_stack, K_THREAD_STACK_SIZEOF(lowprio_q_stack),
+                       CONFIG_ZMK_LOW_PRIORITY_THREAD_PRIORITY, &queue_config);
+    return 0;
+}
+
+SYS_INIT(workqueue_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);


### PR DESCRIPTION
Blocking operations on the high priority system workqueue may result in deadlocks, particularly when Bluetooth is in use.
