### PR TITLE
fix(blog): Correct incorrect info re: global-quick-tap

### DIFF
--- a/docs/blog/2023-10-05-zmk-sotf-6.md
+++ b/docs/blog/2023-10-05-zmk-sotf-6.md
@@ -21,7 +21,7 @@ Here's a summary of the various major changes since last time, broken down by th
 
 [andrewjrae] added the [`require-prior-idle-ms` property](/docs/behaviors/hold-tap#require-prior-idle-ms) to the hold-tap behavior in [#1187](https://github.com/zmkfirmware/zmk/pull/1187) and [#1387](https://github.com/zmkfirmware/zmk/pull/1387), which prevents the hold behavior from triggering if it hasn't been a certain duration since the last key press. This is a useful feature to prevent accidental hold activations during quick typing and made its way into many keymaps! The same property was added to [combos](/docs/features/combos#configuration) as well to help prevent false combo activations.
 
-Note that an earlier iteration of this feature was supported with the `global-quick-tap` property, which did not allow customizing the timeout and used the value of `tapping-term-ms` for it. This property is now deprecated and users are encouraged to use `require-prior-idle-ms` instead.
+Note that an earlier iteration of this feature was supported with the `global-quick-tap` property, which did not allow customizing the timeout and used the value of `quick-tap-ms` for it. This property is now deprecated and users are encouraged to use `require-prior-idle-ms` instead.
 
 [urob] added the [`hold-trigger-on-release` property](/docs/behaviors/hold-tap#positional-hold-tap-and-hold-trigger-key-positions) in [#1423](https://github.com/zmkfirmware/zmk/pull/1423). This significantly increases the usefulness of positional constraints on hold-taps, since it allows combining multiple holds such as different modifiers for home row mods usage.
 


### PR DESCRIPTION
Fixes a mistake I made in the description of the deprecated `global-quick-tap` flag which was compared to the `require-prior-idle-ms` property.