### PR TITLE
feat(boards): Add the Pico 87 Keyboard

### DIFF
--- a/app/boards/arm/rpi_pico/rpi_pico.zmk.yml
+++ b/app/boards/arm/rpi_pico/rpi_pico.zmk.yml
@@ -1,0 +1,9 @@
+file_format: "1"
+id: rpi_pico
+name: Raspberry Pi Pico
+type: board
+arch: arm
+outputs:
+  - usb
+url: https://www.raspberrypi.com/products/raspberry-pi-pico
+exposes: [rpi_pico]

--- a/app/boards/shields/pico87/Kconfig.defconfig
+++ b/app/boards/shields/pico87/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+if SHIELD_PICO87
+
+config ZMK_KEYBOARD_NAME
+    default "Pico 87"
+
+endif

--- a/app/boards/shields/pico87/Kconfig.shield
+++ b/app/boards/shields/pico87/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2023 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_PICO87
+    def_bool $(shields_list_contains,pico87)

--- a/app/boards/shields/pico87/pico87.keymap
+++ b/app/boards/shields/pico87/pico87.keymap
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+// | Esc |  | F1 | F2 | F3 | F4 | | F5 | F6 | F7 | F8 | | F9 | F10 | F11 | F12 | | PS | SL | PB |
+// | `~  |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 |  0 |  - |  = | BS|      | Ins | HM | PU |
+// | Tab |  Q |  W |  E |  R |  S |  T |  Y |  U |  I |  O |  P |  [ |  ] |  \ | | Del | End | PD |
+// | Caps |  A |  S |  D |  F |  G |  H |  J |  K |  L |  ; |  ' | Enter |
+// |Shift |  Z |  X |  C |  V |  B |  N |  M |  , |  . |  / | Shift |      | Up |
+// | Ctrl | Meta | Alt | Space | Alt | Fn | Meta | Ctrl |         | Left | Down | Right |
+            bindings = <
+&kp ESC              &kp F1  &kp F2  &kp F3  &kp F4  &kp F5  &kp F6  &kp F7    &kp F8   &kp F9   &kp F10    &kp F11   &kp F12  &kp PSCRN &kp SLCK &kp PAUSE_BREAK
+&kp TILDE  &kp N1    &kp N2  &kp N3  &kp N4  &kp N5  &kp N6  &kp N7  &kp N8    &kp N9   &kp N0   &kp MINUS  &kp EQUAL &kp BSPC &kp INS   &kp HOME &kp PG_UP
+&kp TAB    &kp Q     &kp W   &kp E   &kp R   &kp T   &kp Y   &kp U   &kp I     &kp O    &kp P    &kp LBKT   &kp RBKT  &kp BSLH &kp DEL   &kp END  &kp PG_DN
+&kp CLCK   &kp A     &kp S   &kp D   &kp F   &kp G   &kp H   &kp J   &kp K     &kp L    &kp SEMI &kp SQT    &kp RET
+&kp LSHFT  &kp Z     &kp X   &kp C   &kp V   &kp B   &kp N   &kp M   &kp COMMA &kp DOT  &kp FSLH &kp RSHFT                               &kp UP
+&kp LCTRL  &kp LGUI  &kp LALT                &kp SPACE                         &kp RALT &trans   &kp K_CMENU &kp RCTRL         &kp LEFT  &kp DOWN &kp RIGHT
+            >;
+        };
+    };
+};

--- a/app/boards/shields/pico87/pico87.overlay
+++ b/app/boards/shields/pico87/pico87.overlay
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "col2row";
+        col-gpios
+            = <&gpio0 0 GPIO_ACTIVE_HIGH>
+            , <&gpio0 1 GPIO_ACTIVE_HIGH>
+            , <&gpio0 2 GPIO_ACTIVE_HIGH>
+            , <&gpio0 3 GPIO_ACTIVE_HIGH>
+            , <&gpio0 4 GPIO_ACTIVE_HIGH>
+            , <&gpio0 5 GPIO_ACTIVE_HIGH>
+            , <&gpio0 6 GPIO_ACTIVE_HIGH>
+            , <&gpio0 7 GPIO_ACTIVE_HIGH>
+            , <&gpio0 8 GPIO_ACTIVE_HIGH>
+            , <&gpio0 9 GPIO_ACTIVE_HIGH>
+            , <&gpio0 10 GPIO_ACTIVE_HIGH>
+            , <&gpio0 11 GPIO_ACTIVE_HIGH>
+            , <&gpio0 12 GPIO_ACTIVE_HIGH>
+            , <&gpio0 13 GPIO_ACTIVE_HIGH>
+            , <&gpio0 14 GPIO_ACTIVE_HIGH>
+            , <&gpio0 15 GPIO_ACTIVE_HIGH>
+            , <&gpio0 16 GPIO_ACTIVE_HIGH>
+            , <&gpio0 17 GPIO_ACTIVE_HIGH>
+            ;
+        row-gpios
+            = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&gpio0 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&gpio0 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&gpio0 22 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&gpio0 26 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <18>;
+        rows = <6>;
+        map = <
+RC(0,0)         RC(0,2) RC(0,3) RC(0,4) RC(0,5)         RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12) RC(0,13) RC(0,14) RC(0,15) RC(0,16) RC(0,17)
+RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12)          RC(1,14) RC(1,15) RC(1,16) RC(1,17)
+RC(2,0)         RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11) RC(2,12) RC(2,13) RC(2,14) RC(2,15) RC(2,16) RC(2,17)
+RC(3,0)         RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11) RC(3,12) RC(3,13)
+        RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10) RC(4,11)          RC(4,13)                   RC(4,16)
+RC(5,0) RC(5,1)         RC(5,3)                 RC(5,6)                         RC(5,10) RC(5,11)          RC(5,13) RC(5,14) RC(5,15) RC(5,16) RC(5,17)
+        >;
+    };
+};

--- a/app/boards/shields/pico87/pico87.zmk.yml
+++ b/app/boards/shields/pico87/pico87.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: pico87
+name: Pico 87
+type: shield
+url: https://github.com/mountainmannm/Bolt-Industries/
+requires: [rpi_pico]
+features:
+  - keys


### PR DESCRIPTION
Add the Bolt Industries Pico 87 keyboard, a DIY tenkeyless keyboard using the Raspberry Pi Pico.

Since there is no common connector defined for the board, the GPIO bank is referenced directly as &gpio0 in the device tree overlay.

The board is available here: https://www.boltind.com/product/bolt-industries-pico-87-mechanical-keyboard-pcbs-and-hardware-kit/

## Board/Shield Check-list

- [x] This board/shield is tested working on real hardware
- [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [x] `.zmk.yml` metadata file added
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] General consistent formatting of DeviceTree files
- [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [ ] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
