### PR TITLE
feat(split): Add peripheral is bonded/connected to central

### DIFF
--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -36,4 +36,5 @@ int zmk_ble_unpair_all();
 
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
 int zmk_ble_put_peripheral_addr(const bt_addr_le_t *addr);
+bt_addr_le_t *zmk_ble_get_peripheral_addr(uint8_t index);
 #endif /* IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL) */

--- a/app/include/zmk/split/bluetooth/central.h
+++ b/app/include/zmk/split/bluetooth/central.h
@@ -6,3 +6,6 @@
 
 int zmk_split_bt_invoke_behavior(uint8_t source, struct zmk_behavior_binding *binding,
                                  struct zmk_behavior_binding_event event, bool state);
+
+bool zmk_split_bt_central_peripheral_is_connected(uint8_t index);
+bool zmk_split_bt_central_peripheral_is_bonded(uint8_t index);

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -333,6 +333,14 @@ int zmk_ble_put_peripheral_addr(const bt_addr_le_t *addr) {
     return -ENOMEM;
 }
 
+bt_addr_le_t *zmk_ble_get_peripheral_addr(uint8_t index) {
+    if (index < ZMK_SPLIT_BLE_PERIPHERAL_COUNT) {
+        return &peripheral_addrs[index];
+    }
+    // Peripheral index out of range
+    return (bt_addr_le_t *)BT_ADDR_LE_NONE;
+}
+
 #endif /* IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL) */
 
 #if IS_ENABLED(CONFIG_SETTINGS)

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -600,6 +600,22 @@ static struct bt_conn_cb conn_callbacks = {
     .disconnected = split_central_disconnected,
 };
 
+bool zmk_split_bt_central_peripheral_is_connected(uint8_t index) {
+    // If index is out of range always not connected
+    if (index >= ZMK_SPLIT_BLE_PERIPHERAL_COUNT)
+        return false;
+    else
+        return (peripherals[index].state == PERIPHERAL_SLOT_STATE_CONNECTED);
+}
+
+bool zmk_split_bt_central_peripheral_is_bonded(uint8_t index) {
+    // If index is out of range always not bonded
+    if (index >= ZMK_SPLIT_BLE_PERIPHERAL_COUNT)
+        return false;
+    else
+        return (bt_addr_le_cmp(zmk_ble_get_peripheral_addr(index), BT_ADDR_LE_ANY) == 0);
+}
+
 K_THREAD_STACK_DEFINE(split_central_split_run_q_stack,
                       CONFIG_ZMK_SPLIT_BLE_CENTRAL_SPLIT_RUN_STACK_SIZE);
 


### PR DESCRIPTION
For easy use by displays and indicators it would be helpful to be able to see if any peripheral at an index is connected and bonded, follow on from #2032 


