### PR TITLE
refactor(underglow): allow full range for initial brightness

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -249,8 +249,8 @@ config ZMK_RGB_UNDERGLOW_SAT_START
 
 config ZMK_RGB_UNDERGLOW_BRT_START
     int "RGB underglow start brightness value in percent"
-    range ZMK_RGB_UNDERGLOW_BRT_MIN ZMK_RGB_UNDERGLOW_BRT_MAX
-    default ZMK_RGB_UNDERGLOW_BRT_MAX
+    range 0 100
+    default 100
 
 config ZMK_RGB_UNDERGLOW_SPD_START
     int "RGB underglow start animation speed value"


### PR DESCRIPTION
The brightness is already scaled within zmk_rgb_underglow_tick(). With the current range condition, setting max brightness to 20% results in starting with 4% (20% of 20%) brightness.