### PR TITLE
boards: nrf52840dk_nrf52840: default kscan

### DIFF
--- a/app/boards/nrf52840dk_nrf52840.keymap
+++ b/app/boards/nrf52840dk_nrf52840.keymap
@@ -1,0 +1,16 @@
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        layer_1 {
+            label = "base";
+            bindings = <
+                &kp A &kp B
+                &kp C &kp D
+            >;
+        };
+    };
+};

--- a/app/boards/nrf52840dk_nrf52840.overlay
+++ b/app/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,32 @@
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix-transform = &layout_grid_transform;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-direct";
+        label = "direct";
+        input-gpios
+            = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+            <&gpio0 12 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+            <&gpio0 24 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>,
+            <&gpio0 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>
+            ;
+    };
+
+    layout_grid_transform:
+        keymap_transform_0 {
+            compatible = "zmk,matrix-transform";
+            columns = <2>;
+            rows = <2>;
+            map = <
+            RC(0,0) RC(0,1)
+            RC(1,0) RC(1,1)
+            >;
+    };
+};


### PR DESCRIPTION
Adds a default kscan and keymap for the nRF52840DK

Signed-off-by: Kelly Helmut Lord <helmut@helmutlord.com>
