### PR TITLE
fix(driver): Fix broken compilation for MAX7318 driver

### DIFF
--- a/app/module/drivers/gpio/gpio_max7318.c
+++ b/app/module/drivers/gpio/gpio_max7318.c
@@ -12,16 +12,16 @@
 
 #include <errno.h>
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
-#include <sys/byteorder.h>
-#include <drivers/gpio.h>
-#include <drivers/i2c.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
 #include <drivers/ext_power.h>
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(gpio_max7318);
 

--- a/app/module/drivers/gpio/gpio_max7318.c
+++ b/app/module/drivers/gpio/gpio_max7318.c
@@ -18,7 +18,6 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/i2c.h>
-#include <drivers/ext_power.h>
 
 #define LOG_LEVEL CONFIG_GPIO_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/app/module/dts/bindings/gpio/maxim,max7318.yaml
+++ b/app/module/dts/bindings/gpio/maxim,max7318.yaml
@@ -12,9 +12,6 @@ compatible: "maxim,max7318"
 include: [gpio-controller.yaml, i2c-device.yaml]
 
 properties:
-  label:
-    required: true
-
   "#gpio-cells":
     const: 2
 


### PR DESCRIPTION
The driver got neglected and didn't compile. Now it does (:

Tested to work on real hardware.

EDIT: what's the best way to make a CI test for this so that it keeps being compiled?