### PR TITLE
 Documentation update for layer-tap in docs/docs/behaviors/layers.md

### DIFF
--- a/docs/docs/behaviors/layers.md
+++ b/docs/docs/behaviors/layers.md
@@ -59,7 +59,7 @@ Example:
 
 ### Configuration
 
-You can configure a different tapping term in your keymap or others options from the [hold-tap](hold-tap.md#advanced-configuration) documentation page:
+You can configure a different tapping term or tweak other properties noted in the [hold-tap](hold-tap.md#advanced-configuration) documentation page in your keymap:
 
 ```
 &lt {

--- a/docs/docs/behaviors/layers.md
+++ b/docs/docs/behaviors/layers.md
@@ -57,6 +57,22 @@ Example:
 &lt LOWER SPACE
 ```
 
+### Configuration
+
+You can configure a different tapping term in your keymap or others options from the [hold-tap](hold-tap.md#advanced-configuration) documentation page:
+
+```
+&lt {
+    tapping-term-ms = <200>;
+};
+
+/ {
+    keymap {
+        ...
+    };
+};
+```
+
 :::info
 Functionally, the layer-tap is a [hold-tap](hold-tap.md) of the ["tap-preferred" flavor](hold-tap.md/#flavors) and a [`tapping-term-ms`](hold-tap.md/#tapping-term-ms) of 200 that takes in a [`momentary layer`](#momentary-layer) and a [keypress](key-press.md) as its "hold" and "tap" parameters, respectively.
 


### PR DESCRIPTION
Added documentation details for layer-tap.

The mod-tap documentation page has a configuration portion where it shows how to change some values for the behavior ( https://zmk.dev/docs/behaviors/mod-tap#configuration )

I suggest adding the same thing for the layer-tap behavior documentation portion.

Changes have been tested according to : 
https://zmk.dev/docs/development/documentation

