### PR TITLE
Battery percentage widget for nice!view vertical layout

### DIFF
--- a/app/boards/shields/nice_view/Kconfig.defconfig
+++ b/app/boards/shields/nice_view/Kconfig.defconfig
@@ -36,6 +36,10 @@ config NICE_VIEW_WIDGET_STATUS
 config NICE_VIEW_BATTERY_SHOW_PERCENTAGE
     bool "Show battery percentage instead of icon"
 
+config NICE_VIEW_BATTERY_SHOW_BIG_PERCENTAGE
+    bool "Show battery percentage instead of WPM widget"
+    select LV_FONT_MONTSERRAT_26
+
 config NICE_VIEW_WIDGET_INVERTED
     bool "Invert custom status widget colors"
 

--- a/app/boards/shields/nice_view/Kconfig.defconfig
+++ b/app/boards/shields/nice_view/Kconfig.defconfig
@@ -33,6 +33,9 @@ config NICE_VIEW_WIDGET_STATUS
     select LV_USE_IMG
     select LV_USE_CANVAS
 
+config NICE_VIEW_BATTERY_SHOW_PERCENTAGE
+    bool "Show battery percentage instead of icon"
+
 config NICE_VIEW_WIDGET_INVERTED
     bool "Invert custom status widget colors"
 

--- a/app/boards/shields/nice_view/widgets/peripheral_status.c
+++ b/app/boards/shields/nice_view/widgets/peripheral_status.c
@@ -116,7 +116,11 @@ int zmk_widget_status_init(struct zmk_widget_status *widget, lv_obj_t *parent) {
     lv_obj_t *art = lv_img_create(widget->obj);
     bool random = sys_rand32_get() & 1;
     lv_img_set_src(art, random ? &balloon : &mountain);
+#if IS_ENABLED(CONFIG_NICE_VIEW_BATTERY_SHOW_BIG_PERCENTAGE)
+    lv_obj_align(art, LV_ALIGN_TOP_LEFT, -48, 0);
+#else
     lv_obj_align(art, LV_ALIGN_TOP_LEFT, 0, 0);
+#endif
 
     sys_slist_append(&widgets, &widget->node);
     widget_battery_status_init();

--- a/app/boards/shields/nice_view/widgets/status.c
+++ b/app/boards/shields/nice_view/widgets/status.c
@@ -86,6 +86,7 @@ static void draw_top(lv_obj_t *widget, lv_color_t cbuf[], const struct status_st
 
     lv_canvas_draw_text(canvas, 0, 0, CANVAS_SIZE, &label_dsc, output_text);
 
+#if !IS_ENABLED(CONFIG_NICE_VIEW_BATTERY_SHOW_BIG_PERCENTAGE)
     // Draw WPM
     lv_canvas_draw_rect(canvas, 0, 21, 68, 42, &rect_white_dsc);
     lv_canvas_draw_rect(canvas, 1, 22, 66, 40, &rect_black_dsc);
@@ -117,6 +118,7 @@ static void draw_top(lv_obj_t *widget, lv_color_t cbuf[], const struct status_st
         points[i].y = 60 - (state->wpm[i] - min) * 36 / range;
     }
     lv_canvas_draw_line(canvas, points, 10, &line_dsc);
+#endif
 
     // Rotate canvas
     rotate_canvas(canvas, cbuf);

--- a/app/boards/shields/nice_view/widgets/util.c
+++ b/app/boards/shields/nice_view/widgets/util.c
@@ -30,6 +30,18 @@ void draw_battery(lv_obj_t *canvas, const struct status_state *state) {
     lv_draw_rect_dsc_t rect_white_dsc;
     init_rect_dsc(&rect_white_dsc, LVGL_FOREGROUND);
 
+#if IS_ENABLED(CONFIG_NICE_VIEW_BATTERY_SHOW_PERCENTAGE)
+    char text[4] = {};
+    sprintf(text, "%i%%", state->battery);
+    lv_draw_label_dsc_t label_dsc;
+    init_label_dsc(&label_dsc, LVGL_FOREGROUND, &lv_font_montserrat_16, LV_TEXT_ALIGN_CENTER);
+    lv_canvas_draw_text(canvas, 0, 5, 68, &label_dsc, text);
+    if (state->charging) {
+        lv_draw_img_dsc_t img_dsc;
+        lv_draw_img_dsc_init(&img_dsc);
+        lv_canvas_draw_img(canvas, 1, -1, &bolt, &img_dsc);
+    }
+#else
     lv_canvas_draw_rect(canvas, 0, 2, 29, 12, &rect_white_dsc);
     lv_canvas_draw_rect(canvas, 1, 3, 27, 10, &rect_black_dsc);
     lv_canvas_draw_rect(canvas, 2, 4, (state->battery + 2) / 4, 8, &rect_white_dsc);
@@ -41,6 +53,7 @@ void draw_battery(lv_obj_t *canvas, const struct status_state *state) {
         lv_draw_img_dsc_init(&img_dsc);
         lv_canvas_draw_img(canvas, 9, -1, &bolt, &img_dsc);
     }
+#endif
 }
 
 void init_label_dsc(lv_draw_label_dsc_t *label_dsc, lv_color_t color, const lv_font_t *font,

--- a/app/boards/shields/nice_view/widgets/util.c
+++ b/app/boards/shields/nice_view/widgets/util.c
@@ -30,6 +30,14 @@ void draw_battery(lv_obj_t *canvas, const struct status_state *state) {
     lv_draw_rect_dsc_t rect_white_dsc;
     init_rect_dsc(&rect_white_dsc, LVGL_FOREGROUND);
 
+#if IS_ENABLED(CONFIG_NICE_VIEW_BATTERY_SHOW_BIG_PERCENTAGE)
+    char big_text[4] = {};
+    sprintf(big_text, "%i%%", state->battery);
+    lv_draw_label_dsc_t big_label_dsc;
+    init_label_dsc(&big_label_dsc, LVGL_FOREGROUND, &lv_font_montserrat_26, LV_TEXT_ALIGN_CENTER);
+    lv_canvas_draw_text(canvas, 0, 25, 68, &big_label_dsc, big_text);
+#endif
+
 #if IS_ENABLED(CONFIG_NICE_VIEW_BATTERY_SHOW_PERCENTAGE)
     char text[4] = {};
     sprintf(text, "%i%%", state->battery);


### PR DESCRIPTION
This PR adds battery percentage widget to nice!view vertical layout. 

I thought I will post it here, even if its not merged it may help some folks that would like to have percentage information on the screen.

There are 2 options added:

**CONFIG_NICE_VIEW_BATTERY_SHOW_PERCENTAGE=y**
This will replace battery icon with percentage information.

![screenshot_from_2023-11-11_21-42-50](https://github.com/zmkfirmware/zmk/assets/1702152/38d9b5a8-340a-439f-a601-3da035d4323d)

![screenshot_from_2023-11-11_21-44-03](https://github.com/zmkfirmware/zmk/assets/1702152/02ffe93d-09e0-4719-a2e5-47aa2603940a)



**CONFIG_NICE_VIEW_BATTERY_SHOW_BIG_PERCENTAGE=y**
This one will replace WPM widget with battery percentage written in bigger font.
It will also push art on peripheral in order to make space for battery information.

![screenshot_from_2023-11-11_21-45-17](https://github.com/zmkfirmware/zmk/assets/1702152/2744831c-d255-446b-8a46-4cac93457e56)

![screenshot_from_2023-11-11_21-44-55](https://github.com/zmkfirmware/zmk/assets/1702152/8d780e67-42fd-4c7b-8a59-79da256aae33)

 
**CONFIG_NICE_VIEW_BATTERY_SHOW_PERCENTAGE=y**
**CONFIG_NICE_VIEW_BATTERY_SHOW_BIG_PERCENTAGE=y**
Both can be used together, though I'm not sure why anyone would want that.

![screenshot_from_2023-11-11_21-49-22](https://github.com/zmkfirmware/zmk/assets/1702152/cdee908b-9a54-4df4-91bf-36592b992f06)
