### PR TITLE
Leeloo-Micro set status disabled for encoders.

### DIFF
--- a/app/boards/shields/leeloo_micro/leeloo_micro.dtsi
+++ b/app/boards/shields/leeloo_micro/leeloo_micro.dtsi
@@ -48,7 +48,8 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(3,4) RC(3,5) RC(2,5) RC(2,6) RC(2,7) 
         label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
-        steps = <120>;
+        status = "disabled";
+        steps = <60>;
     };
 
     right_encoder: right_encoder {
@@ -56,7 +57,8 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(3,4) RC(3,5) RC(2,5) RC(2,6) RC(2,7) 
         label = "RIGHT_ENCODER";
         a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
-        steps = <120>;
+        status = "disabled";
+        steps = <60>;
     };
 
     sensors {


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
Update Leeloo-Micro's .dtsi file to set encoder status to disabled; and, adjusted steps to be behave smoother.  

Thank yous to @mstralenya for catching the fix in Leeloo v2, and @petejohanson for approving and merging the change.
