### PR TITLE
refactor!: Remove deprecated label property

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND ZEPHYR_EXTRA_MODULES
 find_package(Zephyr REQUIRED HINTS ../zephyr)
 project(zmk)
 
+zephyr_linker_sources(SECTIONS include/linker/zmk-behaviors.ld)
 zephyr_linker_sources(RODATA include/linker/zmk-events.ld)
 
 # Add your source file to the "app" target. This must come after
@@ -22,6 +23,7 @@ zephyr_linker_sources(RODATA include/linker/zmk-events.ld)
 target_include_directories(app PRIVATE include)
 target_sources(app PRIVATE src/stdlib.c)
 target_sources(app PRIVATE src/activity.c)
+target_sources(app PRIVATE src/behavior.c)
 target_sources(app PRIVATE src/kscan.c)
 target_sources(app PRIVATE src/matrix_transform.c)
 target_sources(app PRIVATE src/sensors.c)

--- a/app/boards/arm/adv360pro/adv360pro.dtsi
+++ b/app/boards/arm/adv360pro/adv360pro.dtsi
@@ -46,7 +46,6 @@
     };
     ext-power {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
     };
 
@@ -107,11 +106,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -125,12 +122,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };
@@ -145,7 +140,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>;

--- a/app/boards/arm/bdn9/bdn9_rev2.dts
+++ b/app/boards/arm/bdn9/bdn9_rev2.dts
@@ -23,7 +23,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-direct";
-        label = "KSCAN";
 
         input-gpios
             = <&gpiob 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
@@ -40,7 +39,6 @@
 
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&gpioa 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&gpioa 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -48,7 +46,6 @@
     };
     mid_encoder: encoder_mid {
         compatible = "alps,ec11";
-        label = "MID_ENCODER";
         a-gpios = <&gpioa 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&gpioa 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -56,7 +53,6 @@
     };
     right_encoder: encoder_right {
         compatible = "alps,ec11";
-        label = "RIGHT_ENCODER";
         a-gpios = <&gpioa 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&gpiob 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -78,7 +74,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */
@@ -117,7 +112,6 @@
     pinctrl-names = "default";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -137,7 +131,6 @@
 
         /* Set 6Kb of storage at the end of the 128Kb of flash */
         storage_partition: partition@1e800 {
-            label = "storage";
             reg = <0x0001e800 0x00001800>;
         };
     };

--- a/app/boards/arm/bluemicro840/bluemicro840_v1.dts
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1.dts
@@ -29,9 +29,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         init-delay-ms = <20>;
         control-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
     };

--- a/app/boards/arm/bluemicro840/bluemicro840_v1.dts
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1.dts
@@ -25,7 +25,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
@@ -38,7 +37,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 7>;
         output-ohms = <2000000>;
         full-ohms = <(2000000 + 806000)>;
@@ -81,7 +79,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -97,11 +94,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -115,12 +110,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/bt60/bt60.dtsi
+++ b/app/boards/arm/bt60/bt60.dtsi
@@ -32,7 +32,6 @@
 
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&gpio1 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -44,13 +43,11 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 2>;
         output-ohms = <2000000>;
         full-ohms = <(2000000 + 806000)>;
@@ -89,7 +86,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -105,11 +101,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -123,12 +117,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/bt60/bt60_v1.dts
+++ b/app/boards/arm/bt60/bt60_v1.dts
@@ -81,7 +81,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/arm/bt60/bt60_v1_hs.dts
+++ b/app/boards/arm/bt60/bt60_v1_hs.dts
@@ -30,7 +30,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/arm/ckp/ckp.dtsi
+++ b/app/boards/arm/ckp/ckp.dtsi
@@ -34,7 +34,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios
@@ -74,7 +73,6 @@
 
     encoder_1: encoder_1 {
         compatible = "alps,ec11";
-        label = "ENCODER_ONE";
         a-gpios = <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&gpio0 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -83,7 +81,6 @@
 
     encoder_2: encoder_2 {
         compatible = "alps,ec11";
-        label = "ENCODER_TWO";
         a-gpios = <&gpio0 26 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&gpio0 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -92,7 +89,6 @@
 
     encoder_3: encoder_3 {
         compatible = "alps,ec11";
-        label = "encoder_3";
         a-gpios = <&gpio0 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&gpio0 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -101,7 +97,6 @@
 
     backlight: pwmleds {
         compatible = "pwm-leds";
-        label = "Backlight LEDs";
         pwm_led_0 {
             pwms = <&pwm0 0 10000 PWM_POLARITY_NORMAL>;
         };
@@ -111,13 +106,11 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "VBATT";
         io-channels = <&adc 2>;
         output-ohms = <100000>;
         full-ohms = <(100000 + 100000)>;
@@ -163,11 +156,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -181,12 +172,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };
@@ -201,7 +190,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>;

--- a/app/boards/arm/ckp/ckp.dtsi
+++ b/app/boards/arm/ckp/ckp.dtsi
@@ -66,9 +66,9 @@
             ;
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
     };
 

--- a/app/boards/arm/corneish_zen/corneish_zen.dtsi
+++ b/app/boards/arm/corneish_zen/corneish_zen.dtsi
@@ -80,7 +80,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -95,11 +94,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -113,12 +110,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/corneish_zen/corneish_zen.keymap
+++ b/app/boards/arm/corneish_zen/corneish_zen.keymap
@@ -21,7 +21,7 @@
         compatible = "zmk,keymap";
 
         default_layer {
-            label = "QWERTY";
+            display-name = "QWERTY";
 // --------------------------------------------------------------------------------
 // |  TAB |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  | BKSP |
 // | CTRL |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |  '   |
@@ -36,7 +36,7 @@
         };
 
         lower_layer {
-            label = "NUMBER";
+            display-name = "NUMBER";
 // -----------------------------------------------------------------------------------------
 // |  TAB |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  | BKSP |
 // | BTCLR| BT1 | BT2 | BT3 | BT4 | BT5 |   | LFT | DWN |  UP | RGT |     |      |
@@ -51,7 +51,7 @@
         };
 
         raise_layer {
-            label = "SYMBOL";
+            display-name = "SYMBOL";
 // -----------------------------------------------------------------------------------------
 // |  TAB |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  (  |  )  | BKSP |
 // | CTRL |     |     |     |     |     |   |  -  |  =  |  [  |  ]  |  \  |  `   |

--- a/app/boards/arm/corneish_zen/corneish_zen_v1_left.dts
+++ b/app/boards/arm/corneish_zen/corneish_zen_v1_left.dts
@@ -15,7 +15,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -39,7 +38,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 };
@@ -88,7 +86,6 @@
 
     fuelgauge: bq274xx@55 {
         compatible = "ti,bq274xx";
-        label = "BATTERY";
         reg = <0x55>;
         design-voltage = <3700>; //Battery Design Volatge in mV
         design-capacity = <180>; //Battery Design Capacity in mAh
@@ -109,7 +106,6 @@
     epd: il0323@0 {
         compatible = "gooddisplay,il0323";
         reg =  <0>;
-        label = "DISPLAY";
         width = <80>;
         height = <128>;
         spi-max-frequency = <4000000>;

--- a/app/boards/arm/corneish_zen/corneish_zen_v1_right.dts
+++ b/app/boards/arm/corneish_zen/corneish_zen_v1_right.dts
@@ -15,7 +15,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -39,7 +38,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 };
@@ -96,7 +94,6 @@
 
     fuelgauge: bq274xx@55 {
         compatible = "ti,bq274xx";
-        label = "BATTERY";
         reg = <0x55>;
         design-voltage = <3700>; //Battery Design Volatge in mV
         design-capacity = <180>; //Battery Design Capacity in mAh
@@ -117,7 +114,6 @@
     epd: il0323@0 {
         compatible = "gooddisplay,il0323";
         reg =  <0>;
-        label = "DISPLAY";
         width = <80>;
         height = <128>;
         spi-max-frequency = <4000000>;

--- a/app/boards/arm/corneish_zen/corneish_zen_v2_left.dts
+++ b/app/boards/arm/corneish_zen/corneish_zen_v2_left.dts
@@ -15,7 +15,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -39,13 +38,11 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 0>;
         output-ohms = <1960000>;
         full-ohms = <(1960000 + 810000)>;
@@ -83,7 +80,6 @@
     epd: il0323@0 {
         compatible = "gooddisplay,il0323";
         reg =  <0>;
-        label = "DISPLAY";
         width = <80>;
         height = <128>;
         spi-max-frequency = <4000000>;

--- a/app/boards/arm/corneish_zen/corneish_zen_v2_right.dts
+++ b/app/boards/arm/corneish_zen/corneish_zen_v2_right.dts
@@ -15,7 +15,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -39,13 +38,11 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 0>;
         output-ohms = <1960000>;
         full-ohms = <(1960000 + 810000)>;
@@ -90,7 +87,6 @@
     epd: il0323@0 {
         compatible = "gooddisplay,il0323";
         reg =  <0>;
-        label = "DISPLAY";
         width = <80>;
         height = <128>;
         spi-max-frequency = <4000000>;

--- a/app/boards/arm/corneish_zen/widgets/layer_status.c
+++ b/app/boards/arm/corneish_zen/widgets/layer_status.c
@@ -45,7 +45,7 @@ static void layer_status_update_cb(struct layer_status_state state) {
 
 static struct layer_status_state layer_status_get_state(const zmk_event_t *eh) {
     uint8_t index = zmk_keymap_highest_layer_active();
-    return (struct layer_status_state){.index = index, .label = zmk_keymap_layer_label(index)};
+    return (struct layer_status_state){.index = index, .label = zmk_keymap_layer_name(index)};
 }
 
 ZMK_DISPLAY_WIDGET_LISTENER(widget_layer_status, struct layer_status_state, layer_status_update_cb,

--- a/app/boards/arm/dz60rgb/dz60rgb_rev1.dts
+++ b/app/boards/arm/dz60rgb/dz60rgb_rev1.dts
@@ -36,7 +36,6 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                     RC(
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -70,7 +69,6 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                     RC(
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -86,7 +84,6 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                     RC(
 
         /* Set 6Kb of storage at the end of the 256Kb of flash */
         storage_partition: partition@3e800 {
-            label = "storage";
             reg = <0x0003e800 0x00001800>;
         };
     };

--- a/app/boards/arm/ferris/ferris_rev02.dts
+++ b/app/boards/arm/ferris/ferris_rev02.dts
@@ -40,7 +40,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-composite";
-        label = "KSCAN";
         rows = <4>;
         columns = <10>;
 
@@ -56,7 +55,6 @@
 
     kscan_left: kscan_left {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN_LEFT";
 
         diode-direction = "col2row";
 
@@ -77,7 +75,6 @@
 
     kscan_right: kscan_right {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN_RIGHT";
 
         diode-direction = "row2col";
 
@@ -117,7 +114,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -156,7 +152,6 @@
 
         /* Set 6Kb of storage at the end of the 128Kb of flash */
         storage_partition: partition@3e800 {
-            label = "storage";
             reg = <0x0001e800 0x00001800>;
         };
     };

--- a/app/boards/arm/ferris/ferris_rev02.keymap
+++ b/app/boards/arm/ferris/ferris_rev02.keymap
@@ -20,7 +20,6 @@
     behaviors {
         hm: homerow_mods {
             compatible = "zmk,behavior-hold-tap";
-            label = "homerow mods";
             #binding-cells = <2>;
             tapping_term_ms = <200>;
             flavor = "tap-preferred";

--- a/app/boards/arm/glove80/glove80.dtsi
+++ b/app/boards/arm/glove80/glove80.dtsi
@@ -34,7 +34,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
         debounce-press-ms = <4>;
         debounce-release-ms = <20>;
@@ -62,7 +61,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -77,11 +75,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -95,12 +91,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/glove80/glove80.keymap
+++ b/app/boards/arm/glove80/glove80.keymap
@@ -22,7 +22,6 @@
         // Configure it as a tap dance, so the first tap (or hold) is a &mo and the second tap is a &to
         layer_td: tap_dance_0 {
             compatible = "zmk,behavior-tap-dance";
-            label = "LAYER_TAP_DANCE";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&mo LOWER>, <&to LOWER>;
@@ -31,7 +30,6 @@
 
     macros {
         bt_0: bt_profile_macro_0 {
-            label = "BT_0";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings
@@ -40,7 +38,6 @@
         };
 
         bt_1: bt_profile_macro_1 {
-            label = "BT_1";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings
@@ -49,7 +46,6 @@
         };
 
         bt_2: bt_profile_macro_2 {
-            label = "BT_2";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings
@@ -58,7 +54,6 @@
         };
 
         bt_3: bt_profile_macro_3 {
-            label = "BT_3";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings

--- a/app/boards/arm/glove80/glove80_lh.dts
+++ b/app/boards/arm/glove80/glove80_lh.dts
@@ -21,10 +21,8 @@
 
     back_led_backlight: pwmleds {
         compatible = "pwm-leds";
-        label = "BACK LED";
         pwm_led_0 {
             pwms = <&pwm0 0 PWM_USEC(20) PWM_POLARITY_NORMAL>;
-            label = "Back LED configured as backlight";
         };
     };
 
@@ -37,7 +35,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-nrf-vddh";
-        label = "BATTERY";
     };
 };
 
@@ -51,7 +48,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812C-2020";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/arm/glove80/glove80_lh.dts
+++ b/app/boards/arm/glove80/glove80_lh.dts
@@ -28,9 +28,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>; /* WS2812_CE */
         init-delay-ms = <100>;
     };

--- a/app/boards/arm/glove80/glove80_rh.dts
+++ b/app/boards/arm/glove80/glove80_rh.dts
@@ -22,10 +22,8 @@
 
     back_led_backlight: pwmleds {
         compatible = "pwm-leds";
-        label = "BACK LED";
         pwm_led_0 {
             pwms = <&pwm0 0 PWM_USEC(20) PWM_POLARITY_NORMAL>;
-            label = "Back LED configured as backlight";
         };
     };
 
@@ -38,7 +36,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-nrf-vddh";
-        label = "BATTERY";
     };
 };
 
@@ -52,7 +49,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812C-2020";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/arm/glove80/glove80_rh.dts
+++ b/app/boards/arm/glove80/glove80_rh.dts
@@ -29,9 +29,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>; /* WS2812_CE */
         init-delay-ms = <100>;
     };

--- a/app/boards/arm/kbdfans_tofu65/kbdfans_tofu65_v2.dts
+++ b/app/boards/arm/kbdfans_tofu65/kbdfans_tofu65_v2.dts
@@ -53,7 +53,6 @@ RC(4,0) RC(4,1) RC(4,2)                         RC(4,6)         RC(4,8) RC(4,9) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -93,7 +92,6 @@ RC(4,0) RC(4,1) RC(4,2)                         RC(4,6)         RC(4,8) RC(4,9) 
 
         /* Reserved memory for the second stage bootloader */
         second_stage_bootloader: partition@0 {
-            label = "second_stage_bootloader";
             reg = <0x00000000 0x100>;
             read-only;
         };
@@ -103,7 +101,6 @@ RC(4,0) RC(4,1) RC(4,2)                         RC(4,6)         RC(4,8) RC(4,9) 
          * size is 16MB minus the 0x100 bytes taken by the bootloader.
          */
         code_partition: partition@100 {
-            label = "code";
             reg = <0x100 (DT_SIZE_M(16) - 0x100)>;
             read-only;
         };

--- a/app/boards/arm/mikoto/mikoto_520.dts
+++ b/app/boards/arm/mikoto/mikoto_520.dts
@@ -25,7 +25,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
@@ -38,7 +37,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 1>;
         output-ohms = <10000000>;
         full-ohms = <(10000000 + 4000000)>;
@@ -80,7 +78,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -96,11 +93,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -114,12 +109,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/mikoto/mikoto_520.dts
+++ b/app/boards/arm/mikoto/mikoto_520.dts
@@ -29,9 +29,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
         init-delay-ms = <50>;
     };

--- a/app/boards/arm/nice60/nice60.dts
+++ b/app/boards/arm/nice60/nice60.dts
@@ -42,7 +42,6 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -74,7 +73,6 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
@@ -86,7 +84,6 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 2>;
         output-ohms = <2000000>;
         full-ohms = <(2000000 + 806000)>;
@@ -118,7 +115,6 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */
@@ -136,7 +132,6 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -151,12 +146,10 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "mbr";
             reg = <0x00000000 0x00001000>;
         };
 
         code_partition: partition@1000 {
-            label = "code_partition";
             reg = <0x00001000 0x000d3000>;
         };
 
@@ -170,12 +163,10 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
          * if enabled.
          */
         storage_partition: partition@d4000 {
-            label = "storage";
             reg = <0x000d4000 0x00020000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/nice60/nice60.dts
+++ b/app/boards/arm/nice60/nice60.dts
@@ -78,9 +78,9 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
     };
 

--- a/app/boards/arm/nice_nano/nice_nano.dts
+++ b/app/boards/arm/nice_nano/nice_nano.dts
@@ -20,7 +20,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 2>;
         output-ohms = <2000000>;
         full-ohms = <(2000000 + 806000)>;

--- a/app/boards/arm/nice_nano/nice_nano.dts
+++ b/app/boards/arm/nice_nano/nice_nano.dts
@@ -12,9 +12,9 @@
         zmk,battery = &vbatt;
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
     };
 

--- a/app/boards/arm/nice_nano/nice_nano.dtsi
+++ b/app/boards/arm/nice_nano/nice_nano.dtsi
@@ -23,7 +23,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 };
@@ -63,7 +62,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -79,11 +77,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -97,12 +93,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/nice_nano/nice_nano_v2.dts
+++ b/app/boards/arm/nice_nano/nice_nano_v2.dts
@@ -12,9 +12,9 @@
         zmk,battery = &vbatt;
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
         init-delay-ms = <50>;
     };

--- a/app/boards/arm/nice_nano/nice_nano_v2.dts
+++ b/app/boards/arm/nice_nano/nice_nano_v2.dts
@@ -21,6 +21,5 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-nrf-vddh";
-        label = "BATTERY";
     };
 };

--- a/app/boards/arm/nrf52840_m2/nrf52840_m2.dts
+++ b/app/boards/arm/nrf52840_m2/nrf52840_m2.dts
@@ -23,21 +23,17 @@
         compatible = "gpio-leds";
         red_led: led_0 {
             gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
-            label = "Red LED";
         };
         green_led: led_1 {
             gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
-            label = "Green LED";
         };
         blue_led: led_2 {
             gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 0>;
         output-ohms = <1000000>;
         full-ohms = <(1000000 + 1000000)>;
@@ -66,7 +62,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -82,11 +77,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -100,12 +93,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/nrfmicro/nrfmicro_11.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11.dts
@@ -28,9 +28,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
     };
 };

--- a/app/boards/arm/nrfmicro/nrfmicro_11.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11.dts
@@ -24,7 +24,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
@@ -66,7 +65,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -82,11 +80,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -100,12 +96,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
@@ -28,9 +28,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
     };
 };

--- a/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
@@ -24,7 +24,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
@@ -66,7 +65,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -82,11 +80,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -100,12 +96,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/nrfmicro/nrfmicro_13.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13.dts
@@ -25,7 +25,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
@@ -37,7 +36,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 2>;
         output-ohms = <2000000>;
         full-ohms = <(2000000 + 820000)>;
@@ -79,7 +77,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -95,11 +92,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -113,12 +108,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/nrfmicro/nrfmicro_13.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13.dts
@@ -29,9 +29,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
     };
 

--- a/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
@@ -29,9 +29,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
     };
 

--- a/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
@@ -25,7 +25,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
@@ -37,7 +36,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 2>;
         output-ohms = <2000000>;
         full-ohms = <(2000000 + 820000)>;
@@ -79,7 +77,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -95,11 +92,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x00046000>;
         };
 
@@ -113,12 +108,10 @@
          * if enabled.
          */
         storage_partition: partition@6c000 {
-            label = "storage";
             reg = <0x0006c000 0x00008000>;
         };
 
         boot_partition: partition@74000 {
-            label = "adafruit_boot";
             reg = <0x00074000 0x0000c000>;
         };
     };

--- a/app/boards/arm/pillbug/pillbug.dts
+++ b/app/boards/arm/pillbug/pillbug.dts
@@ -30,9 +30,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
         init-delay-ms = <50>;
     };

--- a/app/boards/arm/pillbug/pillbug.dts
+++ b/app/boards/arm/pillbug/pillbug.dts
@@ -26,7 +26,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
-            label = "Blue LED";
         };
     };
 
@@ -39,7 +38,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 2>;
         output-ohms = <2000000>;
         full-ohms = <(2000000 + 820000)>;
@@ -89,7 +87,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -105,12 +102,10 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "mbr";
             reg = <0x00000000 0x00001000>;
         };
 
         code_partition: partition@1000 {
-            label = "code_partition";
             reg = <0x00001000 0x000d3000>;
         };
 
@@ -124,12 +119,10 @@
          * if enabled.
          */
         storage_partition: partition@d4000 {
-            label = "storage";
             reg = <0x000d4000 0x00020000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/planck/planck_rev6.dts
+++ b/app/boards/arm/planck/planck_rev6.dts
@@ -23,7 +23,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
                 diode-direction = "col2row";
         row-gpios
             = <&gpioa 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
@@ -89,7 +88,6 @@ layout_2x2u_transform:
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -125,7 +123,6 @@ layout_2x2u_transform:
 
         /* Set 6Kb of storage at the end of the 256Kb of flash */
         storage_partition: partition@3e800 {
-            label = "storage";
             reg = <0x0003e800 0x00001800>;
         };
     };

--- a/app/boards/arm/preonic/preonic_rev3.dts
+++ b/app/boards/arm/preonic/preonic_rev3.dts
@@ -23,7 +23,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
         row-gpios
             = <&gpioa 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
@@ -96,7 +95,6 @@
     status = "okay";
 cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -132,7 +130,6 @@ cdc_acm_uart: cdc_acm_uart {
 
         /* Set 6Kb of storage at the end of the 256Kb of flash */
         storage_partition: partition@3e800 {
-            label = "storage";
             reg = <0x0003e800 0x00001800>;
         };
     };

--- a/app/boards/arm/proton_c/proton_c.dts
+++ b/app/boards/arm/proton_c/proton_c.dts
@@ -27,7 +27,6 @@
         compatible = "gpio-leds";
         led: led_0 {
             gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
-            label = "User LED";
         };
     };
 };
@@ -73,7 +72,6 @@
     status = "okay";
     cdc_acm_uart0: cdc_acm_uart0 {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -93,7 +91,6 @@
 
         /* Set 6Kb of storage at the end of the 256Kb of flash */
         storage_partition: partition@3e800 {
-            label = "storage";
             reg = <0x0003e800 0x00001800>;
         };
     };

--- a/app/boards/arm/puchi_ble/puchi_ble_v1.dts
+++ b/app/boards/arm/puchi_ble/puchi_ble_v1.dts
@@ -29,9 +29,9 @@
         };
     };
 
-    ext-power {
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
         control-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
     };
 

--- a/app/boards/arm/puchi_ble/puchi_ble_v1.dts
+++ b/app/boards/arm/puchi_ble/puchi_ble_v1.dts
@@ -25,7 +25,6 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
@@ -37,7 +36,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 2>;
         output-ohms = <2000000>;
         full-ohms = <(2000000 + 820000)>;
@@ -78,7 +76,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -94,11 +91,9 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "softdevice";
             reg = <0x00000000 0x00026000>;
         };
         code_partition: partition@26000 {
-            label = "code_partition";
             reg = <0x00026000 0x000c6000>;
         };
 
@@ -112,12 +107,10 @@
          * if enabled.
          */
         storage_partition: partition@ec000 {
-            label = "storage";
             reg = <0x000ec000 0x00008000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/arm/s40nc/s40nc.dts
+++ b/app/boards/arm/s40nc/s40nc.dts
@@ -37,7 +37,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -66,13 +65,11 @@
         compatible = "gpio-leds";
         blue_led: led_0 {
             gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
-            label = "Blue LED";
         };
     };
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 2>;
         output-ohms = <2000000>;
         full-ohms = <(2000000 + 820000)>;
@@ -99,7 +96,6 @@
     status = "okay";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 
@@ -114,12 +110,10 @@
         #size-cells = <1>;
 
         sd_partition: partition@0 {
-            label = "mbr";
             reg = <0x00000000 0x00001000>;
         };
 
         code_partition: partition@1000 {
-            label = "code_partition";
             reg = <0x00001000 0x000d3000>;
         };
 
@@ -133,12 +127,10 @@
          * if enabled.
          */
         storage_partition: partition@d4000 {
-            label = "storage";
             reg = <0x000d4000 0x00020000>;
         };
 
         boot_partition: partition@f4000 {
-            label = "adafruit_boot";
             reg = <0x000f4000 0x0000c000>;
         };
     };

--- a/app/boards/native_posix.overlay
+++ b/app/boards/native_posix.overlay
@@ -9,7 +9,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-mock";
-        label = "KSCAN_MOCK";
 
         rows = <2>;
         columns = <2>;

--- a/app/boards/native_posix_64.overlay
+++ b/app/boards/native_posix_64.overlay
@@ -10,7 +10,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-mock";
-        label = "KSCAN_MOCK";
 
         rows = <2>;
         columns = <2>;

--- a/app/boards/nrf52_bsim.overlay
+++ b/app/boards/nrf52_bsim.overlay
@@ -9,7 +9,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-mock";
-        label = "KSCAN_MOCK";
 
         rows = <2>;
         columns = <2>;

--- a/app/boards/seeeduino_xiao.overlay
+++ b/app/boards/seeeduino_xiao.overlay
@@ -13,7 +13,6 @@
 &usb0 {
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 

--- a/app/boards/seeeduino_xiao_ble.overlay
+++ b/app/boards/seeeduino_xiao_ble.overlay
@@ -13,7 +13,6 @@
 
     vbatt: vbatt {
         compatible = "zmk,battery-voltage-divider";
-        label = "BATTERY";
         io-channels = <&adc 7>;
         power-gpios = <&gpio0 14 (GPIO_OPEN_DRAIN | GPIO_ACTIVE_LOW)>;
         output-ohms = <510000>;
@@ -28,7 +27,6 @@
 &usbd {
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 

--- a/app/boards/shields/a_dux/a_dux.dtsi
+++ b/app/boards/shields/a_dux/a_dux.dtsi
@@ -27,7 +27,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-direct";
-        label = "KSCAN";
         input-gpios =
             <&pro_micro  5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,
             <&pro_micro  0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>,

--- a/app/boards/shields/bat43/bat43.overlay
+++ b/app/boards/shields/bat43/bat43.overlay
@@ -28,7 +28,6 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)         RC(6,0) RC(6,1) RC(6,2) 
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/bfo9000/bfo9000.dtsi
+++ b/app/boards/shields/bfo9000/bfo9000.dtsi
@@ -28,7 +28,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios

--- a/app/boards/shields/boardsource3x4/boardsource3x4.overlay
+++ b/app/boards/shields/boardsource3x4/boardsource3x4.overlay
@@ -13,7 +13,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
          row-gpios

--- a/app/boards/shields/boardsource5x12/boardsource5x12.overlay
+++ b/app/boards/shields/boardsource5x12/boardsource5x12.overlay
@@ -13,7 +13,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         row-gpios

--- a/app/boards/shields/chalice/boards/nice_nano.overlay
+++ b/app/boards/shields/chalice/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/chalice/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/chalice/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/chalice/chalice.overlay
+++ b/app/boards/shields/chalice/chalice.overlay
@@ -44,7 +44,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/clog/clog.dtsi
+++ b/app/boards/shields/clog/clog.dtsi
@@ -26,7 +26,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-direct";
-        label = "KSCAN";
 
         input-gpios
             = <&pro_micro 18 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>

--- a/app/boards/shields/clueboard_california/clueboard_california.overlay
+++ b/app/boards/shields/clueboard_california/clueboard_california.overlay
@@ -12,8 +12,6 @@
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-direct";
 
-        label = "KSCAN";
-
         input-gpios
             = <&gpioa 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
             , <&gpioa 9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>

--- a/app/boards/shields/contra/contra.overlay
+++ b/app/boards/shields/contra/contra.overlay
@@ -11,7 +11,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/corne/boards/nice_nano.overlay
+++ b/app/boards/shields/corne/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/corne/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/corne/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/corne/corne.dtsi
+++ b/app/boards/shields/corne/corne.dtsi
@@ -47,7 +47,6 @@ RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -68,7 +67,6 @@ RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/cradio/cradio.dtsi
+++ b/app/boards/shields/cradio/cradio.dtsi
@@ -27,7 +27,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-direct";
-        label = "KSCAN";
         input-gpios
         = <&pro_micro  7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
         , <&pro_micro 18 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>

--- a/app/boards/shields/cradio/cradio.keymap
+++ b/app/boards/shields/cradio/cradio.keymap
@@ -12,7 +12,6 @@
 / {
     behaviors {
         ht: hold_tap {
-            label = "hold_tap";
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-preferred";

--- a/app/boards/shields/crbn/crbn.overlay
+++ b/app/boards/shields/crbn/crbn.overlay
@@ -13,7 +13,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios
@@ -41,7 +40,6 @@
 
     encoder: encoder {
         compatible = "alps,ec11";
-        label = "ENCODER";
         a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         resolution = <2>;

--- a/app/boards/shields/eek/eek.overlay
+++ b/app/boards/shields/eek/eek.overlay
@@ -26,7 +26,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/elephant42/boards/nice_nano.overlay
+++ b/app/boards/shields/elephant42/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/elephant42/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/elephant42/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/elephant42/elephant42.dtsi
+++ b/app/boards/shields/elephant42/elephant42.dtsi
@@ -26,7 +26,6 @@ RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)                 RC(1,6) RC(1,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -45,7 +44,6 @@ RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5)                 RC(1,6) RC(1,7) 
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/ergodash/ergodash.dtsi
+++ b/app/boards/shields/ergodash/ergodash.dtsi
@@ -35,7 +35,6 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4)         RC(4,5) RC(4,6) RC(4,13) RC(4,12
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
 

--- a/app/boards/shields/eternal_keypad/boards/nice_nano.overlay
+++ b/app/boards/shields/eternal_keypad/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/eternal_keypad/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/eternal_keypad/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/eternal_keypad/eternal_keypad.dtsi
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.dtsi
@@ -14,7 +14,6 @@
 
   kscan0: kscan {
     compatible = "zmk,kscan-gpio-matrix";
-    label = "KSCAN";
 
     diode-direction = "col2row";
 

--- a/app/boards/shields/fourier/fourier.dtsi
+++ b/app/boards/shields/fourier/fourier.dtsi
@@ -30,7 +30,6 @@ RC(3,0)   RC(3,1) RC(3,2) RC(3,3) RC(3,4)            /**/  RC(3,6)        RC(3,9
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios

--- a/app/boards/shields/helix/boards/nice_nano.overlay
+++ b/app/boards/shields/helix/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/helix/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/helix/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/helix/helix.dtsi
+++ b/app/boards/shields/helix/helix.dtsi
@@ -32,7 +32,6 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(4,6)   RC(4,7) RC(4,8) RC(4,9
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios

--- a/app/boards/shields/hummingbird/hummingbird.keymap
+++ b/app/boards/shields/hummingbird/hummingbird.keymap
@@ -66,7 +66,7 @@
         };
 
         nav_layer {
-            label = "Nav";
+            display-name = "Nav";
             bindings = <
                 &trans     &trans     &trans      &trans          &trans       &trans           &kp HOME       &kp UARW &kp PG_UP  &trans
                 &trans     &trans     &trans      &trans          &trans       &trans           &kp LARW       &kp DARW &kp RARW   &trans
@@ -76,7 +76,7 @@
         };
 
         num_layer {
-            label = "Num";
+            display-name = "Num";
             bindings = <
                 &kp LBKT   &kp N7     &kp N8      &kp N9          &kp RBKT      &trans          &trans         &trans      &trans     &trans
                 &kp SEMI   &kp N4     &kp N5      &kp N6          &kp EQUAL     &trans          &trans         &trans      &trans     &trans
@@ -86,7 +86,7 @@
         };
 
         sym_layer {
-            label = "Sym";
+            display-name = "Sym";
             bindings = <
                 &kp LBRC   &kp LS(N7) &kp LS(N8)  &kp LS(N9)      &kp RBRC      &trans          &trans         &trans      &trans     &trans
                 &kp COLON  &kp LS(N4) &kp LS(N5)  &kp LS(N6)      &kp PLUS      &trans          &trans         &trans      &trans     &trans

--- a/app/boards/shields/hummingbird/hummingbird.keymap
+++ b/app/boards/shields/hummingbird/hummingbird.keymap
@@ -19,7 +19,6 @@
     behaviors {
         hm: homerow_mods {
             compatible = "zmk,behavior-hold-tap";
-            label = "homerow mods";
             #binding-cells = <2>;
             tapping_term_ms = <225>;
             flavor = "tap-preferred";

--- a/app/boards/shields/hummingbird/hummingbird.overlay
+++ b/app/boards/shields/hummingbird/hummingbird.overlay
@@ -29,7 +29,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "row2col";
 
         col-gpios

--- a/app/boards/shields/iris/iris.dtsi
+++ b/app/boards/shields/iris/iris.dtsi
@@ -32,7 +32,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,2) RC(4,9) RC(3,6) RC(3,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios

--- a/app/boards/shields/jian/jian.dtsi
+++ b/app/boards/shields/jian/jian.dtsi
@@ -62,7 +62,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios

--- a/app/boards/shields/jiran/jiran.dtsi
+++ b/app/boards/shields/jiran/jiran.dtsi
@@ -67,7 +67,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios

--- a/app/boards/shields/jorne/boards/nice_nano.overlay
+++ b/app/boards/shields/jorne/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/jorne/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/jorne/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/jorne/jorne.dtsi
+++ b/app/boards/shields/jorne/jorne.dtsi
@@ -63,7 +63,6 @@ RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -84,7 +83,6 @@ RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/knob_goblin/knob_goblin.overlay
+++ b/app/boards/shields/knob_goblin/knob_goblin.overlay
@@ -14,7 +14,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
          row-gpios
@@ -36,7 +35,6 @@
 
     top_encoder: encoder_top {
         compatible = "alps,ec11";
-        label = "TOP_ENCODER";
         a-gpios = <&pro_micro 19 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 18 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -45,7 +43,6 @@
 
     bottom_encoder: encoder_bottom {
         compatible = "alps,ec11";
-        label = "BOTTOM_ENCODER";
         a-gpios = <&pro_micro 20 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 21 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -66,7 +63,6 @@
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/kyria/boards/nice_nano.overlay
+++ b/app/boards/shields/kyria/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/kyria/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/kyria/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/kyria/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/kyria/boards/nrfmicro_11.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/kyria/boards/nrfmicro_11_flipped.overlay
+++ b/app/boards/shields/kyria/boards/nrfmicro_11_flipped.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/kyria/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/kyria/boards/nrfmicro_13.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/kyria/kyria_common.dtsi
+++ b/app/boards/shields/kyria/kyria_common.dtsi
@@ -15,21 +15,18 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
     };
 
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         steps = <80>;
         status = "disabled";
     };
 
     right_encoder: encoder_right {
         compatible = "alps,ec11";
-        label = "RIGHT_ENCODER";
         steps = <80>;
         status = "disabled";
     };
@@ -49,7 +46,6 @@
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <64>;
         segment-offset = <0>;

--- a/app/boards/shields/leeloo/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/leeloo/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/leeloo/leeloo.keymap
+++ b/app/boards/shields/leeloo/leeloo.keymap
@@ -25,7 +25,7 @@
         compatible = "zmk,keymap";
 
         default_layer {
-            label = " QWERTY";
+            display-name = " QWERTY";
             bindings = <
 &kp ESC    &kp N1     &kp N2     &kp N3     &kp N4     &kp N5                           &kp N6     &kp N7     &kp N8     &kp N9     &kp N0     &kp BSLH
 &kp TAB    &kp Q      &kp W      &kp E      &kp R      &kp T                            &kp Y      &kp U      &kp I      &kp O      &kp P      &kp GRAV
@@ -38,7 +38,7 @@
         };
 
         lower_layer {
-            label = " Lower";
+            display-name = " Lower";
             bindings = <
 &trans     &kp F1     &kp F2     &kp F3     &kp F4     &kp F5                           &kp F6     &kp F7     &kp F8     &kp F9     &kp F10    &kp F11
 &trans     &trans     &trans     &trans     &trans     &trans                           &kp PG_UP  &kp HOME   &kp UP     &kp END    &trans     &kp F12
@@ -51,7 +51,7 @@
         };
 
         raise_layer {
-            label = " Raise";
+            display-name = " Raise";
             bindings = <
 &trans     &trans     &trans     &trans     &trans     &trans                           &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans
 &trans     &trans     &trans     &trans     &trans     &trans                           &trans        &trans        &trans        &trans        &sys_reset    &bootloader

--- a/app/boards/shields/leeloo/leeloo_common.dtsi
+++ b/app/boards/shields/leeloo/leeloo_common.dtsi
@@ -32,7 +32,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
 
@@ -47,7 +46,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     left_encoder: left_encoder {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <120>;
@@ -56,7 +54,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     right_encoder: right_encoder {
         compatible = "alps,ec11";
-        label = "RIGHT_ENCODER";
         a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <120>;
@@ -77,7 +74,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/leeloo/leeloo_rev2.keymap
+++ b/app/boards/shields/leeloo/leeloo_rev2.keymap
@@ -37,7 +37,7 @@
         compatible = "zmk,keymap";
 
         default_layer {
-            label = " QWERTY";
+            display-name = " QWERTY";
             bindings = <
 &kp ESC    &kp N1     &kp N2     &kp N3     &kp N4     &kp N5                           &kp N6     &kp N7     &kp N8     &kp N9     &kp N0     &kp BSLH
 &kp TAB    &kp Q      &kp W      &kp E      &kp R      &kp T                            &kp Y      &kp U      &kp I      &kp O      &kp P      &kp GRAV
@@ -50,7 +50,7 @@
         };
 
         lower_layer {
-            label = " Lower";
+            display-name = " Lower";
             bindings = <
 &trans     &kp F1     &kp F2     &kp F3     &kp F4     &kp F5                           &kp F6     &kp F7     &kp F8     &kp F9     &kp F10    &kp F11
 &trans     &trans     &trans     &trans     &trans     &trans                           &kp PG_UP  &kp HOME   &kp UP     &kp END    &trans     &kp F12
@@ -63,7 +63,7 @@
         };
 
         raise_layer {
-            label = " Raise";
+            display-name = " Raise";
             bindings = <
 &trans     &trans     &trans     &trans     &trans     &trans                           &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans
 &trans     &trans     &trans     &trans     &trans     &trans                           &trans        &trans        &trans        &trans        &sys_reset    &bootloader

--- a/app/boards/shields/leeloo_micro/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/leeloo_micro/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/leeloo_micro/leeloo_micro.dtsi
+++ b/app/boards/shields/leeloo_micro/leeloo_micro.dtsi
@@ -31,7 +31,6 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(3,4) RC(3,5) RC(2,5) RC(2,6) RC(2,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
 
@@ -45,7 +44,6 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(3,4) RC(3,5) RC(2,5) RC(2,6) RC(2,7) 
 
     left_encoder: left_encoder {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         status = "disabled";
@@ -54,7 +52,6 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(3,4) RC(3,5) RC(2,5) RC(2,6) RC(2,7) 
 
     right_encoder: right_encoder {
         compatible = "alps,ec11";
-        label = "RIGHT_ENCODER";
         a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         status = "disabled";
@@ -75,7 +72,6 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(3,4) RC(3,5) RC(2,5) RC(2,6) RC(2,7) 
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/leeloo_micro/leeloo_micro.keymap
+++ b/app/boards/shields/leeloo_micro/leeloo_micro.keymap
@@ -73,7 +73,7 @@
         compatible = "zmk,keymap";
 
         default_layer {
-            label = " QWERTY";
+            display-name = " QWERTY";
             bindings = <
 &kp Q      &kp W      &kp E      &kp R      &kp T                            &kp Y      &kp U      &kp I      &kp O      &kp P
 &kp A      &kp S      &kp D      &kp F      &kp G                            &kp H      &kp J      &kp K      &kp L      &kp SEMI
@@ -85,7 +85,7 @@
         };
 
         lower_layer {
-            label = " Lower";
+            display-name = " Lower";
             bindings = <
 &kp N1     &kp N2     &kp N3     &kp N4     &kp N5                           &kp N6     &kp N7     &kp N8     &kp N9     &kp N0
 &trans     &trans     &trans     &trans     &trans                           &trans     &trans     &trans     &trans     &kp QUOT
@@ -97,7 +97,7 @@
         };
 
         raise_layer {
-            label = " Raise";
+            display-name = " Raise";
             bindings = <
 &kp TAB    &trans     &trans     &trans     &trans                           &kp PG_UP  &kp HOME   &kp UP     &kp END    &kp BSLH
 &kp CAPS   &trans     &trans     &trans     &trans                           &kp PG_DN  &kp LEFT   &kp DOWN   &kp RIGHT  &kp GRAVE
@@ -109,7 +109,7 @@
         };
 
         adjust_layer {
-            label = " Adjust";
+            display-name = " Adjust";
             bindings = <
 
 &kp F1     &kp F2     &kp F3     &kp F4     &kp F5                           &trans     &trans     &trans     &trans     &trans
@@ -122,7 +122,7 @@
         };
 
         numpad_layer {
-            label = " NumPad";
+            display-name = " NumPad";
             bindings = <
 
 &trans     &none      &none      &none      &none                            &kp SLASH  &kp N7     &kp N8     &kp N9     &kp MINUS
@@ -135,7 +135,7 @@ RGBOFF     RGBEFF     RGBHUD     RGBSAD     RGBBRD     &trans     &trans     &no
         };
 
         ble_layer {
-            label = " BLE";
+            display-name = " BLE";
             bindings = <
 
 &bt BT0    &bt BT1    &bt BT2    &bt BT3    &bt BT4                          &bt BT0    &bt BT1    &bt BT2    &bt BT3    &bt BT4

--- a/app/boards/shields/lily58/boards/nice_nano.overlay
+++ b/app/boards/shields/lily58/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/lily58/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/lily58/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/lily58/lily58.dtsi
+++ b/app/boards/shields/lily58/lily58.dtsi
@@ -33,7 +33,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -48,7 +47,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -67,7 +65,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/lotus58/lotus58.dtsi
+++ b/app/boards/shields/lotus58/lotus58.dtsi
@@ -33,7 +33,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5)  RC(4,6)  RC(3,6) RC(3,7
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -47,7 +46,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5)  RC(4,6)  RC(3,6) RC(3,7
 
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -56,7 +54,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5)  RC(4,6)  RC(3,6) RC(3,7
 
     right_encoder: encoder_right {
         compatible = "alps,ec11";
-        label = "RIGHT_ENCODER";
         a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -76,7 +73,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5)  RC(4,6)  RC(3,6) RC(3,7
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/lotus58/lotus58.keymap
+++ b/app/boards/shields/lotus58/lotus58.keymap
@@ -23,21 +23,18 @@
     behaviors {
         fofunc: four_ffour {
             compatible = "zmk,behavior-mod-morph";
-            label = "FOUR_FUNCFOUR";
             #binding-cells = <0>;
             bindings = <&kp N4>, <&kp F4>;
             mods = <(MOD_LALT|MOD_RALT)>;
         };
         sleft: s_left {
             compatible = "zmk,behavior-mod-morph";
-            label = "S_LEFT";
             #binding-cells = <0>;
             bindings = <&kp S>, <&kp LEFT>;
             mods = <(MOD_LGUI|MOD_RGUI)>;
         };
         fright: f_right {
             compatible = "zmk,behavior-mod-morph";
-            label = "R_RIGHT";
             #binding-cells = <0>;
             bindings = <&kp F>, <&kp RIGHT>;
             mods = <(MOD_LGUI|MOD_RGUI)>;

--- a/app/boards/shields/m60/m60.overlay
+++ b/app/boards/shields/m60/m60.overlay
@@ -14,7 +14,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios

--- a/app/boards/shields/microdox/boards/nice_nano.overlay
+++ b/app/boards/shields/microdox/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/microdox/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/microdox/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/microdox/microdox.dtsi
+++ b/app/boards/shields/microdox/microdox.dtsi
@@ -9,7 +9,6 @@
 / {
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
         row-gpios
             = <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>

--- a/app/boards/shields/microdox/microdox_common.dtsi
+++ b/app/boards/shields/microdox/microdox_common.dtsi
@@ -38,7 +38,6 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4)  RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9)
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/microdox/microdox_v2.dtsi
+++ b/app/boards/shields/microdox/microdox_v2.dtsi
@@ -9,7 +9,6 @@
 / {
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
     };
 };

--- a/app/boards/shields/murphpad/boards/nice_nano.overlay
+++ b/app/boards/shields/murphpad/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/murphpad/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/murphpad/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/murphpad/murphpad.keymap
+++ b/app/boards/shields/murphpad/murphpad.keymap
@@ -56,7 +56,7 @@
         compatible = "zmk,keymap";
 
         default_layer {
-            label = "default layer";
+            display-name = "default layer";
             bindings = <
                 &bt BT_CLR       &kp TAB      &kp F5          &kp LC(LA(C))     &kp LG(D)
                 &rgb_ug RGB_TOG  &kp ESC      &kp KP_DIVIDE   &kp KP_MULTIPLY   &kp KP_MINUS
@@ -70,7 +70,7 @@
         };
 
         fn_layer {
-            label = "fn layer";
+            display-name = "fn layer";
             bindings = <
                 &trans      &trans     &trans        &trans          &trans
                 &trans      &kp KP_NUM &trans        &trans          &trans

--- a/app/boards/shields/murphpad/murphpad.overlay
+++ b/app/boards/shields/murphpad/murphpad.overlay
@@ -14,7 +14,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -36,7 +35,6 @@
 
     encoder_1: encoder_1 {
         compatible = "alps,ec11";
-        label = "Encoder 1";
         a-gpios = <&pro_micro 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 7 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -45,7 +43,6 @@
 
     encoder_2: encoder_2 {
         compatible = "alps,ec11";
-        label = "Encoder 2";
         a-gpios = <&pro_micro 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -60,7 +57,6 @@
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/naked60/naked60.overlay
+++ b/app/boards/shields/naked60/naked60.overlay
@@ -11,7 +11,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/nibble/boards/nice_nano.overlay
+++ b/app/boards/shields/nibble/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/nibble/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/nibble/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/nibble/nibble.keymap
+++ b/app/boards/shields/nibble/nibble.keymap
@@ -19,7 +19,7 @@
         compatible = "zmk,keymap";
 
         default_layer {
-            label = "Default";
+            display-name = "Default";
 
             sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;
 
@@ -32,7 +32,7 @@
             >;
         };
         function_layer {
-            label = "Function";
+            display-name = "Function";
 
             sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;
 

--- a/app/boards/shields/nibble/nibble.overlay
+++ b/app/boards/shields/nibble/nibble.overlay
@@ -15,7 +15,6 @@
 
     encoder_1: encoder_1 {
         compatible = "alps,ec11";
-        label = "Encoder 1";
         a-gpios = <&pro_micro 9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -24,7 +23,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-demux";
-        label = "KSCAN";
         polling-interval-msec = <25>;
         input-gpios
             = <&pro_micro 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
@@ -62,7 +60,6 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3)                 RC(4,6)                 RC(4,9) 
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/nice_view/nice_view.overlay
+++ b/app/boards/shields/nice_view/nice_view.overlay
@@ -8,7 +8,6 @@
     status = "okay";
     nice_view: ls0xx@0 {
         compatible = "sharp,ls0xx";
-        label = "DISPLAY";
         spi-max-frequency = <1000000>;
         reg = <0>;
         width = <160>;

--- a/app/boards/shields/nice_view/widgets/status.c
+++ b/app/boards/shields/nice_view/widgets/status.c
@@ -276,7 +276,7 @@ static void layer_status_update_cb(struct layer_status_state state) {
 
 static struct layer_status_state layer_status_get_state(const zmk_event_t *eh) {
     uint8_t index = zmk_keymap_highest_layer_active();
-    return (struct layer_status_state){.index = index, .label = zmk_keymap_layer_label(index)};
+    return (struct layer_status_state){.index = index, .label = zmk_keymap_layer_name(index)};
 }
 
 ZMK_DISPLAY_WIDGET_LISTENER(widget_layer_status, struct layer_status_state, layer_status_update_cb,

--- a/app/boards/shields/osprette/osprette.overlay
+++ b/app/boards/shields/osprette/osprette.overlay
@@ -26,7 +26,6 @@ RC(0,0) RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) 
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "row2col";
 
         col-gpios

--- a/app/boards/shields/pancake/pancake.overlay
+++ b/app/boards/shields/pancake/pancake.overlay
@@ -11,7 +11,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/qaz/qaz.keymap
+++ b/app/boards/shields/qaz/qaz.keymap
@@ -16,7 +16,6 @@
     behaviors {
         hm: homerow_mods {
             compatible = "zmk,behavior-hold-tap";
-            label = "homerow mods";
             #binding-cells = <2>;
             tapping-term-ms = <225>;
             flavor = "tap-preferred";

--- a/app/boards/shields/qaz/qaz.overlay
+++ b/app/boards/shields/qaz/qaz.overlay
@@ -27,7 +27,6 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/quefrency/quefrency_left.overlay
+++ b/app/boards/shields/quefrency/quefrency_left.overlay
@@ -12,7 +12,6 @@
      */
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
 

--- a/app/boards/shields/quefrency/quefrency_right.overlay
+++ b/app/boards/shields/quefrency/quefrency_right.overlay
@@ -17,7 +17,6 @@
      */
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
 

--- a/app/boards/shields/redox/boards/nice_nano.overlay
+++ b/app/boards/shields/redox/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/redox/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/redox/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/redox/redox.dtsi
+++ b/app/boards/shields/redox/redox.dtsi
@@ -32,7 +32,6 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3)      RC(4,4)    RC(4,5) RC(4,6) RC(4,7) RC(4,8) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios

--- a/app/boards/shields/reviung34/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/reviung34/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/reviung34/reviung34.keymap
+++ b/app/boards/shields/reviung34/reviung34.keymap
@@ -25,7 +25,7 @@
         compatible = "zmk,keymap";
 
         base {
-            label = "Base";
+            display-name = "Base";
             bindings = <
 &kp Q       &kp W       &kp E      &kp R &kp T    &kp Y      &kp U       &kp I          &kp O         &kp P
 &kp A       &kp S       &kp D      &kp F &kp G    &kp H      &kp J       &kp K          &kp L         &kp SEMI
@@ -35,7 +35,7 @@
         };
 
         lower {
-            label = "Lower";
+            display-name = "Lower";
             bindings = <
 &kp EXCL &kp AT    &kp HASH &kp DLLR &kp PRCNT &kp CARET &kp AMPS  &kp ASTRK &kp LPAR &kp RPAR
 &trans   &kp TILDE &kp DQT  &kp PIPE &trans    &trans    &kp UNDER &kp PLUS  &kp LBRC &kp RBRC
@@ -45,7 +45,7 @@
         };
 
         upper {
-            label = "Upper";
+            display-name = "Upper";
             bindings = <
 &kp N1 &kp N2    &kp N3  &kp N4   &kp N5 &kp N6 &kp N7    &kp N8    &kp N9   &kp N0
 &trans &kp GRAVE &kp SQT &kp BSLH &trans &trans &kp MINUS &kp EQUAL &kp LBKT &kp RBKT
@@ -55,7 +55,7 @@
         };
 
         function {
-            label = "Function";
+            display-name = "Function";
             bindings = <
 &kp TAB &trans       &kp C_VOL_UP &trans       &trans    &trans &trans   &trans   &trans &kp ENTER
 &kp ESC &kp C_BRI_DN &kp C_VOL_DN &kp C_BRI_UP &trans    &trans &kp LEFT &kp DOWN &kp UP &kp RIGHT
@@ -65,7 +65,7 @@
         };
 
         meta {
-            label = "Meta";
+            display-name = "Meta";
             bindings = <
 &rgb_ug RGB_HUI &rgb_ug RGB_SAI &rgb_ug RGB_BRI &rgb_ug RGB_SPI &rgb_ug RGB_EFF &none        &none        &none        &none        &none
 &rgb_ug RGB_HUD &rgb_ug RGB_SAD &rgb_ug RGB_BRD &rgb_ug RGB_SPD &rgb_ug RGB_EFR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4

--- a/app/boards/shields/reviung34/reviung34.overlay
+++ b/app/boards/shields/reviung34/reviung34.overlay
@@ -38,7 +38,6 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(3,7)
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/reviung41/boards/nice_nano.overlay
+++ b/app/boards/shields/reviung41/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/reviung41/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/reviung41/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/reviung41/reviung41.overlay
+++ b/app/boards/shields/reviung41/reviung41.overlay
@@ -27,7 +27,6 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(5,0) RC(5,1) RC(5,2) RC(5,3) 
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/reviung5/reviung5.keymap
+++ b/app/boards/shields/reviung5/reviung5.keymap
@@ -17,7 +17,7 @@
             compatible = "zmk,keymap";
 
             base_layer {
-              label = "BASE";
+              display-name = "BASE";
               bindings = <
                 // ╭─────────────┬──────────────┬──────────────────┬─────────────┬─────────────╮
                      &mo BLE      &kp C_PREVIOUS  &kp C_PLAY_PAUSE    &kp C_NEXT   &kp C_MUTE
@@ -27,7 +27,7 @@
             };
 
             ble_layer {
-              label = "BLE";
+              display-name = "BLE";
               bindings = <
                 // ╭─────────────┬─────────────┬─────────────┬─────────────┬─────────────╮
                      &trans     &out OUT_TOG   &bt BT_PRV    &bt BT_NXT    &bt BT_CLR

--- a/app/boards/shields/reviung5/reviung5.overlay
+++ b/app/boards/shields/reviung5/reviung5.overlay
@@ -22,7 +22,6 @@
 
     kscan0: kscan_0 {
             compatible = "zmk,kscan-gpio-matrix";
-            label = "KSCAN";
             diode-direction = "col2row";
 
             col-gpios
@@ -40,7 +39,6 @@
 
     encoder: encoder {
         compatible = "alps,ec11";
-        label = "encoder";
         a-gpios = <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;

--- a/app/boards/shields/reviung53/boards/nice_nano.overlay
+++ b/app/boards/shields/reviung53/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/reviung53/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/reviung53/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/reviung53/reviung53.overlay
+++ b/app/boards/shields/reviung53/reviung53.overlay
@@ -28,7 +28,6 @@ RC(6,0) RC(6,1) RC(6,2)      RC(6,3)         RC(6,4)                    RC(6,5) 
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios

--- a/app/boards/shields/romac/romac.overlay
+++ b/app/boards/shields/romac/romac.overlay
@@ -13,7 +13,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios

--- a/app/boards/shields/romac_plus/boards/nice_nano.overlay
+++ b/app/boards/shields/romac_plus/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/romac_plus/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/romac_plus/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/romac_plus/romac_plus.dtsi
+++ b/app/boards/shields/romac_plus/romac_plus.dtsi
@@ -27,7 +27,6 @@ RC(3,0) RC(3,1) RC(3,2)
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -40,7 +39,6 @@ RC(3,0) RC(3,1) RC(3,2)
 
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;

--- a/app/boards/shields/romac_plus/romac_plus.overlay
+++ b/app/boards/shields/romac_plus/romac_plus.overlay
@@ -13,7 +13,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
 

--- a/app/boards/shields/settings_reset/settings_reset.overlay
+++ b/app/boards/shields/settings_reset/settings_reset.overlay
@@ -13,7 +13,6 @@
 
     kscan0: kscan {
         compatible = "zmk,kscan-mock";
-        label = "KSCAN";
         columns = <1>;
         rows = <0>;
 

--- a/app/boards/shields/snap/boards/nice_nano.overlay
+++ b/app/boards/shields/snap/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/snap/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/snap/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/snap/snap.dtsi
+++ b/app/boards/shields/snap/snap.dtsi
@@ -15,14 +15,12 @@
 
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         steps = <80>;
         status = "disabled";
     };
 
     right_encoder: encoder_right {
         compatible = "alps,ec11";
-        label = "RIGHT_ENCODER";
         steps = <80>;
         status = "disabled";
     };
@@ -51,7 +49,6 @@ RC(5,7) RC(5,6) RC(5,5) RC(5,4)         RC(5,2)         RC(5,0)    RC(5,15)     
 
     kscan_composite: kscan {
         compatible = "zmk,kscan-composite";
-        label = "KSCAN";
         rows = <6>;
         columns = <17>;
 
@@ -62,7 +59,6 @@ RC(5,7) RC(5,6) RC(5,5) RC(5,4)         RC(5,2)         RC(5,0)    RC(5,15)     
 
     kscan_demux: kscan_demux {
         compatible = "zmk,kscan-gpio-demux";
-        label = "DEMUX";
         polling-interval-msec = <25>;
     };
 };
@@ -73,7 +69,6 @@ RC(5,7) RC(5,6) RC(5,5) RC(5,4)         RC(5,2)         RC(5,0)    RC(5,15)     
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/snap/snap.keymap
+++ b/app/boards/shields/snap/snap.keymap
@@ -20,7 +20,7 @@
         compatible = "zmk,keymap";
 
         default_layer {
-            label = "Default";
+            display-name = "Default";
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN &inc_dec_kp C_VOL_UP C_VOL_DN>;
             bindings = <
              &kp ESC     &kp F1   &kp F2   &kp F3   &kp F4   &kp F5   &kp F6     &kp F7   &kp F8   &kp F9    &kp F10  &kp F11     &kp F12     &kp KP_NUM   &kp PAUSE_BREAK
@@ -33,7 +33,7 @@
         };
 
         function_layer {
-            label = "Function";
+            display-name = "Function";
             sensor-bindings = <&inc_dec_kp C_NEXT C_PREV &inc_dec_kp C_NEXT C_PREV>;
             bindings = <
              &bootloader &trans   &trans   &trans   &trans   &trans   &trans     &trans   &trans   &trans   &trans    &trans      &trans      &trans       &bootloader

--- a/app/boards/shields/snap/snap_right.overlay
+++ b/app/boards/shields/snap/snap_right.overlay
@@ -9,7 +9,6 @@
 / {
 kscan_direct: kscan_direct {
     compatible = "zmk,kscan-gpio-direct";
-    label = "DIRECT";
     input-gpios
         = <&pro_micro 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
         ;

--- a/app/boards/shields/sofle/boards/nice_nano.overlay
+++ b/app/boards/shields/sofle/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/sofle/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/sofle/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/sofle/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/sofle/boards/nrfmicro_11.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/sofle/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/sofle/boards/nrfmicro_13.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/sofle/sofle.dtsi
+++ b/app/boards/shields/sofle/sofle.dtsi
@@ -33,7 +33,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -47,7 +46,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -56,7 +54,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     right_encoder: encoder_right {
         compatible = "alps,ec11";
-        label = "RIGHT_ENCODER";
         a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -76,7 +73,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/sofle/sofle.keymap
+++ b/app/boards/shields/sofle/sofle.keymap
@@ -30,7 +30,7 @@
         compatible = "zmk,keymap";
 
         default_layer {
-            label = "default";
+            display-name = "default";
 // ------------------------------------------------------------------------------------------------------------
 // |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |       |
 // |  ESC  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   | BKSPC |
@@ -49,7 +49,7 @@
         };
 
         lower_layer {
-            label = "lower";
+            display-name = "lower";
 // TODO: Some binds are waiting for shifted keycode support.
 // ------------------------------------------------------------------------------------------------------------
 // |       |  F1 |  F2 |  F3  |  F4  |  F5  |                   |  F6  |  F7   |  F8   |  F9  |  F10  |  F11  |
@@ -69,7 +69,7 @@
         };
 
         raise_layer {
-            label = "raise";
+            display-name = "raise";
 // ------------------------------------------------------------------------------------------------------------
 // | BTCLR | BT1  | BT2  |  BT3  |  BT4  |  BT5 |                |      |      |       |      |       |       |
 // |       | INS  | PSCR | GUI   |       |      |                | PGUP |      |   ^   |      |       |       |
@@ -94,7 +94,7 @@
 // |        | RGB_BRD | RGB_BRI |         |         |         |                  |      |      |       |      |       |       |
 // |        |         |         |         |         |         | RGB_TOG | |      |      |      |       |      |       |       |
 //                    |         |         |         |         |         | |      |      |      |       |      |
-            label = "adjust";
+            display-name = "adjust";
             bindings = <
 &bt BT_CLR        &bt BT_SEL 0    &bt BT_SEL 1    &bt BT_SEL 2    &bt BT_SEL 3    &bt BT_SEL 4                            &none &none &none &none &none &none
 &ext_power EP_TOG &rgb_ug RGB_HUD &rgb_ug RGB_HUI &rgb_ug RGB_SAD &rgb_ug RGB_SAI &rgb_ug RGB_EFF                         &none &none &none &none &none &none

--- a/app/boards/shields/splitkb_aurora_corne/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_corne/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.dtsi
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.dtsi
@@ -47,7 +47,6 @@ RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10
 
     left_encoder: left_encoder {
         compatible = "alps,ec11";
-        label = "L_ENCODER";
         steps = <80>;
         status = "disabled";
 
@@ -57,7 +56,6 @@ RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10
 
     right_encoder: right_encoder {
         compatible = "alps,ec11";
-        label = "R_ENCODER";
         steps = <80>;
         status = "disabled";
 
@@ -78,7 +76,6 @@ RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)  RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_left.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_left.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "col2row";
 
         row-gpios

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_right.overlay
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne_right.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "col2row";
 
         row-gpios

--- a/app/boards/shields/splitkb_aurora_helix/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_helix/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_helix/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_helix/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.dtsi
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.dtsi
@@ -33,7 +33,6 @@
 
     left_encoder: left_encoder {
         compatible = "alps,ec11";
-        label = "L_ENCODER";
         steps = <144>;
         status = "disabled";
 
@@ -43,7 +42,6 @@
 
     right_encoder: right_encoder {
         compatible = "alps,ec11";
-        label = "R_ENCODER";
         steps = <144>;
         status = "disabled";
 
@@ -64,7 +62,6 @@
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix_left.overlay
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix_left.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "col2row";
 
         row-gpios

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix_right.overlay
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix_right.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "col2row";
 
         row-gpios

--- a/app/boards/shields/splitkb_aurora_lily58/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_lily58/boards/nice_nano.overlay
@@ -26,7 +26,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_lily58/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_lily58/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58.dtsi
+++ b/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58.dtsi
@@ -33,7 +33,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,1) RC(4,10) RC(3,6) RC(3,7)
 
     left_encoder: left_encoder {
         compatible = "alps,ec11";
-        label = "L_ENCODER";
         steps = <80>;
         status = "disabled";
 
@@ -43,7 +42,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,1) RC(4,10) RC(3,6) RC(3,7)
 
     right_encoder: right_encoder {
         compatible = "alps,ec11";
-        label = "R_ENCODER";
         steps = <80>;
         status = "disabled";
 
@@ -64,7 +62,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,1) RC(4,10) RC(3,6) RC(3,7)
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58_left.overlay
+++ b/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58_left.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "row2col";
 
         row-gpios

--- a/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58_right.overlay
+++ b/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58_right.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "row2col";
 
         row-gpios

--- a/app/boards/shields/splitkb_aurora_sofle/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_sofle/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_sofle/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_sofle/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.dtsi
+++ b/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.dtsi
@@ -33,7 +33,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     left_encoder: left_encoder {
         compatible = "alps,ec11";
-        label = "L_ENCODER";
         steps = <144>;
         status = "disabled";
 
@@ -43,7 +42,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
 
     right_encoder: right_encoder {
         compatible = "alps,ec11";
-        label = "R_ENCODER";
         steps = <144>;
         status = "disabled";
 
@@ -64,7 +62,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle_left.overlay
+++ b/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle_left.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "col2row";
 
         row-gpios

--- a/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle_right.overlay
+++ b/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle_right.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "col2row";
 
         row-gpios

--- a/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.dtsi
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.dtsi
@@ -27,28 +27,24 @@
 
     left_encoder1: left_encoder1 {
         compatible = "alps,ec11";
-        label = "L_ENCODER1";
         steps = <80>;
         status = "disabled";
     };
 
     left_encoder2: left_encoder2 {
         compatible = "alps,ec11";
-        label = "L_ENCODER2";
         steps = <80>;
         status = "disabled";
     };
 
     right_encoder1: right_encoder1 {
         compatible = "alps,ec11";
-        label = "R_ENCODER1";
         steps = <80>;
         status = "disabled";
     };
 
     right_encoder2: right_encoder2 {
         compatible = "alps,ec11";
-        label = "R_ENCODER2";
         steps = <80>;
         status = "disabled";
     };
@@ -66,7 +62,6 @@
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep_left.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep_left.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "row2col";
 
         row-gpios

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep_right.overlay
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep_right.overlay
@@ -13,8 +13,6 @@
 
     kscan: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
-        label = "KSCAN";
         diode-direction = "row2col";
 
         row-gpios

--- a/app/boards/shields/splitreus62/splitreus62.dtsi
+++ b/app/boards/shields/splitreus62/splitreus62.dtsi
@@ -34,7 +34,6 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5)                 RC(4,6) RC(4,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "row2col";
         row-gpios

--- a/app/boards/shields/tg4x/boards/nice_nano.overlay
+++ b/app/boards/shields/tg4x/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/tg4x/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/tg4x/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/tg4x/tg4x.keymap
+++ b/app/boards/shields/tg4x/tg4x.keymap
@@ -12,7 +12,6 @@
     behaviors {
         ht: hold_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "Hold Tap";
             #binding-cells = <2>;
             tapping-term-ms = <200>;
             flavor = "tap-preferred";

--- a/app/boards/shields/tg4x/tg4x.overlay
+++ b/app/boards/shields/tg4x/tg4x.overlay
@@ -9,7 +9,6 @@
 / {
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
 

--- a/app/boards/shields/tidbit/boards/nice_nano.overlay
+++ b/app/boards/shields/tidbit/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/tidbit/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/tidbit/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/tidbit/tidbit.dtsi
+++ b/app/boards/shields/tidbit/tidbit.dtsi
@@ -9,7 +9,6 @@
 / {
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "row2col";
 
@@ -46,7 +45,6 @@
 
     encoder_1_top_row: encoder_1_top_row {
         compatible = "alps,ec11";
-        label = "Top Row Encoder";
         a-gpios = <&pro_micro 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -55,7 +53,6 @@
 
     encoder_1: encoder_1 {
         compatible = "alps,ec11";
-        label = "Encoder 1";
         a-gpios = <&pro_micro 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 16 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -64,7 +61,6 @@
 
     encoder_2: encoder_2 {
         compatible = "alps,ec11";
-        label = "Encoder 2";
         a-gpios = <&pro_micro 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 9 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -73,7 +69,6 @@
 
     encoder_3: encoder_3 {
         compatible = "alps,ec11";
-        label = "Encoder 3";
         a-gpios = <&pro_micro 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -82,7 +77,6 @@
 
     encoder_4: encoder_4 {
         compatible = "alps,ec11";
-        label = "Encoder 4";
         a-gpios = <&pro_micro 1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <80>;
@@ -102,7 +96,6 @@
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <32>;
         segment-offset = <0>;

--- a/app/boards/shields/two_percent_milk/boards/nice_nano.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nice_nano.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/two_percent_milk/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nice_nano_v2.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/two_percent_milk/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nrfmicro_11.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/two_percent_milk/boards/nrfmicro_11_flipped.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nrfmicro_11_flipped.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/two_percent_milk/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/two_percent_milk/boards/nrfmicro_13.overlay
@@ -25,7 +25,6 @@
 
     led_strip: ws2812@0 {
         compatible = "worldsemi,ws2812-spi";
-        label = "WS2812";
 
         /* SPI */
         reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/app/boards/shields/two_percent_milk/two_percent_milk.overlay
+++ b/app/boards/shields/two_percent_milk/two_percent_milk.overlay
@@ -12,8 +12,6 @@
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-direct";
 
-        label = "KSCAN";
-
         input-gpios
             = <&pro_micro 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
             , <&pro_micro 5 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>

--- a/app/boards/shields/waterfowl/waterfowl.dtsi
+++ b/app/boards/shields/waterfowl/waterfowl.dtsi
@@ -31,7 +31,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)                                 RC(3,5) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -44,7 +43,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)                                 RC(3,5) 
 
     roller_left_encoder: encoder_left_roller {
         compatible = "alps,ec11";
-        label = "ROLLER_LEFT_ENCODER";
         a-gpios = <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -53,7 +51,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)                                 RC(3,5) 
 
     dial_left_encoder: encoder_left_dial {
         compatible = "alps,ec11";
-        label = "DIAL_LEFT_ENCODER";
         a-gpios = <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -62,7 +59,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)                                 RC(3,5) 
 
     roller_right_encoder: encoder_right_roller {
         compatible = "alps,ec11";
-        label = "ROLLER_RIGHT_ENCODER";
         a-gpios = <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 9 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -71,7 +67,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)                                 RC(3,5) 
 
     dial_right_encoder: encoder_right_dial {
         compatible = "alps,ec11";
-        label = "DIAL_RIGHT_ENCODER";
         a-gpios = <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -98,7 +93,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)                                 RC(3,5) 
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <64>;
         segment-offset = <0>;

--- a/app/boards/shields/zmk_uno/zmk_uno.overlay
+++ b/app/boards/shields/zmk_uno/zmk_uno.overlay
@@ -49,15 +49,12 @@ nice_view_spi: &arduino_spi {
     // Commented out until we add more powerful power domain support
     // external_power {
         //  compatible = "zmk,ext-power-generic";
-        //  label = "EXT_POWER";
         //  init-delay-ms = <200>;
         //  control-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>;
     // };
 
     rgb_power {
         compatible = "zmk,ext-power-generic";
-        label = "EXT_POWER";
-        // label = "RGB_POWER";
         init-delay-ms = <200>;
         control-gpios = <&arduino_header 1 GPIO_ACTIVE_LOW>;
     };

--- a/app/boards/shields/zmk_uno/zmk_uno.overlay
+++ b/app/boards/shields/zmk_uno/zmk_uno.overlay
@@ -61,10 +61,8 @@ nice_view_spi: &arduino_spi {
 
     backlight: gpioleds {
         compatible = "gpio-leds";
-        label = "Backlight LEDs";
         gpio_led_0 {
             gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;
-            label = "Backlight LED 0";
         };
     };
 
@@ -97,8 +95,6 @@ nice_view_spi: &arduino_spi {
         rows = <1>;
         columns = <7>;
 
-        label = "KSCAN_MATRIX_COMP";
-
         matrix {
             kscan = <&kscan_matrix>;
         };
@@ -112,8 +108,6 @@ nice_view_spi: &arduino_spi {
 
     kscan_direct_comp: kscan_direct_comp {
         compatible = "zmk,kscan-composite";
-
-        label = "KSCAN_DIRECT_COMP";
         status = "disabled";
 
         matrix {
@@ -169,7 +163,6 @@ nice_view_spi: &arduino_spi {
     };
 
     encoder: encoder {
-        label = "ENCODER";
         steps = <80>;
         compatible = "alps,ec11";
         a-gpios = <&arduino_header 15 GPIO_PULL_UP>;

--- a/app/boards/shields/zodiark/zodiark.dtsi
+++ b/app/boards/shields/zodiark/zodiark.dtsi
@@ -33,7 +33,6 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4)      RC(4,5)    RC(4,6)   RC(4,7)      R
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -47,7 +46,6 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4)      RC(4,5)    RC(4,6)   RC(4,7)      R
 
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -56,7 +54,6 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4)      RC(4,5)    RC(4,6)   RC(4,7)      R
 
     right_encoder: encoder_right {
         compatible = "alps,ec11";
-        label = "RIGHT_ENCODER";
         a-gpios = <&pro_micro 4 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -76,7 +73,6 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4)      RC(4,5)    RC(4,6)   RC(4,7)      R
     oled: ssd1306@3c {
         compatible = "solomon,ssd1306fb";
         reg = <0x3c>;
-        label = "DISPLAY";
         width = <128>;
         height = <64>;
         segment-offset = <0>;

--- a/app/boards/usb_console.dtsi
+++ b/app/boards/usb_console.dtsi
@@ -14,7 +14,6 @@
 &usbd {
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
-        label = "CDC_ACM_0";
     };
 };
 

--- a/app/dts/behaviors/backlight.dtsi
+++ b/app/dts/behaviors/backlight.dtsi
@@ -6,9 +6,9 @@
 
  / {
     behaviors {
-        /omit-if-no-ref/ bl: behavior_backlight {
+        // Behavior can be invoked on peripherals, so name must be <= 8 characters.
+        /omit-if-no-ref/ bl: bcklight {
             compatible = "zmk,behavior-backlight";
-            label = "BCKLGHT";
             #binding-cells = <2>;
         };
     };

--- a/app/dts/behaviors/bluetooth.dtsi
+++ b/app/dts/behaviors/bluetooth.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ bt: behavior_bluetooth {
+        /omit-if-no-ref/ bt: bluetooth {
             compatible = "zmk,behavior-bluetooth";
-            label = "BLUETOOTH";
             #binding-cells = <2>;
         };
     };

--- a/app/dts/behaviors/caps_word.dtsi
+++ b/app/dts/behaviors/caps_word.dtsi
@@ -8,9 +8,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ caps_word: behavior_caps_word {
+        /omit-if-no-ref/ caps_word: caps_word {
             compatible = "zmk,behavior-caps-word";
-            label = "CAPS_WORD";
             #binding-cells = <0>;
             continue-list = <UNDERSCORE BACKSPACE DELETE>;
         };

--- a/app/dts/behaviors/ext_power.dtsi
+++ b/app/dts/behaviors/ext_power.dtsi
@@ -6,9 +6,9 @@
 
 / {
     behaviors {
-        ext_power: behavior_ext_power {
+        // Behavior can be invoked on peripherals, so name must be <= 8 characters.
+        ext_power: extpower {
             compatible = "zmk,behavior-ext-power";
-            label = "EXTPOWER";
             #binding-cells = <1>;
         };
     };

--- a/app/dts/behaviors/gresc.dtsi
+++ b/app/dts/behaviors/gresc.dtsi
@@ -10,7 +10,6 @@
     behaviors {
         /omit-if-no-ref/ gresc: grave_escape {
             compatible = "zmk,behavior-mod-morph";
-            label = "GRAVE_ESCAPE";
             #binding-cells = <0>;
             bindings = <&kp ESC>, <&kp GRAVE>;
             mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;

--- a/app/dts/behaviors/key_press.dtsi
+++ b/app/dts/behaviors/key_press.dtsi
@@ -7,9 +7,8 @@
 / {
     behaviors {
         /* DEPRECATED: `cp` will be removed in the future */
-        /omit-if-no-ref/ cp: kp: behavior_key_press {
+        /omit-if-no-ref/ cp: kp: key_press {
             compatible = "zmk,behavior-key-press";
-            label = "KEY_PRESS";
             #binding-cells = <1>;
         };
     };

--- a/app/dts/behaviors/key_repeat.dtsi
+++ b/app/dts/behaviors/key_repeat.dtsi
@@ -8,9 +8,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ key_repeat: behavior_key_repeat {
+        /omit-if-no-ref/ key_repeat: key_repeat {
             compatible = "zmk,behavior-key-repeat";
-            label = "KEY_REPEAT";
             #binding-cells = <0>;
             usage-pages = <HID_USAGE_KEY>;
         };

--- a/app/dts/behaviors/key_toggle.dtsi
+++ b/app/dts/behaviors/key_toggle.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ kt: behavior_key_toggle {
+        /omit-if-no-ref/ kt: key_toggle {
             compatible = "zmk,behavior-key-toggle";
-            label = "KEY_TOGGLE";
             #binding-cells = <1>;
         };
     };

--- a/app/dts/behaviors/layer_tap.dtsi
+++ b/app/dts/behaviors/layer_tap.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ lt: behavior_layer_tap {
+        /omit-if-no-ref/ lt: layer_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "LAYER_TAP";
             #binding-cells = <2>;
             flavor = "tap-preferred";
             tapping-term-ms = <200>;

--- a/app/dts/behaviors/macros.dtsi
+++ b/app/dts/behaviors/macros.dtsi
@@ -5,10 +5,8 @@
  */
 
 #define MACRO_PLACEHOLDER 0
-#define ZMK_MACRO_STRINGIFY(x) #x
 #define ZMK_MACRO(name,...) \
 name: name { \
-    label = ZMK_MACRO_STRINGIFY(ZM_ ## name); \
     compatible = "zmk,behavior-macro"; \
     #binding-cells = <0>; \
     __VA_ARGS__ \
@@ -16,7 +14,6 @@ name: name { \
 
 #define ZMK_MACRO1(name,...) \
 name: name { \
-    label = ZMK_MACRO_STRINGIFY(ZM_ ## name); \
     compatible = "zmk,behavior-macro-one-param"; \
     #binding-cells = <1>; \
     __VA_ARGS__ \
@@ -24,7 +21,6 @@ name: name { \
 
 #define ZMK_MACRO2(name,...) \
 name: name { \
-    label = ZMK_MACRO_STRINGIFY(ZM_ ## name); \
     compatible = "zmk,behavior-macro-two-param"; \
     #binding-cells = <2>; \
     __VA_ARGS__ \
@@ -32,63 +28,53 @@ name: name { \
 
 / {
     behaviors {
-        macro_tap: macro_control_mode_tap {
+        macro_tap: macro_tap {
             compatible = "zmk,macro-control-mode-tap";
-            label = "MAC_TAP";
             #binding-cells = <0>;
         };
 
-        macro_press: macro_control_mode_press {
+        macro_press: macro_press {
             compatible = "zmk,macro-control-mode-press";
-            label = "MAC_PRESS";
             #binding-cells = <0>;
         };
 
-        macro_release: macro_control_mode_release {
+        macro_release: macro_release {
             compatible = "zmk,macro-control-mode-release";
-            label = "MAC_REL";
             #binding-cells = <0>;
         };
 
-        macro_tap_time: macro_control_tap_time {
+        macro_tap_time: macro_tap_time {
             compatible = "zmk,macro-control-tap-time";
-            label = "MAC_TAP_TIME";
             #binding-cells = <1>;
         };
 
-        macro_wait_time: macro_control_wait_time {
+        macro_wait_time: macro_wait_time {
             compatible = "zmk,macro-control-wait-time";
-            label = "MAC_WAIT_TIME";
             #binding-cells = <1>;
         };
 
         macro_pause_for_release: macro_pause_for_release {
             compatible = "zmk,macro-pause-for-release";
-            label = "MAC_WAIT_REL";
             #binding-cells = <0>;
         };
 
         macro_param_1to1: macro_param_1to1 {
             compatible = "zmk,macro-param-1to1";
-            label = "MAC_PARAM_1TO1";
             #binding-cells = <0>;
         };
 
         macro_param_1to2: macro_param_1to2 {
             compatible = "zmk,macro-param-1to2";
-            label = "MAC_PARAM_1TO2";
             #binding-cells = <0>;
         };
 
         macro_param_2to1: macro_param_2to1 {
             compatible = "zmk,macro-param-2to1";
-            label = "MAC_PARAM_2TO1";
             #binding-cells = <0>;
         };
 
         macro_param_2to2: macro_param_2to2 {
             compatible = "zmk,macro-param-2to2";
-            label = "MAC_PARAM_2TO2";
             #binding-cells = <0>;
         };
     };

--- a/app/dts/behaviors/mod_tap.dtsi
+++ b/app/dts/behaviors/mod_tap.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ mt: behavior_mod_tap {
+        /omit-if-no-ref/ mt: mod_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP";
             #binding-cells = <2>;
             flavor = "hold-preferred";
             tapping-term-ms = <200>;

--- a/app/dts/behaviors/momentary_layer.dtsi
+++ b/app/dts/behaviors/momentary_layer.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ mo: behavior_momentary_layer {
+        /omit-if-no-ref/ mo: momentary_layer {
             compatible = "zmk,behavior-momentary-layer";
-            label = "MO";
             #binding-cells = <1>;
         };
     };

--- a/app/dts/behaviors/mouse_key_press.dtsi
+++ b/app/dts/behaviors/mouse_key_press.dtsi
@@ -1,8 +1,7 @@
 / {
     behaviors {
-        /omit-if-no-ref/ mkp: behavior_mouse_key_press {
+        /omit-if-no-ref/ mkp: mouse_key_press {
             compatible = "zmk,behavior-mouse-key-press";
-            label = "MOUSE_KEY_PRESS";
             #binding-cells = <1>;
         };
     };

--- a/app/dts/behaviors/none.dtsi
+++ b/app/dts/behaviors/none.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ none: behavior_none {
+        /omit-if-no-ref/ none: none {
             compatible = "zmk,behavior-none";
-            label = "NONE";
             #binding-cells = <0>;
         };
     };

--- a/app/dts/behaviors/outputs.dtsi
+++ b/app/dts/behaviors/outputs.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ out: behavior_outputs {
+        /omit-if-no-ref/ out: outputs {
             compatible = "zmk,behavior-outputs";
-            label = "OUTPUTS";
             #binding-cells = <1>;
         };
     };

--- a/app/dts/behaviors/reset.dtsi
+++ b/app/dts/behaviors/reset.dtsi
@@ -8,15 +8,15 @@
 
 / {
     behaviors {
-        sys_reset: behavior_reset {
+        // Behavior can be invoked on peripherals, so name must be <= 8 characters.
+        sys_reset: sysreset {
             compatible = "zmk,behavior-reset";
-            label = "SYSRESET";
             #binding-cells = <0>;
         };
 
-        bootloader: behavior_reset_dfu {
+        // Behavior can be invoked on peripherals, so name must be <= 8 characters.
+        bootloader: bootload {
             compatible = "zmk,behavior-reset";
-            label = "BOOTLOAD";
             type = <RST_UF2>;
             #binding-cells = <0>;
         };

--- a/app/dts/behaviors/rgb_underglow.dtsi
+++ b/app/dts/behaviors/rgb_underglow.dtsi
@@ -6,9 +6,9 @@
 
 / {
     behaviors {
-        rgb_ug: behavior_rgb_underglow {
+        // Behavior can be invoked on peripherals, so name must be <= 8 characters.
+        rgb_ug: rgb_ug {
             compatible = "zmk,behavior-rgb-underglow";
-            label = "RGB_UG";
             #binding-cells = <2>;
         };
     };

--- a/app/dts/behaviors/sensor_rotate_key_press.dtsi
+++ b/app/dts/behaviors/sensor_rotate_key_press.dtsi
@@ -7,9 +7,8 @@
 / {
     behaviors {
         /* DEPRECATED: `inc_dec_cp` will be removed in the future */
-        /omit-if-no-ref/ inc_dec_cp: inc_dec_kp: behavior_sensor_rotate_key_press {
+        /omit-if-no-ref/ inc_dec_cp: inc_dec_kp: enc_key_press {
             compatible = "zmk,behavior-sensor-rotate-var";
-            label = "ENC_KEY_PRESS";
             #sensor-binding-cells = <2>;
             bindings = <&kp>, <&kp>;
         };

--- a/app/dts/behaviors/sticky_key.dtsi
+++ b/app/dts/behaviors/sticky_key.dtsi
@@ -6,17 +6,15 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ sk: behavior_sticky_key {
+        /omit-if-no-ref/ sk: sticky_key {
             compatible = "zmk,behavior-sticky-key";
-            label = "STICKY_KEY";
             #binding-cells = <1>;
             release-after-ms = <1000>;
             bindings = <&kp>;
             ignore-modifiers;
         };
-        /omit-if-no-ref/ sl: behavior_sticky_layer {
+        /omit-if-no-ref/ sl: sticky_layer {
             compatible = "zmk,behavior-sticky-key";
-            label = "STICKY_LAYER";
             #binding-cells = <1>;
             release-after-ms = <1000>;
             bindings = <&mo>;

--- a/app/dts/behaviors/to_layer.dtsi
+++ b/app/dts/behaviors/to_layer.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ to: behavior_to_layer {
+        /omit-if-no-ref/ to: to_layer {
             compatible = "zmk,behavior-to-layer";
-            label = "TO_LAYER";
             #binding-cells = <1>;
         };
     };

--- a/app/dts/behaviors/toggle_layer.dtsi
+++ b/app/dts/behaviors/toggle_layer.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ tog: behavior_toggle_layer {
+        /omit-if-no-ref/ tog: toggle_layer {
             compatible = "zmk,behavior-toggle-layer";
-            label = "TOGGLE_LAYER";
             #binding-cells = <1>;
         };
     };

--- a/app/dts/behaviors/transparent.dtsi
+++ b/app/dts/behaviors/transparent.dtsi
@@ -6,9 +6,8 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ trans: behavior_transparent {
+        /omit-if-no-ref/ trans: transparent {
             compatible = "zmk,behavior-transparent";
-            label = "TRANS";
             #binding-cells = <0>;
         };
     };

--- a/app/dts/bindings/behaviors/one_param.yaml
+++ b/app/dts/bindings/behaviors/one_param.yaml
@@ -4,7 +4,8 @@
 properties:
   label:
     type: string
-    required: true
+    required: false
+    deprecated: true
   "#binding-cells":
     type: int
     required: true

--- a/app/dts/bindings/behaviors/two_param.yaml
+++ b/app/dts/bindings/behaviors/two_param.yaml
@@ -4,7 +4,8 @@
 properties:
   label:
     type: string
-    required: true
+    required: false
+    deprecated: true
   "#binding-cells":
     type: int
     required: true

--- a/app/dts/bindings/behaviors/zero_param.yaml
+++ b/app/dts/bindings/behaviors/zero_param.yaml
@@ -4,7 +4,8 @@
 properties:
   label:
     type: string
-    required: true
+    required: false
+    deprecated: true
   "#binding-cells":
     type: int
     required: true

--- a/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate-var.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate-var.yaml
@@ -8,7 +8,8 @@ compatible: "zmk,behavior-sensor-rotate-var"
 properties:
   label:
     type: string
-    required: true
+    required: false
+    deprecated: true
   "#sensor-binding-cells":
     type: int
     required: true

--- a/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate.yaml
@@ -8,7 +8,8 @@ compatible: "zmk,behavior-sensor-rotate"
 properties:
   label:
     type: string
-    required: true
+    required: false
+    deprecated: true
   "#sensor-binding-cells":
     type: int
     required: true

--- a/app/dts/bindings/zmk,ext-power-generic.yaml
+++ b/app/dts/bindings/zmk,ext-power-generic.yaml
@@ -14,7 +14,8 @@ properties:
     required: true
   label:
     type: string
-    required: true
+    required: false
+    deprecated: true
   init-delay-ms:
     type: int
     description: Number of milliseconds to delay after initializing driver

--- a/app/dts/bindings/zmk,keymap.yaml
+++ b/app/dts/bindings/zmk,keymap.yaml
@@ -7,12 +7,19 @@ child-binding:
   description: "A layer to be used in a keymap"
 
   properties:
-    label:
+    display-name:
       type: string
       required: false
+      description: The name of this layer to show on displays
     bindings:
       type: phandle-array
       required: true
     sensor-bindings:
       type: phandle-array
       required: false
+
+    label:
+      type: string
+      required: false
+      deprecated: true
+      description: Deprecated. Use "name" instead.

--- a/app/dts/bindings/zmk,kscan-composite.yaml
+++ b/app/dts/bindings/zmk,kscan-composite.yaml
@@ -6,6 +6,8 @@ compatible: "zmk,kscan-composite"
 properties:
   label:
     type: string
+    required: false
+    deprecated: true
   rows:
     type: int
   columns:
@@ -17,6 +19,8 @@ child-binding:
   properties:
     label:
       type: string
+      required: false
+      deprecated: true
     kscan:
       type: phandle
     row-offset:

--- a/app/dts/bindings/zmk,kscan-mock.yaml
+++ b/app/dts/bindings/zmk,kscan-mock.yaml
@@ -6,6 +6,8 @@ compatible: "zmk,kscan-mock"
 properties:
   label:
     type: string
+    required: false
+    deprecated: true
   event-period:
     type: int
     description: Milliseconds between each generated event

--- a/app/include/linker/zmk-behaviors.ld
+++ b/app/include/linker/zmk-behaviors.ld
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/linker/linker-defs.h>
+
+ITERABLE_SECTION_ROM(zmk_behavior_ref, 4)

--- a/app/include/zmk/behavior.h
+++ b/app/include/zmk/behavior.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <zephyr/device.h>
+
 #define ZMK_BEHAVIOR_OPAQUE 0
 #define ZMK_BEHAVIOR_TRANSPARENT 1
 
@@ -20,3 +22,17 @@ struct zmk_behavior_binding_event {
     uint32_t position;
     int64_t timestamp;
 };
+
+/**
+ * @brief Get a const struct device* for a behavior from its @p name field.
+ *
+ * @param name Behavior name to search for.
+ *
+ * @retval Pointer to the device structure for the behavior with the given name.
+ * @retval NULL if the behavior is not found or its initialization function failed.
+ *
+ * @note This is equivalent to device_get_binding(), except it only searches
+ * behavior devices, so it is faster and there is no chance of it returning an
+ * unrelated node which shares the same name as a behavior.
+ */
+const struct device *zmk_behavior_get_binding(const char *name);

--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -22,7 +22,7 @@ int zmk_keymap_layer_activate(uint8_t layer);
 int zmk_keymap_layer_deactivate(uint8_t layer);
 int zmk_keymap_layer_toggle(uint8_t layer);
 int zmk_keymap_layer_to(uint8_t layer);
-const char *zmk_keymap_layer_label(uint8_t layer);
+const char *zmk_keymap_layer_name(uint8_t layer);
 
 int zmk_keymap_position_state_changed(uint8_t source, uint32_t position, bool pressed,
                                       int64_t timestamp);

--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -29,7 +29,7 @@ int zmk_keymap_position_state_changed(uint8_t source, uint32_t position, bool pr
 
 #define ZMK_KEYMAP_EXTRACT_BINDING(idx, drv_inst)                                                  \
     {                                                                                              \
-        .behavior_dev = DT_PROP(DT_PHANDLE_BY_IDX(drv_inst, bindings, idx), label),                \
+        .behavior_dev = DEVICE_DT_NAME(DT_PHANDLE_BY_IDX(drv_inst, bindings, idx)),                \
         .param1 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(drv_inst, bindings, idx, param1), (0),        \
                               (DT_PHA_BY_IDX(drv_inst, bindings, idx, param1))),                   \
         .param2 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(drv_inst, bindings, idx, param2), (0),        \

--- a/app/module/dts/bindings/sensor/alps,ec11.yaml
+++ b/app/module/dts/bindings/sensor/alps,ec11.yaml
@@ -6,7 +6,8 @@ compatible: "alps,ec11"
 properties:
   label:
     type: string
-    required: true
+    required: false
+    deprecated: true
   a-gpios:
     type: phandle-array
     required: true

--- a/app/src/behavior.c
+++ b/app/src/behavior.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/util_macro.h>
+#include <string.h>
+
+#include <drivers/behavior.h>
+#include <zmk/behavior.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+const struct device *zmk_behavior_get_binding(const char *name) {
+    return behavior_get_binding(name);
+}
+
+const struct device *z_impl_behavior_get_binding(const char *name) {
+    if (name == NULL || name[0] == '\0') {
+        return NULL;
+    }
+
+    STRUCT_SECTION_FOREACH(zmk_behavior_ref, item) {
+        if (z_device_is_ready(item->device) && item->device->name == name) {
+            return item->device;
+        }
+    }
+
+    STRUCT_SECTION_FOREACH(zmk_behavior_ref, item) {
+        if (z_device_is_ready(item->device) && strcmp(item->device->name, name) == 0) {
+            return item->device;
+        }
+    }
+
+    return NULL;
+}
+
+#if IS_ENABLED(CONFIG_LOG)
+static int check_behavior_names(const struct device *dev) {
+    ARG_UNUSED(dev);
+
+    // Behavior names must be unique, but we don't have a good way to enforce this
+    // at compile time, so log an error at runtime if they aren't unique.
+    ptrdiff_t count;
+    STRUCT_SECTION_COUNT(zmk_behavior_ref, &count);
+
+    for (ptrdiff_t i = 0; i < count; i++) {
+        const struct zmk_behavior_ref *current;
+        STRUCT_SECTION_GET(zmk_behavior_ref, i, &current);
+
+        for (ptrdiff_t j = i + 1; j < count; j++) {
+            const struct zmk_behavior_ref *other;
+            STRUCT_SECTION_GET(zmk_behavior_ref, j, &other);
+
+            if (strcmp(current->device->name, other->device->name) == 0) {
+                LOG_ERR("Multiple behaviors have the same name '%s'", current->device->name);
+            }
+        }
+    }
+
+    return 0;
+}
+
+SYS_INIT(check_behavior_names, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+#endif // IS_ENABLED(CONFIG_LOG)

--- a/app/src/behaviors/behavior_backlight.c
+++ b/app/src/behaviors/behavior_backlight.c
@@ -91,7 +91,7 @@ static const struct behavior_driver_api behavior_backlight_driver_api = {
     .locality = BEHAVIOR_LOCALITY_GLOBAL,
 };
 
-DEVICE_DT_INST_DEFINE(0, behavior_backlight_init, NULL, NULL, NULL, APPLICATION,
-                      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_backlight_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_backlight_init, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_backlight_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_bt.c
+++ b/app/src/behaviors/behavior_bt.c
@@ -52,7 +52,7 @@ static const struct behavior_driver_api behavior_bt_driver_api = {
     .binding_released = on_keymap_binding_released,
 };
 
-DEVICE_DT_INST_DEFINE(0, behavior_bt_init, NULL, NULL, NULL, APPLICATION,
-                      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_bt_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_bt_init, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_bt_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -55,7 +55,7 @@ static void deactivate_caps_word(const struct device *dev) {
 
 static int on_caps_word_binding_pressed(struct zmk_behavior_binding *binding,
                                         struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     struct behavior_caps_word_data *data = dev->data;
 
     if (data->active) {
@@ -181,9 +181,9 @@ static int behavior_caps_word_init(const struct device *dev) {
         .continuations = {LISTIFY(DT_INST_PROP_LEN(n, continue_list), BREAK_ITEM, (, ), n)},       \
         .continuations_count = DT_INST_PROP_LEN(n, continue_list),                                 \
     };                                                                                             \
-    DEVICE_DT_INST_DEFINE(n, behavior_caps_word_init, NULL, &behavior_caps_word_data_##n,          \
-                          &behavior_caps_word_config_##n, APPLICATION,                             \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_caps_word_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_caps_word_init, NULL, &behavior_caps_word_data_##n,        \
+                            &behavior_caps_word_config_##n, APPLICATION,                           \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_caps_word_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)
 

--- a/app/src/behaviors/behavior_ext_power.c
+++ b/app/src/behaviors/behavior_ext_power.c
@@ -74,7 +74,7 @@ static const struct behavior_driver_api behavior_ext_power_driver_api = {
     .locality = BEHAVIOR_LOCALITY_GLOBAL,
 };
 
-DEVICE_DT_INST_DEFINE(0, behavior_ext_power_init, NULL, NULL, NULL, APPLICATION,
-                      CONFIG_APPLICATION_INIT_PRIORITY, &behavior_ext_power_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_ext_power_init, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_APPLICATION_INIT_PRIORITY, &behavior_ext_power_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -511,7 +511,7 @@ static void update_hold_status_for_retro_tap(uint32_t ignore_position) {
 
 static int on_hold_tap_binding_pressed(struct zmk_behavior_binding *binding,
                                        struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct behavior_hold_tap_config *cfg = dev->config;
 
     if (undecided_hold_tap != NULL) {
@@ -715,9 +715,9 @@ static int behavior_hold_tap_init(const struct device *dev) {
         .hold_trigger_key_positions = DT_INST_PROP(n, hold_trigger_key_positions),                 \
         .hold_trigger_key_positions_len = DT_INST_PROP_LEN(n, hold_trigger_key_positions),         \
     };                                                                                             \
-    DEVICE_DT_INST_DEFINE(n, behavior_hold_tap_init, NULL, NULL, &behavior_hold_tap_config_##n,    \
-                          APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                        \
-                          &behavior_hold_tap_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_hold_tap_init, NULL, NULL, &behavior_hold_tap_config_##n,  \
+                            APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                      \
+                            &behavior_hold_tap_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)
 

--- a/app/src/behaviors/behavior_hold_tap.c
+++ b/app/src/behaviors/behavior_hold_tap.c
@@ -703,8 +703,8 @@ static int behavior_hold_tap_init(const struct device *dev) {
 #define KP_INST(n)                                                                                 \
     static struct behavior_hold_tap_config behavior_hold_tap_config_##n = {                        \
         .tapping_term_ms = DT_INST_PROP(n, tapping_term_ms),                                       \
-        .hold_behavior_dev = DT_PROP(DT_INST_PHANDLE_BY_IDX(n, bindings, 0), label),               \
-        .tap_behavior_dev = DT_PROP(DT_INST_PHANDLE_BY_IDX(n, bindings, 1), label),                \
+        .hold_behavior_dev = DEVICE_DT_NAME(DT_INST_PHANDLE_BY_IDX(n, bindings, 0)),               \
+        .tap_behavior_dev = DEVICE_DT_NAME(DT_INST_PHANDLE_BY_IDX(n, bindings, 1)),                \
         .quick_tap_ms = DT_INST_PROP(n, quick_tap_ms),                                             \
         .require_prior_idle_ms = DT_INST_PROP(n, global_quick_tap)                                 \
                                      ? DT_INST_PROP(n, quick_tap_ms)                               \

--- a/app/src/behaviors/behavior_key_press.c
+++ b/app/src/behaviors/behavior_key_press.c
@@ -36,7 +36,7 @@ static const struct behavior_driver_api behavior_key_press_driver_api = {
     .binding_pressed = on_keymap_binding_pressed, .binding_released = on_keymap_binding_released};
 
 #define KP_INST(n)                                                                                 \
-    DEVICE_DT_INST_DEFINE(n, behavior_key_press_init, NULL, NULL, NULL, APPLICATION,               \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_key_press_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_key_press_init, NULL, NULL, NULL, APPLICATION,             \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_key_press_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)

--- a/app/src/behaviors/behavior_key_repeat.c
+++ b/app/src/behaviors/behavior_key_repeat.c
@@ -32,7 +32,7 @@ struct behavior_key_repeat_data {
 
 static int on_key_repeat_binding_pressed(struct zmk_behavior_binding *binding,
                                          struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     struct behavior_key_repeat_data *data = dev->data;
 
     if (data->last_keycode_pressed.usage_page == 0) {
@@ -50,7 +50,7 @@ static int on_key_repeat_binding_pressed(struct zmk_behavior_binding *binding,
 
 static int on_key_repeat_binding_released(struct zmk_behavior_binding *binding,
                                           struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     struct behavior_key_repeat_data *data = dev->data;
 
     if (data->current_keycode_pressed.usage_page == 0) {
@@ -116,9 +116,9 @@ static int behavior_key_repeat_init(const struct device *dev) {
         .usage_pages = DT_INST_PROP(n, usage_pages),                                               \
         .usage_pages_count = DT_INST_PROP_LEN(n, usage_pages),                                     \
     };                                                                                             \
-    DEVICE_DT_INST_DEFINE(n, behavior_key_repeat_init, NULL, &behavior_key_repeat_data_##n,        \
-                          &behavior_key_repeat_config_##n, APPLICATION,                            \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_key_repeat_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_key_repeat_init, NULL, &behavior_key_repeat_data_##n,      \
+                            &behavior_key_repeat_config_##n, APPLICATION,                          \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_key_repeat_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KR_INST)
 

--- a/app/src/behaviors/behavior_key_toggle.c
+++ b/app/src/behaviors/behavior_key_toggle.c
@@ -38,7 +38,7 @@ static const struct behavior_driver_api behavior_key_toggle_driver_api = {
 };
 
 #define KT_INST(n)                                                                                 \
-    DEVICE_DT_INST_DEFINE(n, behavior_key_toggle_init, NULL, NULL, NULL, APPLICATION,              \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_key_toggle_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_key_toggle_init, NULL, NULL, NULL, APPLICATION,            \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_key_toggle_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KT_INST)

--- a/app/src/behaviors/behavior_macro.c
+++ b/app/src/behaviors/behavior_macro.c
@@ -184,7 +184,7 @@ static void queue_macro(uint32_t position, const struct zmk_behavior_binding bin
 
 static int on_macro_binding_pressed(struct zmk_behavior_binding *binding,
                                     struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct behavior_macro_config *cfg = dev->config;
     struct behavior_macro_state *state = dev->data;
     struct behavior_macro_trigger_state trigger_state = {.mode = MACRO_MODE_TAP,
@@ -200,7 +200,7 @@ static int on_macro_binding_pressed(struct zmk_behavior_binding *binding,
 
 static int on_macro_binding_released(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct behavior_macro_config *cfg = dev->config;
     struct behavior_macro_state *state = dev->data;
 
@@ -224,9 +224,9 @@ static const struct behavior_driver_api behavior_macro_driver_api = {
         .default_tap_ms = DT_PROP_OR(inst, tap_ms, CONFIG_ZMK_MACRO_DEFAULT_TAP_MS),               \
         .count = DT_PROP_LEN(inst, bindings),                                                      \
         .bindings = TRANSFORMED_BEHAVIORS(inst)};                                                  \
-    DEVICE_DT_DEFINE(inst, behavior_macro_init, NULL, &behavior_macro_state_##inst,                \
-                     &behavior_macro_config_##inst, APPLICATION,                                   \
-                     CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_macro_driver_api);
+    BEHAVIOR_DT_DEFINE(inst, behavior_macro_init, NULL, &behavior_macro_state_##inst,              \
+                       &behavior_macro_config_##inst, APPLICATION,                                 \
+                       CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_macro_driver_api);
 
 DT_FOREACH_STATUS_OKAY(zmk_behavior_macro, MACRO_INST)
 DT_FOREACH_STATUS_OKAY(zmk_behavior_macro_one_param, MACRO_INST)

--- a/app/src/behaviors/behavior_macro.c
+++ b/app/src/behaviors/behavior_macro.c
@@ -44,18 +44,18 @@ struct behavior_macro_config {
     struct zmk_behavior_binding bindings[];
 };
 
-#define TAP_MODE DT_PROP(DT_INST(0, zmk_macro_control_mode_tap), label)
-#define PRESS_MODE DT_PROP(DT_INST(0, zmk_macro_control_mode_press), label)
-#define REL_MODE DT_PROP(DT_INST(0, zmk_macro_control_mode_release), label)
+#define TAP_MODE DEVICE_DT_NAME(DT_INST(0, zmk_macro_control_mode_tap))
+#define PRESS_MODE DEVICE_DT_NAME(DT_INST(0, zmk_macro_control_mode_press))
+#define REL_MODE DEVICE_DT_NAME(DT_INST(0, zmk_macro_control_mode_release))
 
-#define TAP_TIME DT_PROP(DT_INST(0, zmk_macro_control_tap_time), label)
-#define WAIT_TIME DT_PROP(DT_INST(0, zmk_macro_control_wait_time), label)
-#define WAIT_REL DT_PROP(DT_INST(0, zmk_macro_pause_for_release), label)
+#define TAP_TIME DEVICE_DT_NAME(DT_INST(0, zmk_macro_control_tap_time))
+#define WAIT_TIME DEVICE_DT_NAME(DT_INST(0, zmk_macro_control_wait_time))
+#define WAIT_REL DEVICE_DT_NAME(DT_INST(0, zmk_macro_pause_for_release))
 
-#define P1TO1 DT_PROP(DT_INST(0, zmk_macro_param_1to1), label)
-#define P1TO2 DT_PROP(DT_INST(0, zmk_macro_param_1to2), label)
-#define P2TO1 DT_PROP(DT_INST(0, zmk_macro_param_2to1), label)
-#define P2TO2 DT_PROP(DT_INST(0, zmk_macro_param_2to2), label)
+#define P1TO1 DEVICE_DT_NAME(DT_INST(0, zmk_macro_param_1to1))
+#define P1TO2 DEVICE_DT_NAME(DT_INST(0, zmk_macro_param_1to2))
+#define P2TO1 DEVICE_DT_NAME(DT_INST(0, zmk_macro_param_2to1))
+#define P2TO2 DEVICE_DT_NAME(DT_INST(0, zmk_macro_param_2to2))
 
 #define ZM_IS_NODE_MATCH(a, b) (strcmp(a, b) == 0)
 #define IS_TAP_MODE(dev) ZM_IS_NODE_MATCH(dev, TAP_MODE)

--- a/app/src/behaviors/behavior_mod_morph.c
+++ b/app/src/behaviors/behavior_mod_morph.c
@@ -81,7 +81,7 @@ static int behavior_mod_morph_init(const struct device *dev) { return 0; }
 
 #define _TRANSFORM_ENTRY(idx, node)                                                                \
     {                                                                                              \
-        .behavior_dev = DT_PROP(DT_INST_PHANDLE_BY_IDX(node, bindings, idx), label),               \
+        .behavior_dev = DEVICE_DT_NAME(DT_INST_PHANDLE_BY_IDX(node, bindings, idx)),               \
         .param1 = COND_CODE_0(DT_INST_PHA_HAS_CELL_AT_IDX(node, bindings, idx, param1), (0),       \
                               (DT_INST_PHA_BY_IDX(node, bindings, idx, param1))),                  \
         .param2 = COND_CODE_0(DT_INST_PHA_HAS_CELL_AT_IDX(node, bindings, idx, param2), (0),       \

--- a/app/src/behaviors/behavior_mod_morph.c
+++ b/app/src/behaviors/behavior_mod_morph.c
@@ -36,7 +36,7 @@ struct behavior_mod_morph_data {
 
 static int on_mod_morph_binding_pressed(struct zmk_behavior_binding *binding,
                                         struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct behavior_mod_morph_config *cfg = dev->config;
     struct behavior_mod_morph_data *data = dev->data;
 
@@ -56,7 +56,7 @@ static int on_mod_morph_binding_pressed(struct zmk_behavior_binding *binding,
 
 static int on_mod_morph_binding_released(struct zmk_behavior_binding *binding,
                                          struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     struct behavior_mod_morph_data *data = dev->data;
 
     if (data->pressed_binding == NULL) {
@@ -97,9 +97,9 @@ static int behavior_mod_morph_init(const struct device *dev) { return 0; }
                                    (DT_INST_PROP(n, mods) & ~DT_INST_PROP(n, keep_mods))),         \
     };                                                                                             \
     static struct behavior_mod_morph_data behavior_mod_morph_data_##n = {};                        \
-    DEVICE_DT_INST_DEFINE(n, behavior_mod_morph_init, NULL, &behavior_mod_morph_data_##n,          \
-                          &behavior_mod_morph_config_##n, APPLICATION,                             \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mod_morph_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_mod_morph_init, NULL, &behavior_mod_morph_data_##n,        \
+                            &behavior_mod_morph_config_##n, APPLICATION,                           \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mod_morph_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)
 

--- a/app/src/behaviors/behavior_momentary_layer.c
+++ b/app/src/behaviors/behavior_momentary_layer.c
@@ -39,5 +39,5 @@ static const struct behavior_mo_config behavior_mo_config = {};
 
 static struct behavior_mo_data behavior_mo_data;
 
-DEVICE_DT_INST_DEFINE(0, behavior_mo_init, NULL, &behavior_mo_data, &behavior_mo_config,
-                      APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mo_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_mo_init, NULL, &behavior_mo_data, &behavior_mo_config,
+                        APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mo_driver_api);

--- a/app/src/behaviors/behavior_mouse_key_press.c
+++ b/app/src/behaviors/behavior_mouse_key_press.c
@@ -39,9 +39,9 @@ static const struct behavior_driver_api behavior_mouse_key_press_driver_api = {
     .binding_pressed = on_keymap_binding_pressed, .binding_released = on_keymap_binding_released};
 
 #define MKP_INST(n)                                                                                \
-    DEVICE_DT_INST_DEFINE(n, behavior_mouse_key_press_init, NULL, NULL, NULL, APPLICATION,         \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                                     \
-                          &behavior_mouse_key_press_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_mouse_key_press_init, NULL, NULL, NULL, APPLICATION,       \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                                   \
+                            &behavior_mouse_key_press_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(MKP_INST)
 

--- a/app/src/behaviors/behavior_none.c
+++ b/app/src/behaviors/behavior_none.c
@@ -33,7 +33,7 @@ static const struct behavior_driver_api behavior_none_driver_api = {
     .binding_released = on_keymap_binding_released,
 };
 
-DEVICE_DT_INST_DEFINE(0, behavior_none_init, NULL, NULL, NULL, APPLICATION,
-                      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_none_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_none_init, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_none_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_outputs.c
+++ b/app/src/behaviors/behavior_outputs.c
@@ -42,7 +42,7 @@ static const struct behavior_driver_api behavior_outputs_driver_api = {
     .binding_pressed = on_keymap_binding_pressed,
 };
 
-DEVICE_DT_INST_DEFINE(0, behavior_out_init, NULL, NULL, NULL, APPLICATION,
-                      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_outputs_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_out_init, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_outputs_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_reset.c
+++ b/app/src/behaviors/behavior_reset.c
@@ -25,7 +25,7 @@ static int behavior_reset_init(const struct device *dev) { return 0; };
 
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct behavior_reset_config *cfg = dev->config;
 
     // TODO: Correct magic code for going into DFU?
@@ -43,9 +43,9 @@ static const struct behavior_driver_api behavior_reset_driver_api = {
 #define RST_INST(n)                                                                                \
     static const struct behavior_reset_config behavior_reset_config_##n = {                        \
         .type = DT_INST_PROP(n, type)};                                                            \
-    DEVICE_DT_INST_DEFINE(n, behavior_reset_init, NULL, NULL, &behavior_reset_config_##n,          \
-                          APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                        \
-                          &behavior_reset_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_reset_init, NULL, NULL, &behavior_reset_config_##n,        \
+                            APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                      \
+                            &behavior_reset_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(RST_INST)
 

--- a/app/src/behaviors/behavior_rgb_underglow.c
+++ b/app/src/behaviors/behavior_rgb_underglow.c
@@ -149,7 +149,7 @@ static const struct behavior_driver_api behavior_rgb_underglow_driver_api = {
     .locality = BEHAVIOR_LOCALITY_GLOBAL,
 };
 
-DEVICE_DT_INST_DEFINE(0, behavior_rgb_underglow_init, NULL, NULL, NULL, APPLICATION,
-                      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_rgb_underglow_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_rgb_underglow_init, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_rgb_underglow_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_sensor_rotate.c
+++ b/app/src/behaviors/behavior_sensor_rotate.c
@@ -35,9 +35,9 @@ static int behavior_sensor_rotate_init(const struct device *dev) { return 0; };
         .override_params = false,                                                                  \
     };                                                                                             \
     static struct behavior_sensor_rotate_data behavior_sensor_rotate_data_##n = {};                \
-    DEVICE_DT_INST_DEFINE(n, behavior_sensor_rotate_init, NULL, &behavior_sensor_rotate_data_##n,  \
-                          &behavior_sensor_rotate_config_##n, APPLICATION,                         \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                                     \
-                          &behavior_sensor_rotate_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_sensor_rotate_init, NULL,                                  \
+                            &behavior_sensor_rotate_data_##n, &behavior_sensor_rotate_config_##n,  \
+                            APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                      \
+                            &behavior_sensor_rotate_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SENSOR_ROTATE_INST)

--- a/app/src/behaviors/behavior_sensor_rotate.c
+++ b/app/src/behaviors/behavior_sensor_rotate.c
@@ -20,7 +20,7 @@ static int behavior_sensor_rotate_init(const struct device *dev) { return 0; };
 
 #define _TRANSFORM_ENTRY(idx, node)                                                                \
     {                                                                                              \
-        .behavior_dev = DT_PROP(DT_INST_PHANDLE_BY_IDX(node, bindings, idx), label),               \
+        .behavior_dev = DEVICE_DT_NAME(DT_INST_PHANDLE_BY_IDX(node, bindings, idx)),               \
         .param1 = COND_CODE_0(DT_INST_PHA_HAS_CELL_AT_IDX(node, bindings, idx, param1), (0),       \
                               (DT_INST_PHA_BY_IDX(node, bindings, idx, param1))),                  \
         .param2 = COND_CODE_0(DT_INST_PHA_HAS_CELL_AT_IDX(node, bindings, idx, param2), (0),       \

--- a/app/src/behaviors/behavior_sensor_rotate_common.c
+++ b/app/src/behaviors/behavior_sensor_rotate_common.c
@@ -15,7 +15,7 @@ int zmk_behavior_sensor_rotate_common_accept_data(
     struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
     const struct zmk_sensor_config *sensor_config, size_t channel_data_size,
     const struct zmk_sensor_channel_data *channel_data) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     struct behavior_sensor_rotate_data *data = dev->data;
 
     const struct sensor_value value = channel_data[0].value;
@@ -58,7 +58,7 @@ int zmk_behavior_sensor_rotate_common_accept_data(
 int zmk_behavior_sensor_rotate_common_process(struct zmk_behavior_binding *binding,
                                               struct zmk_behavior_binding_event event,
                                               enum behavior_sensor_binding_process_mode mode) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct behavior_sensor_rotate_config *cfg = dev->config;
     struct behavior_sensor_rotate_data *data = dev->data;
 

--- a/app/src/behaviors/behavior_sensor_rotate_var.c
+++ b/app/src/behaviors/behavior_sensor_rotate_var.c
@@ -26,7 +26,7 @@ static int behavior_sensor_rotate_var_init(const struct device *dev) { return 0;
         .override_params = true,                                                                   \
     };                                                                                             \
     static struct behavior_sensor_rotate_data behavior_sensor_rotate_var_data_##n = {};            \
-    DEVICE_DT_INST_DEFINE(                                                                         \
+    BEHAVIOR_DT_INST_DEFINE(                                                                       \
         n, behavior_sensor_rotate_var_init, NULL, &behavior_sensor_rotate_var_data_##n,            \
         &behavior_sensor_rotate_var_config_##n, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  \
         &behavior_sensor_rotate_var_driver_api);

--- a/app/src/behaviors/behavior_sensor_rotate_var.c
+++ b/app/src/behaviors/behavior_sensor_rotate_var.c
@@ -20,8 +20,8 @@ static int behavior_sensor_rotate_var_init(const struct device *dev) { return 0;
 
 #define SENSOR_ROTATE_VAR_INST(n)                                                                  \
     static struct behavior_sensor_rotate_config behavior_sensor_rotate_var_config_##n = {          \
-        .cw_binding = {.behavior_dev = DT_PROP(DT_INST_PHANDLE_BY_IDX(n, bindings, 0), label)},    \
-        .ccw_binding = {.behavior_dev = DT_PROP(DT_INST_PHANDLE_BY_IDX(n, bindings, 1), label)},   \
+        .cw_binding = {.behavior_dev = DEVICE_DT_NAME(DT_INST_PHANDLE_BY_IDX(n, bindings, 0))},    \
+        .ccw_binding = {.behavior_dev = DEVICE_DT_NAME(DT_INST_PHANDLE_BY_IDX(n, bindings, 1))},   \
         .tap_ms = DT_INST_PROP(n, tap_ms),                                                         \
         .override_params = true,                                                                   \
     };                                                                                             \

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -129,7 +129,7 @@ static int stop_timer(struct active_sticky_key *sticky_key) {
 
 static int on_sticky_key_binding_pressed(struct zmk_behavior_binding *binding,
                                          struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct behavior_sticky_key_config *cfg = dev->config;
     struct active_sticky_key *sticky_key;
     sticky_key = find_sticky_key(event.position);
@@ -293,9 +293,9 @@ static struct behavior_sticky_key_data behavior_sticky_key_data;
         .ignore_modifiers = DT_INST_PROP(n, ignore_modifiers),                                     \
         .quick_release = DT_INST_PROP(n, quick_release),                                           \
     };                                                                                             \
-    DEVICE_DT_INST_DEFINE(n, behavior_sticky_key_init, NULL, &behavior_sticky_key_data,            \
-                          &behavior_sticky_key_config_##n, APPLICATION,                            \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_sticky_key_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_sticky_key_init, NULL, &behavior_sticky_key_data,          \
+                            &behavior_sticky_key_config_##n, APPLICATION,                          \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_sticky_key_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)
 

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -24,6 +24,8 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
+#define KEY_PRESS DEVICE_DT_NAME(DT_INST(0, zmk_behavior_key_press))
+
 #define ZMK_BHV_STICKY_KEY_MAX_HELD 10
 
 #define ZMK_BHV_STICKY_KEY_POSITION_FREE UINT32_MAX
@@ -202,7 +204,7 @@ static int sticky_key_keycode_state_changed_listener(const zmk_event_t *eh) {
             continue;
         }
 
-        if (strcmp(sticky_key->config->behavior.behavior_dev, "KEY_PRESS") == 0 &&
+        if (strcmp(sticky_key->config->behavior.behavior_dev, KEY_PRESS) == 0 &&
             ZMK_HID_USAGE_ID(sticky_key->param1) == ev_copy.keycode &&
             ZMK_HID_USAGE_PAGE(sticky_key->param1) == ev_copy.usage_page &&
             SELECT_MODS(sticky_key->param1) == ev_copy.implicit_modifiers) {

--- a/app/src/behaviors/behavior_tap_dance.c
+++ b/app/src/behaviors/behavior_tap_dance.c
@@ -125,7 +125,7 @@ static inline int release_tap_dance_behavior(struct active_tap_dance *tap_dance,
 
 static int on_tap_dance_binding_pressed(struct zmk_behavior_binding *binding,
                                         struct zmk_behavior_binding_event event) {
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct behavior_tap_dance_config *cfg = dev->config;
     struct active_tap_dance *tap_dance;
     tap_dance = find_tap_dance(event.position);
@@ -250,9 +250,9 @@ static int behavior_tap_dance_init(const struct device *dev) {
         .tapping_term_ms = DT_INST_PROP(n, tapping_term_ms),                                       \
         .behaviors = behavior_tap_dance_config_##n##_bindings,                                     \
         .behavior_count = DT_INST_PROP_LEN(n, bindings)};                                          \
-    DEVICE_DT_INST_DEFINE(n, behavior_tap_dance_init, NULL, NULL, &behavior_tap_dance_config_##n,  \
-                          APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                        \
-                          &behavior_tap_dance_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_tap_dance_init, NULL, NULL,                                \
+                            &behavior_tap_dance_config_##n, APPLICATION,                           \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_tap_dance_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)
 

--- a/app/src/behaviors/behavior_to_layer.c
+++ b/app/src/behaviors/behavior_to_layer.c
@@ -37,7 +37,7 @@ static const struct behavior_driver_api behavior_to_driver_api = {
     .binding_released = to_keymap_binding_released,
 };
 
-DEVICE_DT_INST_DEFINE(0, behavior_to_init, NULL, NULL, NULL, APPLICATION,
-                      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_to_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_to_init, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_to_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_toggle_layer.c
+++ b/app/src/behaviors/behavior_toggle_layer.c
@@ -43,7 +43,7 @@ static const struct behavior_tog_config behavior_tog_config = {};
 
 static struct behavior_tog_data behavior_tog_data;
 
-DEVICE_DT_INST_DEFINE(0, behavior_tog_init, NULL, &behavior_tog_data, &behavior_tog_config,
-                      APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_tog_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_tog_init, NULL, &behavior_tog_data, &behavior_tog_config,
+                        APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_tog_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_transparent.c
+++ b/app/src/behaviors/behavior_transparent.c
@@ -33,7 +33,7 @@ static const struct behavior_driver_api behavior_transparent_driver_api = {
     .binding_released = on_keymap_binding_released,
 };
 
-DEVICE_DT_INST_DEFINE(0, behavior_transparent_init, NULL, NULL, NULL, APPLICATION,
-                      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_transparent_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, behavior_transparent_init, NULL, NULL, NULL, APPLICATION,
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_transparent_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/display/widgets/layer_status.c
+++ b/app/src/display/widgets/layer_status.c
@@ -45,7 +45,7 @@ static void layer_status_update_cb(struct layer_status_state state) {
 
 static struct layer_status_state layer_status_get_state(const zmk_event_t *eh) {
     uint8_t index = zmk_keymap_highest_layer_active();
-    return (struct layer_status_state){.index = index, .label = zmk_keymap_layer_label(index)};
+    return (struct layer_status_state){.index = index, .label = zmk_keymap_layer_name(index)};
 }
 
 ZMK_DISPLAY_WIDGET_LISTENER(widget_layer_status, struct layer_status_state, layer_status_update_cb,

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -39,7 +39,7 @@ static void ext_power_save_state_work(struct k_work *work) {
     const struct device *ext_power = DEVICE_DT_GET(DT_DRV_INST(0));
     struct ext_power_generic_data *data = ext_power->data;
 
-    snprintf(setting_path, 40, "ext_power/state/%s", DT_INST_PROP(0, label));
+    snprintf(setting_path, sizeof(setting_path), "ext_power/state/%s", ext_power->name);
     settings_save_one(setting_path, &data->status, sizeof(data->status));
 }
 
@@ -86,38 +86,38 @@ static int ext_power_generic_get(const struct device *dev) {
 }
 
 #if IS_ENABLED(CONFIG_SETTINGS)
+static int ext_power_settings_set_status(const struct device *dev, size_t len,
+                                         settings_read_cb read_cb, void *cb_arg) {
+    struct ext_power_generic_data *data = dev->data;
+
+    if (len != sizeof(data->status)) {
+        return -EINVAL;
+    }
+
+    int rc = read_cb(cb_arg, &data->status, sizeof(data->status));
+    if (rc >= 0) {
+        data->settings_init = true;
+
+        if (data->status) {
+            ext_power_generic_enable(dev);
+        } else {
+            ext_power_generic_disable(dev);
+        }
+
+        return 0;
+    }
+    return rc;
+}
+
 static int ext_power_settings_set(const char *name, size_t len, settings_read_cb read_cb,
                                   void *cb_arg) {
+    const struct device *ext_power = DEVICE_DT_GET(DT_DRV_INST(0));
+
     const char *next;
-    int rc;
-
-    if (settings_name_steq(name, DT_INST_PROP(0, label), &next) && !next) {
-        const struct device *ext_power = DEVICE_DT_GET(DT_DRV_INST(0));
-        struct ext_power_generic_data *data = ext_power->data;
-
-        if (len != sizeof(data->status)) {
-            return -EINVAL;
-        }
-
-        rc = read_cb(cb_arg, &data->status, sizeof(data->status));
-        if (rc >= 0) {
-            data->settings_init = true;
-
-            if (ext_power == NULL) {
-                LOG_ERR("Unable to retrieve ext_power device: %s", DT_INST_PROP(0, label));
-                return -EIO;
-            }
-
-            if (data->status) {
-                ext_power_generic_enable(ext_power);
-            } else {
-                ext_power_generic_disable(ext_power);
-            }
-
-            return 0;
-        }
-        return rc;
+    if (settings_name_steq(name, ext_power->name, &next) && !next) {
+        return ext_power_settings_set_status(ext_power, len, read_cb, cb_arg);
     }
+
     return -ENOENT;
 }
 

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -31,15 +31,13 @@ static uint8_t _zmk_keymap_layer_default = 0;
 
 #define DT_DRV_COMPAT zmk_keymap
 
-#define BINDING_WITH_COMMA(idx, drv_inst) ZMK_KEYMAP_EXTRACT_BINDING(idx, drv_inst)
-
 #define TRANSFORMED_LAYER(node)                                                                    \
-    {LISTIFY(DT_PROP_LEN(node, bindings), BINDING_WITH_COMMA, (, ), node)},
+    { LISTIFY(DT_PROP_LEN(node, bindings), ZMK_KEYMAP_EXTRACT_BINDING, (, ), node) }
 
 #if ZMK_KEYMAP_HAS_SENSORS
 #define _TRANSFORM_SENSOR_ENTRY(idx, layer)                                                        \
     {                                                                                              \
-        .behavior_dev = DT_PROP(DT_PHANDLE_BY_IDX(layer, sensor_bindings, idx), label),            \
+        .behavior_dev = DEVICE_DT_NAME(DT_PHANDLE_BY_IDX(layer, sensor_bindings, idx)),            \
         .param1 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(layer, sensor_bindings, idx, param1), (0),    \
                               (DT_PHA_BY_IDX(layer, sensor_bindings, idx, param1))),               \
         .param2 = COND_CODE_0(DT_PHA_HAS_CELL_AT_IDX(layer, sensor_bindings, idx, param2), (0),    \
@@ -50,12 +48,11 @@ static uint8_t _zmk_keymap_layer_default = 0;
     COND_CODE_1(                                                                                   \
         DT_NODE_HAS_PROP(node, sensor_bindings),                                                   \
         ({LISTIFY(DT_PROP_LEN(node, sensor_bindings), _TRANSFORM_SENSOR_ENTRY, (, ), node)}),      \
-        ({})),
+        ({}))
 
 #endif /* ZMK_KEYMAP_HAS_SENSORS */
 
-#define LAYER_LABEL(node)                                                                          \
-    COND_CODE_0(DT_NODE_HAS_PROP(node, label), (NULL), (DT_PROP(node, label))),
+#define LAYER_LABEL(node) DT_PROP_OR(node, label, NULL)
 
 // State
 
@@ -65,16 +62,16 @@ static uint8_t _zmk_keymap_layer_default = 0;
 static uint32_t zmk_keymap_active_behavior_layer[ZMK_KEYMAP_LEN];
 
 static struct zmk_behavior_binding zmk_keymap[ZMK_KEYMAP_LAYERS_LEN][ZMK_KEYMAP_LEN] = {
-    DT_INST_FOREACH_CHILD(0, TRANSFORMED_LAYER)};
+    DT_INST_FOREACH_CHILD_SEP(0, TRANSFORMED_LAYER, (, ))};
 
 static const char *zmk_keymap_layer_names[ZMK_KEYMAP_LAYERS_LEN] = {
-    DT_INST_FOREACH_CHILD(0, LAYER_LABEL)};
+    DT_INST_FOREACH_CHILD_SEP(0, LAYER_LABEL, (, ))};
 
 #if ZMK_KEYMAP_HAS_SENSORS
 
-static struct zmk_behavior_binding zmk_sensor_keymap[ZMK_KEYMAP_LAYERS_LEN]
-                                                    [ZMK_KEYMAP_SENSORS_LEN] = {
-                                                        DT_INST_FOREACH_CHILD(0, SENSOR_LAYER)};
+static struct zmk_behavior_binding
+    zmk_sensor_keymap[ZMK_KEYMAP_LAYERS_LEN][ZMK_KEYMAP_SENSORS_LEN] = {
+        DT_INST_FOREACH_CHILD_SEP(0, SENSOR_LAYER, (, ))};
 
 #endif /* ZMK_KEYMAP_HAS_SENSORS */
 

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -176,7 +176,7 @@ int zmk_keymap_apply_position_state(uint8_t source, int layer, uint32_t position
 
     LOG_DBG("layer: %d position: %d, binding name: %s", layer, position, binding.behavior_dev);
 
-    behavior = device_get_binding(binding.behavior_dev);
+    behavior = zmk_behavior_get_binding(binding.behavior_dev);
 
     if (!behavior) {
         LOG_WRN("No behavior assigned to %d on layer %d", position, layer);
@@ -256,7 +256,7 @@ int zmk_keymap_sensor_event(uint8_t sensor_index,
         LOG_DBG("layer: %d sensor_index: %d, binding name: %s", layer, sensor_index,
                 binding->behavior_dev);
 
-        const struct device *behavior = device_get_binding(binding->behavior_dev);
+        const struct device *behavior = zmk_behavior_get_binding(binding->behavior_dev);
         if (!behavior) {
             LOG_DBG("No behavior assigned to %d on layer %d", sensor_index, layer);
             continue;

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -52,7 +52,7 @@ static uint8_t _zmk_keymap_layer_default = 0;
 
 #endif /* ZMK_KEYMAP_HAS_SENSORS */
 
-#define LAYER_LABEL(node) DT_PROP_OR(node, label, NULL)
+#define LAYER_NAME(node) DT_PROP_OR(node, display_name, DT_PROP_OR(node, label, NULL))
 
 // State
 
@@ -65,7 +65,7 @@ static struct zmk_behavior_binding zmk_keymap[ZMK_KEYMAP_LAYERS_LEN][ZMK_KEYMAP_
     DT_INST_FOREACH_CHILD_SEP(0, TRANSFORMED_LAYER, (, ))};
 
 static const char *zmk_keymap_layer_names[ZMK_KEYMAP_LAYERS_LEN] = {
-    DT_INST_FOREACH_CHILD_SEP(0, LAYER_LABEL, (, ))};
+    DT_INST_FOREACH_CHILD_SEP(0, LAYER_NAME, (, ))};
 
 #if ZMK_KEYMAP_HAS_SENSORS
 
@@ -145,7 +145,7 @@ bool is_active_layer(uint8_t layer, zmk_keymap_layers_state_t layer_state) {
     return (layer_state & BIT(layer)) == BIT(layer) || layer == _zmk_keymap_layer_default;
 }
 
-const char *zmk_keymap_layer_label(uint8_t layer) {
+const char *zmk_keymap_layer_name(uint8_t layer) {
     if (layer >= ZMK_KEYMAP_LAYERS_LEN) {
         return NULL;
     }

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -67,7 +67,7 @@ static struct led_rgb pixels[STRIP_NUM_PIXELS];
 static struct rgb_underglow_state state;
 
 #if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
-static const struct device *ext_power;
+static const struct device *const ext_power = DEVICE_DT_GET(DT_INST(0, zmk_ext_power_generic));
 #endif
 
 static struct zmk_led_hsb hsb_scale_min_max(struct zmk_led_hsb hsb) {
@@ -243,9 +243,9 @@ static int zmk_rgb_underglow_init(const struct device *_arg) {
     led_strip = DEVICE_DT_GET(STRIP_CHOSEN);
 
 #if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
-    ext_power = device_get_binding("EXT_POWER");
-    if (ext_power == NULL) {
-        LOG_ERR("Unable to retrieve ext_power device: EXT_POWER");
+    if (!device_is_ready(ext_power)) {
+        LOG_ERR("External power device \"%s\" is not ready", ext_power->name);
+        return -ENODEV;
     }
 #endif
 

--- a/app/tests/backlight/behavior_keymap.dtsi
+++ b/app/tests/backlight/behavior_keymap.dtsi
@@ -12,17 +12,14 @@
         compatible = "gpio-leds";
         led_0 {
             gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
-            label = "Backlight LED 0";
         };
         led_1 {
             gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
-            label = "Backlight LED 1";
         };
     };
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/backlight/cycle/native_posix_64.keymap
+++ b/app/tests/backlight/cycle/native_posix_64.keymap
@@ -12,17 +12,14 @@
         compatible = "gpio-leds";
         led_0 {
             gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
-            label = "Backlight LED 0";
         };
         led_1 {
             gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
-            label = "Backlight LED 1";
         };
     };
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/ble/profiles/bond-clear-then-bond-second-client/nrf52_bsim.keymap
+++ b/app/tests/ble/profiles/bond-clear-then-bond-second-client/nrf52_bsim.keymap
@@ -14,7 +14,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/ble/profiles/bond-to-cleared-profile/nrf52_bsim.keymap
+++ b/app/tests/ble/profiles/bond-to-cleared-profile/nrf52_bsim.keymap
@@ -14,7 +14,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/ble/profiles/connnect-and-output-to-selection/nrf52_bsim.keymap
+++ b/app/tests/ble/profiles/connnect-and-output-to-selection/nrf52_bsim.keymap
@@ -14,7 +14,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/ble/profiles/dont-bond-to-taken-profile/nrf52_bsim.keymap
+++ b/app/tests/ble/profiles/dont-bond-to-taken-profile/nrf52_bsim.keymap
@@ -14,7 +14,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/ble/profiles/first-and-second-profile-paired-then-send-data/nrf52_bsim.keymap
+++ b/app/tests/ble/profiles/first-and-second-profile-paired-then-send-data/nrf52_bsim.keymap
@@ -16,7 +16,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/ble/profiles/reconnect-then-output-to-selection/nrf52_bsim.keymap
+++ b/app/tests/ble/profiles/reconnect-then-output-to-selection/nrf52_bsim.keymap
@@ -14,7 +14,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/caps-word/behavior_keymap.dtsi
+++ b/app/tests/caps-word/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/caps-word/continue-with-modifiers/native_posix_64.keymap
+++ b/app/tests/caps-word/continue-with-modifiers/native_posix_64.keymap
@@ -6,7 +6,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/combos-and-holdtaps-0/native_posix_64.keymap
+++ b/app/tests/combo/combos-and-holdtaps-0/native_posix_64.keymap
@@ -24,7 +24,6 @@ first so the decision to hold or tap can be made.
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/combos-and-holdtaps-1/native_posix_64.keymap
+++ b/app/tests/combo/combos-and-holdtaps-1/native_posix_64.keymap
@@ -19,7 +19,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/combos-and-holdtaps-2/native_posix_64.keymap
+++ b/app/tests/combo/combos-and-holdtaps-2/native_posix_64.keymap
@@ -26,7 +26,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/combos-and-holdtaps-3/native_posix_64.keymap
+++ b/app/tests/combo/combos-and-holdtaps-3/native_posix_64.keymap
@@ -18,7 +18,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/combos-and-holdtaps-4/native_posix_64.keymap
+++ b/app/tests/combo/combos-and-holdtaps-4/native_posix_64.keymap
@@ -22,7 +22,6 @@ ZMK_COMBO(tilde, &kp TILDE,     3 4, 50)
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/layer-filter-0/native_posix_64.keymap
+++ b/app/tests/combo/layer-filter-0/native_posix_64.keymap
@@ -31,7 +31,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/layer-filter-1/native_posix_64.keymap
+++ b/app/tests/combo/layer-filter-1/native_posix_64.keymap
@@ -18,7 +18,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/multiple-timeouts/native_posix_64.keymap
+++ b/app/tests/combo/multiple-timeouts/native_posix_64.keymap
@@ -19,7 +19,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/overlapping-combos-0/native_posix_64.keymap
+++ b/app/tests/combo/overlapping-combos-0/native_posix_64.keymap
@@ -37,7 +37,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/overlapping-combos-1/native_posix_64.keymap
+++ b/app/tests/combo/overlapping-combos-1/native_posix_64.keymap
@@ -26,7 +26,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/overlapping-combos-2/native_posix_64.keymap
+++ b/app/tests/combo/overlapping-combos-2/native_posix_64.keymap
@@ -27,7 +27,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/overlapping-combos-3/native_posix_64.keymap
+++ b/app/tests/combo/overlapping-combos-3/native_posix_64.keymap
@@ -28,7 +28,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/overlapping-combos-4-different-timeouts/native_posix_64.keymap
+++ b/app/tests/combo/overlapping-combos-4-different-timeouts/native_posix_64.keymap
@@ -32,7 +32,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/partially-overlapping-combos/native_posix_64.keymap
+++ b/app/tests/combo/partially-overlapping-combos/native_posix_64.keymap
@@ -26,7 +26,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/press-release-long-combo-complete/native_posix_64.keymap
+++ b/app/tests/combo/press-release-long-combo-complete/native_posix_64.keymap
@@ -14,7 +14,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/press-release-long-combo-incomplete/native_posix_64.keymap
+++ b/app/tests/combo/press-release-long-combo-incomplete/native_posix_64.keymap
@@ -14,7 +14,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/press-release-long-combo-wrong-last-key/native_posix_64.keymap
+++ b/app/tests/combo/press-release-long-combo-wrong-last-key/native_posix_64.keymap
@@ -14,7 +14,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/press-release/native_posix_64.keymap
+++ b/app/tests/combo/press-release/native_posix_64.keymap
@@ -14,7 +14,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/press-timeout/native_posix_64.keymap
+++ b/app/tests/combo/press-timeout/native_posix_64.keymap
@@ -14,7 +14,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/press1-press2-release1-release2/native_posix_64.keymap
+++ b/app/tests/combo/press1-press2-release1-release2/native_posix_64.keymap
@@ -20,7 +20,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/press1-press2-release2-release1/native_posix_64.keymap
+++ b/app/tests/combo/press1-press2-release2-release1/native_posix_64.keymap
@@ -20,7 +20,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/press1-release1-press2-release2/native_posix_64.keymap
+++ b/app/tests/combo/press1-release1-press2-release2/native_posix_64.keymap
@@ -20,7 +20,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/require-prior-idle/native_posix_64.keymap
+++ b/app/tests/combo/require-prior-idle/native_posix_64.keymap
@@ -21,7 +21,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/slowrelease-disabled/native_posix_64.keymap
+++ b/app/tests/combo/slowrelease-disabled/native_posix_64.keymap
@@ -15,7 +15,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/combo/slowrelease-enabled/native_posix_64.keymap
+++ b/app/tests/combo/slowrelease-enabled/native_posix_64.keymap
@@ -15,7 +15,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/gresc/gresc-press-release/native_posix_64.keymap
+++ b/app/tests/gresc/gresc-press-release/native_posix_64.keymap
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/gresc/gresc-two-instances/native_posix_64.keymap
+++ b/app/tests/gresc/gresc-two-instances/native_posix_64.keymap
@@ -13,7 +13,6 @@ The first gresc that is released releases the key.
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/balanced/6-retro-tap/native_posix_64.keymap
+++ b/app/tests/hold-tap/balanced/6-retro-tap/native_posix_64.keymap
@@ -6,7 +6,6 @@
     behaviors {
         ht_bal: behavior_balanced {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP";
             #binding-cells = <2>;
             flavor = "balanced";
             tapping_term_ms = <300>;
@@ -17,7 +16,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/balanced/7-positional/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/balanced/7-positional/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         ht_bal: behavior_hold_tap_balanced {
             compatible = "zmk,behavior-hold-tap";
-            label = "HOLD_TAP_BALANCED";
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <300>;
@@ -18,7 +17,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/balanced/8-require-prior-idle/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/balanced/8-require-prior-idle/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         ht_bal: behavior_balanced {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP";
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <300>;
@@ -18,7 +17,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/balanced/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/balanced/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         ht_bal: behavior_hold_tap_balanced {
             compatible = "zmk,behavior-hold-tap";
-            label = "HOLD_TAP_BALANCED";
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <300>;
@@ -17,7 +16,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/balanced/many-nested/native_posix_64.keymap
+++ b/app/tests/hold-tap/balanced/many-nested/native_posix_64.keymap
@@ -6,7 +6,6 @@
     behaviors {
         ht_bal: behavior_hold_tap_balanced {
             compatible = "zmk,behavior-hold-tap";
-            label = "HOLD_TAP_BALANCED";
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <300>;
@@ -16,7 +15,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/hold-preferred/6-retro-tap/native_posix_64.keymap
+++ b/app/tests/hold-tap/hold-preferred/6-retro-tap/native_posix_64.keymap
@@ -6,7 +6,6 @@
     behaviors {
         hp: behavior_hold_preferred {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP";
             #binding-cells = <2>;
             flavor = "hold-preferred";
             tapping_term_ms = <300>;
@@ -17,7 +16,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/hold-preferred/7-positional/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/hold-preferred/7-positional/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         ht_hold: behavior_hold_hold_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "hold_hold_tap";
             #binding-cells = <2>;
             flavor = "hold-preferred";
             tapping-term-ms = <300>;
@@ -18,7 +17,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/hold-preferred/8-require-prior-idle/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/hold-preferred/8-require-prior-idle/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         hp: behavior_hold_preferred {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP";
             #binding-cells = <2>;
             flavor = "hold-preferred";
             tapping-term-ms = <300>;
@@ -18,7 +17,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/hold-preferred/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/hold-preferred/behavior_keymap.dtsi
@@ -8,7 +8,6 @@
     behaviors {
         ht_hold: behavior_hold_hold_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "hold_hold_tap";
             #binding-cells = <2>;
             flavor = "hold-preferred";
             tapping-term-ms = <300>;
@@ -19,7 +18,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/tap-preferred/6-nested-timeouts/native_posix_64.keymap
+++ b/app/tests/hold-tap/tap-preferred/6-nested-timeouts/native_posix_64.keymap
@@ -12,7 +12,6 @@
     behaviors {
         tp_short: short_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP_SHORT";
             #binding-cells = <2>;
             flavor = "tap-preferred";
             tapping-term-ms = <100>;
@@ -21,7 +20,6 @@
         };
         tp_long: long_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP_LONG";
             #binding-cells = <2>;
             flavor = "tap-preferred";
             tapping-term-ms = <200>;
@@ -32,7 +30,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/tap-preferred/7-positional/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-preferred/7-positional/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         tp: behavior_tap_preferred {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP";
             #binding-cells = <2>;
             flavor = "tap-preferred";
             tapping-term-ms = <300>;
@@ -18,7 +17,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/tap-preferred/8-require-prior-idle/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-preferred/8-require-prior-idle/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         tp: behavior_tap_preferred {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP";
             #binding-cells = <2>;
             flavor = "tap-preferred";
             tapping-term-ms = <300>;
@@ -18,7 +17,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/tap-preferred/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-preferred/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         tp: behavior_tap_preferred {
             compatible = "zmk,behavior-hold-tap";
-            label = "MOD_TAP";
             #binding-cells = <2>;
             flavor = "tap-preferred";
             tapping-term-ms = <300>;
@@ -17,7 +16,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/tap-unless-interrupted/6-require-prior-idle/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-unless-interrupted/6-require-prior-idle/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         ht_tui: behavior_hold_tap_tap_unless_interrupted {
             compatible = "zmk,behavior-hold-tap";
-            label = "hold_tap_tap_unless_interrupted";
             #binding-cells = <2>;
             flavor = "tap-unless-interrupted";
             tapping-term-ms = <300>;
@@ -18,7 +17,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/hold-tap/tap-unless-interrupted/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-unless-interrupted/behavior_keymap.dtsi
@@ -8,7 +8,6 @@
     behaviors {
         ht_tui: behavior_hold_tap_tap_unless_interrupted {
             compatible = "zmk,behavior-hold-tap";
-            label = "hold_tap_tap_unless_interrupted";
             #binding-cells = <2>;
             flavor = "tap-unless-interrupted";
             tapping-term-ms = <300>;
@@ -19,7 +18,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/key-repeat/behavior_keymap.dtsi
+++ b/app/tests/key-repeat/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/keypress/behavior_keymap.dtsi
+++ b/app/tests/keypress/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/keytoggle/behavior_keymap.dtsi
+++ b/app/tests/keytoggle/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/keytoggle/kt-alt-tab/native_posix_64.keymap
+++ b/app/tests/keytoggle/kt-alt-tab/native_posix_64.keymap
@@ -36,7 +36,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/keytoggle/kt-modded-alpha/native_posix_64.keymap
+++ b/app/tests/keytoggle/kt-modded-alpha/native_posix_64.keymap
@@ -26,7 +26,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/macros/basic/keycode_events.snapshot
+++ b/app/tests/macros/basic/keycode_events.snapshot
@@ -1,18 +1,18 @@
-queue_process_next: Invoking KEY_PRESS: 0x70004 0x00
+queue_process_next: Invoking key_press: 0x70004 0x00
 kp_pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 50ms
-queue_process_next: Invoking KEY_PRESS: 0x70004 0x00
+queue_process_next: Invoking key_press: 0x70004 0x00
 kp_released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 10ms
-queue_process_next: Invoking KEY_PRESS: 0x70005 0x00
+queue_process_next: Invoking key_press: 0x70005 0x00
 kp_pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 50ms
-queue_process_next: Invoking KEY_PRESS: 0x70005 0x00
+queue_process_next: Invoking key_press: 0x70005 0x00
 kp_released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 10ms
-queue_process_next: Invoking KEY_PRESS: 0x70006 0x00
+queue_process_next: Invoking key_press: 0x70006 0x00
 kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 50ms
-queue_process_next: Invoking KEY_PRESS: 0x70006 0x00
+queue_process_next: Invoking key_press: 0x70006 0x00
 kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 10ms

--- a/app/tests/macros/behavior_keymap.dtsi
+++ b/app/tests/macros/behavior_keymap.dtsi
@@ -49,7 +49,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/macros/mo-plus-modifier-from-hold-tap/native_posix_64.keymap
+++ b/app/tests/macros/mo-plus-modifier-from-hold-tap/native_posix_64.keymap
@@ -24,7 +24,6 @@
     behaviors {
         mth: macro_tap_hold {
             compatible = "zmk,behavior-hold-tap";
-            label = "MACRO_TAP_HOLD";
             #binding-cells = <2>;
             flavor = "tap-unless-interrupted";
             tapping-term-ms = <200>;
@@ -34,7 +33,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/macros/mo-plus-modifier-macro/native_posix_64.keymap
+++ b/app/tests/macros/mo-plus-modifier-macro/native_posix_64.keymap
@@ -23,7 +23,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/macros/place-holder-parameters/native_posix_64.keymap
+++ b/app/tests/macros/place-holder-parameters/native_posix_64.keymap
@@ -12,7 +12,6 @@
     macros {
         slash_macro: slash_macro {
             #binding-cells = <2>;
-            label = "ZM_SLASH";
             compatible = "zmk,behavior-macro-two-param";
             wait-ms = <40>;
             tap-ms = <40>;
@@ -24,7 +23,6 @@
 
         to_second_macro: to_second_macro {
             #binding-cells = <2>;
-            label = "ZMK_TO_SECOND";
             compatible = "zmk,behavior-macro-two-param";
             wait-ms = <40>;
             tap-ms = <40>;
@@ -35,7 +33,6 @@
 
         quote_letter_macro: quote_letter_macro {
             #binding-cells = <1>;
-            label = "ZMK_QLET";
             compatible = "zmk,behavior-macro-one-param";
             wait-ms = <40>;
             tap-ms = <40>;
@@ -48,7 +45,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/macros/press-mid-macro/keycode_events.snapshot
+++ b/app/tests/macros/press-mid-macro/keycode_events.snapshot
@@ -1,8 +1,8 @@
-pos_state: layer: 0 position: 0, binding name: ZM_abc_macro
+pos_state: layer: 0 position: 0, binding name: abc_macro
 kp_pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
-pos_state: layer: 0 position: 0, binding name: ZM_abc_macro
-pos_state: layer: 0 position: 1, binding name: MO
-pos_state: layer: 0 position: 1, binding name: MO
+pos_state: layer: 0 position: 0, binding name: abc_macro
+pos_state: layer: 0 position: 1, binding name: momentary_layer
+pos_state: layer: 0 position: 1, binding name: momentary_layer
 kp_released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 kp_pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
 kp_released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/macros/timing-override/keycode_events.snapshot
+++ b/app/tests/macros/timing-override/keycode_events.snapshot
@@ -1,18 +1,18 @@
-queue_process_next: Invoking KEY_PRESS: 0x70004 0x00
+queue_process_next: Invoking key_press: 0x70004 0x00
 kp_pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 30ms
-queue_process_next: Invoking KEY_PRESS: 0x70004 0x00
+queue_process_next: Invoking key_press: 0x70004 0x00
 kp_released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 50ms
-queue_process_next: Invoking KEY_PRESS: 0x70005 0x00
+queue_process_next: Invoking key_press: 0x70005 0x00
 kp_pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 20ms
-queue_process_next: Invoking KEY_PRESS: 0x70005 0x00
+queue_process_next: Invoking key_press: 0x70005 0x00
 kp_released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 50ms
-queue_process_next: Invoking KEY_PRESS: 0x70006 0x00
+queue_process_next: Invoking key_press: 0x70006 0x00
 kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 20ms
-queue_process_next: Invoking KEY_PRESS: 0x70006 0x00
+queue_process_next: Invoking key_press: 0x70006 0x00
 kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 50ms

--- a/app/tests/macros/wait-macro-release/keycode_events.snapshot
+++ b/app/tests/macros/wait-macro-release/keycode_events.snapshot
@@ -1,16 +1,16 @@
 qm: Iterating macro bindings - starting: 0, count: 4
-queue_process_next: Invoking KEY_PRESS: 0x700e2 0x00
+queue_process_next: Invoking key_press: 0x700e2 0x00
 kp_pressed: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 10ms
-queue_process_next: Invoking KEY_PRESS: 0x7002b 0x00
+queue_process_next: Invoking key_press: 0x7002b 0x00
 kp_pressed: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 40ms
-queue_process_next: Invoking KEY_PRESS: 0x7002b 0x00
+queue_process_next: Invoking key_press: 0x7002b 0x00
 kp_released: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 10ms
 kp_pressed: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
 kp_released: usage_page 0x07 keycode 0x2B implicit_mods 0x00 explicit_mods 0x00
 qm: Iterating macro bindings - starting: 5, count: 2
-queue_process_next: Invoking KEY_PRESS: 0x700e2 0x00
+queue_process_next: Invoking key_press: 0x700e2 0x00
 kp_released: usage_page 0x07 keycode 0xE2 implicit_mods 0x00 explicit_mods 0x00
 queue_process_next: Processing next queued behavior in 0ms

--- a/app/tests/mod-morph/2b-masked-morph-implicit-overwrite/native_posix_64.keymap
+++ b/app/tests/mod-morph/2b-masked-morph-implicit-overwrite/native_posix_64.keymap
@@ -6,7 +6,6 @@
     behaviors {
         mod_morph: mod_morph {
             compatible = "zmk,behavior-mod-morph";
-            label = "MOD_MORPH_TEST";
             #binding-cells = <0>;
             bindings = <&kp A>, <&kp LS(B)>;  // implict mod overwrite
             mods = <(MOD_LSFT|MOD_RSFT)>;
@@ -15,7 +14,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/mod-morph/2d-masked-morph-into-hold-tap-tap/native_posix_64.keymap
+++ b/app/tests/mod-morph/2d-masked-morph-into-hold-tap-tap/native_posix_64.keymap
@@ -16,7 +16,6 @@
     behaviors {
         mod_morph: mod_morph {
             compatible = "zmk,behavior-mod-morph";
-            label = "MOD_MORPH_TEST";
             #binding-cells = <0>;
             bindings = <&kp A>, <&lt 1 B>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
@@ -26,7 +25,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/mod-morph/2e-masked-morph-into-hold-tap-hold/native_posix_64.keymap
+++ b/app/tests/mod-morph/2e-masked-morph-into-hold-tap-hold/native_posix_64.keymap
@@ -18,7 +18,6 @@
     behaviors {
         mod_morph: mod_morph {
             compatible = "zmk,behavior-mod-morph";
-            label = "MOD_MORPH_TEST";
             #binding-cells = <0>;
             bindings = <&kp A>, <&lt 1 B>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
@@ -28,7 +27,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/mod-morph/3-unmasked-morph/native_posix_64.keymap
+++ b/app/tests/mod-morph/3-unmasked-morph/native_posix_64.keymap
@@ -6,7 +6,6 @@
     behaviors {
         mod_morph: mod_morph {
             compatible = "zmk,behavior-mod-morph";
-            label = "MOD_MORPH_TEST";
             #binding-cells = <0>;
             bindings = <&kp A>, <&kp B>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
@@ -16,7 +15,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/mod-morph/behavior_keymap.dtsi
+++ b/app/tests/mod-morph/behavior_keymap.dtsi
@@ -2,7 +2,6 @@
     behaviors {
         mod_morph: mod_morph {
             compatible = "zmk,behavior-mod-morph";
-            label = "MOD_MORPH_TEST";
             #binding-cells = <0>;
             bindings = <&kp A>, <&kp B>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
@@ -11,7 +10,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/explicit/kp-hyper-dn-a-dn-a-up-hyper-up/native_posix_64.keymap
+++ b/app/tests/modifiers/explicit/kp-hyper-dn-a-dn-a-up-hyper-up/native_posix_64.keymap
@@ -16,7 +16,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/explicit/kp-lctl-dn-lctl-dn-lctl-up-lctl-up/native_posix_64.keymap
+++ b/app/tests/modifiers/explicit/kp-lctl-dn-lctl-dn-lctl-up-lctl-up/native_posix_64.keymap
@@ -15,7 +15,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/explicit/kp-lctl-dn-lctl-up/native_posix_64.keymap
+++ b/app/tests/modifiers/explicit/kp-lctl-dn-lctl-up/native_posix_64.keymap
@@ -13,7 +13,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/explicit/kp-lctl-dn-lsft-dn-lctl-up-lsft-up/native_posix_64.keymap
+++ b/app/tests/modifiers/explicit/kp-lctl-dn-lsft-dn-lctl-up-lsft-up/native_posix_64.keymap
@@ -15,7 +15,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/explicit/kp-lctl-dn-lsft-dn-lsft-up-lctl-up/native_posix_64.keymap
+++ b/app/tests/modifiers/explicit/kp-lctl-dn-lsft-dn-lsft-up-lctl-up/native_posix_64.keymap
@@ -16,7 +16,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/implicit/kp-mod1-dn-mod2-dn-mod1-up-mod2-up/native_posix_64.keymap
+++ b/app/tests/modifiers/implicit/kp-mod1-dn-mod2-dn-mod1-up-mod2-up/native_posix_64.keymap
@@ -15,7 +15,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/implicit/kp-mod1-dn-mod2-dn-mod2-up-mod1-up/native_posix_64.keymap
+++ b/app/tests/modifiers/implicit/kp-mod1-dn-mod2-dn-mod2-up-mod1-up/native_posix_64.keymap
@@ -15,7 +15,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/implicit/kp-rolling-symbols-same-key/native_posix_64.keymap
+++ b/app/tests/modifiers/implicit/kp-rolling-symbols-same-key/native_posix_64.keymap
@@ -15,7 +15,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-lctl-up-mod-up/native_posix_64.keymap
+++ b/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-lctl-up-mod-up/native_posix_64.keymap
@@ -15,7 +15,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-mod-up-lctl-up/native_posix_64.keymap
+++ b/app/tests/modifiers/mixed/kp-lctl-dn-mod-dn-mod-up-lctl-up/native_posix_64.keymap
@@ -15,7 +15,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/momentary-layer/1-normal/native_posix_64.keymap
+++ b/app/tests/momentary-layer/1-normal/native_posix_64.keymap
@@ -6,7 +6,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/momentary-layer/2-early-key-release/native_posix_64.keymap
+++ b/app/tests/momentary-layer/2-early-key-release/native_posix_64.keymap
@@ -6,7 +6,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/momentary-layer/3-covered/native_posix_64.keymap
+++ b/app/tests/momentary-layer/3-covered/native_posix_64.keymap
@@ -9,7 +9,6 @@ and the original key is "covered".
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/momentary-layer/4-nested/native_posix_64.keymap
+++ b/app/tests/momentary-layer/4-nested/native_posix_64.keymap
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/momentary-layer/5-nested-early-key-release/native_posix_64.keymap
+++ b/app/tests/momentary-layer/5-nested-early-key-release/native_posix_64.keymap
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/momentary-layer/behavior_keymap.dtsi
+++ b/app/tests/momentary-layer/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/mouse-keys/mkp/native_posix.keymap
+++ b/app/tests/mouse-keys/mkp/native_posix.keymap
@@ -6,7 +6,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/mouse-keys/mkp/native_posix_64.keymap
+++ b/app/tests/mouse-keys/mkp/native_posix_64.keymap
@@ -6,7 +6,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/none/behavior_keymap.dtsi
+++ b/app/tests/none/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/sticky-keys/10-callum-mods-quick-release/native_posix_64.keymap
+++ b/app/tests/sticky-keys/10-callum-mods-quick-release/native_posix_64.keymap
@@ -9,7 +9,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/sticky-keys/10-callum-mods/native_posix_64.keymap
+++ b/app/tests/sticky-keys/10-callum-mods/native_posix_64.keymap
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/sticky-keys/10-sl-sl-kp/native_posix_64.keymap
+++ b/app/tests/sticky-keys/10-sl-sl-kp/native_posix_64.keymap
@@ -10,7 +10,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/sticky-keys/2-sl-dn-up-kcdn-kcup/native_posix_64.keymap
+++ b/app/tests/sticky-keys/2-sl-dn-up-kcdn-kcup/native_posix_64.keymap
@@ -10,7 +10,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/sticky-keys/8-lsk-osk-combination-quick-release/native_posix_64.keymap
+++ b/app/tests/sticky-keys/8-lsk-osk-combination-quick-release/native_posix_64.keymap
@@ -9,7 +9,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/sticky-keys/8-lsk-osk-combination/native_posix_64.keymap
+++ b/app/tests/sticky-keys/8-lsk-osk-combination/native_posix_64.keymap
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/sticky-keys/9-sk-dn-up-dn-up/native_posix_64.keymap
+++ b/app/tests/sticky-keys/9-sk-dn-up-dn-up/native_posix_64.keymap
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/sticky-keys/behavior_keymap.dtsi
+++ b/app/tests/sticky-keys/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/tap-dance/behavior_keymap.dtsi
+++ b/app/tests/tap-dance/behavior_keymap.dtsi
@@ -6,7 +6,6 @@
     behaviors {
         ht: hold_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "HOLD_TAP";
             #binding-cells = <2>;
             tapping-term-ms = <200>;
             quick_tap_ms = <0>;
@@ -16,7 +15,6 @@
 
         tdm: tap_dance_mixed {
             compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MOD";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&ht LSHIFT A>, <&ht LALT B>, <&ht LGUI C>;
@@ -24,7 +22,6 @@
 
         tdb: tap_dance_basic {
             compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_BASIC";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&kp N1>, <&kp N2>, <&kp N3>;
@@ -32,7 +29,6 @@
 
         td2: tap_dance_basic_2 {
             compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_BASIC_2";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&kp A>, <&kp B>, <&kp C>;
@@ -40,7 +36,6 @@
 
         tds: tap_dance_single {
             compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_SINGlE";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&kp S>;
@@ -59,7 +54,6 @@
 
     keymap {
         compatible = "zmk,keymap";
-        label = "Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/to-layer/behavior_keymap.dtsi
+++ b/app/tests/to-layer/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/toggle-layer/behavior_keymap.dtsi
+++ b/app/tests/toggle-layer/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/transparent/behavior_keymap.dtsi
+++ b/app/tests/transparent/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/app/tests/wpm/behavior_keymap.dtsi
+++ b/app/tests/wpm/behavior_keymap.dtsi
@@ -5,7 +5,6 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
 
         default_layer {
             bindings = <

--- a/docs/blog/2020-10-03-bootloader-fix.md
+++ b/docs/blog/2020-10-03-bootloader-fix.md
@@ -176,7 +176,6 @@ this to all of the `.dts` files for the boards that were affected by this issue.
 
 ```diff
         code_partition: partition@26000 {
-            label = "code_partition";
 -           reg = <0x00026000 0x000d2000>;
 +           reg = <0x00026000 0x000c6000>;
         };
@@ -184,7 +183,6 @@ this to all of the `.dts` files for the boards that were affected by this issue.
 
 -       storage_partition: partition@f8000 {
 +       storage_partition: partition@ec000 {
-            label = "storage";
 -           reg = <0x000f8000 0x00008000>;
 +           reg = <0x000ec000 0x00008000>;
         };
@@ -193,3 +191,7 @@ this to all of the `.dts` files for the boards that were affected by this issue.
 And with those changes, we should no longer run into this issue! In the process
 of these changes, we lost 48KB of space for application code, but we're only
 using around 20% of it anyways. 🎉
+
+## Article Updates
+
+- 12/2023: Removed the deprecated `label` property from code snippets.

--- a/docs/blog/2021-01-27-zmk-sotf-4.md
+++ b/docs/blog/2021-01-27-zmk-sotf-4.md
@@ -98,7 +98,7 @@ There has been lots of work to get display support complete enough for use by en
 
 #### Highest Layer Display
 
-[mcrosson] has contributed the next display widget, showing the highest active layer in the keymap. [petejohanson] then added a small follow up to allow layers in keymaps to add a `label` property to each layer, e.g. `label = "Nav";` and have that label be displayed in the widget instead of the numeric layer number.
+[mcrosson] has contributed the next display widget, showing the highest active layer in the keymap. [petejohanson] then added a small follow up to allow layers in keymaps to add a `name` property to each layer, e.g. `name = "Nav";` and have that name be displayed in the widget instead of the numeric layer number.
 
 #### WPM
 
@@ -192,3 +192,7 @@ Thanks again to the numerous contributors, testers, and users who have made work
 [petejohanson]: https://github.com/petejohanson
 [innovaker]: https://github.com/innovaker
 [joelspadin]: https://github.com/joelspadin
+
+## Article Updates
+
+- 12/2023: The `label` property for keymap layers was renamed to `display-name`.

--- a/docs/blog/2022-04-02-zephyr-3-0.md
+++ b/docs/blog/2022-04-02-zephyr-3-0.md
@@ -79,7 +79,6 @@ Zephyr's WS2812 `led_strip` driver added a new required property. When adding [u
 ```dts
 led_strip: ws2812@0 {
   compatible = "worldsemi,ws2812-spi";
-  label = "WS2812";
 
   /* SPI */
   reg = <0>; /* ignored, but necessary for SPI bindings */
@@ -115,7 +114,6 @@ For example, for a shield with:
   oled: ssd1306@3c {
     compatible = "solomon,ssd1306fb";
     reg = <0x3c>;
-    label = "SSD1306";
     width = <128>;
     height = <32>;
     segment-offset = <0>;
@@ -153,7 +151,6 @@ Underneath the USB device, add the CDC ACM node:
   status = "okay";
   cdc_acm_uart: cdc_acm_uart {
     compatible = "zephyr,cdc-acm-uart";
-    label = "CDC_ACM_0";
   };
 };
 ```
@@ -226,3 +223,7 @@ This will also enable us to support the XIAO compatible Adafruit Qt Py RP2040 an
 Thanks to all the testers who have helped verify ZMK functionality on the newer Zephyr version.
 
 [petejohanson]: https://github.com/petejohanson
+
+## Article Updates
+
+- 12/2023: Removed the deprecated `label` property from code snippets.

--- a/docs/blog/2022-04-10-zmk-sotf-5.md
+++ b/docs/blog/2022-04-10-zmk-sotf-5.md
@@ -55,7 +55,6 @@ a user taps a single key in their keymap, e.g.
     behaviors {
         td0: tap_dance_0 {
             compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_0";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&kp N1>, <&kp N2>, <&kp N3>;
@@ -263,3 +262,7 @@ As we approach the two year birthday for ZMK, I am reminded of how far we have c
 [joelspadin]: https://github.com/joelspadin
 [bcat]: https://github.com/bcat
 [dxmh]: https://github.com/dxmh
+
+## Article Updates
+
+- 12/2023: Removed the deprecated `label` property from code snippets.

--- a/docs/blog/2023-06-18-encoder-refactors.md
+++ b/docs/blog/2023-06-18-encoder-refactors.md
@@ -38,7 +38,6 @@ Previously, an encoder configuration looked like:
 ```dts
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         resolution = <4>;
@@ -61,7 +60,6 @@ That was the entirety of the configuration for encoders.
 ```dts
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;
@@ -117,3 +115,7 @@ The old configuration will be supported for a period of one month, and then remo
 
 [petejohanson]: https://github.com/petejohanson
 [joelspadin]: https://github.com/joelspadin
+
+## Article Updates
+
+- 12/2023: Removed the deprecated `label` property from code snippets.

--- a/docs/blog/2023-10-05-zmk-sotf-6.md
+++ b/docs/blog/2023-10-05-zmk-sotf-6.md
@@ -34,7 +34,6 @@ As an example, you can now define a mod-morph that swaps `;` and `:` so that the
 ```dts
         col_semi: colon_semicolon {
             compatible = "zmk,behavior-mod-morph";
-            label = "COLON_SEMICOLON";
             #binding-cells = <0>;
             bindings = <&kp COLON>, <&kp SEMI>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
@@ -48,9 +47,8 @@ As an example, you can now define a mod-morph that swaps `;` and `:` so that the
 As a simple example, you could define a macro that puts any keycode provided between double quotes as below, then use it like `&ql A` in your keymap:
 
 ```dts
-        ql: quoted_letter_macro {
+        ql: quoted_letter {
             #binding-cells = <1>;
-            label = "QUOTED_LETTER";
             compatible = "zmk,behavior-macro-one-param";
             bindings =
                 <&kp DQT>,
@@ -293,3 +291,7 @@ Also a big thank you to contributors that submit patches and perform reviews, te
 [urob]: https://github.com/urob
 [filterpaper]: https://github.com/filterpaper
 [ReFil]: https://github.com/ReFil
+
+## Article Updates
+
+- 12/2023: Removed the deprecated `label` property from code snippets.

--- a/docs/docs/behaviors/caps-word.md
+++ b/docs/docs/behaviors/caps-word.md
@@ -59,9 +59,8 @@ If you want to use multiple caps breaks with different codes to break the caps, 
 
 ```dts
 / {
-    prog_caps: behavior_prog_caps_word {
+    prog_caps: prog_caps {
         compatible = "zmk,behavior-caps-word";
-        label = "PROG_CAPS";
         #binding-cells = <0>;
         continue-list = <UNDERSCORE>;
     };

--- a/docs/docs/behaviors/hold-tap.md
+++ b/docs/docs/behaviors/hold-tap.md
@@ -58,7 +58,6 @@ For example, the following hold-tap configuration enables `require-prior-idle-ms
 ```dts
 rpi: require_prior_idle {
     compatible = "zmk,behavior-hold-tap";
-    label = "REQUIRE_PRIOR_IDLE";
     #binding-cells = <2>;
     flavor = "tap-preferred";
     tapping-term-ms = <200>;
@@ -104,7 +103,6 @@ See the following example, which uses a hold-tap behavior definition, configured
     behaviors {
         pht: positional_hold_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "POSITIONAL_HOLD_TAP";
             #binding-cells = <2>;
             flavor = "hold-preferred";
             tapping-term-ms = <400>;
@@ -115,7 +113,6 @@ See the following example, which uses a hold-tap behavior definition, configured
     };
     keymap {
         compatible = "zmk,keymap";
-        label ="Default keymap";
         default_layer {
             bindings = <
                 //  position 0         position 1       position 2
@@ -172,9 +169,8 @@ The following are suggested hold-tap configurations that work well with home row
 
 / {
     behaviors {
-        lh_pht: left_hand_positional_hold_tap {
+        lh_pht: left_positional_hold_tap {
             compatible = "zmk,behavior-hold-tap";
-            label = "LEFT_POSITIONAL_HOLD_TAP";
             #binding-cells = <2>;
             flavor = "tap-unless-interrupted";
             tapping-term-ms = <100>;                        // <---[[produces tap if held longer than tapping-term-ms]]
@@ -206,7 +202,6 @@ The following are suggested hold-tap configurations that work well with home row
     behaviors {
         hm: homerow_mods {
             compatible = "zmk,behavior-hold-tap";
-            label = "HOMEROW_MODS";
             #binding-cells = <2>;
             tapping-term-ms = <150>;
             quick-tap-ms = <0>;
@@ -236,7 +231,6 @@ The following are suggested hold-tap configurations that work well with home row
     behaviors {
         bhm: balanced_homerow_mods {
             compatible = "zmk,behavior-hold-tap";
-            label = "HOMEROW_MODS";
             #binding-cells = <2>;
             tapping-term-ms = <200>;    // <---[[moderate duration]]
             quick-tap-ms = <0>;
@@ -272,7 +266,6 @@ A popular method of implementing Autoshift in ZMK involves a C-preprocessor macr
     behaviors {
         as: auto_shift {
             compatible = "zmk,behavior-hold-tap";
-            label = "AUTO_SHIFT";
             #binding-cells = <2>;
             tapping_term_ms = <135>;
             quick_tap_ms = <0>;
@@ -308,7 +301,6 @@ This hold-tap example implements a [momentary-layer](layers.md/#momentary-layer)
     behaviors {
         mo_tog: behavior_mo_tog {
             compatible = "zmk,behavior-hold-tap";
-            label = "mo_tog";
             #binding-cells = <2>;
             flavor = "hold-preferred";
             tapping-term-ms = <200>;

--- a/docs/docs/behaviors/macros.md
+++ b/docs/docs/behaviors/macros.md
@@ -18,7 +18,6 @@ A macro definition looks like:
 / {
     macros {
         zed_em_kay: zed_em_kay {
-            label = "ZM_zed_em_kay";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings
@@ -239,7 +238,6 @@ To achieve this, a combination of a 0ms wait time and splitting the press and re
  *  `&lm NUM_LAYER LSHIFT`
  */
 lm: lm {
-    label = "LAYER_MOD";
     compatible = "zmk,behavior-macro-two-param";
     wait-ms = <0>;
     tap-ms = <0>;
@@ -323,7 +321,6 @@ This can be used instead of a complete macro definition. During the firmware bui
 ```dts
     my_zero_param_macro: my_zero_param_macro {
         compatible = "zmk,behavior-macro";
-        label = "ZM_my_macro";
         #binding-cells = <0>;
         wait-ms = <30>;
         tap-ms = <40>;

--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -23,7 +23,6 @@ An example of how to implement the mod-morph "Grave Escape":
     behaviors {
         gresc: grave_escape {
             compatible = "zmk,behavior-mod-morph";
-            label = "GRAVE_ESCAPE";
             #binding-cells = <0>;
             bindings = <&kp ESC>, <&kp GRAVE>;
             mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
@@ -79,7 +78,6 @@ For example, the following configuration morphs `LEFT_SHIFT` + `BACKSPACE` into 
     behaviors {
         bspc_del: backspace_delete {
             compatible = "zmk,behavior-mod-morph";
-            label = "BACKSPACE_DELETE";
             #binding-cells = <0>;
             bindings = <&kp BACKSPACE>, <&kp DELETE>;
             mods = <(MOD_LSFT|MOD_RSFT)>;

--- a/docs/docs/behaviors/sensor-rotate.md
+++ b/docs/docs/behaviors/sensor-rotate.md
@@ -24,7 +24,6 @@ Here is an example that binds the [RGB Underglow Behavior](/docs/behaviors/under
     behaviors {
         rgb_encoder: rgb_encoder {
             compatible = "zmk,behavior-sensor-rotate";
-            label = "RGB_ENCODER";
             #sensor-binding-cells = <0>;
             bindings = <&rgb_ug RGB_BRI>, <&rgb_ug RGB_BRD>;
         };
@@ -58,9 +57,8 @@ First, defining the sensor rotation itself, binding the [Key Press Behavior](/do
 ```dts
 / {
     behaviors {
-        rot_kp: behavior_sensor_rotate_kp {
+        rot_kp: sensor_rotate_kp {
             compatible = "zmk,behavior-sensor-rotate-var";
-            label = "ENC_KP";
             #sensor-binding-cells = <2>;
             bindings = <&kp>, <&kp>;
         };

--- a/docs/docs/behaviors/sticky-key.md
+++ b/docs/docs/behaviors/sticky-key.md
@@ -61,7 +61,6 @@ This configuration would apply to all sticky keys. This may not be appropriate i
     behaviors {
       skq: sticky_key_quick_release {
         compatible = "zmk,behavior-sticky-key";
-        label = "STICKY_KEY_QUICK_RELEASE";
         #binding-cells = <1>;
         bindings = <&kp>;
         release-after-ms = <1000>;

--- a/docs/docs/behaviors/tap-dance.md
+++ b/docs/docs/behaviors/tap-dance.md
@@ -45,7 +45,6 @@ This example configures a tap-dance named `td0` that outputs the number of times
     behaviors {
         td0: tap_dance_0 {
             compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_0";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&kp N1>, <&kp N2>, <&kp N3>;
@@ -86,7 +85,6 @@ This example configures a mod-tap inside a tap-dance named `td_mt` that outputs 
     behaviors {
         td_mt: tap_dance_mod_tap {
             compatible = "zmk,behavior-tap-dance";
-            label = "TAP_DANCE_MOD_TAP";
             #binding-cells = <0>;
             tapping-term-ms = <200>;
             bindings = <&mt LSHIFT CAPSLOCK>, <&kp LCTRL>;

--- a/docs/docs/config/battery.md
+++ b/docs/docs/config/battery.md
@@ -48,7 +48,7 @@ See [Zephyr's voltage divider documentation](https://docs.zephyrproject.org/late
 
 ## nRF VDDH Battery Sensor
 
-Driver for reading the voltage of a battery using a Nordic nRF52's VDDH pin. This driver has no configuration except for the required `label` property.
+Driver for reading the voltage of a battery using a Nordic nRF52's VDDH pin.
 
 ### Devicetree
 
@@ -56,6 +56,4 @@ Applies to: `compatible = "zmk,battery-nrf-vddh"`
 
 Definition file: [zmk/app/module/dts/bindings/sensor/zmk,battery-nrf-vddh.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/module/dts/bindings/sensor/zmk%2Cbattery-nrf-vddh.yaml)
 
-| Property | Type   | Description               |
-| -------- | ------ | ------------------------- |
-| `label`  | string | Unique label for the node |
+This driver has no configuration.

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -29,12 +29,11 @@ Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-caps-word.yaml](ht
 
 Applies to: `compatible = "zmk,behavior-caps-word"`
 
-| Property         | Type   | Description                                                        | Default                         |
-| ---------------- | ------ | ------------------------------------------------------------------ | ------------------------------- |
-| `label`          | string | Unique label for the node                                          |                                 |
-| `#binding-cells` | int    | Must be `<0>`                                                      |                                 |
-| `continue-list`  | array  | List of [key codes](/docs/codes) which do not deactivate caps lock | `<UNDERSCORE BACKSPACE DELETE>` |
-| `mods`           | int    | A bit field of modifiers to apply                                  | `<MOD_LSFT>`                    |
+| Property         | Type  | Description                                                        | Default                         |
+| ---------------- | ----- | ------------------------------------------------------------------ | ------------------------------- |
+| `#binding-cells` | int   | Must be `<0>`                                                      |                                 |
+| `continue-list`  | array | List of [key codes](/docs/codes) which do not deactivate caps lock | `<UNDERSCORE BACKSPACE DELETE>` |
+| `mods`           | int   | A bit field of modifiers to apply                                  | `<MOD_LSFT>`                    |
 
 `continue-list` is treated as if it always includes alphanumeric characters (A-Z, 0-9).
 
@@ -60,7 +59,6 @@ Applies to: `compatible = "zmk,behavior-hold-tap"`
 
 | Property                     | Type          | Description                                                                                                    | Default            |
 | ---------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `label`                      | string        | Unique label for the node                                                                                      |                    |
 | `#binding-cells`             | int           | Must be `<2>`                                                                                                  |                    |
 | `bindings`                   | phandle array | A list of two behaviors (without parameters): one for hold and one for tap                                     |                    |
 | `flavor`                     | string        | Adjusts how the behavior chooses between hold and tap                                                          | `"hold-preferred"` |
@@ -100,11 +98,10 @@ Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-key-repeat.yaml](h
 
 Applies to: `compatible = "zmk,behavior-key-repeat"`
 
-| Property         | Type   | Description                      | Default           |
-| ---------------- | ------ | -------------------------------- | ----------------- |
-| `label`          | string | Unique label for the node        |                   |
-| `#binding-cells` | int    | Must be `<0>`                    |                   |
-| `usage-pages`    | array  | List of HID usage pages to track | `<HID_USAGE_KEY>` |
+| Property         | Type  | Description                      | Default           |
+| ---------------- | ----- | -------------------------------- | ----------------- |
+| `#binding-cells` | int   | Must be `<0>`                    |                   |
+| `usage-pages`    | array | List of HID usage pages to track | `<HID_USAGE_KEY>` |
 
 For the `usage-pages` property, use the `HID_USAGE_*` defines from [dt-bindings/zmk/hid_usage_pages.h](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/hid_usage_pages.h).
 
@@ -133,7 +130,6 @@ Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-macro.yaml](https:
 
 | Property         | Type          | Description                                                                                                                                  | Default                            |
 | ---------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `label`          | string        | Unique label for the node                                                                                                                    |                                    |
 | `compatible`     | string        | Macro type, **must be _one_ of**:<br/>• `"zmk,behavior-macro"`<br/>• `"zmk,behavior-macro-one-param"`<br/>• `"zmk,behavior-macro-two-param"` |                                    |
 | `#binding-cells` | int           | Number of params accepted (depends on `compatible` property), **must be _one_ of**:<br/>• `<0>`<br/>• `<1>`<br/>• `<2>`                      |                                    |
 | `bindings`       | phandle array | List of behaviors to trigger                                                                                                                 |                                    |
@@ -169,7 +165,6 @@ Applies to: `compatible = "zmk,behavior-mod-morph"`
 
 | Property         | Type          | Description                                                                       |
 | ---------------- | ------------- | --------------------------------------------------------------------------------- |
-| `label`          | string        | Unique label for the node                                                         |
 | `#binding-cells` | int           | Must be `<0>`                                                                     |
 | `bindings`       | phandle array | A list of two behaviors: one for normal press and one for mod morphed press       |
 | `mods`           | int           | A bit field of modifiers. The morph behavior is used if any of these are pressed. |
@@ -196,7 +191,6 @@ Applies to: `compatible = "zmk,behavior-sticky-key"`
 
 | Property           | Type          | Description                                                              | Default |
 | ------------------ | ------------- | ------------------------------------------------------------------------ | ------- |
-| `label`            | string        | Unique label for the node                                                |         |
 | `#binding-cells`   | int           | Must match the number of parameters the `bindings` behavior uses         |         |
 | `bindings`         | phandle array | A behavior (without parameters) to trigger                               |         |
 | `release-after-ms` | int           | Releases the key after this many milliseconds if no other key is pressed | 1000    |
@@ -222,7 +216,6 @@ Applies to: `compatible = "zmk,behavior-tap-dance"`
 
 | Property          | Type          | Description                                                                                  | Default |
 | ----------------- | ------------- | -------------------------------------------------------------------------------------------- | ------- |
-| `label`           | string        | Unique label for the node                                                                    |         |
 | `#binding-cells`  | int           | Must be `<0>`                                                                                |         |
 | `bindings`        | phandle array | A list of behaviors from which to select                                                     |         |
 | `tapping-term-ms` | int           | The maximum time (in milliseconds) between taps before an item from `bindings` is triggered. | 200     |

--- a/docs/docs/config/encoders.md
+++ b/docs/docs/config/encoders.md
@@ -77,7 +77,6 @@ Definition file: [zmk/app/module/dts/bindings/sensor/alps,ec11.yaml](https://git
 
 | Property  | Type       | Description                                    | Default |
 | --------- | ---------- | ---------------------------------------------- | ------- |
-| `label`   | string     | Unique label for the node                      |         |
 | `a-gpios` | GPIO array | GPIO connected to the encoder's A pin          |         |
 | `b-gpios` | GPIO array | GPIO connected to the encoder's B pin          |         |
 | `steps`   | int        | Number of encoder pulses per complete rotation |         |

--- a/docs/docs/config/index.md
+++ b/docs/docs/config/index.md
@@ -122,7 +122,6 @@ Devicetree files look like this:
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
     };
 };
 ```

--- a/docs/docs/config/keymap.md
+++ b/docs/docs/config/keymap.md
@@ -19,7 +19,7 @@ Each child node can have the following properties:
 
 | Property          | Type          | Description                                                            |
 | ----------------- | ------------- | ---------------------------------------------------------------------- |
-| `label`           | string        | Unique label for the node                                              |
+| `display-name`    | string        | Name for the layer on displays                                         |
 | `bindings`        | phandle-array | List of [key behaviors](../features/keymaps.md#behaviors), one per key |
 | `sensor-bindings` | phandle-array | List of sensor behaviors, one per sensor                               |
 

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -48,7 +48,6 @@ Definition file: [zmk/app/module/dts/bindings/kscan/zmk,kscan-gpio-demux.yaml](h
 
 | Property                | Type       | Description                      | Default |
 | ----------------------- | ---------- | -------------------------------- | ------- |
-| `label`                 | string     | Unique label for the node        |         |
 | `input-gpios`           | GPIO array | Input GPIOs                      |         |
 | `output-gpios`          | GPIO array | Demultiplexer address GPIOs      |         |
 | `debounce-period`       | int        | Debounce period in milliseconds  | 5       |
@@ -74,7 +73,6 @@ Definition file: [zmk/app/module/dts/bindings/kscan/zmk,kscan-gpio-direct.yaml](
 
 | Property                  | Type       | Description                                                                                                 | Default |
 | ------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- | ------- |
-| `label`                   | string     | Unique label for the node                                                                                   |         |
 | `input-gpios`             | GPIO array | Input GPIOs (one per key)                                                                                   |         |
 | `debounce-press-ms`       | int        | Debounce time for key press in milliseconds. Use 0 for eager debouncing.                                    | 5       |
 | `debounce-release-ms`     | int        | Debounce time for key release in milliseconds.                                                              | 5       |
@@ -118,7 +116,6 @@ Definition file: [zmk/app/module/dts/bindings/kscan/zmk,kscan-gpio-matrix.yaml](
 
 | Property                  | Type       | Description                                                                                                 | Default     |
 | ------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------- | ----------- |
-| `label`                   | string     | Unique label for the node                                                                                   |             |
 | `row-gpios`               | GPIO array | Matrix row GPIOs in order, starting from the top row                                                        |             |
 | `col-gpios`               | GPIO array | Matrix column GPIOs in order, starting from the leftmost row                                                |             |
 | `debounce-press-ms`       | int        | Debounce time for key press in milliseconds. Use 0 for eager debouncing.                                    | 5           |
@@ -162,17 +159,15 @@ Applies to : `compatible = "zmk,kscan-composite"`
 
 Definition file: [zmk/app/dts/bindings/zmk,kscan-composite.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk,kscan-composite.yaml)
 
-| Property | Type   | Description                                   | Default |
-| -------- | ------ | --------------------------------------------- | ------- |
-| `label`  | string | Unique label for the node                     |         |
-| `rows`   | int    | The number of rows in the composite matrix    |         |
-| `cols`   | int    | The number of columns in the composite matrix |         |
+| Property | Type | Description                                   | Default |
+| -------- | ---- | --------------------------------------------- | ------- |
+| `rows`   | int  | The number of rows in the composite matrix    |         |
+| `cols`   | int  | The number of columns in the composite matrix |         |
 
 The `zmk,kscan-composite` node should have one child node per keyboard scan driver that should be composited. Each child node can have the following properties:
 
 | Property        | Type    | Description                                                                    | Default |
 | --------------- | ------- | ------------------------------------------------------------------------------ | ------- |
-| `label`         | string  | Unique label for the node                                                      |         |
 | `kscan`         | phandle | Label of the kscan driver to include                                           |         |
 | `row-offset`    | int     | Shifts row 0 of the included driver to a new row in the composite matrix       | 0       |
 | `column-offset` | int     | Shifts column 0 of the included driver to a new column in the composite matrix | 0       |
@@ -237,7 +232,6 @@ One possible way to do this is a 3x4 matrix where the direct GPIO keys are shift
 
     kscan0: kscan_composite {
         compatible = "zmk,kscan-composite";
-        label = "KSCAN0";
         rows = <4>;
         columns = <3>;
 
@@ -275,14 +269,13 @@ Applies to: `compatible = "zmk,kscan-mock"`
 
 Definition file: [zmk/app/dts/bindings/zmk,kscan-mock.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk%2Ckscan-mock.yaml)
 
-| Property       | Type   | Description                                   | Default |
-| -------------- | ------ | --------------------------------------------- | ------- |
-| `label`        | string | Unique label for the node                     |         |
-| `event-period` | int    | Milliseconds between each generated event     |         |
-| `events`       | array  | List of key events to simulate                |         |
-| `rows`         | int    | The number of rows in the composite matrix    |         |
-| `cols`         | int    | The number of columns in the composite matrix |         |
-| `exit-after`   | bool   | Exit the program after running all events     | false   |
+| Property       | Type  | Description                                   | Default |
+| -------------- | ----- | --------------------------------------------- | ------- |
+| `event-period` | int   | Milliseconds between each generated event     |         |
+| `events`       | array | List of key events to simulate                |         |
+| `rows`         | int   | The number of rows in the composite matrix    |         |
+| `cols`         | int   | The number of columns in the composite matrix |         |
+| `exit-after`   | bool  | Exit the program after running all events     | false   |
 
 The `events` array should be defined using the macros from [app/module/include/dt-bindings/zmk/kscan_mock.h](https://github.com/zmkfirmware/zmk/blob/main/app/module/include/dt-bindings/zmk/kscan_mock.h).
 

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -42,6 +42,5 @@ Applies to: `compatible = "zmk,ext-power-generic"`
 
 | Property        | Type       | Description                                                   |
 | --------------- | ---------- | ------------------------------------------------------------- |
-| `label`         | string     | Unique label for the node                                     |
 | `control-gpios` | GPIO array | List of GPIOs which should be active to enable external power |
 | `init-delay-ms` | int        | number of milliseconds to delay after initializing the driver |

--- a/docs/docs/development/new-behavior.md
+++ b/docs/docs/development/new-behavior.md
@@ -370,7 +370,6 @@ For the purpose of this section, we will discuss the structure of `app/dts/behav
     behaviors {
         /omit-if-no-ref/ gresc: grave_escape {
             compatible = "zmk,behavior-mod-morph";
-            label = "GRAVE_ESCAPE";
             #binding-cells = <0>;
             bindings = <&kp ESC>, <&kp GRAVE>;
             mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;

--- a/docs/docs/development/new-behavior.md
+++ b/docs/docs/development/new-behavior.md
@@ -380,7 +380,20 @@ For the purpose of this section, we will discuss the structure of `app/dts/behav
 };
 ```
 
-The format of a behavior's `.dtsi` file is identical to declaring an instance of the behavior in a user's keymap. The only major difference is that the value `/omit-if-no-ref/` should be placed adjacent to the name of the behavior, as seen in line 11 of the `gresc` example.
+The format of a behavior's `.dtsi` file is identical to declaring an instance of the behavior in a user's keymap. The only major difference is that the value `/omit-if-no-ref/` should be placed adjacent to the label and name of the behavior, as seen in line 11 of the `gresc` example.
+
+:::caution
+
+If your behavior has its [`locality`](#api-structure) property set to anything other than `BEHAVIOR_LOCALITY_CENTRAL`, then the name of the node must be at most 8 characters long, or it will fail to be invoked on the peripheral half of a split keyboard.
+
+In the above example, `grave_escape` is too long, so it would need to be shortened, e.g.
+
+```dts
+// Behavior can be invoked on peripherals, so name must be <= 8 characters.
+/omit-if-no-ref/ gresc: gresc { ... };
+```
+
+:::
 
 After creating the `.dtsi` from above, update `app/dts/behaviors.dtsi` to include your newly predefined behavior instance, making it accessible by the devicetree.
 

--- a/docs/docs/development/new-shield.md
+++ b/docs/docs/development/new-shield.md
@@ -144,7 +144,6 @@ this might look something like:
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
         diode-direction = "col2row";
 
         col-gpios
@@ -203,7 +202,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,2) RC(4,9) RC(3,6) RC(3,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-        label = "KSCAN";
 
         diode-direction = "col2row";
         row-gpios
@@ -432,7 +430,6 @@ In your device tree file you will need to add the following lines to define the 
 ```dts
     left_encoder: encoder_left {
         compatible = "alps,ec11";
-        label = "LEFT_ENCODER";
         a-gpios = <PIN_A (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <PIN_B (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         steps = <80>;

--- a/docs/docs/features/backlight.md
+++ b/docs/docs/features/backlight.md
@@ -242,7 +242,6 @@ Add each of your LEDs to the backlight node in the same manner as for one LED, u
 ```dts
 backlight: pwmleds {
     compatible = "pwm-leds";
-    label = "Backlight LEDs";
     pwm_led_0: pwm_led_0 {
         pwms = <&pwm0 0 PWM_MSEC(10) PWM_POLARITY_NORMAL>;
     };

--- a/docs/docs/features/battery.md
+++ b/docs/docs/features/battery.md
@@ -34,7 +34,6 @@ Once you have the sensor driver defined, add a `zmk,battery` property to the `ch
 
     vbatt: vbatt {
         compatible = "zmk,battery-nrf-vddh";
-        label = "VBATT";
     };
 }
 ```

--- a/docs/docs/features/underglow.md
+++ b/docs/docs/features/underglow.md
@@ -98,7 +98,6 @@ Here's an example on a definition that uses P0.06:
 
   led_strip: ws2812@0 {
     compatible = "worldsemi,ws2812-spi";
-    label = "WS2812";
 
     /* SPI */
     reg = <0>; /* ignored, but necessary for SPI bindings */
@@ -142,7 +141,6 @@ Here's another example for a non-nRF52 board on `spi3`:
 
   led_strip: ws2812@0 {
     compatible = "worldsemi,ws2812-spi";
-    label = "WS2812";
 
     /* SPI */
     reg = <0>;


### PR DESCRIPTION
Zephyr has deprecated the `label` property in favor of using the devicetree node name as a node identifier. This PR contains several changes to remove all instances of `label` from the codebase. The property is still supported, however, so most user keymaps will not need to be changed.

The most significant changes are:

- Layers have a new `name` property to replace `label` when determining the layer name shown on displays.
- Node names for all predefined behaviors have been shortened.
- Behaviors now use `BEHAVIOR_*_DEFINE()` macros instead of `DEVICE_*_DEFINE()`. These define the device as before, but also add it to a new list of behavior devices.
- Looking up a behavior by name is now done with `zmk_behavior_get_binding()` instead of `device_get_binding()`. This searches only the list of devices, so it is faster, and there is no possibility of returning the wrong device if one of the shortened behavior names collides with another node defined by the SoC.
- If logging is enabled, an additional check will be run at system init, which will log an error if any two behaviors have the same name.

For the most part, these changes are non-breaking. However, because the names of predefined behavior nodes have been changed, if any keymap changes the settings on a behavior like

```dts
/ {
  behaviors {
    behavior_mod_tap {
      tapping-term-ms = <150>;
    };
  };
};
```
instead of the more common
```dts
&mt {
  tapping-term-ms = <150>;
};
```
then it will need to be updated to use the new name.