### PR TITLE
feat(docs): Document ZMK_BATTERY_REPORTING config

### DIFF
--- a/docs/docs/config/battery.md
+++ b/docs/docs/config/battery.md
@@ -7,6 +7,21 @@ See the [battery level feature page](../features/battery.md) for more details on
 
 See [Configuration Overview](index.md) for instructions on how to change these settings.
 
+### Kconfig
+
+Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
+
+| Config                               | Type | Description                                            | Default |
+| ------------------------------------ | ---- | ------------------------------------------------------ | ------- |
+| `CONFIG_ZMK_BATTERY_REPORTING`       | bool | Enables/disables all battery level detection/reporting | n       |
+| `CONFIG_ZMK_BATTERY_REPORT_INTERVAL` | int  | Battery level report interval in seconds               | 60      |
+
+:::note Default setting
+
+Whilst this is disabled by default it is implied by `CONFIG_ZMK_BLE`, thus any board with BLE enabled will have this automatically enabled unless explicitly overriden.
+
+:::
+
 ### Devicetree
 
 Applies to: [`/chosen` node](https://docs.zephyrproject.org/latest/guides/dts/intro.html#aliases-and-chosen-nodes)

--- a/docs/docs/config/battery.md
+++ b/docs/docs/config/battery.md
@@ -18,7 +18,7 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 
 :::note Default setting
 
-Whilst this is disabled by default it is implied by `CONFIG_ZMK_BLE`, thus any board with BLE enabled will have this automatically enabled unless explicitly overriden.
+While `CONFIG_ZMK_BATTERY_REPORTING` is disabled by default it is implied by `CONFIG_ZMK_BLE`, thus any board with BLE enabled will have this automatically enabled unless explicitly overriden.
 
 :::
 

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -13,13 +13,12 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 
 ### General
 
-| Config                               | Type   | Description                                                                   | Default |
-| ------------------------------------ | ------ | ----------------------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_KEYBOARD_NAME`           | string | The name of the keyboard (max 16 characters)                                  |         |
-| `CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`  | int    | Milliseconds to wait after a setting change before writing it to flash memory | 60000   |
-| `CONFIG_ZMK_WPM`                     | bool   | Enable calculating words per minute                                           | n       |
-| `CONFIG_HEAP_MEM_POOL_SIZE`          | int    | Size of the heap memory pool                                                  | 8192    |
-| `CONFIG_ZMK_BATTERY_REPORT_INTERVAL` | int    | Battery level report interval in seconds                                      | 60      |
+| Config                              | Type   | Description                                                                   | Default |
+| ----------------------------------- | ------ | ----------------------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_KEYBOARD_NAME`          | string | The name of the keyboard (max 16 characters)                                  |         |
+| `CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE` | int    | Milliseconds to wait after a setting change before writing it to flash memory | 60000   |
+| `CONFIG_ZMK_WPM`                    | bool   | Enable calculating words per minute                                           | n       |
+| `CONFIG_HEAP_MEM_POOL_SIZE`         | int    | Size of the heap memory pool                                                  | 8192    |
 
 ### HID
 


### PR DESCRIPTION
Whilst working on other battery reporting stuff i noticed `CONFIG_ZMK_BATTERY_REPORTING` is currently undocumented, A new KConfig heading for battery.md has been added in line with the other sections in the configuration section of the docs, `CONFIG_ZMK_BATTERY_REPORT_INTERVAL` has been moved from system to battery for consistency.
