### PR TITLE
feat(build): Add support for artifact-name in build.yaml, correctly

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -55,12 +55,14 @@ jobs:
       - name: Prepare variables
         shell: sh -x {0}
         env:
+          board: ${{ matrix.board }}
           shield: ${{ matrix.shield }}
+          artifact_name: ${{ matrix.artifact-name }}
         run: |
           echo "zephyr_version=${ZEPHYR_VERSION}" >> $GITHUB_ENV
           echo "extra_cmake_args=${shield:+-DSHIELD=\"$shield\"}" >> $GITHUB_ENV
-          echo "display_name=${shield:+$shield - }${{ matrix.board }}" >> $GITHUB_ENV
-          echo "artifact_name=${shield:+$shield-}${{ matrix.board }}-zmk" >> $GITHUB_ENV
+          echo "display_name=${shield:+$shield - }${board}" >> $GITHUB_ENV
+          echo "artifact_name=${artifact_name:-${shield:+$shield-}${board}-zmk}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Another try at #2004, this time with more exhaustive testing of following combinations:
- board only/board+shield/board+multiple shields
- no/given `artifact-name` (including spaces in the value)
- empty/non-empty `cmake-args` 

[Input file](https://github.com/caksoylar/zmk-config/blob/2deb21a/build.yaml):
```yaml
include:
  - board: corneish_zen_v2_left    # board only
  - board: corneish_zen_v1_right   # board only, with name
    artifact-name: zen_right
  - board: nice_nano_v2            # board+shield
    shield: corne_left
  - board: nice_nano_v2            # board+shield, with name
    shield: corne_left
    artifact-name: stock_corne_left
  - board: nice_nano               # board+shield, cmake-args
    shield: corne_left
    cmake-args: -DKEYMAP_FILE=/__w/zmk-config/zmk-config/config/corneish_zen.keymap
  - board: nice_nano               # board+shield, cmake-args, with name
    shield: corne_left
    cmake-args: -DKEYMAP_FILE=/__w/zmk-config/zmk-config/config/corneish_zen.keymap
    artifact-name: zen_corne
  - board: nice_nano_v2            # board+multiple shields
    shield: corne_left nice_view_adapter nice_view
  - board: nice_nano_v2            # board+multiple shields, with name (containing spaces)
    shield: corne_left nice_view_adapter nice_view
    artifact-name: corne with a view
```

[Workflow output](https://github.com/caksoylar/zmk-config/actions/runs/6859644767):
![image](https://github.com/zmkfirmware/zmk/assets/7876996/93b08d2c-4088-4b70-94c6-c24e8bfaae09)
