### PR TITLE
feat(shields): Add ZMK Uno nice!view support.

### DIFF
--- a/app/boards/shields/zmk_uno/zmk_uno.overlay
+++ b/app/boards/shields/zmk_uno/zmk_uno.overlay
@@ -11,8 +11,16 @@
     status = "okay";
 };
 
-&arduino_spi {
+nice_view_spi: &arduino_spi {
     status = "okay";
+
+    cs-gpios = <&arduino_header 16 GPIO_ACTIVE_HIGH>;
+
+    // Needed so the nice_view shield will enhance the existing node which falls *first*
+    // on the bus, properly picking up the first `cs-gpios` specifier.
+    ls0xx@0 {
+        reg = <0>;
+    };
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";


### PR DESCRIPTION
Export the `nice_view_spi` node properly from the ZMK Uno overlay to ensure the shield will work when built along with the `nice_view` shield.

Example:

![zmk-uno-nice-view](https://github.com/zmkfirmware/zmk/assets/202695/7560a6f6-0e33-4ce5-a84f-5f41ffd88273)
