### PR TITLE
Fix bug with overlapping combos timeouts

### DIFF
--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -204,22 +204,33 @@ static inline bool candidate_is_completely_pressed(struct combo_cfg *candidate) 
 static int cleanup();
 
 static int filter_timed_out_candidates(int64_t timestamp) {
-    int num_candidates = 0;
+    int remaining_candidates = 0;
     for (int i = 0; i < CONFIG_ZMK_COMBO_MAX_COMBOS_PER_KEY; i++) {
         struct combo_candidate *candidate = &candidates[i];
         if (candidate->combo == NULL) {
             break;
         }
         if (candidate->timeout_at > timestamp) {
-            // reorder candidates so they're contiguous
-            candidates[num_candidates].combo = candidate->combo;
-            candidates[num_candidates].timeout_at = candidate->timeout_at;
-            num_candidates++;
+            bool need_to_bubble_up = remaining_candidates != i;
+            if (need_to_bubble_up) {
+                // bubble up => reorder candidates so they're contiguous
+                candidates[remaining_candidates].combo = candidate->combo;
+                candidates[remaining_candidates].timeout_at = candidate->timeout_at;
+                // clear the previous location
+                candidates[i].combo = NULL;
+                candidates[i].timeout_at = 0;
+            }
+
+            remaining_candidates++;
         } else {
             candidate->combo = NULL;
         }
     }
-    return num_candidates;
+
+    LOG_DBG("after filtering out timed out combo candidates: remaining_candidates=%d timestamp=%d",
+            remaining_candidates, timestamp);
+
+    return remaining_candidates;
 }
 
 static int clear_candidates() {
@@ -449,7 +460,7 @@ static void combo_timeout_handler(struct k_work *item) {
         // timer was cancelled or rescheduled.
         return;
     }
-    if (filter_timed_out_candidates(timeout_task_timeout_at) < 2) {
+    if (filter_timed_out_candidates(timeout_task_timeout_at) == 0) {
         cleanup();
     }
     update_timeout_task();

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -227,8 +227,9 @@ static int filter_timed_out_candidates(int64_t timestamp) {
         }
     }
 
-    LOG_DBG("after filtering out timed out combo candidates: remaining_candidates=%d timestamp=%d",
-            remaining_candidates, timestamp);
+    LOG_DBG(
+        "after filtering out timed out combo candidates: remaining_candidates=%d timestamp=%lld",
+        remaining_candidates, timestamp);
 
     return remaining_candidates;
 }

--- a/app/tests/combo/overlapping-combos-4-different-timeouts/events.patterns
+++ b/app/tests/combo/overlapping-combos-4-different-timeouts/events.patterns
@@ -1,0 +1,1 @@
+s/.*\(hid_listener_keycode_pressed\|filter_timed_out_candidates\): //p

--- a/app/tests/combo/overlapping-combos-4-different-timeouts/keycode_events.snapshot
+++ b/app/tests/combo/overlapping-combos-4-different-timeouts/keycode_events.snapshot
@@ -1,0 +1,8 @@
+after filtering out timed out combo candidates: remaining_candidates=2 timestamp=71
+after filtering out timed out combo candidates: remaining_candidates=1 timestamp=81
+after filtering out timed out combo candidates: remaining_candidates=0 timestamp=91
+usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+after filtering out timed out combo candidates: remaining_candidates=2 timestamp=143
+after filtering out timed out combo candidates: remaining_candidates=1 timestamp=153
+after filtering out timed out combo candidates: remaining_candidates=1 timestamp=159
+usage_page 0x07 keycode 0x1D implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/combo/overlapping-combos-4-different-timeouts/native_posix_64.keymap
+++ b/app/tests/combo/overlapping-combos-4-different-timeouts/native_posix_64.keymap
@@ -56,7 +56,7 @@
     ZMK_MOCK_RELEASE(0,0,delay_next)
 #define release_D_and_wait(delay_next) \
     ZMK_MOCK_RELEASE(1,1,delay_next)
- 
+
 &kscan {
     events = <
         /* Note: This starts at T+50 because the ZMK_MOCK_PRESS seems to launch the first event at T+(first wait duration). So in our case T+50 */

--- a/app/tests/combo/overlapping-combos-4-different-timeouts/native_posix_64.keymap
+++ b/app/tests/combo/overlapping-combos-4-different-timeouts/native_posix_64.keymap
@@ -1,0 +1,98 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+#define kA 0
+#define kB 1
+#define kC 2
+#define kD 3
+
+/ {
+    combos {
+        compatible = "zmk,combos";
+
+        // Intentionally out of order in the config, to make sure 'combo.c' handles it properly
+        combo_40 {
+            timeout-ms = <40>;
+            key-positions = <kA kD>;
+            bindings = <&kp Z>;
+        };
+        combo_20 {
+            timeout-ms = <20>;
+            key-positions = <kA kB>;
+            bindings = <&kp X>;
+        };
+        combo_30 {
+            timeout-ms = <30>;
+            key-positions = <kA kC>;
+            bindings = <&kp Y>;
+        };
+
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+        label ="Default keymap";
+
+        default_layer {
+            bindings = <
+                &kp A &kp B
+                &kp C &kp D
+            >;
+        };
+    };
+};
+
+#define press_A_and_wait(delay_next) \
+    ZMK_MOCK_PRESS(0,0,delay_next)
+#define press_B_and_wait(delay_next) \
+    ZMK_MOCK_PRESS(0,1,delay_next)
+#define press_C_and_wait(delay_next) \
+    ZMK_MOCK_PRESS(1,0,delay_next)
+#define press_D_and_wait(delay_next) \
+    ZMK_MOCK_PRESS(1,1,delay_next)
+
+#define release_A_and_wait(delay_next) \
+    ZMK_MOCK_RELEASE(0,0,delay_next)
+#define release_D_and_wait(delay_next) \
+    ZMK_MOCK_RELEASE(1,1,delay_next)
+ 
+&kscan {
+    events = <
+        /* Note: This starts at T+50 because the ZMK_MOCK_PRESS seems to launch the first event at T+(first wait duration). So in our case T+50 */
+
+
+
+        /*** First Phase: All 3 combos expire ***/
+
+        /* T+50+0=    T+50: Press A and wait 50ms */
+        press_A_and_wait(50)
+
+        /* T+50+20=   T+70: 'combo_20' should expire */
+        /* T+50+30=   T+80: 'combo_30' should expire */
+        /* T+50+40=   T+90: 'combo_40' should expire, and we should send the keycode 'A' */
+
+        /* T+50+50=  T+100: We release A and wait 20ms */
+        release_A_and_wait(20)
+
+
+
+        /*** Second Phase: 2 combo expire, 1 combo triggers ***/
+
+        /* T+120+0=  T+120: Press A and wait 35ms */
+        press_A_and_wait(35)
+
+        /* T+120+20= T+140: 'combo_20' should expire */
+        /* T+120+30= T+150: 'combo_30' should expire */
+
+        /* T+120+35= T+155: We press 'D', this should trigger 'combo_40' and send the keycode 'Z'. We wait 15ms */
+        press_D_and_wait(15)
+
+
+
+        /*** Cleanup ***/
+        /* T+120+50= T+170: We release both keys */
+        release_A_and_wait(20)
+        release_D_and_wait(0)
+    >;
+};


### PR DESCRIPTION
> ### This is a follow-up to #1944 . See the issue for more context.
> This PR fixes the bug mentioned in the issue


## Context

When a timeout fires, the code will filter the remaining combos. Eliminating the one the just timed out, and reordering the remaining ones.

The code _does_ filter the timed out combos correctly, and it does re-order the remaining ones correctly. But! It didn’t clean up properly the position of the very last candidate.

They all move one spot, so when they move, they override the one that was previously there. But the very last combo doesn’t get overridden by anything.

```
Timestamp = 60ms

Before filtering
Combo expires_at=60ms
Combo expires_at=70ms
Combo expires_at=80ms
Combo expires_at=90ms

After filtering
Combo expires_at=70ms
Combo expires_at=80ms
Combo expires_at=90ms
Combo expires_at=90ms <- This extra one is the problem
```

After filtering it returns the number of active candidates. The first time it does it, the number returned is correct, even though this extra entry in `candidates` is not cleaned up.

But then second time it looks at the list, it will return an incorrect number of active candidates. Because of the duplication that happens each time the last candidate is moved up one spot.

## The Bug

When a combo is timing out, the `filter_timed_out_candidates` function is called by `combo_timeout_handler`. 

When a combo times out, we know it’s not going to be activated. The only times when a combo can activate is when a key is pressed (which also calls `filter_timed_out_candidates`).

Since a combo can not be triggered by a timeout, we should only `cleanup()` once **no candidates are remaining.**

However the current code will `cleanup()` if `0 or 1` candidates are remaining. I’m not quite sure why that was implemented this way, maybe it was a quick fix for the issue described above in the context section. Or maybe the idea was that when we have 1 candidate remaining we should clean up. Either way, this was the source of the problem described in #1944 

## Solution

1. Make sure we properly clear out the unused spots in the `candidates` list
2. On timeout, only `cleanup()` if exactly `0 candidates` are left

I also added a test to showcase the proper timeout behavior, and added some debug logging to make this test possible.

I ran all the tests, they all pass ✅

It’s my first PR on this repo, so let me know if if I should update something.

Thanks for this amazing piece of software 😍