### PR TITLE
feat(boards): Add nRF52 high voltage DC/DC config

### DIFF
--- a/app/boards/arm/mikoto/Kconfig
+++ b/app/boards/arm/mikoto/Kconfig
@@ -4,6 +4,12 @@ config BOARD_ENABLE_DCDC
     default y
     depends on (BOARD_MIKOTO_520)
 
+config BOARD_ENABLE_DCDC_HV
+    bool "High voltage DCDC converter"
+    select SOC_DCDC_NRF52X_HV
+    default y
+    depends on (BOARD_MIKOTO_520)
+
 choice BOARD_MIKOTO_CHARGER_CURRENT
     prompt "Charge current to supply to attached batteries"
     depends on (BOARD_MIKOTO_520)

--- a/app/boards/arm/nice_nano/Kconfig
+++ b/app/boards/arm/nice_nano/Kconfig
@@ -5,3 +5,9 @@ config BOARD_ENABLE_DCDC
     select SOC_DCDC_NRF52X
     default y
     depends on (BOARD_NICE_NANO || BOARD_NICE_NANO_V2)
+
+config BOARD_ENABLE_DCDC_HV
+    bool "High voltage DCDC converter"
+    select SOC_DCDC_NRF52X_HV
+    default y
+    depends on (BOARD_NICE_NANO_V2)


### PR DESCRIPTION
Added a Kconfig option to enable SOC_DCDC_NRF52X_HV for nice_nano_v2 and mikoto. According to Nordic's documentation, the DC/DC regulator is more efficient than the LDO regulator, so this is enabled by default.

The following boards do not support this mode and were not changed:

- nice_nano
- nice60
- nrfmicro_11, nrfmicro_13
- nrf52840_m2
- bluemicro840

I could not find schematics to confirm whether the following boards support this mode:

- bt60_v1, bt60_v2
- bt65_v1
- bt75_v1
- corneish_zen_v1, corneish_zen_v2
- pillbug
- puchi_ble_v1
- s40nc