### PR TITLE
chore(docs): Fix links to relocated files

### DIFF
--- a/docs/docs/config/battery.md
+++ b/docs/docs/config/battery.md
@@ -48,7 +48,7 @@ Driver for reading the voltage of a battery using a Nordic nRF52's VDDH pin. Thi
 
 Applies to: `compatible = "zmk,battery-nrf-vddh"`
 
-Definition file: [zmk/app/drivers/zephyr/dts/bindings/sensor/zmk,battery-nrf-vddh.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/sensor/zmk%2Cbattery-nrf-vddh.yaml)
+Definition file: [zmk/app/module/dts/bindings/sensor/zmk,battery-nrf-vddh.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/module/dts/bindings/sensor/zmk%2Cbattery-nrf-vddh.yaml)
 
 | Property | Type   | Description               |
 | -------- | ------ | ------------------------- |

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -49,7 +49,7 @@ Using a dedicated thread requires more memory but prevents displays with slow up
 
 You must also configure the driver for your display. ZMK provides the following display drivers:
 
-- [IL0323](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/display/Kconfig.il0323)
+- [IL0323](https://github.com/zmkfirmware/zmk/blob/main/app/module/drivers/display/Kconfig.il0323)
 
 Zephyr provides several display drivers as well. Search for the name of your display in [Zephyr's Kconfig options](https://docs.zephyrproject.org/latest/kconfig.html) documentation.
 
@@ -57,7 +57,7 @@ Zephyr provides several display drivers as well. Search for the name of your dis
 
 See the Devicetree bindings for your display. Here are the bindings for common displays:
 
-- [IL0323](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/display/gooddisplay%2Cil0323.yaml)
+- [IL0323](https://github.com/zmkfirmware/zmk/blob/main/app/module/dts/bindings/display/gooddisplay%2Cil0323.yaml)
 - [SSD1306 (i2c)](https://docs.zephyrproject.org/latest/build/dts/api/bindings/display/solomon,ssd1306fb-i2c.html)
 - [SSD1306 (spi)](https://docs.zephyrproject.org/latest/build/dts/api/bindings/display/solomon,ssd1306fb-spi.html)
 

--- a/docs/docs/config/encoders.md
+++ b/docs/docs/config/encoders.md
@@ -11,7 +11,7 @@ See [Configuration Overview](index.md) for instructions on how to change these s
 
 ### Kconfig
 
-Definition file: [zmk/app/drivers/sensor/ec11/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/sensor/ec11/Kconfig)
+Definition file: [zmk/app/module/drivers/sensor/ec11/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/module/drivers/sensor/ec11/Kconfig)
 
 | Config                          | Type | Description                      | Default |
 | ------------------------------- | ---- | -------------------------------- | ------- |
@@ -31,8 +31,8 @@ If `CONFIG_EC11` is enabled, exactly one of the following options must be set to
 
 Applies to: `compatible = "alps,ec11"`
 
-Definition file: [zmk/app/drivers/zephyr/dts/bindings/sensor/alps,ec11.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/sensor/alps%2Cec11.yaml)
-
+Definition file: [zmk/app/module/dts/bindings/sensor/alps,ec11.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/module/dts/bindings/sensor/alps%2Cec11.yaml)
+app/module/dts/bindings/sensor/alps,ec11.yaml
 | Property     | Type       | Description                           | Default |
 | ------------ | ---------- | ------------------------------------- | ------- |
 | `label`      | string     | Unique label for the node             |         |

--- a/docs/docs/config/encoders.md
+++ b/docs/docs/config/encoders.md
@@ -32,7 +32,7 @@ If `CONFIG_EC11` is enabled, exactly one of the following options must be set to
 Applies to: `compatible = "alps,ec11"`
 
 Definition file: [zmk/app/module/dts/bindings/sensor/alps,ec11.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/module/dts/bindings/sensor/alps%2Cec11.yaml)
-app/module/dts/bindings/sensor/alps,ec11.yaml
+
 | Property     | Type       | Description                           | Default |
 | ------------ | ---------- | ------------------------------------- | ------- |
 | `label`      | string     | Unique label for the node             |         |

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -12,7 +12,7 @@ See [Configuration Overview](index.md) for instructions on how to change these s
 Definition files:
 
 - [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
-- [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/kscan/Kconfig)
+- [zmk/app/module/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/module/drivers/kscan/Kconfig)
 
 | Config                                 | Type | Description                                          | Default |
 | -------------------------------------- | ---- | ---------------------------------------------------- | ------- |
@@ -44,7 +44,7 @@ Currently this driver does not honor the `CONFIG_ZMK_KSCAN_DEBOUNCE_*` settings.
 
 Applies to: `compatible = "zmk,kscan-gpio-demux"`
 
-Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-demux.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/kscan/zmk%2Ckscan-gpio-demux.yaml)
+Definition file: [zmk/app/module/dts/bindings/kscan/zmk,kscan-gpio-demux.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/module/dts/bindings/kscan/zmk%2Ckscan-gpio-demux.yaml)
 
 | Property                | Type       | Description                      | Default |
 | ----------------------- | ---------- | -------------------------------- | ------- |
@@ -60,7 +60,7 @@ Keyboard scan driver where each key has a dedicated GPIO.
 
 ### Kconfig
 
-Definition file: [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/kscan/Kconfig)
+Definition file: [zmk/app/module/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/module/drivers/kscan/Kconfig)
 
 | Config                            | Type | Description                                      | Default |
 | --------------------------------- | ---- | ------------------------------------------------ | ------- |
@@ -70,7 +70,7 @@ Definition file: [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/
 
 Applies to: `compatible = "zmk,kscan-gpio-direct"`
 
-Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-direct.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/kscan/zmk%2Ckscan-gpio-direct.yaml)
+Definition file: [zmk/app/module/dts/bindings/kscan/zmk,kscan-gpio-direct.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/module/dts/bindings/kscan/zmk%2Ckscan-gpio-direct.yaml)
 
 | Property                  | Type       | Description                                                                                                 | Default |
 | ------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- | ------- |
@@ -102,7 +102,7 @@ Assuming the switches connect each GPIO pin to the ground, the [GPIO flags](http
 
 Keyboard scan driver where keys are arranged on a matrix with one GPIO per row and column.
 
-Definition file: [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/kscan/Kconfig)
+Definition file: [zmk/app/module/drivers/kscan/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/module/drivers/kscan/Kconfig)
 
 | Config                                         | Type        | Description                                                               | Default |
 | ---------------------------------------------- | ----------- | ------------------------------------------------------------------------- | ------- |
@@ -114,7 +114,7 @@ Definition file: [zmk/app/drivers/kscan/Kconfig](https://github.com/zmkfirmware/
 
 Applies to: `compatible = "zmk,kscan-gpio-matrix"`
 
-Definition file: [zmk/app/drivers/zephyr/dts/bindings/kscan/zmk,kscan-gpio-matrix.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/drivers/zephyr/dts/bindings/kscan/zmk%2Ckscan-gpio-matrix.yaml)
+Definition file: [zmk/app/module/dts/bindings/kscan/zmk,kscan-gpio-matrix.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/module/dts/bindings/kscan/zmk%2Ckscan-gpio-matrix.yaml)
 
 | Property                  | Type       | Description                                                                                                 | Default     |
 | ------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- | ----------- |

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -284,7 +284,7 @@ Definition file: [zmk/app/dts/bindings/zmk,kscan-mock.yaml](https://github.com/z
 | `cols`         | int    | The number of columns in the composite matrix |         |
 | `exit-after`   | bool   | Exit the program after running all events     | false   |
 
-The `events` array should be defined using the macros from [dt-bindings/zmk/kscan_mock.h](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/kscan_mock.h).
+The `events` array should be defined using the macros from [app/module/include/dt-bindings/zmk/kscan_mock.h](https://github.com/zmkfirmware/zmk/blob/main/app/module/include/dt-bindings/zmk/kscan_mock.h).
 
 ## Matrix Transform
 


### PR DESCRIPTION
Some of the driver code directory structure was reorganized recently to match Zephyr better, but the existing links in the documentation hadn't been updated.

I _think_ this is everything, after some manual checking I looked at the PR where the files were moved and used that to look for affected files.