### PR TITLE
feat(docs): Document globe key specific quirks

### DIFF
--- a/docs/docs/codes/_footnotes/globe.mdx
+++ b/docs/docs/codes/_footnotes/globe.mdx
@@ -1,0 +1,1 @@
+Does not exactly replicate original key behavior on macOS, works for Globe+key modifiers but not Fn+key ([#1938](https://github.com/zmkfirmware/zmk/pull/1938#issuecomment-1744579039)).

--- a/docs/src/data/footnotes.js
+++ b/docs/src/data/footnotes.js
@@ -8,10 +8,12 @@ import example from "@site/docs/codes/_footnotes/example.mdx";
 import iosApplication from "@site/docs/codes/_footnotes/ios-application.mdx";
 import iosPower from "@site/docs/codes/_footnotes/ios-power.mdx";
 import macosPower from "@site/docs/codes/_footnotes/macos-power.mdx";
+import globe from "@site/docs/codes/_footnotes/globe.mdx";
 
 export default {
   example,
   iosApplication,
   iosPower,
   macosPower,
+  globe,
 };

--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -7884,6 +7884,8 @@ export default [
       macos: true,
       ios: true,
     },
-    footnotes: {},
+    footnotes: {
+      macos: ["globe"],
+    },
   },
 ];


### PR DESCRIPTION
Adds the footnote for the issues documented with the new apple globe keycode discovered by some users in #1938 