### PR TITLE
feat(docs): Add keymap recipes section

### DIFF
--- a/docs/docs/recipes/adjust-layer.md
+++ b/docs/docs/recipes/adjust-layer.md
@@ -1,0 +1,12 @@
+---
+title: Adjust Layer
+sidebar_label: Adjust Layer
+---
+
+## Summary
+
+Recipe summary
+
+## Implementation
+
+Recipe implementation

--- a/docs/docs/recipes/callum-mods.md
+++ b/docs/docs/recipes/callum-mods.md
@@ -1,0 +1,12 @@
+---
+title: Callum Mods
+sidebar_label: Callum Mods
+---
+
+## Summary
+
+Recipe summary
+
+## Implementation
+
+Recipe implementation

--- a/docs/docs/recipes/home-row-mods.md
+++ b/docs/docs/recipes/home-row-mods.md
@@ -1,0 +1,12 @@
+---
+title: Home Row Mods
+sidebar_label: Home Row Mods
+---
+
+## Summary
+
+Recipe summary
+
+## Implementation
+
+Recipe implementation

--- a/docs/docs/recipes/multiple-base-layers.md
+++ b/docs/docs/recipes/multiple-base-layers.md
@@ -1,0 +1,12 @@
+---
+title: Multiple Base Layers
+sidebar_label: Multiple Base Layers
+---
+
+## Summary
+
+Recipe summary
+
+## Implementation
+
+Recipe implementation

--- a/docs/docs/recipes/os-profile-layer.md
+++ b/docs/docs/recipes/os-profile-layer.md
@@ -1,0 +1,12 @@
+---
+title: OS Profile Layer
+sidebar_label: OS Profile Layer
+---
+
+## Summary
+
+Recipe summary
+
+## Implementation
+
+Recipe implementation

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -43,6 +43,13 @@ module.exports = {
       "behaviors/backlight",
       "behaviors/power",
     ],
+    Recipes: [
+      "recipes/adjust-layer",
+      "recipes/callum-mods",
+      "recipes/home-row-mods",
+      "recipes/multiple-base-layers",
+      "recipes/os-profile-layer",
+    ],
     Codes: [
       "codes/index",
       "codes/keyboard-keypad",


### PR DESCRIPTION
(Opening to replace #1952 for the branch to be part of the `zmkfirmware/zmk` repo, thanks for getting this going @SethMilliken! Copied the description verbatim.)

ZMK enables myriad functionality that is technically neither feature nor behavior, but typically results from novel composition of configuration, features, and behaviors. Questions about this class of functionality often arise in Discord server discussion, and the techniques to implement them are currently passed on informally by reference to personal configurations. Having official documentation for this functionality could help with standardization and transmission of these techniques.

The name "recipes" seems to capture the nature of this type of functionality.

Some examples of recipes include:
- Home Row Mods
- Callum Mods
- Adjust Layer
- Multiple Base Layers
- OS Profile Layer Change

This draft PR is intended to explore documenting these recipes, and to refine the definition of a "recipe".

Tasks:
- [ ] formulate clear definition of recipe
- [ ] find appropriate home in docs for definition
- [ ] fill out initial recipe pages
- [ ] settle on structure/template for a typical recipe page
- [ ] identify additional recipes

Feel free to contribute using comments here, comments in the #documentation channel in the Discord, or directly as PRs targeting [this branch](https://github.com/zmkfirmware/zmk/tree/docs/recipes) (`docs/recipes`). Once we have above tasks completed, this PR will be published.

[ZMK Discord discussion](https://discord.com/channels/719497620560543766/883452966114324550/1158897136876924958) where this idea originated.



