### PR TITLE
feat(docs): Note how to use GPIO outside interconnect definition

### DIFF
--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -120,6 +120,10 @@ endif
 
 <InterconnectTabs items={Metadata}/>
 
+To use GPIO pins that are not part of the interconnects as described above, you can use the GPIO labels that are specific to each controller type.
+For instance, pins numbered `PX.Y` in nRF52840-based boards can be referred to via `&gpioX Y` labels.
+An example is `&gpio1 7` for the `P1.07` pin that the nice!nano exposes in the middle of the board.
+
 <Tabs
 defaultValue="unibody"
 values={[


### PR DESCRIPTION
This is to answer a question that comes up often, usually in the context of using the three middle pins in nice!nanos. I put it right after the interconnects section so it appears below everything, but any suggestions on where else this could be mentioned is welcome.