### PR TITLE
feat(display): Add label widget

### DIFF
--- a/app/include/zmk/display/widgets/label.h
+++ b/app/include/zmk/display/widgets/label.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The ZMK Contributors
+ * Copyright (c) 2024 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/include/zmk/display/widgets/label.h
+++ b/app/include/zmk/display/widgets/label.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <lvgl.h>
+#include <zephyr/kernel.h>
+
+struct zmk_widget_label {
+    sys_snode_t node;
+    lv_obj_t *obj;
+};
+
+int zmk_widget_label_init(struct zmk_widget_label *widget, lv_obj_t *parent);
+lv_obj_t *zmk_widget_label_obj(struct zmk_widget_label *widget);

--- a/app/src/display/status_screen.c
+++ b/app/src/display/status_screen.c
@@ -9,6 +9,7 @@
 #include <zmk/display/widgets/battery_status.h>
 #include <zmk/display/widgets/layer_status.h>
 #include <zmk/display/widgets/wpm_status.h>
+#include <zmk/display/widgets/label.h>
 #include <zmk/display/status_screen.h>
 
 #include <zephyr/logging/log.h>
@@ -32,6 +33,10 @@ static struct zmk_widget_layer_status layer_status_widget;
 
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_WPM_STATUS)
 static struct zmk_widget_wpm_status wpm_status_widget;
+#endif
+
+#if IS_ENABLED(CONFIG_ZMK_WIDGET_LABEL)
+static struct zmk_widget_label label_widget;
 #endif
 
 lv_obj_t *zmk_display_status_screen() {
@@ -64,6 +69,13 @@ lv_obj_t *zmk_display_status_screen() {
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_WPM_STATUS)
     zmk_widget_wpm_status_init(&wpm_status_widget, screen);
     lv_obj_align(zmk_widget_wpm_status_obj(&wpm_status_widget), LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+#endif
+
+#if IS_ENABLED(CONFIG_ZMK_WIDGET_LABEL)
+    zmk_widget_label_init(&label_widget, screen);
+    lv_obj_set_style_text_font(zmk_widget_label_obj(&label_widget), lv_theme_get_font_small(screen),
+                               LV_PART_MAIN);
+    lv_obj_align(zmk_widget_label_obj(&label_widget), LV_ALIGN_CENTER, 0, 0);
 #endif
     return screen;
 }

--- a/app/src/display/widgets/CMakeLists.txt
+++ b/app/src/display/widgets/CMakeLists.txt
@@ -6,3 +6,4 @@ target_sources_ifdef(CONFIG_ZMK_WIDGET_OUTPUT_STATUS app PRIVATE output_status.c
 target_sources_ifdef(CONFIG_ZMK_WIDGET_PERIPHERAL_STATUS app PRIVATE peripheral_status.c)
 target_sources_ifdef(CONFIG_ZMK_WIDGET_LAYER_STATUS app PRIVATE layer_status.c)
 target_sources_ifdef(CONFIG_ZMK_WIDGET_WPM_STATUS app PRIVATE wpm_status.c)
+target_sources_ifdef(CONFIG_ZMK_WIDGET_LABEL app PRIVATE label.c)

--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -41,7 +41,7 @@ config ZMK_WIDGET_LABEL
     select LV_USE_LABEL
 
 config ZMK_WIDGET_LABEL_TEXT
-    string "Custom message to display, up to 7 characters"
+    string "Custom message to display"
     default "ZMK"
 
 endmenu

--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -43,5 +43,6 @@ config ZMK_WIDGET_LABEL
 config ZMK_WIDGET_LABEL_TEXT
     string "Custom message to display"
     default "ZMK"
+    depends on ZMK_WIDGET_LABEL
 
 endmenu

--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -36,4 +36,12 @@ config ZMK_WIDGET_WPM_STATUS
     select LV_USE_LABEL
     select ZMK_WPM
 
+config ZMK_WIDGET_LABEL
+    bool "Widget for displaying custom messages"
+    select LV_USE_LABEL
+
+config ZMK_WIDGET_LABEL_TEXT
+    string "Custom message to display, up to 7 characters"
+    default "ZMK"
+
 endmenu

--- a/app/src/display/widgets/label.c
+++ b/app/src/display/widgets/label.c
@@ -14,6 +14,11 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/events/activity_state_changed.h>
 #include <zmk/event_manager.h>
 
+#define WIDGET_LABEL_TEXT 7
+
+BUILD_ASSERT(sizeof(CONFIG_ZMK_WIDGET_LABEL_TEXT) - 1 <= WIDGET_LABEL_TEXT,
+             "ERROR: Widget label text length is too long. Max length: 7");
+
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
 
 struct label_state {};
@@ -21,11 +26,7 @@ struct label_state {};
 static struct label_state get_state(const zmk_event_t *_eh) { return (struct label_state){}; }
 
 static void set_label_symbol(lv_obj_t *label) {
-    char text[7] = {};
-
-    strcat(text, CONFIG_ZMK_WIDGET_LABEL_TEXT);
-
-    lv_label_set_text(label, text);
+    lv_label_set_text(label, CONFIG_ZMK_WIDGET_LABEL_TEXT);
 }
 
 static void label_update_cb() {

--- a/app/src/display/widgets/label.c
+++ b/app/src/display/widgets/label.c
@@ -11,38 +11,16 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include <zmk/display.h>
 #include <zmk/display/widgets/label.h>
-#include <zmk/events/activity_state_changed.h>
-#include <zmk/event_manager.h>
 
 #define WIDGET_LABEL_TEXT_MAX 7
 
 BUILD_ASSERT(sizeof(CONFIG_ZMK_WIDGET_LABEL_TEXT) - 1 <= WIDGET_LABEL_TEXT_MAX,
              "ERROR: Widget label text length is too long. Max length: 7");
 
-static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
-
-struct label_state {};
-
-static struct label_state get_state(const zmk_event_t *_eh) { return (struct label_state){}; }
-
-static void set_label_symbol(lv_obj_t *label) {
-    lv_label_set_text(label, CONFIG_ZMK_WIDGET_LABEL_TEXT);
-}
-
-static void label_update_cb() {
-    struct zmk_widget_label *widget;
-    SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { set_label_symbol(widget->obj); }
-}
-
-ZMK_DISPLAY_WIDGET_LISTENER(widget_label, struct label_state, label_update_cb, get_state)
-ZMK_SUBSCRIPTION(widget_label, zmk_activity_state_changed);
-
 int zmk_widget_label_init(struct zmk_widget_label *widget, lv_obj_t *parent) {
     widget->obj = lv_label_create(parent);
+    lv_label_set_text(widget->obj, CONFIG_ZMK_WIDGET_LABEL_TEXT);
 
-    sys_slist_append(&widgets, &widget->node);
-
-    widget_label_init();
     return 0;
 }
 

--- a/app/src/display/widgets/label.c
+++ b/app/src/display/widgets/label.c
@@ -14,9 +14,9 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/events/activity_state_changed.h>
 #include <zmk/event_manager.h>
 
-#define WIDGET_LABEL_TEXT 7
+#define WIDGET_LABEL_TEXT_MAX 7
 
-BUILD_ASSERT(sizeof(CONFIG_ZMK_WIDGET_LABEL_TEXT) - 1 <= WIDGET_LABEL_TEXT,
+BUILD_ASSERT(sizeof(CONFIG_ZMK_WIDGET_LABEL_TEXT) - 1 <= WIDGET_LABEL_TEXT_MAX,
              "ERROR: Widget label text length is too long. Max length: 7");
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);

--- a/app/src/display/widgets/label.c
+++ b/app/src/display/widgets/label.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/kernel.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+#include <zmk/display.h>
+#include <zmk/display/widgets/label.h>
+#include <zmk/events/activity_state_changed.h>
+#include <zmk/event_manager.h>
+
+static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
+
+struct label_state {};
+
+static struct label_state get_state(const zmk_event_t *_eh) { return (struct label_state){}; }
+
+static void set_label_symbol(lv_obj_t *label) {
+    char text[7] = {};
+
+    strcat(text, CONFIG_ZMK_WIDGET_LABEL_TEXT);
+
+    lv_label_set_text(label, text);
+}
+
+static void label_update_cb() {
+    struct zmk_widget_label *widget;
+    SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) { set_label_symbol(widget->obj); }
+}
+
+ZMK_DISPLAY_WIDGET_LISTENER(widget_label, struct label_state, label_update_cb, get_state)
+ZMK_SUBSCRIPTION(widget_label, zmk_activity_state_changed);
+
+int zmk_widget_label_init(struct zmk_widget_label *widget, lv_obj_t *parent) {
+    widget->obj = lv_label_create(parent);
+
+    sys_slist_append(&widgets, &widget->node);
+
+    widget_label_init();
+    return 0;
+}
+
+lv_obj_t *zmk_widget_label_obj(struct zmk_widget_label *widget) { return widget->obj; }

--- a/app/src/display/widgets/label.c
+++ b/app/src/display/widgets/label.c
@@ -1,21 +1,13 @@
 /*
- * Copyright (c) 2020 The ZMK Contributors
+ * Copyright (c) 2024 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */
 
 #include <zephyr/kernel.h>
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
-
 #include <zmk/display.h>
 #include <zmk/display/widgets/label.h>
-
-#define WIDGET_LABEL_TEXT_MAX 7
-
-BUILD_ASSERT(sizeof(CONFIG_ZMK_WIDGET_LABEL_TEXT) - 1 <= WIDGET_LABEL_TEXT_MAX,
-             "ERROR: Widget label text length is too long. Max length: 7");
 
 int zmk_widget_label_init(struct zmk_widget_label *widget, lv_obj_t *parent) {
     widget->obj = lv_label_create(parent);

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -14,15 +14,17 @@ Definition files:
 - [zmk/app/src/display/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/Kconfig)
 - [zmk/app/src/display/widgets/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/widgets/Kconfig)
 
-| Config                                             | Type | Description                                                    | Default |
-| -------------------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_DISPLAY`                               | bool | Enable support for displays                                    | n       |
-| `CONFIG_ZMK_DISPLAY_INVERT`                        | bool | Invert display colors from black-on-white to white-on-black    | n       |
-| `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool | Enable a widget to show the highest, active layer              | y       |
-| `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool | Enable a widget to show battery charge information             | y       |
-| `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool | If battery widget is enabled, show percentage instead of icons | n       |
-| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool | Enable a widget to show the current output (USB/BLE)           | y       |
-| `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool | Enable a widget to show words per minute                       | n       |
+| Config                                             | Type   | Description                                                    | Default |
+| -------------------------------------------------- | ------ | -------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_DISPLAY`                               | bool   | Enable support for displays                                    | n       |
+| `CONFIG_ZMK_DISPLAY_INVERT`                        | bool   | Invert display colors from black-on-white to white-on-black    | n       |
+| `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool   | Enable a widget to show the highest, active layer              | y       |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool   | Enable a widget to show battery charge information             | y       |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool   | If battery widget is enabled, show percentage instead of icons | n       |
+| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool   | Enable a widget to show the current output (USB/BLE)           | y       |
+| `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool   | Enable a widget to show words per minute                       | n       |
+| `ZMK_WIDGET_LABEL`                                 | bool   | Enable a widget to display custom messages                     | n       |
+| `ZMK_WIDGET_LABEL_TEXT`                            | string | Custom message to display, up to 7 characters                  | ZMK     |
 
 Note that `CONFIG_ZMK_DISPLAY_INVERT` setting might not work as expected with custom status screens that utilize images.
 

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -24,7 +24,7 @@ Definition files:
 | `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool   | Enable a widget to show the current output (USB/BLE)           | y       |
 | `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool   | Enable a widget to show words per minute                       | n       |
 | `ZMK_WIDGET_LABEL`                                 | bool   | Enable a widget to display custom messages                     | n       |
-| `ZMK_WIDGET_LABEL_TEXT`                            | string | Custom message to display, up to 7 characters                  | ZMK     |
+| `ZMK_WIDGET_LABEL_TEXT`                            | string | Custom message to display                                      | ZMK     |
 
 Note that `CONFIG_ZMK_DISPLAY_INVERT` setting might not work as expected with custom status screens that utilize images.
 

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -23,8 +23,8 @@ Definition files:
 | `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool   | If battery widget is enabled, show percentage instead of icons | n       |
 | `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool   | Enable a widget to show the current output (USB/BLE)           | y       |
 | `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool   | Enable a widget to show words per minute                       | n       |
-| `ZMK_WIDGET_LABEL`                                 | bool   | Enable a widget to display custom messages                     | n       |
-| `ZMK_WIDGET_LABEL_TEXT`                            | string | Custom message to display                                      | ZMK     |
+| `CONFIG_ZMK_WIDGET_LABEL`                          | bool   | Enable a widget to display custom messages                     | n       |
+| `CONFIG_ZMK_WIDGET_LABEL_TEXT`                     | string | Custom message to display                                      | ZMK     |
 
 Note that `CONFIG_ZMK_DISPLAY_INVERT` setting might not work as expected with custom status screens that utilize images.
 


### PR DESCRIPTION
This is a barebones label widget for displaying a small(up to 7 chars) custom message in the center of display.

The widget can be enabled using `CONFIG_ZMK_WIDGET_LABEL` in the .conf file.
The displayed message is configured using `CONFIG_ZMK_WIDGET_LABEL_TEXT`(default is "ZMK").
Docs have been updated to include the new configuration options.

Demo example:
![image](https://github.com/zmkfirmware/zmk/assets/40597439/12fdc705-b7d2-4a63-9aa1-17c0327b5219)

This is my first time around `zmk` and `lvgl` so every feedback is appreciated!
My end goal is to create a widget capable of displaying custom icons, using lvgls' image lib.