### PR TITLE
refactor: address transport switch enumeration warning

### DIFF
--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -122,57 +122,69 @@ struct zmk_endpoint_instance zmk_endpoints_selected(void) {
 
 static int send_keyboard_report(void) {
     switch (current_instance.transport) {
-#if IS_ENABLED(CONFIG_ZMK_USB)
     case ZMK_TRANSPORT_USB: {
+#if IS_ENABLED(CONFIG_ZMK_USB)
         int err = zmk_usb_hid_send_keyboard_report();
         if (err) {
             LOG_ERR("FAILED TO SEND OVER USB: %d", err);
         }
         return err;
-    }
+#else
+        LOG_ERR("USB endpoint is not supported");
+        return -ENOTSUP;
 #endif /* IS_ENABLED(CONFIG_ZMK_USB) */
+    }
 
-#if IS_ENABLED(CONFIG_ZMK_BLE)
     case ZMK_TRANSPORT_BLE: {
+#if IS_ENABLED(CONFIG_ZMK_BLE)
         struct zmk_hid_keyboard_report *keyboard_report = zmk_hid_get_keyboard_report();
         int err = zmk_hog_send_keyboard_report(&keyboard_report->body);
         if (err) {
             LOG_ERR("FAILED TO SEND OVER HOG: %d", err);
         }
         return err;
-    }
+#else
+        LOG_ERR("BLE HOG endpoint is not supported");
+        return -ENOTSUP;
 #endif /* IS_ENABLED(CONFIG_ZMK_BLE) */
     }
+    }
 
-    LOG_ERR("Unsupported endpoint transport %d", current_instance.transport);
+    LOG_ERR("Unhandled endpoint transport %d", current_instance.transport);
     return -ENOTSUP;
 }
 
 static int send_consumer_report(void) {
     switch (current_instance.transport) {
-#if IS_ENABLED(CONFIG_ZMK_USB)
     case ZMK_TRANSPORT_USB: {
+#if IS_ENABLED(CONFIG_ZMK_USB)
         int err = zmk_usb_hid_send_consumer_report();
         if (err) {
             LOG_ERR("FAILED TO SEND OVER USB: %d", err);
         }
         return err;
-    }
+#else
+        LOG_ERR("USB endpoint is not supported");
+        return -ENOTSUP;
 #endif /* IS_ENABLED(CONFIG_ZMK_USB) */
+    }
 
-#if IS_ENABLED(CONFIG_ZMK_BLE)
     case ZMK_TRANSPORT_BLE: {
+#if IS_ENABLED(CONFIG_ZMK_BLE)
         struct zmk_hid_consumer_report *consumer_report = zmk_hid_get_consumer_report();
         int err = zmk_hog_send_consumer_report(&consumer_report->body);
         if (err) {
             LOG_ERR("FAILED TO SEND OVER HOG: %d", err);
         }
         return err;
-    }
+#else
+        LOG_ERR("BLE HOG endpoint is not supported");
+        return -ENOTSUP;
 #endif /* IS_ENABLED(CONFIG_ZMK_BLE) */
     }
+    }
 
-    LOG_ERR("Unsupported endpoint transport %d", current_instance.transport);
+    LOG_ERR("Unhandled endpoint transport %d", current_instance.transport);
     return -ENOTSUP;
 }
 
@@ -194,29 +206,35 @@ int zmk_endpoints_send_report(uint16_t usage_page) {
 #if IS_ENABLED(CONFIG_ZMK_MOUSE)
 int zmk_endpoints_send_mouse_report() {
     switch (current_instance.transport) {
-#if IS_ENABLED(CONFIG_ZMK_USB)
     case ZMK_TRANSPORT_USB: {
+#if IS_ENABLED(CONFIG_ZMK_USB)
         int err = zmk_usb_hid_send_mouse_report();
         if (err) {
             LOG_ERR("FAILED TO SEND OVER USB: %d", err);
         }
         return err;
-    }
+#else
+        LOG_ERR("USB endpoint is not supported");
+        return -ENOTSUP;
 #endif /* IS_ENABLED(CONFIG_ZMK_USB) */
+    }
 
-#if IS_ENABLED(CONFIG_ZMK_BLE)
     case ZMK_TRANSPORT_BLE: {
+#if IS_ENABLED(CONFIG_ZMK_BLE)
         struct zmk_hid_mouse_report *mouse_report = zmk_hid_get_mouse_report();
         int err = zmk_hog_send_mouse_report(&mouse_report->body);
         if (err) {
             LOG_ERR("FAILED TO SEND OVER HOG: %d", err);
         }
         return err;
-    }
+#else
+        LOG_ERR("BLE HOG endpoint is not supported");
+        return -ENOTSUP;
 #endif /* IS_ENABLED(CONFIG_ZMK_BLE) */
     }
+    }
 
-    LOG_ERR("Unsupported endpoint transport %d", current_instance.transport);
+    LOG_ERR("Unhandled endpoint transport %d", current_instance.transport);
     return -ENOTSUP;
 }
 #endif // IS_ENABLED(CONFIG_ZMK_MOUSE)


### PR DESCRIPTION
When building without USB or Bluetooth, the compiler would emit a warning due to ZMK_TRANSPORT_USB or ZMK_TRANSPORT_BLE not being handled.
