### PR TITLE
docs: Document necessary flags for kscan GPIOs

### DIFF
--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -87,6 +87,18 @@ By default, a switch will drain current through the internal pull up/down resist
 
 `toggle-mode` applies to all switches handled by the instance of the driver. To use a toggle switch with other, non-toggle, direct GPIO switches, create two instances of the direct GPIO driver, one with `toggle-mode` and the other without. Then, use a [composite driver](#composite-driver) to combine them.
 
+Assuming the switches connect each GPIO pin to the ground, the [GPIO flags](https://docs.zephyrproject.org/3.2.0/hardware/peripherals/gpio.html#api-reference) for the elements in `input-gpios` should be `(GPIO_ACTIVE_LOW | GPIO_PULL_UP)`:
+
+```devicetree
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-direct";
+        input-gpios
+            = <&pro_micro 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+            , <&pro_micro 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+            ;
+    };
+```
+
 ## Matrix Driver
 
 Keyboard scan driver where keys are arranged on a matrix with one GPIO per row and column.
@@ -122,6 +134,24 @@ The `diode-direction` property must be one of:
 | ----------- | --------------------------------------------------------------------- |
 | `"row2col"` | Diodes point from rows to columns (cathodes are connected to columns) |
 | `"col2row"` | Diodes point from columns to rows (cathodes are connected to rows)    |
+
+Given the `diode-direction`, the [GPIO flags](https://docs.zephyrproject.org/3.2.0/hardware/peripherals/gpio.html#api-reference) for the elements in `row-` and `col-gpios` should be set appropriately.
+The output pins (e.g. columns for `col2row`) should have the flag `GPIO_ACTIVE_HIGH`, and input pins (e.g. rows for `col2row`) should have the flags `(GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)`:
+
+```devicetree
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        diode-direction = "col2row";
+        col-gpios
+            = <&pro_micro 4 GPIO_ACTIVE_HIGH>
+            , <&pro_micro 5 GPIO_ACTIVE_HIGH>
+            ;
+        row-gpios
+            = <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+            ;
+    };
+```
 
 ## Composite Driver
 

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -297,9 +297,7 @@ Any keyboard which is not a grid of 1 unit keys will likely have some unused pos
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        rows = <5>;
-        columns = <4>;
-        // define the matrix...
+        // define row-gpios with 5 elements and col-gpios with 4...
     };
 
     default_transform: matrix_transform {
@@ -359,9 +357,7 @@ Consider a keyboard with a [duplex matrix](https://wiki.ai03.com/books/pcb-desig
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        rows = <12>;
-        columns = <8>;
-        // define the matrix...
+        // define row-gpios with 12 elements and col-gpios with 8...
     };
 
     default_transform: matrix_transform {


### PR DESCRIPTION
I noticed that the GPIO flags aren't really explained anywhere and they are frequently missed by people when they e.g. swap diode directions. This adds prescriptive paragraphs for matrix and direct pin kscans. It is not actually explaining what the flags do, but this doesn't seem to be the right place for it and in practice it should help.

~~Perhaps we should add a link to Zephyr docs for the explanations of the flags, I'll see if I can find one.~~ Added a link.

Also includes a fix for the examples, where `rows/cols` are incorrectly implied to be supported by the kscan nodes.