### PR TITLE
feat(core): enable FPU if CPU has FPU

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -541,6 +541,9 @@ config REBOOT
 config USB_DEVICE_STACK
     default y if HAS_HW_NRF_USBD
 
+config FPU
+    default CPU_HAS_FPU
+
 config ZMK_WPM
     bool "Calculate WPM"
     default n


### PR DESCRIPTION
`zmk_rgb_underglow_effect_swirl()` with 256 LEDs on Nordic nRF52833 takes around 170 ticks (32.768kHz) without FPU and around 32 ticks with FPU.

Fixes #1641