### PR TITLE
feat(shields): Allow settings_reset to build with board-only keyboards

### DIFF
--- a/app/boards/shields/settings_reset/settings_reset.overlay
+++ b/app/boards/shields/settings_reset/settings_reset.overlay
@@ -8,10 +8,10 @@
 
 / {
     chosen {
-        zmk,kscan = &kscan0;
+        zmk,kscan = &settings_reset_kscan;
     };
 
-    kscan0: kscan {
+    settings_reset_kscan: settings_reset_kscan {
         compatible = "zmk,kscan-mock";
         columns = <1>;
         rows = <0>;


### PR DESCRIPTION
This tweak would allow building the `settings_reset` shield with board-only keyboards, since previously the kscan name/label of the reset shield tended to conflict with the kscan of the boards. Happy to tweak the new name if anyone else has suggestions.

Discussion on the Discord: https://discord.com/channels/719497620560543766/719909884769992755/1171173924877373481