### PR TITLE
refactor: rearrange Kconfig inclusion order

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -1,6 +1,13 @@
 # Copyright (c) 2020 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
+osource "$(ZMK_CONFIG)/boards/shields/*/Kconfig.defconfig"
+osource "$(ZMK_CONFIG)/boards/shields/*/Kconfig.shield"
+
+rsource "boards/shields/*/Kconfig.defconfig"
+rsource "boards/shields/*/Kconfig.shield"
+rsource "boards/Kconfig"
+
 mainmenu "ZMK Firmware"
 
 menu "ZMK"
@@ -716,13 +723,6 @@ endchoice
 module = ZMK
 module-str = zmk
 source "subsys/logging/Kconfig.template.log_config"
-
-rsource "boards/Kconfig"
-rsource "boards/shields/*/Kconfig.defconfig"
-rsource "boards/shields/*/Kconfig.shield"
-
-osource "$(ZMK_CONFIG)/boards/shields/*/Kconfig.defconfig"
-osource "$(ZMK_CONFIG)/boards/shields/*/Kconfig.shield"
 
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
This makes it possible to override ZMK Kconfig options from shields.

This is useful for options such as `ZMK_SPLIT_BLE_CENTRAL_PERIPHERALS`, `BT_MAX_PAIRED`, `BT_MAX_CONN`, among others. Defining these in the shield `Kconfig.defconfig` works better than in the `.conf` since the they can be overridden from the user ZMK config repository.