### PR TITLE
feat(docs): Document persisted settings and debouncing

### DIFF
--- a/docs/docs/behaviors/backlight.md
+++ b/docs/docs/behaviors/backlight.md
@@ -36,6 +36,12 @@ Here is a table describing the action for each define:
 - Parameter #1: The backlight action define, e.g. `BL_TOG` or `BL_INC`
 - Parameter #2: Only applies to `BL_SET`and is the brightness value
 
+:::note Backlight settings persistence
+The backlight settings that are changed via the `&bl` behavior will be saved to flash storage and hence persist across restarts and firmware flashes.
+They will also override the start values set by [`CONFIG_ZMK_BACKLIGHT_*_START` settings](../config/backlight.md#kconfig).
+However the settings will only be saved after [`CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`](../config/system.md#general) milliseconds in order to reduce potential wear on the flash memory.
+:::
+
 ### Examples
 
 1. Toggle backlight on/off

--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -35,6 +35,11 @@ Here is a table describing the command for each define:
 | `BT_PRV` | Switch to the previous profile, cycling through to the last one when the beginning is reached.                                                            |
 | `BT_SEL` | Select the 0-indexed profile by number. Please note: this definition must include a number as an argument in the keymap to work correctly. eg. `BT_SEL 0` |
 
+:::note Selected profile persistence
+The profile that is selected by the `BT_SEL`/`BT_PRV`/`BT_NXT` actions will be saved to flash storage and hence persist across restarts and firmware flashes.
+However it will only be saved after [`CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`](../config/system.md#general) milliseconds in order to reduce potential wear on the flash memory.
+:::
+
 ## Bluetooth Behavior
 
 The bluetooth behavior completes an bluetooth action given on press.

--- a/docs/docs/behaviors/outputs.md
+++ b/docs/docs/behaviors/outputs.md
@@ -44,6 +44,11 @@ The output selection behavior changes the preferred output on press.
 - Reference: `&out`
 - Parameter #1: Command, e.g. `OUT_BLE`
 
+:::note External power state persistence
+The endpoint that is selected by the `&out` behavior will be saved to flash storage and hence persist across restarts and firmware flashes.
+However it will only be saved after [`CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`](../config/system.md#general) milliseconds in order to reduce potential wear on the flash memory.
+:::
+
 ### Examples
 
 1. Behavior binding to prefer sending keyboard output to USB

--- a/docs/docs/behaviors/power.md
+++ b/docs/docs/behaviors/power.md
@@ -43,6 +43,11 @@ Here is a table describing the command for each define:
 - Reference: `&ext_power`
 - Parameter#1: Command, e.g `EP_ON`
 
+:::note External power state persistence
+The on/off state that is set by the `&ext_power` behavior will be saved to flash storage and hence persist across restarts and firmware flashes.
+However it will only be saved after [`CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`](../config/system.md#general) milliseconds in order to reduce potential wear on the flash memory.
+:::
+
 ### Example:
 
 1. Behavior binding to enable the external power

--- a/docs/docs/behaviors/underglow.md
+++ b/docs/docs/behaviors/underglow.md
@@ -55,6 +55,12 @@ Value Limits:
 
 :::
 
+:::note RGB settings persistence
+The RGB settings that are changed via the `&rgb_ug` behavior will be saved to flash storage and hence persist across restarts and firmware flashes.
+They will also override the start values set by [`CONFIG_ZMK_RGB_*_START` settings](../config/underglow.md#kconfig).
+However the settings will only be saved after [`CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`](../config/system.md#general) milliseconds in order to reduce potential wear on the flash memory.
+:::
+
 ## Examples
 
 1. Toggle underglow on/off


### PR DESCRIPTION
Document which behaviors lead to certain settings being persisted in flash memory. Also remark that settings save happens only after the debounce period.

(Random note: looking at the code, I don't think `&rgb_ug RGB_COLOR_HSB(...)` persists the setting, unlike the other commands.)