### PR TITLE
app: cmake: use $ENV{ZEPHYR_BASE} as hint

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND ZEPHYR_EXTRA_MODULES
 )
 
 # Find Zephyr. This also loads Zephyr's build system.
-find_package(Zephyr REQUIRED HINTS ../zephyr)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(zmk)
 
 zephyr_linker_sources(RODATA include/linker/zmk-events.ld)


### PR DESCRIPTION
That's the common way to do this and has the advantage that it works when the zephyr repo is an a different location and was not registered in the users cmake registry - which is a very common usecase supported by zephyr. You end up with that by `west init`-ing the git url of either the zmk repo directly or another manifest repo which imports the zmk repo. This is more convenient than the whole manual `west init -l` stuff.

This works because west automatically exports the `ZEPHYR_BASE` environment variable to all extensions - including `west build`. For that exact reason it should not break anyones scripts unless they're using cmake directly and didn't set the $ZEPHYR_BASE environment variable.