### PR TITLE
Update leeloo_common.dtsi

### DIFF
--- a/app/boards/shields/leeloo/leeloo_common.dtsi
+++ b/app/boards/shields/leeloo/leeloo_common.dtsi
@@ -51,6 +51,7 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
         a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <120>;
+        status = "disabled";
     };
 
     right_encoder: right_encoder {
@@ -59,6 +60,7 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
         a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <120>;
+        status = "disabled";
     };
 
     sensors {


### PR DESCRIPTION
Added status "disabled" by default for Leeloo to avoid triggering of all encoder actions
