### PR TITLE
feat(shields): Add splitkb.com Aurora Helix

### DIFF
--- a/app/boards/shields/splitkb_aurora_helix/Kconfig.defconfig
+++ b/app/boards/shields/splitkb_aurora_helix/Kconfig.defconfig
@@ -1,0 +1,53 @@
+# Copyright (c) 2023 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_SPLITKB_AURORA_HELIX_LEFT
+
+config ZMK_KEYBOARD_NAME
+    default "Aurora Helix"
+
+config ZMK_SPLIT_ROLE_CENTRAL
+    default y
+
+endif # SHIELD_SPLITKB_AURORA_HELIX_LEFT
+
+if SHIELD_SPLITKB_AURORA_HELIX_LEFT || SHIELD_SPLITKB_AURORA_HELIX_RIGHT
+
+config ZMK_SPLIT
+    default y
+
+config ZMK_RGB_UNDERGLOW
+    select WS2812_STRIP
+    select SPI
+
+if ZMK_DISPLAY
+
+config SSD1306
+    default y
+
+config I2C
+    default y
+
+config SSD1306_REVERSE_MODE
+    default y
+
+endif # ZMK_DISPLAY
+
+if LVGL
+
+config LV_Z_VDB_SIZE
+    default 64
+
+config LV_DPI_DEF
+    default 148
+
+config LV_Z_BITS_PER_PIXEL
+    default 1
+
+choice LV_COLOR_DEPTH
+    default LV_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL
+
+endif # SHIELD_SPLITKB_AURORA_HELIX_LEFT || SHIELD_SPLITKB_AURORA_HELIX_RIGHT

--- a/app/boards/shields/splitkb_aurora_helix/Kconfig.shield
+++ b/app/boards/shields/splitkb_aurora_helix/Kconfig.shield
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_SPLITKB_AURORA_HELIX_LEFT
+    def_bool $(shields_list_contains,splitkb_aurora_helix_left)
+
+config SHIELD_SPLITKB_AURORA_HELIX_RIGHT
+    def_bool $(shields_list_contains,splitkb_aurora_helix_right)

--- a/app/boards/shields/splitkb_aurora_helix/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_helix/boards/nice_nano.overlay
@@ -1,0 +1,46 @@
+#include <dt-bindings/led/led.h>
+
+&pinctrl {
+    spi3_default: spi3_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+        };
+    };
+
+    spi3_sleep: spi3_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+            low-power-enable;
+        };
+    };
+};
+
+&spi3 {
+    compatible = "nordic,nrf-spim";
+    status = "okay";
+
+    pinctrl-0 = <&spi3_default>;
+    pinctrl-1 = <&spi3_sleep>;
+    pinctrl-names = "default", "sleep";
+
+    led_strip: ws2812@0 {
+        compatible = "worldsemi,ws2812-spi";
+        label = "WS2812";
+
+        /* SPI */
+        reg = <0>; /* ignored, but necessary for SPI bindings */
+        spi-max-frequency = <4000000>;
+
+        /* WS2812 */
+        chain-length = <6>; /* arbitrary; change at will */
+        spi-one-frame = <0x70>;
+        spi-zero-frame = <0x40>;
+        color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+    };
+};
+
+/ {
+    chosen {
+        zmk,underglow = &led_strip;
+    };
+};

--- a/app/boards/shields/splitkb_aurora_helix/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_helix/boards/nice_nano_v2.overlay
@@ -1,0 +1,46 @@
+#include <dt-bindings/led/led.h>
+
+&pinctrl {
+    spi3_default: spi3_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+        };
+    };
+
+    spi3_sleep: spi3_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+            low-power-enable;
+        };
+    };
+};
+
+&spi3 {
+    compatible = "nordic,nrf-spim";
+    status = "okay";
+
+    pinctrl-0 = <&spi3_default>;
+    pinctrl-1 = <&spi3_sleep>;
+    pinctrl-names = "default", "sleep";
+
+    led_strip: ws2812@0 {
+        compatible = "worldsemi,ws2812-spi";
+        label = "WS2812";
+
+        /* SPI */
+        reg = <0>; /* ignored, but necessary for SPI bindings */
+        spi-max-frequency = <4000000>;
+
+        /* WS2812 */
+        chain-length = <6>; /* arbitrary; change at will */
+        spi-one-frame = <0x70>;
+        spi-zero-frame = <0x40>;
+        color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+    };
+};
+
+/ {
+    chosen {
+        zmk,underglow = &led_strip;
+    };
+};

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.conf
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.conf
@@ -1,0 +1,9 @@
+# Uncomment these two line to add support for encoders to your firmware
+# CONFIG_EC11=y
+# CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Uncomment the following line to enable the OLED Display
+# CONFIG_ZMK_DISPLAY=y
+
+# Uncomment the following line to enable RGB underglow
+# CONFIG_ZMK_RGB_UNDERGLOW=y

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.dtsi
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.dtsi
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+
+    chosen {
+        zephyr,display = &oled;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <14>;
+        rows = <5>;
+        // | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  |                 | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |
+        // | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 |                 | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |
+        // | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 |                 | SW18 | SW17 | SW16 | SW15 | SW14 | SW13 |
+        // | SW19 | SW20 | SW21 | SW22 | SW23 | SW24 | SW25 |   | SW25 | SW24 | SW23 | SW22 | SW21 | SW20 | SW19 |
+        // | SW26 | SW27 | SW28 | SW29 | SW30 | SW31 | SW32 |   | SW32 | SW31 | SW30 | SW29 | SW28 | SW27 | SW26 |
+        map = <
+        RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5)                 RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12) RC(0,13)
+        RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)                 RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12) RC(1,13)
+        RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)                 RC(2,8) RC(2,9) RC(2,10) RC(2,11) RC(2,12) RC(2,13)
+        RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11) RC(3,12) RC(3,13)
+        RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10) RC(4,11) RC(4,12) RC(4,13)
+        >;
+    };
+
+    left_encoder: left_encoder {
+        compatible = "alps,ec11";
+        label = "L_ENCODER";
+        steps = <144>;
+        status = "disabled";
+
+        a-gpios = <&pro_micro 7 GPIO_PULL_UP>;
+        b-gpios = <&pro_micro 8 GPIO_PULL_UP>;
+    };
+
+    right_encoder: right_encoder {
+        compatible = "alps,ec11";
+        label = "R_ENCODER";
+        steps = <144>;
+        status = "disabled";
+
+        a-gpios = <&pro_micro 16 GPIO_PULL_UP>;
+        b-gpios = <&pro_micro 14 GPIO_PULL_UP>;
+    };
+
+    sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&left_encoder &right_encoder>;
+        triggers-per-rotation = <36>;
+    };
+};
+
+&pro_micro_i2c {
+    status = "okay";
+
+    oled: ssd1306@3c {
+        compatible = "solomon,ssd1306fb";
+        reg = <0x3c>;
+        label = "DISPLAY";
+        width = <128>;
+        height = <32>;
+        segment-offset = <0>;
+        page-offset = <0>;
+        display-offset = <0>;
+        multiplex-ratio = <31>;
+        segment-remap;
+        com-invdir;
+        com-sequential;
+        prechargep = <0x22>;
+    };
+};

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.keymap
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.keymap
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/ext_power.h>
+#include <dt-bindings/zmk/outputs.h>
+
+#define DEFAULT 0
+#define LOWER  1
+#define RAISE  2
+#define ADJUST 3
+
+/* Uncomment this block if using RGB
+&led_strip {
+       chain-length = <6>;
+       // chain-length = <38>; // Uncomment if using both per-key and underglow LEDs
+       // chain-length = <32>; // Uncomment if using only per-key LEDs.
+};
+ */
+
+/* NOTE: At the time of the creation of this keymap, there are no specified codes for 'eisuu' and 'kana' input in ZMK.
+However, 'LANG1' and 'LANG2' are fully-functioning candidates for 'kana' and 'eisuu' input respectively.
+As such, those are in use within the default layer at this time.*/
+
+/ {
+       keymap {
+              compatible = "zmk,keymap";
+
+              default_layer {
+                     // ---------------------------------------------------------------------------------------------------------------------------------
+                     // | GRAVE  |   1    |   2    |   3    |   4    |   5    |                                      |   6    |   7    |   8    |   9    |   0    |  DEL   |
+                     // |  TAB   |   Q    |   W    |   E    |   R    |   T    |                                      |   Y    |   U    |   I    |   O    |   P    |  BSPC  |
+                     // |  CTRL  |   A    |   S    |   D    |   F    |   G    |                                      |   H    |   J    |   K    |   L    |   ;    |   '    |
+                     // |  SHIFT |   Z    |   X    |   C    |   V    |   B    |  LBKT  |                    |  RBKT  |   N    |   M    |   ,    |   .    |   /    |  RET   |
+                     // | ADJUST |  ESC   |  ALT   |  LGUI  | EISUU  | LOWER  | SPACE  |                    |  SPACE | RAISE  |  KANA  |  LEFT  |  DOWN  |  UP    |  RIGHT |
+                     bindings = <
+                     &kp GRAVE  &kp N1  &kp N2   &kp N3   &kp N4    &kp N5                               &kp N6    &kp N7    &kp N8    &kp N9     &kp N0    &kp DEL
+                     &kp TAB    &kp Q   &kp W    &kp E    &kp R     &kp T                                &kp Y     &kp U     &kp I     &kp O      &kp P     &kp BSPC
+                     &kp LCTRL  &kp A   &kp S    &kp D    &kp F     &kp G                                &kp H     &kp J     &kp K     &kp L      &kp SEMI  &kp SQT
+                     &kp LSHFT  &kp Z   &kp X    &kp C    &kp V     &kp B     &kp LBKT         &kp RBKT  &kp N     &kp M     &kp COMMA &kp PERIOD &kp SLASH &kp RET
+                     &mo ADJUST &kp ESC &kp LALT &kp LGUI &kp LANG2 &mo LOWER &kp SPACE        &kp SPACE &mo RAISE &kp LANG1 &kp LEFT  &kp DOWN   &kp UP    &kp RIGHT
+                     >;
+              };
+              lower_layer {
+                     // ---------------------------------------------------------------------------------------------------------------------------------
+                     // |      |      |      |      |      |      |                                  |      |      |      |      |      |      |
+                     // |  ~   |  !   |  @   |  #   |  $   |  %   |                                  |  ^   |  &   |  *   |  (   |  )   |      |
+                     // |      |      |      |      |      |      |                                  |      |  _   |  +   |  {   |  }   | PIPE |
+                     // |      |      |      |      |      |      |  (   |                    |  )   |      |      |      | HOME | END  |      |
+                     // |      |      |      |      |      |      |      |                    |      |      |      |      |      |      |      |
+                     bindings = <
+                     &trans    &trans   &trans &trans   &trans   &trans                             &trans    &trans    &trans    &trans   &trans   &trans
+                     &kp TILDE &kp EXCL &kp AT &kp HASH &kp DLLR &kp PRCNT                          &kp CARET &kp AMPS  &kp ASTRK &kp LPAR &kp RPAR &trans
+                     &trans    &trans   &trans &trans   &trans   &trans                             &trans    &kp UNDER &kp PLUS  &kp LBRC &kp RBRC &kp PIPE
+                     &trans    &trans   &trans &trans   &trans   &trans    &kp LPAR        &kp RPAR &trans    &trans    &trans    &kp HOME &kp END  &trans
+                     &trans    &trans   &trans &trans   &trans   &trans    &trans          &trans   &trans    &trans    &trans    &trans   &trans   &trans
+                     >;
+              };
+              raise_layer {
+                     // ---------------------------------------------------------------------------------------------------------------------------------
+                     // |       |       |       |       |       |       |                                    |       |       |       |       |       |       |
+                     // |   `   |   1   |   2   |   3   |   4   |   5   |                                    |   6   |   7   |   8   |   9   |   0   |  DEL  |
+                     // |       |  F1   |  F2   |  F3   |  F4   |  F5   |                                    |  F6   |   -   |   =   |   [   |   ]   |   \   |
+                     // |       |  F7   |  F8   |  F9   |  F10  |  F11  |       |                    |       |  F12  |       | PSCRN | PG_DN | PG_UP |       |
+                     // |       |       |       |       |       |       |       |                    |       |       |       | NEXT  | VOL-  | VOL+  | PLAY  |
+                     bindings = <
+                     &trans    &trans &trans &trans &trans  &trans                       &trans  &trans    &trans     &trans       &trans       &trans
+                     &kp GRAVE &kp N1 &kp N2 &kp N3 &kp N4  &kp N5                       &kp N6  &kp N7    &kp N8     &kp N9       &kp N0       &kp DEL
+                     &trans    &kp F1 &kp F2 &kp F3 &kp F4  &kp F5                       &kp F6  &kp MINUS &kp EQUAL  &kp LBKT     &kp RBKT     &kp BSLH
+                     &trans    &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &trans        &trans &kp F12 &trans    &kp PSCRN  &kp PG_DN    &kp PG_UP    &trans
+                     &trans    &trans &trans &trans &trans  &trans  &trans        &trans &trans  &trans    &kp C_NEXT &kp C_VOL_DN &kp C_VOL_UP &kp C_PP
+                     >;
+              };
+              adjust_layer {
+                     // ---------------------------------------------------------------------------------------------------------------------------------
+                     // |    `     |    !     |    @     |    #     |    $     |    %     |                                          |    ^     |    &     |    *     |    (     |    )     |  EP TOG  |
+                     // |  BT CLR  | BT SEL0  | BT SEL1  | BT SEL2  | BGT SEL3 | BT SEL4  |                                          | RGB EFF+ | RGB HUE+ | RGB SAT+ | RGB SPD+ | RGB BRI+ | RGB TOG  |
+                     // |  BT NXT  | OUT TOG  | OUT USB  | OUT BLE  |          |          |                                          | RGB EFF- | RGB HUE- | RGB SAT- | RGB SPD- | RGB BRI- |          |
+                     // |  BT PRV  |          |          |          |          |          |    {     |                    |    }     |          |          |          |          |          |          |
+                     // |          |          |          |          |          |          |          |                    |          |          |          |          |          |          |          |
+                     bindings = <
+                     &kp GRAVE  &kp EXCL     &kp AT       &kp HASH     &kp DLLR     &kp PRCNT                             &kp CARET       &kp AMPS        &kp ASTRK       &kp LPAR        &kp RPAR        &ext_power EP_TOG
+                     &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4                          &rgb_ug RGB_EFF &rgb_ug RGB_HUI &rgb_ug RGB_SAI &rgb_ug RGB_SPI &rgb_ug RGB_BRI &rgb_ug RGB_TOG
+                     &bt BT_NXT &out OUT_TOG &out OUT_USB &out OUT_BLE &trans       &trans                                &rgb_ug RGB_EFR &rgb_ug RGB_HUD &rgb_ug RGB_SAD &rgb_ug RGB_SPD &rgb_ug RGB_BRD &trans
+                     &bt BT_PRV &trans       &trans       &trans       &trans       &trans       &kp LBRC        &kp RBRC &trans          &trans          &trans          &trans          &trans          &trans
+                     &trans     &trans       &trans       &trans       &trans       &trans       &trans          &trans   &trans          &trans          &trans          &trans          &trans          &trans
+                     >;
+              };
+       };
+};

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.zmk.yml
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.zmk.yml
@@ -1,0 +1,15 @@
+file_format: "1"
+id: splitkb_aurora_helix
+name: splitkb.com Aurora Helix
+type: shield
+url: https://splitkb.com/products/aurora-helix-pcb-kit
+requires: [pro_micro]
+exposes: [i2c_oled]
+features:
+  - keys
+  - display
+  - encoder
+  - underglow
+siblings:
+  - splitkb_aurora_helix_left
+  - splitkb_aurora_helix_right

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix_left.overlay
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix_left.overlay
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "splitkb_aurora_helix.dtsi"
+
+/ {
+    chosen {
+        zmk,kscan = &kscan;
+    };
+
+    kscan: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+
+        label = "KSCAN";
+        diode-direction = "col2row";
+
+        row-gpios
+        = <&pro_micro 21 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+        , <&pro_micro 20 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+        , <&pro_micro 4  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+        , <&pro_micro 5  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+        , <&pro_micro 6  (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+        ;
+
+        col-gpios
+        = <&pro_micro 19 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 18 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 15 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 14 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 16 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 10 GPIO_ACTIVE_HIGH>
+        , <&pro_micro 9 GPIO_ACTIVE_HIGH>
+        ;
+    };
+};
+
+&left_encoder {
+    status = "okay";
+};

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix_right.overlay
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix_right.overlay
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "splitkb_aurora_helix.dtsi"
+
+/ {
+    chosen {
+        zmk,kscan = &kscan;
+    };
+
+    kscan: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+
+        label = "KSCAN";
+        diode-direction = "col2row";
+
+        row-gpios
+            = <&pro_micro 21 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+            , <&pro_micro 20 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+            , <&pro_micro 19 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+            , <&pro_micro 18 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+            , <&pro_micro 15 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>
+            ;
+
+        col-gpios
+            = <&pro_micro 10 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 9  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 8  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 7  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 6  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 5  GPIO_ACTIVE_HIGH>
+            , <&pro_micro 4  GPIO_ACTIVE_HIGH>
+            ;
+    };
+};
+
+&right_encoder {
+    status = "okay";
+};
+
+&default_transform {
+    col-offset = <7>;
+};


### PR DESCRIPTION
* Add new shield for splitkb.com Aurora Helix, supporting keys, encoder(s), displays, and RGB.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [x] `.zmk.yml` metadata file added
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] General consistent formatting of DeviceTree files
- [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [x] If split, no name added for the right/peripheral half
- [x] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [x] `.conf` file has optional extra features commented out
- [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
