### PR TITLE
Test Zephyr fork with shield load order fix.

### DIFF
--- a/app/west.yml
+++ b/app/west.yml
@@ -2,12 +2,12 @@ manifest:
   remotes:
     - name: zephyrproject-rtos
       url-base: https://github.com/zephyrproject-rtos
-    - name: zmkfirmware
-      url-base: https://github.com/zmkfirmware
+    - name: petejohanson
+      url-base: https://github.com/petejohanson
   projects:
     - name: zephyr
-      remote: zmkfirmware
-      revision: v3.2.0+zmk-fixes
+      remote: petejohanson
+      revision: fix-dir-order-two-phase
       clone-depth: 1
       import:
         name-blocklist:


### PR DESCRIPTION
This is a placeholder branch, just here so folks can test the PR from zmkfirmware/zephyr#26 easily with their user config repos, etc.

