### PR TITLE
feat(hid): Add KConfig option for higher NKRO usages

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -53,9 +53,18 @@ config ZMK_HID_REPORT_TYPE_NKRO
     help
       Enable full N-Key Roll Over for HID output. This selection will prevent the keyboard
       from working with some BIOS/UEFI versions that only support "boot keyboard" support.
-      This option also prevents using some infrequently used higher range HID usages.
+      This option also prevents using some infrequently used higher range HID usages (notably F13-F24 and INTL1-9)
+      These usages can be re enabled with ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT.
 
 endchoice
+
+if ZMK_HID_REPORT_TYPE_NKRO
+
+config ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT
+    bool "Enable extended NKRO reporting"
+    default n
+
+endif
 
 if ZMK_HID_REPORT_TYPE_HKRO
 

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -60,8 +60,10 @@ endchoice
 
 config ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT
     bool "Enable extended NKRO reporting"
-    default n
     depends on ZMK_HID_REPORT_TYPE_NKRO
+    help
+      Enables higher usage range for NKRO (F13-F24 and INTL1-9).
+      Please note this is not compatible with Android currently and you will get no input
 
 
 if ZMK_HID_REPORT_TYPE_HKRO

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -58,13 +58,11 @@ config ZMK_HID_REPORT_TYPE_NKRO
 
 endchoice
 
-if ZMK_HID_REPORT_TYPE_NKRO
-
 config ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT
     bool "Enable extended NKRO reporting"
     default n
+    depends on ZMK_HID_REPORT_TYPE_NKRO
 
-endif
 
 if ZMK_HID_REPORT_TYPE_HKRO
 

--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -17,7 +17,12 @@
 #include <dt-bindings/zmk/hid_usage.h>
 #include <dt-bindings/zmk/hid_usage_pages.h>
 
+#if IS_ENABLED(CONFIG_ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT)
+#define ZMK_HID_KEYBOARD_NKRO_MAX_USAGE HID_USAGE_KEY_KEYBOARD_LANG8
+#else
 #define ZMK_HID_KEYBOARD_NKRO_MAX_USAGE HID_USAGE_KEY_KEYPAD_EQUAL
+#endif
+
 #define ZMK_HID_MOUSE_NUM_BUTTONS 0x05
 
 // See https://www.usb.org/sites/default/files/hid1_11.pdf section 6.2.2.4 Main Items

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -35,7 +35,7 @@ Exactly zero or one of the following options may be set to `y`. The first is use
 
 :::note NKRO usages
 
-By default the NKRO max usage is set so as to maximise compatibility, however certain less frequently used keys (F13-F24 and INTL1-8) will not work. The solution is to set 'CONFIG_ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT=y'. This is known to break compatibility with Android.
+By default the NKRO max usage is set so as to maximize compatibility, however certain less frequently used keys (F13-F24 and INTL1-8) will not work with it. One solution is to set `CONFIG_ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT=y`, however this is known to break compatibility with Android and thus not enabled by default.
 
 :::
 

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -33,11 +33,23 @@ Exactly zero or one of the following options may be set to `y`. The first is use
 | `CONFIG_ZMK_HID_REPORT_TYPE_HKRO` | Enable `CONFIG_ZMK_HID_KEYBOARD_REPORT_SIZE` key roll over.                                           |
 | `CONFIG_ZMK_HID_REPORT_TYPE_NKRO` | Enable full N-key roll over. This may prevent the keyboard from working with some BIOS/UEFI versions. |
 
+:::note NKRO usages
+
+By default the NKRO max usage is set so as to maximise compatibility, however certain less frequently used keys (F13-F24 and INTL1-8) will not work. The solution is to set 'CONFIG_ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT=y'. This is known to break compatibility with Android.
+
+:::
+
 If `CONFIG_ZMK_HID_REPORT_TYPE_HKRO` is enabled, it may be configured with the following options:
 
 | Config                                | Type | Description                                       | Default |
 | ------------------------------------- | ---- | ------------------------------------------------- | ------- |
 | `CONFIG_ZMK_HID_KEYBOARD_REPORT_SIZE` | int  | Number of keyboard keys simultaneously reportable | 6       |
+
+If `CONFIG_ZMK_HID_REPORT_TYPE_NKRO` is enabled, it may be configured with the following options:
+
+| Config                                         | Type | Description                                                          | Default |
+| ---------------------------------------------- | ---- | -------------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_HID_KEYBOARD_NKRO_EXTENDED_REPORT` | bool | Enable less frequently used key usages, at the cost of compatibility | n       |
 
 Exactly zero or one of the following options may be set to `y`. The first is used if none are set.
 


### PR DESCRIPTION
By default, the maximum NKRO usage is set to maximize compatibility, but some keys don't work. This adds the ability to use those extended keys, at the cost of compatibility (android doesn't like the higher usage range, it seems). The chosen max was largely arbitrary, although it needs to be a multiple of 8 - 1 (otherwise windows will refuse to enumerate it properly, reporting "driver error"), For this reason I made it a configurable bool rather than a variable value. There's also no reason to have it variable across a wide range, a low and a high value seem like a good compromise

This fix addresses #1460 and is linked to #1236 

