### PR TITLE
Added devicetree for TR60 keyboard

### DIFF
--- a/app/boards/arm/tr60/Kconfig
+++ b/app/boards/arm/tr60/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Srishtik Bhandarkar
+# SPDX-License-Identifier: MIT
+
+config BOARD_ENABLE_DCDC
+    bool "Enable DCDC mode"
+    select SOC_DCDC_NRF52X
+    default y
+    depends on BOARD_TR60

--- a/app/boards/arm/tr60/Kconfig.board
+++ b/app/boards/arm/tr60/Kconfig.board
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Srishtik Bhandarkar
+# SPDX-License-Identifier: MIT
+
+config BOARD_TR60
+    bool "TR60"
+    depends on SOC_NRF52840_QIAA

--- a/app/boards/arm/tr60/Kconfig.defconfig
+++ b/app/boards/arm/tr60/Kconfig.defconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 Srishtik Bhandarkar
+# SPDX-License-Identifier: MIT
+
+if BOARD_TR60
+config ZMK_KEYBOARD_NAME
+    default "tr60"
+
+if USB_DEVICE_STACK
+
+config USB_NRFX
+    default y
+
+endif # USB_DEVICE_STACK
+
+config BT_CTLR
+    default BT
+
+config ZMK_BLE
+    default y
+
+config ZMK_USB
+    default y
+
+endif # BOARD_TR60
+

--- a/app/boards/arm/tr60/board.cmake
+++ b/app/boards/arm/tr60/board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Srishtik Bhandarkar
+# SPDX-License-Identifier: MIT
+
+set(OPENOCD_NRF5_SUBFAMILY nrf52)
+board_runner_args(nrfjprog "--nrf-family=NRF52" "--softreset")
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/app/boards/arm/tr60/tr60-pinctrl.dtsi
+++ b/app/boards/arm/tr60/tr60-pinctrl.dtsi
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2023 Srishtik Bhandarkar
+ *
+ * SPDX-License-Identifier: MIT
+ */

--- a/app/boards/arm/tr60/tr60.dts
+++ b/app/boards/arm/tr60/tr60.dts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023 Srishtik Bhandarkar
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/dts-v1/;
+#include <nordic/nrf52840_qiaa.dtsi>
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    model = "tr_60";
+    compatible = "tr60";
+
+    chosen {
+        zephyr,code-partition = &code_partition;
+        zephyr,sram = &sram0;
+        zephyr,flash = &flash0;
+        zephyr,console = &cdc_acm_uart;
+        zmk,battery = &vbatt;
+        zmk,kscan = &kscan0;
+        zmk,matrix_transform = &default_transform;
+    };
+
+    default_transform: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <15>;
+        rows = <5>;
+        map = <
+                RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12)  RC(0,13) RC(0,14)
+                RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12)  RC(1,13)
+                RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11)           RC(2,13)
+                RC(3,0)         RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11) RC(3,12)  RC(3,13)
+                RC(4,0) RC(4,1) RC(4,2)                         RC(4,6)                         RC(4,10) RC(4,11) RC(4,12)  RC(4,13)
+        >;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+
+        diode-direction = "col2row";
+        row-gpios
+            = <&gpio1 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>  //row0
+            , <&gpio1 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>  //row1
+            , <&gpio0 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>  //row2
+            , <&gpio0 9  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>  //row3
+            , <&gpio1 6  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>  //row4
+            ;
+        col-gpios
+            = <&gpio1 4  (GPIO_ACTIVE_HIGH)>  //col0
+            , <&gpio0 20 (GPIO_ACTIVE_HIGH)>  //col1
+            , <&gpio1 2  (GPIO_ACTIVE_HIGH)>  //col2
+            , <&gpio0 24 (GPIO_ACTIVE_HIGH)>  //col3
+            , <&gpio0 22 (GPIO_ACTIVE_HIGH)>  //col4
+            , <&gpio0 15 (GPIO_ACTIVE_HIGH)>  //col5
+            , <&gpio0 13 (GPIO_ACTIVE_HIGH)>  //col6
+            , <&gpio1 9  (GPIO_ACTIVE_HIGH)>  //col7
+            , <&gpio0 8  (GPIO_ACTIVE_HIGH)>  //col8
+            , <&gpio0 6  (GPIO_ACTIVE_HIGH)>  //col9
+            , <&gpio0 4  (GPIO_ACTIVE_HIGH)>  //col10
+            , <&gpio0 26 (GPIO_ACTIVE_HIGH)>  //col11
+            , <&gpio0 31 (GPIO_ACTIVE_HIGH)>  //col12
+            , <&gpio0 29 (GPIO_ACTIVE_HIGH)>  //col13
+            , <&gpio1 15 (GPIO_ACTIVE_HIGH)>  //col14
+            ;
+    };
+
+    vbatt: vbatt {
+        compatible = "zmk,battery-voltage-divider";
+        label = "BATTERY";
+        io-channels = <&adc 0>;
+        output-ohms = <10000>;
+        full-ohms = <(10000 + 10000)>;
+    };
+};
+
+&adc {
+    status = "okay";
+};
+
+&gpiote {
+    status = "okay";
+};
+
+&gpio0 {
+    status = "okay";
+};
+
+&gpio1 {
+    status = "okay";
+};
+
+&usbd {
+    status = "okay";
+    cdc_acm_uart: cdc_acm_uart {
+        compatible = "zephyr,cdc-acm-uart";
+        label = "CDC_ACM_0";
+    };
+};
+
+
+&flash0 {
+    /*
+     * For more information, see:
+     * http://docs.zephyrproject.org/latest/devices/dts/flash_partitions.html
+     */
+    partitions {
+        compatible = "fixed-partitions";
+        #address-cells = <1>;
+        #size-cells = <1>;
+
+        sd_partition: partition@0 {
+            label = "mbr";
+            reg = <0x00000000 0x00001000>;
+        };
+
+        code_partition: partition@1000 {
+            label = "code_partition";
+            reg = <0x00001000 0x000d3000>;
+        };
+
+        /*
+         * The flash starting at 0x000d4000 and ending at
+         * 0x000f3fff is reserved for use by the application.
+         */
+
+        /*
+         * Storage partition will be used by FCB/LittleFS/NVS
+         * if enabled.
+         */
+        storage_partition: partition@d4000 {
+            label = "storage";
+            reg = <0x000d4000 0x00020000>;
+        };
+
+        boot_partition: partition@f4000 {
+            label = "adafruit_boot";
+            reg = <0x000f4000 0x0000c000>;
+        };
+    };
+};

--- a/app/boards/arm/tr60/tr60.keymap
+++ b/app/boards/arm/tr60/tr60.keymap
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Srishtik Bhandarkar
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+// ------------------------------------------------------------------------------------------
+// | ESC |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  0  |  -  |  =  |   BKSP   |
+// | TAB  |  Q  |  W  |  E  |  R  |  T  |  Y  |  U  |  I  |  O  |  P  |  [  |  ]  |   "|"   |
+// | CAPS  |  A  |  S  |  D  |  F  |  G  |  H  |  J  |  K  |  L  |  ;  |  '  |     ENTER    |
+// |  SHIFT  |  Z  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  |  /  |    SHIFT  | MO(1)|
+// |  CTL  |  WIN  |  ALT  |            SPACE                      |  ALT  |  WIN   |  CTL  |
+// ------------------------------------------------------------------------------------------
+            bindings = <
+    &gresc  &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp N8 &kp N9 &kp N0 &kp MINUS &kp EQUAL  &kp BSPC  &kp BSPC
+    &kp TAB  &kp Q  &kp W  &kp E  &kp R  &kp T  &kp Y  &kp U  &kp I  &kp O  &kp P  &kp LBKT  &kp RBKT  &kp BSLH
+    &kp CLCK  &kp A  &kp S  &kp D  &kp F  &kp G  &kp H  &kp J  &kp K  &kp L  &kp SEMI &kp SQT           &kp RET
+    &kp LSHFT   &kp Z  &kp X  &kp C  &kp V  &kp B  &kp N  &kp M  &kp COMMA &kp DOT &kp FSLH    &kp RSHFT  &mo 1
+    &kp LCTRL &kp LGUI &kp LALT             &kp SPACE                   &kp RALT  &kp RALT  &kp RGUI  &kp RCTRL
+            >;
+        };
+
+        func_layer {
+// ------------------------------------------------------------------------------------------
+// | ~    | F1  | F2  | F3  | F4  | F5  | F6  | F7  | F8  | F9  | F10  | F11 | F12 |    DEL  |
+// |      | PSCRN | SLCK |PAUSE/BREAK|  |  |  |  |   |     |    |  UP  |       |             |
+// |   |INSERT | HOME | PG_UP |    |    |  |  |   |     |  LEFT  |   RIGHT   |               |
+// |        |  DEL  | END  | PG_DN |    |BT_CLR||BS_1|OUT_BLE|OUT_USB|DOWN |     |           |
+// |        |       |      |                                     |       |       |     |     |
+// -------------------------------------------------------------------------------------------
+            bindings = <
+    &kp GRAVE  &kp F1  &kp F2  &kp F2  &kp F3  &kp F4  &kp F5  &kp F6  &kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12  &kp DEL  &kp DEL
+    &trans  &kp PSCRN  &kp SLCK  &kp PAUSE_BREAK  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &kp UP  &trans  &trans
+    &trans  &kp INS  &kp HOME  &kp PG_UP  &trans  &trans  &trans  &trans  &trans  &kp LEFT  &kp RIGHT &trans
+    &trans  &kp DEL  &kp END  &kp PG_DN  &trans  &bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &out OUT_BLE  &out OUT_USB  &kp DOWN  &trans &trans
+    &trans  &trans  &trans           &trans              &trans  &trans  &trans
+            >;
+        };
+    };
+};

--- a/app/boards/arm/tr60/tr60.yaml
+++ b/app/boards/arm/tr60/tr60.yaml
@@ -1,0 +1,14 @@
+identifier: tr60
+name: tr60
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - adc
+  - usb_device
+  - ble
+  - ieee802154
+  - pwm
+  - watchdog

--- a/app/boards/arm/tr60/tr60.zmk.yml
+++ b/app/boards/arm/tr60/tr60.zmk.yml
@@ -1,0 +1,11 @@
+file_format: "1"
+id: tr60
+name: tr60
+type: board
+arch: arm
+features:
+  - keys
+outputs:
+  - usb
+  - ble
+url: https://github.com/hw-tinkerers/TR-60

--- a/app/boards/arm/tr60/tr60_defconfig
+++ b/app/boards/arm/tr60/tr60_defconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2023 Srishtik Bhandarkar
+# SPDX-License-Identifier: MIT
+
+CONFIG_SOC_SERIES_NRF52X=y
+CONFIG_SOC_NRF52840_QIAA=y
+CONFIG_BOARD_TR60=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+CONFIG_PINCTRL=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Use code partition for uf2 bootloader and enable conversion of hex to uf2
+CONFIG_USE_DT_CODE_PARTITION=y
+CONFIG_BUILD_OUTPUT_UF2=y
+
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
+CONFIG_NVS=y
+CONFIG_SETTINGS_NVS=y
+CONFIG_FLASH=y
+CONFIG_FLASH_PAGE_LAYOUT=y
+CONFIG_FLASH_MAP=y
+
+# Uncomment for usb logging
+# CONFIG_ZMK_USB_LOGGING=y


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [x] This board/shield is tested working on real hardware
- [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [x] `.zmk.yml` metadata file added
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] General consistent formatting of DeviceTree files
- [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [x] If split, no name added for the right/peripheral half
- [x] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [x] `.conf` file has optional extra features commented out
- [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
