### PR TITLE
refactor(docs): Clean up customization page and reduce examples using proton_c

### DIFF
--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -11,15 +11,15 @@ This makes flashing ZMK to your keyboard much easier, especially because you don
 
 By default, the `zmk-config` folder should contain two files:
 
-- `<shield>.conf`
-- `<shield>.keymap`
+- `<keyboard>.conf`
+- `<keyboard>.keymap`
 
 However, your config folder can also be modified to include a `boards/` directory for keymaps and configurations for multiple boards/shields
 outside of the default keyboard setting definitions.
 
 ## Configuration Changes
 
-The setup script creates a `config/<shield>.conf` file that allows you to add additional configuration options to
+The setup script creates a `config/<keyboard>.conf` file that allows you to add additional configuration options to
 control what features and options are built into your firmware. Opening that file with your text editor will allow you to see the
 various config settings that can be commented/uncommented to modify how your firmware is built.
 
@@ -27,7 +27,7 @@ Refer to the [Configuration](/docs/config) documentation for more details on thi
 
 ## Keymap
 
-Once you have the basic user config completed, you can find the keymap file in `config/<shield>.keymap` and customize from there.
+Once you have the basic user config completed, you can find the keymap file in `config/<keyboard>.keymap` and customize from there.
 Refer to the [Keymap](features/keymaps.md) documentation to learn more.
 
 ## Publishing
@@ -39,18 +39,11 @@ GitHub Actions job to build your firmware which you can download once it complet
 If you need to, a review of [Learn The Basics Of Git In Under 10 Minutes](https://www.freecodecamp.org/news/learn-the-basics-of-git-in-under-10-minutes-da548267cc91/) will help you get these steps right.
 :::
 
-## Building from a local `zmk` fork using `zmk-config`
-
-[As outlined here](development/build-flash.md), firmware comes in the form of .uf2 files, which can be built locally using the command `west build`. Normally,
-`west build` will default to using the in-tree .keymap and .conf files found in your local copy of the `zmk` repository. However, you can append the command, `-DZMK_CONFIG="C:/the/absolute/path/config"` to `west build` in order to use the contents of your `zmk-config` folder instead of the
-default keyboard settings.
-**Notice that this path should point to the folder labelled `config` within your `zmk-config` folder.**
-
-For instance, building kyria firmware from a user `myUser`'s `zmk-config` folder on Windows 10 may look something like this:
-
-```bash
-west build -b nice_nano -- -DSHIELD=kyria_left -DZMK_CONFIG="C:/Users/myUser/Documents/Github/zmk-config/config"
-```
+:::note
+It is also possible to build firmware locally on your computer by following the [toolchain setup](development/setup.md) and
+[building instructions](development/build-flash.md), which includes pointers to
+[building using your `zmk-config` folder](development/build-flash.md#building-from-zmk-config-folder).
+:::
 
 ## Flashing Your Changes
 

--- a/docs/docs/development/build-flash.md
+++ b/docs/docs/development/build-flash.md
@@ -65,7 +65,7 @@ west build -b planck_rev6
 When building for a new board and/or shield after having built one previously, you may need to enable the pristine build option. This option removes all existing files in the build directory before regenerating them, and can be enabled by adding either --pristine or -p to the command:
 
 ```sh
-west build -p -b proton_c -- -DSHIELD=kyria_left
+west build -p -b nice_nano_v2 -- -DSHIELD=kyria_left
 ```
 
 ### Building For Split Keyboards
@@ -77,13 +77,13 @@ For split keyboards, you will have to build and flash each side separately the f
 By default, the `build` command outputs a single .uf2 file named `zmk.uf2` so building left and then right immediately after will overwrite your left firmware. In addition, you will need to pristine build each side to ensure the correct files are used. To avoid having to pristine build every time and separate the left and right build files, we recommend setting up separate build directories for each half. You can do this by using the `-d` parameter and first building left into `build/left`:
 
 ```sh
-west build -d build/left -b nice_nano -- -DSHIELD=kyria_left
+west build -d build/left -b nice_nano_v2 -- -DSHIELD=kyria_left
 ```
 
 and then building right into `build/right`:
 
 ```sh
-west build -d build/right -b nice_nano -- -DSHIELD=kyria_right
+west build -d build/right -b nice_nano_v2 -- -DSHIELD=kyria_right
 ```
 
 This produces `left` and `right` subfolders under the `build` directory and two separate .uf2 files. For future work on a specific half, use the `-d` parameter again to ensure you are building into the correct location.

--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -493,7 +493,7 @@ Once you've fully created the new keyboard shield definition,
 you should be able to test with a build command like:
 
 ```sh
-west build --pristine -b proton_c -- -DSHIELD=my_board
+west build --pristine -b nice_nano_v2 -- -DSHIELD=my_board
 ```
 
 The above build command generates `build/zephyr/zmk.uf2`. If your board


### PR DESCRIPTION
Two small docs improvements that are semi-related:
- Refactor the "Customizing ZMK/zmk-config" page to remove the out-of-place local build example and add a pointer to its proper doc page instead
- Change `proton_c` build examples on the local build pages where UF2 outputs are mentioned, to reduce confusion. We saw it a [few times on Discord](https://discord.com/channels/719497620560543766/719909884769992755/1171304536787390476) that people look for zmk.uf2 after running the example build and not finding it
  - Also change some occurrences of `nice_nano` to `nice_nano_v2`, I thought this might help reduce some cases where people aren't aware they need to use a different board ID when they aren't using the setup script (this also [came up on Discord](https://discord.com/channels/675924128108118016/698923975002292245/1172674505878011995) yesterday)