### PR TITLE
docs: Correct default macro timings, note DT limits

### DIFF
--- a/docs/docs/behaviors/macros.md
+++ b/docs/docs/behaviors/macros.md
@@ -111,7 +111,8 @@ bindings
 
 ### Wait Time
 
-The wait time setting controls how long of a delay is introduced between behaviors in the `bindings` list. The initial wait time for a macro, 100ms by default, can
+The wait time setting controls how long of a delay is introduced between behaviors in the `bindings` list. The initial wait time for a macro,
+which is equal to the value of [`CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS`](../config/behaviors.md#macro) by default, can
 be set by assigning a value to the `wait-ms` property of the macro, e.g. `wait-ms = <20>;`. If you want to update the wait time at any
 point in the macro bindings list, use `&macro_wait_time`, e.g. `&macro_wait_time 30`. A full example:
 
@@ -126,7 +127,8 @@ bindings
 
 ### Tap Time
 
-The tap time setting controls how long a tapped behavior is held in the `bindings` list. The initial tap time for a macro, 100ms by default, can
+The tap time setting controls how long a tapped behavior is held in the `bindings` list. The initial tap time for a macro,
+which is equal to the value of [`CONFIG_ZMK_MACRO_DEFAULT_TAP_MS`](../config/behaviors.md#macro) by default, can
 be set by assigning a value to the `tap-ms` property of the macro, e.g. `tap-ms = <20>;`. If you want to update the tap time at any
 point in a macro bindings list, use `&macro_tap_time`, e.g. `&macro_tap_time 30`. A full example:
 

--- a/docs/docs/behaviors/macros.md
+++ b/docs/docs/behaviors/macros.md
@@ -147,6 +147,8 @@ Macros use an internal queue to invoke each behavior in the bindings list when t
 
 To prevent issues with longer macros, you can change the size of this queue via the `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE` setting in your configuration, [typically through your `.conf` file](../config/index.md). For example, `CONFIG_ZMK_BEHAVIORS_QUEUE_SIZE=512` would allow your macro to type about 256 characters.
 
+Another limit worth noting is that the maximum number of bindings you can pass to a `bindings` field in the [Devicetree](../config/index.md#devicetree-files) is 256, which also constrains how many behaviors can be invoked by a macro.
+
 ## Parameterized Macros
 
 Macros can also be "parameterized", allowing them to be bound in your keymap with unique values passed into them, e.g.:


### PR DESCRIPTION
Two simple changes: update the wait/tap-ms default values in the macros behavior page which were missed, and add a remark on the limit of number of bindings you can pass (which came up from user questions before, and might come up until #1893 is merged). I tested the bindings limit and saw that it succeeded at 256 items and failed at 257.