### PR TITLE
fix(battery): change nRF52 ADC gain

### DIFF
--- a/app/drivers/sensor/battery/battery_nrf_vddh.c
+++ b/app/drivers/sensor/battery/battery_nrf_vddh.c
@@ -93,7 +93,7 @@ static int vddh_init(const struct device *dev) {
 
 #ifdef CONFIG_ADC_NRFX_SAADC
     drv_data->acc = (struct adc_channel_cfg){
-        .gain = ADC_GAIN_1_5,
+        .gain = ADC_GAIN_1_2,
         .reference = ADC_REF_INTERNAL,
         .acquisition_time = ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 40),
         .input_positive = SAADC_CH_PSELN_PSELN_VDDHDIV5,

--- a/app/drivers/sensor/battery/battery_voltage_divider.c
+++ b/app/drivers/sensor/battery/battery_voltage_divider.c
@@ -140,7 +140,7 @@ static int bvd_init(const struct device *dev) {
 
 #ifdef CONFIG_ADC_NRFX_SAADC
     drv_data->acc = (struct adc_channel_cfg){
-        .gain = ADC_GAIN_1_5,
+        .gain = ADC_GAIN_1_6,
         .reference = ADC_REF_INTERNAL,
         .acquisition_time = ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 40),
         .input_positive = SAADC_CH_PSELP_PSELP_AnalogInput0 + drv_cfg->io_channel.channel,


### PR DESCRIPTION
With ADC pin, maximum 3.6V input needs gain 1/6 to be less than the 0.6V reference.

With VDDHDIV5, maximum 6V input corresponds to 1.2V so gain 1/2 will be less than the 0.6V reference and be slightly more precise.
