### PR TITLE
Various settings reset improvements.

### DIFF
--- a/app/boards/shields/settings_reset/settings_reset.keymap
+++ b/app/boards/shields/settings_reset/settings_reset.keymap
@@ -12,9 +12,7 @@
         compatible = "zmk,keymap";
 
         default_layer {
-            bindings = <
-    &sys_reset
-            >;
+            bindings = <&sys_reset>;
         };
     };
 };

--- a/app/boards/shields/settings_reset/settings_reset.overlay
+++ b/app/boards/shields/settings_reset/settings_reset.overlay
@@ -12,12 +12,12 @@
     };
 
     kscan0: kscan {
-        compatible = "zmk,kscan-gpio-direct";
+        compatible = "zmk,kscan-mock";
         label = "KSCAN";
+        columns = <1>;
+        rows = <0>;
 
-        input-gpios
-            = <&pro_micro 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-            ;
+        events = <>;
     };
 
 };

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -606,7 +606,7 @@ static int zmk_ble_init(const struct device *_arg) {
 
     bt_unpair(BT_ID_DEFAULT, NULL);
 
-    for (int i = 0; i < ZMK_BLE_PROFILE_COUNT; i++) {
+    for (int i = 0; i < 8; i++) {
         char setting_name[15];
         sprintf(setting_name, "ble/profiles/%d", i);
 
@@ -615,7 +615,20 @@ static int zmk_ble_init(const struct device *_arg) {
             LOG_ERR("Failed to delete setting: %d", err);
         }
     }
-#endif
+
+    // Hardcoding a reasonable hardcoded value of peripheral addresses
+    // to clear so we properly clear a split central as well.
+    for (int i = 0; i < 8; i++) {
+        char setting_name[32];
+        sprintf(setting_name, "ble/peripheral_addresses/%d", i);
+
+        err = settings_delete(setting_name);
+        if (err) {
+            LOG_ERR("Failed to delete setting: %d", err);
+        }
+    }
+
+#endif // IS_ENABLED(CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START)
 
     bt_conn_cb_register(&conn_callbacks);
     bt_conn_auth_cb_register(&zmk_ble_auth_cb_display);

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -281,14 +281,14 @@ int zmk_ble_put_peripheral_addr(const bt_addr_le_t *addr) {
     for (int i = 0; i < ZMK_SPLIT_BLE_PERIPHERAL_COUNT; i++) {
         // If the address is recognized and already stored in settings, return
         // index and no additional action is necessary.
-        if (!bt_addr_le_cmp(&peripheral_addrs[i], addr)) {
+        if (bt_addr_le_cmp(&peripheral_addrs[i], addr) == 0) {
             return i;
         }
 
         // If the peripheral address slot is open, store new peripheral in the
         // slot and return index. This compares against BT_ADDR_LE_ANY as that
         // is the zero value.
-        if (!bt_addr_le_cmp(&peripheral_addrs[i], BT_ADDR_LE_ANY)) {
+        if (bt_addr_le_cmp(&peripheral_addrs[i], BT_ADDR_LE_ANY) == 0) {
             char addr_str[BT_ADDR_LE_STR_LEN];
             bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
             LOG_DBG("Storing peripheral %s in slot %d", addr_str, i);

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -282,7 +282,12 @@ int zmk_ble_put_peripheral_addr(const bt_addr_le_t *addr) {
         // If the address is recognized and already stored in settings, return
         // index and no additional action is necessary.
         if (bt_addr_le_cmp(&peripheral_addrs[i], addr) == 0) {
+            LOG_DBG("Found existing peripheral address in slot %d", i);
             return i;
+        } else {
+            char addr_str[BT_ADDR_LE_STR_LEN];
+            bt_addr_le_to_str(&peripheral_addrs[i], addr_str, sizeof(addr_str));
+            LOG_DBG("peripheral slot %d occupied by %s", i, addr_str);
         }
 
         // If the peripheral address slot is open, store new peripheral in the

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -251,8 +251,8 @@ static uint8_t split_central_chrc_discovery_func(struct bt_conn *conn,
 
     LOG_DBG("[ATTRIBUTE] handle %u", attr->handle);
 
-    if (!bt_uuid_cmp(((struct bt_gatt_chrc *)attr->user_data)->uuid,
-                     BT_UUID_DECLARE_128(ZMK_SPLIT_BT_CHAR_POSITION_STATE_UUID))) {
+    if (bt_uuid_cmp(((struct bt_gatt_chrc *)attr->user_data)->uuid,
+                    BT_UUID_DECLARE_128(ZMK_SPLIT_BT_CHAR_POSITION_STATE_UUID)) == 0) {
         LOG_DBG("Found position state characteristic");
         slot->discover_params.uuid = NULL;
         slot->discover_params.start_handle = attr->handle + 2;
@@ -264,8 +264,8 @@ static uint8_t split_central_chrc_discovery_func(struct bt_conn *conn,
         slot->subscribe_params.notify = split_central_notify_func;
         slot->subscribe_params.value = BT_GATT_CCC_NOTIFY;
         split_central_subscribe(conn);
-    } else if (!bt_uuid_cmp(((struct bt_gatt_chrc *)attr->user_data)->uuid,
-                            BT_UUID_DECLARE_128(ZMK_SPLIT_BT_CHAR_RUN_BEHAVIOR_UUID))) {
+    } else if (bt_uuid_cmp(((struct bt_gatt_chrc *)attr->user_data)->uuid,
+                           BT_UUID_DECLARE_128(ZMK_SPLIT_BT_CHAR_RUN_BEHAVIOR_UUID)) == 0) {
         LOG_DBG("Found run behavior handle");
         slot->run_behavior_handle = bt_gatt_attr_value_handle(attr);
     }
@@ -292,7 +292,8 @@ static uint8_t split_central_service_discovery_func(struct bt_conn *conn,
         return BT_GATT_ITER_STOP;
     }
 
-    if (bt_uuid_cmp(slot->discover_params.uuid, BT_UUID_DECLARE_128(ZMK_SPLIT_BT_SERVICE_UUID))) {
+    if (bt_uuid_cmp(slot->discover_params.uuid, BT_UUID_DECLARE_128(ZMK_SPLIT_BT_SERVICE_UUID)) !=
+        0) {
         LOG_DBG("Found other service");
         return BT_GATT_ITER_CONTINUE;
     }
@@ -418,7 +419,7 @@ static bool split_central_eir_parse(struct bt_data *data, void *user_data) {
                 continue;
             }
 
-            if (bt_uuid_cmp(&uuid.uuid, BT_UUID_DECLARE_128(ZMK_SPLIT_BT_SERVICE_UUID))) {
+            if (bt_uuid_cmp(&uuid.uuid, BT_UUID_DECLARE_128(ZMK_SPLIT_BT_SERVICE_UUID)) != 0) {
                 char uuid_str[BT_UUID_STR_LEN];
                 char service_uuid_str[BT_UUID_STR_LEN];
 
@@ -622,7 +623,7 @@ int zmk_split_bt_central_init(const struct device *_arg) {
                        CONFIG_ZMK_BLE_THREAD_PRIORITY, NULL);
     bt_conn_cb_register(&conn_callbacks);
 
-    return start_scanning();
+    return IS_ENABLED(CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START) ? 0 : start_scanning();
 }
 
 SYS_INIT(zmk_split_bt_central_init, APPLICATION, CONFIG_ZMK_BLE_INIT_PRIORITY);

--- a/app/src/split/bluetooth/peripheral.c
+++ b/app/src/split/bluetooth/peripheral.c
@@ -116,11 +116,11 @@ static int zmk_peripheral_ble_init(const struct device *_arg) {
     LOG_WRN("Clearing all existing BLE bond information from the keyboard");
 
     bt_unpair(BT_ID_DEFAULT, NULL);
-#endif
-
+#else
     bt_conn_cb_register(&conn_callbacks);
 
     start_advertising();
+#endif
 
     return 0;
 }


### PR DESCRIPTION
* When the clear bonds Kconfig is set, also clear peripheral
  address slots addresses from settings as well.

fix(shields): Make settings_reset more flexible.
    
    * Don't reference `pro_micro` nexus node in settings_reset
      so it can be used with other controllers.
    * Use mock kscan node instead.

fix(bluetooth): Split improvements
    
    * Proper usage of bt_uuid_cmp.
    * Central's don't start scanning for peripherals if
      `ZMK_BLE_CLEAR_BONDS_ON_START` is enabled.
    * Split peripherals don't advertize if
      `ZMK_BLE_CLEAR_BONDS_ON_START` is enabled.

fix(bluetooth): Corrected use of `bt_addr_le_cmp`
    
    * Properly compare to zero when comparing LE addresses.
