### PR TITLE
feat(build): Add support for artifact-name in build.yaml

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -55,12 +55,14 @@ jobs:
       - name: Prepare variables
         shell: sh -x {0}
         env:
+          board: ${{ matrix.board }}
           shield: ${{ matrix.shield }}
+          artifact_name: ${{ matrix.artifact-name }}
         run: |
           echo "zephyr_version=${ZEPHYR_VERSION}" >> $GITHUB_ENV
           echo "extra_cmake_args=${shield:+-DSHIELD=\"$shield\"}" >> $GITHUB_ENV
-          echo "display_name=${shield:+$shield - }${{ matrix.board }}" >> $GITHUB_ENV
-          echo "artifact_name=${shield:+$shield-}${{ matrix.board }}-zmk" >> $GITHUB_ENV
+          echo "display_name=${shield:+$shield - }${board}" >> $GITHUB_ENV
+          echo "artifact_name=${artifact_name:-\"${shield:+$shield-}${board}-zmk\"}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This change adds a new optional property `artifact-name` to `build.yaml`, so that if provided, the base of the output filename will be equal to that for an entry.

While it isn't discoverable because there isn't a way to document it (besides perhaps expanding the comment section in the template yaml), this field would allow users to build the same board+shield combination with different keymaps or different CMake args (like adding Kconfig settings).

Some context: https://discord.com/channels/719497620560543766/719909884769992755/1171174369045774406

[Example build.yaml](https://github.com/caksoylar/zmk-config/blob/test-artifact-name/build.yaml): 
```yaml
---
include:
  - board: seeeduino_xiao_ble
    shield: rommana_left rgbled_widget
    artifact-name: my_rommana_left
  - board: seeeduino_xiao_ble
    shield: rommana_right rgbled_widget
    artifact-name: my_rommana_right
  - board: nice_nano
    shield: corne_left
    artifact-name: stock_corne_left
  - board: nice_nano
    shield: corne_left
    cmake-args: -DKEYMAP_FILE=/__w/zmk-config/zmk-config/config/corneish_zen.keymap
```
Output from example: https://github.com/caksoylar/zmk-config/actions/runs/6837199541
![image](https://github.com/zmkfirmware/zmk/assets/7876996/7fba8f8c-f6b2-444c-bfd0-0ebeca85f7ac)
