### PR TITLE
fix(docs): detail overriding the `led_strip` `chain-length` property

### DIFF
--- a/docs/docs/features/underglow.md
+++ b/docs/docs/features/underglow.md
@@ -39,6 +39,20 @@ use Kconfig.
 
 If your board or shield does not have RGB underglow configured, refer to [Adding RGB Underglow to a Board](#adding-rgb-underglow-to-a-board).
 
+### Modifying the number of LEDs
+
+A common issue when enabling underglow is that some of the installed LEDs do not illuminate. This can happen when a board's default underglow configuration accounts only for either the downward facing LEDs or the upward facing LEDs under each key. On a split keyboard, a good sign that this may be the problem is that the unilluminated LEDs on each half are symmetrical.
+
+The number of underglow LEDs is controlled by the `chain-length` property in the `led_strip` node. You can [change the value of this property](../config/index.md#changing-devicetree-properties) in the `<keyboard>.keymap` file by adding a stanza like this one outside of any other node (i.e. above or below the `/` node):
+
+```
+&led_strip {
+    chain-length = <21>;
+};
+```
+
+where the value is the total count of LEDs (per half, for split keyboards).
+
 ## Configuring RGB Underglow
 
 See [RGB underglow configuration](/docs/config/underglow).


### PR DESCRIPTION
Quite a few people have struggled with setting the correct `chain-length` for their `led_strip`. For some, this is their first time needing to change a pre-defined devicetree property, and so they aren't familiar with the technique. I commonly see folks adding a duplicate of the entire `*.overlay` file with only the `chain-length` value changed. Having clear documentation for this specific application of the property override technique could help forestall these problems, and give those of us helping out in Discord something to easily reference.