### PR TITLE
fix(boards): Disable QSPI for Xiao BLE

### DIFF
--- a/app/boards/seeeduino_xiao_ble.overlay
+++ b/app/boards/seeeduino_xiao_ble.overlay
@@ -32,3 +32,6 @@
     };
 };
 
+&qspi {
+    status = "disabled";
+};


### PR DESCRIPTION
The GD25Q16 flash connected via QSPI seems to be causing issues with excessive battery use and inability to sleep. Since ZMK doesn't use it, we can disable it as an easy fix. Credit goes to @rich-westarete for figuring out the issue in #1901.

I have been testing this setting in the last few days. Before the change my daily battery use on a split central varied between 3%-12% (with a 350 mAh battery). Deep sleep would not work properly, where about half the times I left it idle it went into sleep and the other half it was awake when I came back. After this change deep sleep is consistent and the battery usage has gone down to 1-2% per day.