### PR TITLE
bt: add BT_CLR_ALL behaviour

### DIFF
--- a/app/include/dt-bindings/zmk/bt.h
+++ b/app/include/dt-bindings/zmk/bt.h
@@ -8,7 +8,7 @@
 #define BT_NXT_CMD 1
 #define BT_PRV_CMD 2
 #define BT_SEL_CMD 3
-// #define BT_FULL_RESET_CMD   4
+#define BT_CLR_ALL_CMD 4
 #define BT_DISC_CMD 5
 
 /*
@@ -20,4 +20,5 @@ defines these aliases up front.
 #define BT_NXT BT_NXT_CMD 0
 #define BT_PRV BT_PRV_CMD 0
 #define BT_SEL BT_SEL_CMD
+#define BT_CLR_ALL BT_CLR_ALL_CMD 0
 #define BT_DISC BT_DISC_CMD

--- a/app/include/zmk/activity.h
+++ b/app/include/zmk/activity.h
@@ -8,4 +8,4 @@
 
 enum zmk_activity_state { ZMK_ACTIVITY_ACTIVE, ZMK_ACTIVITY_IDLE, ZMK_ACTIVITY_SLEEP };
 
-enum zmk_activity_state zmk_activity_get_state();
+enum zmk_activity_state zmk_activity_get_state(void);

--- a/app/include/zmk/backlight.h
+++ b/app/include/zmk/backlight.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
-int zmk_backlight_on();
-int zmk_backlight_off();
-int zmk_backlight_toggle();
-bool zmk_backlight_is_on();
+int zmk_backlight_on(void);
+int zmk_backlight_off(void);
+int zmk_backlight_toggle(void);
+bool zmk_backlight_is_on(void);
 
 int zmk_backlight_set_brt(uint8_t brightness);
-uint8_t zmk_backlight_get_brt();
+uint8_t zmk_backlight_get_brt(void);
 uint8_t zmk_backlight_calc_brt(int direction);
-uint8_t zmk_backlight_calc_brt_cycle();
+uint8_t zmk_backlight_calc_brt_cycle(void);

--- a/app/include/zmk/battery.h
+++ b/app/include/zmk/battery.h
@@ -6,4 +6,4 @@
 
 #pragma once
 
-uint8_t zmk_battery_state_of_charge();
+uint8_t zmk_battery_state_of_charge(void);

--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -24,6 +24,7 @@ int zmk_ble_clear_bonds();
 int zmk_ble_prof_next();
 int zmk_ble_prof_prev();
 int zmk_ble_prof_select(uint8_t index);
+int zmk_ble_clear_all_bonds();
 int zmk_ble_prof_disconnect(uint8_t index);
 
 int zmk_ble_active_profile_index();

--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -20,11 +20,11 @@
 #define ZMK_BLE_PROFILE_COUNT CONFIG_BT_MAX_PAIRED
 #endif
 
-int zmk_ble_clear_bonds(void);
+void zmk_ble_clear_bonds(void);
 int zmk_ble_prof_next(void);
 int zmk_ble_prof_prev(void);
 int zmk_ble_prof_select(uint8_t index);
-int zmk_ble_clear_all_bonds(void);
+void zmk_ble_clear_all_bonds(void);
 int zmk_ble_prof_disconnect(uint8_t index);
 
 int zmk_ble_active_profile_index(void);

--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -20,21 +20,21 @@
 #define ZMK_BLE_PROFILE_COUNT CONFIG_BT_MAX_PAIRED
 #endif
 
-int zmk_ble_clear_bonds();
-int zmk_ble_prof_next();
-int zmk_ble_prof_prev();
+int zmk_ble_clear_bonds(void);
+int zmk_ble_prof_next(void);
+int zmk_ble_prof_prev(void);
 int zmk_ble_prof_select(uint8_t index);
-int zmk_ble_clear_all_bonds();
+int zmk_ble_clear_all_bonds(void);
 int zmk_ble_prof_disconnect(uint8_t index);
 
-int zmk_ble_active_profile_index();
+int zmk_ble_active_profile_index(void);
 int zmk_ble_profile_index(const bt_addr_le_t *addr);
-bt_addr_le_t *zmk_ble_active_profile_addr();
-bool zmk_ble_active_profile_is_open();
-bool zmk_ble_active_profile_is_connected();
-char *zmk_ble_active_profile_name();
+bt_addr_le_t *zmk_ble_active_profile_addr(void);
+bool zmk_ble_active_profile_is_open(void);
+bool zmk_ble_active_profile_is_connected(void);
+char *zmk_ble_active_profile_name(void);
 
-int zmk_ble_unpair_all();
+int zmk_ble_unpair_all(void);
 
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
 int zmk_ble_put_peripheral_addr(const bt_addr_le_t *addr);

--- a/app/include/zmk/display.h
+++ b/app/include/zmk/display.h
@@ -10,10 +10,10 @@
 
 #pragma once
 
-struct k_work_q *zmk_display_work_q();
+struct k_work_q *zmk_display_work_q(void);
 
-bool zmk_display_is_initialized();
-int zmk_display_init();
+bool zmk_display_is_initialized(void);
+int zmk_display_init(void);
 
 /**
  * @brief Macro to define a ZMK event listener that handles the thread safety of fetching

--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -252,7 +252,7 @@ struct zmk_hid_mouse_report {
 
 #endif // IS_ENABLED(CONFIG_ZMK_MOUSE)
 
-zmk_mod_flags_t zmk_hid_get_explicit_mods();
+zmk_mod_flags_t zmk_hid_get_explicit_mods(void);
 int zmk_hid_register_mod(zmk_mod_t modifier);
 int zmk_hid_unregister_mod(zmk_mod_t modifier);
 bool zmk_hid_mod_is_pressed(zmk_mod_t modifier);
@@ -260,18 +260,18 @@ bool zmk_hid_mod_is_pressed(zmk_mod_t modifier);
 int zmk_hid_register_mods(zmk_mod_flags_t explicit_modifiers);
 int zmk_hid_unregister_mods(zmk_mod_flags_t explicit_modifiers);
 int zmk_hid_implicit_modifiers_press(zmk_mod_flags_t implicit_modifiers);
-int zmk_hid_implicit_modifiers_release();
+int zmk_hid_implicit_modifiers_release(void);
 int zmk_hid_masked_modifiers_set(zmk_mod_flags_t masked_modifiers);
-int zmk_hid_masked_modifiers_clear();
+int zmk_hid_masked_modifiers_clear(void);
 
 int zmk_hid_keyboard_press(zmk_key_t key);
 int zmk_hid_keyboard_release(zmk_key_t key);
-void zmk_hid_keyboard_clear();
+void zmk_hid_keyboard_clear(void);
 bool zmk_hid_keyboard_is_pressed(zmk_key_t key);
 
 int zmk_hid_consumer_press(zmk_key_t key);
 int zmk_hid_consumer_release(zmk_key_t key);
-void zmk_hid_consumer_clear();
+void zmk_hid_consumer_clear(void);
 bool zmk_hid_consumer_is_pressed(zmk_key_t key);
 
 int zmk_hid_press(uint32_t usage);
@@ -283,11 +283,11 @@ int zmk_hid_mouse_button_press(zmk_mouse_button_t button);
 int zmk_hid_mouse_button_release(zmk_mouse_button_t button);
 int zmk_hid_mouse_buttons_press(zmk_mouse_button_flags_t buttons);
 int zmk_hid_mouse_buttons_release(zmk_mouse_button_flags_t buttons);
-void zmk_hid_mouse_clear();
+void zmk_hid_mouse_clear(void);
 #endif // IS_ENABLED(CONFIG_ZMK_MOUSE)
 
-struct zmk_hid_keyboard_report *zmk_hid_get_keyboard_report();
-struct zmk_hid_consumer_report *zmk_hid_get_consumer_report();
+struct zmk_hid_keyboard_report *zmk_hid_get_keyboard_report(void);
+struct zmk_hid_consumer_report *zmk_hid_get_consumer_report(void);
 
 #if IS_ENABLED(CONFIG_ZMK_USB_BOOT)
 zmk_hid_boot_report_t *zmk_hid_get_boot_report();

--- a/app/include/zmk/hog.h
+++ b/app/include/zmk/hog.h
@@ -9,7 +9,7 @@
 #include <zmk/keys.h>
 #include <zmk/hid.h>
 
-int zmk_hog_init();
+int zmk_hog_init(const struct device *_arg);
 
 int zmk_hog_send_keyboard_report(struct zmk_hid_keyboard_report_body *body);
 int zmk_hog_send_consumer_report(struct zmk_hid_consumer_report_body *body);

--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -14,10 +14,10 @@
 
 typedef uint32_t zmk_keymap_layers_state_t;
 
-uint8_t zmk_keymap_layer_default();
-zmk_keymap_layers_state_t zmk_keymap_layer_state();
+uint8_t zmk_keymap_layer_default(void);
+zmk_keymap_layers_state_t zmk_keymap_layer_state(void);
 bool zmk_keymap_layer_active(uint8_t layer);
-uint8_t zmk_keymap_highest_layer_active();
+uint8_t zmk_keymap_highest_layer_active(void);
 int zmk_keymap_layer_activate(uint8_t layer);
 int zmk_keymap_layer_deactivate(uint8_t layer);
 int zmk_keymap_layer_toggle(uint8_t layer);

--- a/app/include/zmk/rgb_underglow.h
+++ b/app/include/zmk/rgb_underglow.h
@@ -12,10 +12,10 @@ struct zmk_led_hsb {
     uint8_t b;
 };
 
-int zmk_rgb_underglow_toggle();
+int zmk_rgb_underglow_toggle(void);
 int zmk_rgb_underglow_get_state(bool *state);
-int zmk_rgb_underglow_on();
-int zmk_rgb_underglow_off();
+int zmk_rgb_underglow_on(void);
+int zmk_rgb_underglow_off(void);
 int zmk_rgb_underglow_cycle_effect(int direction);
 int zmk_rgb_underglow_calc_effect(int direction);
 int zmk_rgb_underglow_select_effect(int effect);

--- a/app/include/zmk/usb.h
+++ b/app/include/zmk/usb.h
@@ -18,8 +18,12 @@ enum zmk_usb_conn_state {
     ZMK_USB_CONN_HID,
 };
 
-enum usb_dc_status_code zmk_usb_get_status();
-enum zmk_usb_conn_state zmk_usb_get_conn_state();
+enum usb_dc_status_code zmk_usb_get_status(void);
+enum zmk_usb_conn_state zmk_usb_get_conn_state(void);
 
-static inline bool zmk_usb_is_powered() { return zmk_usb_get_conn_state() != ZMK_USB_CONN_NONE; }
-static inline bool zmk_usb_is_hid_ready() { return zmk_usb_get_conn_state() == ZMK_USB_CONN_HID; }
+static inline bool zmk_usb_is_powered(void) {
+    return zmk_usb_get_conn_state() != ZMK_USB_CONN_NONE;
+}
+static inline bool zmk_usb_is_hid_ready(void) {
+    return zmk_usb_get_conn_state() == ZMK_USB_CONN_HID;
+}

--- a/app/include/zmk/usb_hid.h
+++ b/app/include/zmk/usb_hid.h
@@ -8,9 +8,9 @@
 
 #include <stdint.h>
 
-int zmk_usb_hid_send_keyboard_report();
-int zmk_usb_hid_send_consumer_report();
+int zmk_usb_hid_send_keyboard_report(void);
+int zmk_usb_hid_send_consumer_report(void);
 #if IS_ENABLED(CONFIG_ZMK_MOUSE)
-int zmk_usb_hid_send_mouse_report();
+int zmk_usb_hid_send_mouse_report(void);
 #endif // IS_ENABLED(CONFIG_ZMK_MOUSE)
 void zmk_usb_hid_set_protocol(uint8_t protocol);

--- a/app/include/zmk/workqueue.h
+++ b/app/include/zmk/workqueue.h
@@ -1,1 +1,1 @@
-struct k_work_q *zmk_workqueue_lowprio_work_q();
+struct k_work_q *zmk_workqueue_lowprio_work_q(void);

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -80,11 +80,11 @@ void activity_work_handler(struct k_work *work) {
 
 K_WORK_DEFINE(activity_work, activity_work_handler);
 
-void activity_expiry_function(void) { k_work_submit(&activity_work); }
+void activity_expiry_function(struct k_timer *_timer) { k_work_submit(&activity_work); }
 
 K_TIMER_DEFINE(activity_timer, activity_expiry_function, NULL);
 
-int activity_init(void) {
+int activity_init(const struct device *_device) {
     activity_last_uptime = k_uptime_get();
 
     k_timer_start(&activity_timer, K_SECONDS(1), K_SECONDS(1));

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -24,7 +24,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/usb.h>
 #endif
 
-bool is_usb_power_present() {
+bool is_usb_power_present(void) {
 #if IS_ENABLED(CONFIG_USB_DEVICE_STACK)
     return zmk_usb_is_powered();
 #else
@@ -42,7 +42,7 @@ static uint32_t activity_last_uptime;
 #define MAX_SLEEP_MS CONFIG_ZMK_IDLE_SLEEP_TIMEOUT
 #endif
 
-int raise_event() {
+int raise_event(void) {
     return ZMK_EVENT_RAISE(new_zmk_activity_state_changed(
         (struct zmk_activity_state_changed){.state = activity_state}));
 }
@@ -55,7 +55,7 @@ int set_state(enum zmk_activity_state state) {
     return raise_event();
 }
 
-enum zmk_activity_state zmk_activity_get_state() { return activity_state; }
+enum zmk_activity_state zmk_activity_get_state(void) { return activity_state; }
 
 int activity_event_listener(const zmk_event_t *eh) {
     activity_last_uptime = k_uptime_get();
@@ -80,11 +80,11 @@ void activity_work_handler(struct k_work *work) {
 
 K_WORK_DEFINE(activity_work, activity_work_handler);
 
-void activity_expiry_function() { k_work_submit(&activity_work); }
+void activity_expiry_function(void) { k_work_submit(&activity_work); }
 
 K_TIMER_DEFINE(activity_timer, activity_expiry_function, NULL);
 
-int activity_init() {
+int activity_init(void) {
     activity_last_uptime = k_uptime_get();
 
     k_timer_start(&activity_timer, K_SECONDS(1), K_SECONDS(1));

--- a/app/src/backlight.c
+++ b/app/src/backlight.c
@@ -42,7 +42,7 @@ struct backlight_state {
 static struct backlight_state state = {.brightness = CONFIG_ZMK_BACKLIGHT_BRT_START,
                                        .on = IS_ENABLED(CONFIG_ZMK_BACKLIGHT_ON_START)};
 
-static int zmk_backlight_update() {
+static int zmk_backlight_update(void) {
     uint8_t brt = zmk_backlight_get_brt();
     LOG_DBG("Update backlight brightness: %d%%", brt);
 
@@ -98,7 +98,7 @@ static int zmk_backlight_init(const struct device *_arg) {
     return zmk_backlight_update();
 }
 
-static int zmk_backlight_update_and_save() {
+static int zmk_backlight_update_and_save(void) {
     int rc = zmk_backlight_update();
     if (rc != 0) {
         return rc;
@@ -112,20 +112,20 @@ static int zmk_backlight_update_and_save() {
 #endif
 }
 
-int zmk_backlight_on() {
+int zmk_backlight_on(void) {
     state.brightness = MAX(state.brightness, CONFIG_ZMK_BACKLIGHT_BRT_STEP);
     state.on = true;
     return zmk_backlight_update_and_save();
 }
 
-int zmk_backlight_off() {
+int zmk_backlight_off(void) {
     state.on = false;
     return zmk_backlight_update_and_save();
 }
 
-int zmk_backlight_toggle() { return state.on ? zmk_backlight_off() : zmk_backlight_on(); }
+int zmk_backlight_toggle(void) { return state.on ? zmk_backlight_off() : zmk_backlight_on(); }
 
-bool zmk_backlight_is_on() { return state.on; }
+bool zmk_backlight_is_on(void) { return state.on; }
 
 int zmk_backlight_set_brt(uint8_t brightness) {
     state.brightness = MIN(brightness, BRT_MAX);
@@ -133,14 +133,14 @@ int zmk_backlight_set_brt(uint8_t brightness) {
     return zmk_backlight_update_and_save();
 }
 
-uint8_t zmk_backlight_get_brt() { return state.on ? state.brightness : 0; }
+uint8_t zmk_backlight_get_brt(void) { return state.on ? state.brightness : 0; }
 
 uint8_t zmk_backlight_calc_brt(int direction) {
     int brt = state.brightness + (direction * CONFIG_ZMK_BACKLIGHT_BRT_STEP);
     return CLAMP(brt, 0, BRT_MAX);
 }
 
-uint8_t zmk_backlight_calc_brt_cycle() {
+uint8_t zmk_backlight_calc_brt_cycle(void) {
     if (state.brightness == BRT_MAX) {
         return 0;
     } else {

--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -24,7 +24,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 static uint8_t last_state_of_charge = 0;
 
-uint8_t zmk_battery_state_of_charge() { return last_state_of_charge; }
+uint8_t zmk_battery_state_of_charge(void) { return last_state_of_charge; }
 
 #if DT_HAS_CHOSEN(zmk_battery)
 static const struct device *const battery = DEVICE_DT_GET(DT_CHOSEN(zmk_battery));

--- a/app/src/behaviors/behavior_bt.c
+++ b/app/src/behaviors/behavior_bt.c
@@ -31,6 +31,8 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
         return zmk_ble_prof_prev();
     case BT_SEL_CMD:
         return zmk_ble_prof_select(binding->param2);
+    case BT_CLR_ALL_CMD:
+        return zmk_ble_clear_all_bonds();
     case BT_DISC_CMD:
         return zmk_ble_prof_disconnect(binding->param2);
     default:

--- a/app/src/behaviors/behavior_bt.c
+++ b/app/src/behaviors/behavior_bt.c
@@ -24,7 +24,8 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     switch (binding->param1) {
     case BT_CLR_CMD:
-        return zmk_ble_clear_bonds();
+        zmk_ble_clear_bonds();
+        return 0;
     case BT_NXT_CMD:
         return zmk_ble_prof_next();
     case BT_PRV_CMD:
@@ -32,7 +33,8 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
     case BT_SEL_CMD:
         return zmk_ble_prof_select(binding->param2);
     case BT_CLR_ALL_CMD:
-        return zmk_ble_clear_all_bonds();
+        zmk_ble_clear_all_bonds();
+        return 0;
     case BT_DISC_CMD:
         return zmk_ble_prof_disconnect(binding->param2);
     default:

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -234,6 +234,7 @@ void zmk_ble_clear_all_bonds(void) {
 
     // Automatically switch to profile 0
     zmk_ble_prof_select(0);
+    update_advertising();
 };
 
 int zmk_ble_active_profile_index(void) { return active_profile; }

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -82,7 +82,7 @@ static bt_addr_le_t peripheral_addrs[ZMK_SPLIT_BLE_PERIPHERAL_COUNT];
 
 #endif /* IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL) */
 
-static void raise_profile_changed_event() {
+static void raise_profile_changed_event(void) {
     ZMK_EVENT_RAISE(new_zmk_ble_active_profile_changed((struct zmk_ble_active_profile_changed){
         .index = active_profile, .profile = &profiles[active_profile]}));
 }
@@ -93,7 +93,7 @@ static void raise_profile_changed_event_callback(struct k_work *work) {
 
 K_WORK_DEFINE(raise_profile_changed_event_work, raise_profile_changed_event_callback);
 
-bool zmk_ble_active_profile_is_open() {
+bool zmk_ble_active_profile_is_open(void) {
     return !bt_addr_le_cmp(&profiles[active_profile].peer, BT_ADDR_LE_ANY);
 }
 
@@ -112,7 +112,7 @@ void set_profile_address(uint8_t index, const bt_addr_le_t *addr) {
     k_work_submit(&raise_profile_changed_event_work);
 }
 
-bool zmk_ble_active_profile_is_connected() {
+bool zmk_ble_active_profile_is_connected(void) {
     struct bt_conn *conn;
     struct bt_conn_info info;
     bt_addr_le_t *addr = zmk_ble_active_profile_addr();
@@ -161,7 +161,7 @@ bool zmk_ble_active_profile_is_connected() {
     }                                                                                              \
     advertising_status = ZMK_ADV_CONN;
 
-int update_advertising() {
+int update_advertising(void) {
     int err = 0;
     bt_addr_le_t *addr;
     struct bt_conn *conn;
@@ -210,7 +210,7 @@ static void update_advertising_callback(struct k_work *work) { update_advertisin
 
 K_WORK_DEFINE(update_advertising_work, update_advertising_callback);
 
-int zmk_ble_clear_bonds() {
+int zmk_ble_clear_bonds(void) {
     LOG_DBG("");
 
     if (bt_addr_le_cmp(&profiles[active_profile].peer, BT_ADDR_LE_ANY)) {
@@ -224,7 +224,7 @@ int zmk_ble_clear_bonds() {
     return 0;
 };
 
-int zmk_ble_clear_all_bonds() {
+int zmk_ble_clear_all_bonds(void) {
     LOG_DBG("zmk_ble_clear_all_bonds()");
 
     // Unpair all profiles
@@ -241,7 +241,7 @@ int zmk_ble_clear_all_bonds() {
     return 0;
 };
 
-int zmk_ble_active_profile_index() { return active_profile; }
+int zmk_ble_active_profile_index(void) { return active_profile; }
 
 int zmk_ble_profile_index(const bt_addr_le_t *addr) {
     for (int i = 0; i < ZMK_BLE_PROFILE_COUNT; i++) {
@@ -260,7 +260,7 @@ static void ble_save_profile_work(struct k_work *work) {
 static struct k_work_delayable ble_save_work;
 #endif
 
-static int ble_save_profile() {
+static int ble_save_profile(void) {
 #if IS_ENABLED(CONFIG_SETTINGS)
     return k_work_reschedule(&ble_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
 #else
@@ -288,12 +288,12 @@ int zmk_ble_prof_select(uint8_t index) {
     return 0;
 };
 
-int zmk_ble_prof_next() {
+int zmk_ble_prof_next(void) {
     LOG_DBG("");
     return zmk_ble_prof_select((active_profile + 1) % ZMK_BLE_PROFILE_COUNT);
 };
 
-int zmk_ble_prof_prev() {
+int zmk_ble_prof_prev(void) {
     LOG_DBG("");
     return zmk_ble_prof_select((active_profile + ZMK_BLE_PROFILE_COUNT - 1) %
                                ZMK_BLE_PROFILE_COUNT);
@@ -320,9 +320,9 @@ int zmk_ble_prof_disconnect(uint8_t index) {
     return result;
 }
 
-bt_addr_le_t *zmk_ble_active_profile_addr() { return &profiles[active_profile].peer; }
+bt_addr_le_t *zmk_ble_active_profile_addr(void) { return &profiles[active_profile].peer; }
 
-char *zmk_ble_active_profile_name() { return profiles[active_profile].name; }
+char *zmk_ble_active_profile_name(void) { return profiles[active_profile].name; }
 
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
 

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -210,7 +210,7 @@ static void update_advertising_callback(struct k_work *work) { update_advertisin
 
 K_WORK_DEFINE(update_advertising_work, update_advertising_callback);
 
-int zmk_ble_clear_bonds(void) {
+void zmk_ble_clear_bonds(void) {
     LOG_DBG("");
 
     if (bt_addr_le_cmp(&profiles[active_profile].peer, BT_ADDR_LE_ANY)) {
@@ -220,11 +220,9 @@ int zmk_ble_clear_bonds(void) {
     }
 
     update_advertising();
-
-    return 0;
 };
 
-int zmk_ble_clear_all_bonds(void) {
+void zmk_ble_clear_all_bonds(void) {
     LOG_DBG("zmk_ble_clear_all_bonds()");
 
     // Unpair all profiles
@@ -237,8 +235,6 @@ int zmk_ble_clear_all_bonds(void) {
 
     // Automatically switch to profile 0
     zmk_ble_prof_select(0);
-
-    return 0;
 };
 
 int zmk_ble_active_profile_index(void) { return active_profile; }

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -228,7 +228,7 @@ void zmk_ble_clear_all_bonds(void) {
     LOG_DBG("zmk_ble_clear_all_bonds()");
 
     // Unpair all profiles
-    for (uint8_t i = 0; i < ZMK_BLE_PROFILE_COUNT; i++) {
+    for (int i = 0; i < ZMK_BLE_PROFILE_COUNT; i++) {
         clear_profile_bond(i);
     }
 

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -210,15 +210,17 @@ static void update_advertising_callback(struct k_work *work) { update_advertisin
 
 K_WORK_DEFINE(update_advertising_work, update_advertising_callback);
 
-void zmk_ble_clear_bonds(void) {
-    LOG_DBG("");
-
-    if (bt_addr_le_cmp(&profiles[active_profile].peer, BT_ADDR_LE_ANY)) {
-        LOG_DBG("Unpairing!");
-        bt_unpair(BT_ID_DEFAULT, &profiles[active_profile].peer);
-        set_profile_address(active_profile, BT_ADDR_LE_ANY);
+static void clear_profile_bond(uint8_t profile) {
+    if (bt_addr_le_cmp(&profiles[profile].peer, BT_ADDR_LE_ANY)) {
+        bt_unpair(BT_ID_DEFAULT, &profiles[profile].peer);
+        set_profile_address(profile, BT_ADDR_LE_ANY);
     }
+}
 
+void zmk_ble_clear_bonds(void) {
+    LOG_DBG("zmk_ble_clear_bonds()");
+
+    clear_profile_bond(active_profile);
     update_advertising();
 };
 
@@ -227,10 +229,7 @@ void zmk_ble_clear_all_bonds(void) {
 
     // Unpair all profiles
     for (uint8_t i = 0; i < ZMK_BLE_PROFILE_COUNT; i++) {
-        if (bt_addr_le_cmp(&profiles[i].peer, BT_ADDR_LE_ANY)) {
-            bt_unpair(BT_ID_DEFAULT, &profiles[i].peer);
-            set_profile_address(i, BT_ADDR_LE_ANY);
-        }
+        clear_profile_bond(i);
     }
 
     // Automatically switch to profile 0

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -224,6 +224,23 @@ int zmk_ble_clear_bonds() {
     return 0;
 };
 
+int zmk_ble_clear_all_bonds() {
+    LOG_DBG("zmk_ble_clear_all_bonds()");
+
+    // Unpair all profiles
+    for (uint8_t i = 0; i < ZMK_BLE_PROFILE_COUNT; i++) {
+        if (bt_addr_le_cmp(&profiles[i].peer, BT_ADDR_LE_ANY)) {
+            bt_unpair(BT_ID_DEFAULT, &profiles[i].peer);
+            set_profile_address(i, BT_ADDR_LE_ANY);
+        }
+    }
+
+    // Automatically switch to profile 0
+    zmk_ble_prof_select(0);
+
+    return 0;
+};
+
 int zmk_ble_active_profile_index() { return active_profile; }
 
 int zmk_ble_profile_index(const bt_addr_le_t *addr) {

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -322,7 +322,7 @@ static int zmk_endpoints_init(const struct device *_arg) {
     return 0;
 }
 
-static void disconnect_current_endpoint() {
+static void disconnect_current_endpoint(void) {
     zmk_hid_keyboard_clear();
     zmk_hid_consumer_clear();
 #if IS_ENABLED(CONFIG_ZMK_MOUSE)

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -46,7 +46,7 @@ static void ext_power_save_state_work(struct k_work *work) {
 static struct k_work_delayable ext_power_save_work;
 #endif
 
-int ext_power_save_state() {
+int ext_power_save_state(void) {
 #if IS_ENABLED(CONFIG_SETTINGS)
     int ret = k_work_reschedule(&ext_power_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
     return MIN(ret, 0);

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -47,7 +47,7 @@ static zmk_mod_flags_t masked_modifiers = 0;
 
 #define GET_MODIFIERS (keyboard_report.body.modifiers)
 
-zmk_mod_flags_t zmk_hid_get_explicit_mods() { return explicit_modifiers; }
+zmk_mod_flags_t zmk_hid_get_explicit_mods(void) { return explicit_modifiers; }
 
 int zmk_hid_register_mod(zmk_mod_t modifier) {
     explicit_modifier_counts[modifier]++;
@@ -117,7 +117,7 @@ static zmk_hid_boot_report_t *boot_report_rollover(uint8_t modifiers) {
 #define TOGGLE_KEYBOARD(code, val) WRITE_BIT(keyboard_report.body.keys[code / 8], code % 8, val)
 
 #if IS_ENABLED(CONFIG_ZMK_USB_BOOT)
-zmk_hid_boot_report_t *zmk_hid_get_boot_report() {
+zmk_hid_boot_report_t *zmk_hid_get_boot_report(void) {
     if (keys_held > HID_BOOT_KEY_LEN) {
         return boot_report_rollover(keyboard_report.body.modifiers);
     }
@@ -187,7 +187,7 @@ static inline bool check_keyboard_usage(zmk_key_t usage) {
     }
 
 #if IS_ENABLED(CONFIG_ZMK_USB_BOOT)
-zmk_hid_boot_report_t *zmk_hid_get_boot_report() {
+zmk_hid_boot_report_t *zmk_hid_get_boot_report(void) {
     if (keys_held > HID_BOOT_KEY_LEN) {
         return boot_report_rollover(keyboard_report.body.modifiers);
     }
@@ -268,7 +268,7 @@ int zmk_hid_implicit_modifiers_press(zmk_mod_flags_t new_implicit_modifiers) {
     return current == GET_MODIFIERS ? 0 : 1;
 }
 
-int zmk_hid_implicit_modifiers_release() {
+int zmk_hid_implicit_modifiers_release(void) {
     implicit_modifiers = 0;
     zmk_mod_flags_t current = GET_MODIFIERS;
     SET_MODIFIERS(explicit_modifiers);
@@ -282,7 +282,7 @@ int zmk_hid_masked_modifiers_set(zmk_mod_flags_t new_masked_modifiers) {
     return current == GET_MODIFIERS ? 0 : 1;
 }
 
-int zmk_hid_masked_modifiers_clear() {
+int zmk_hid_masked_modifiers_clear(void) {
     masked_modifiers = 0;
     zmk_mod_flags_t current = GET_MODIFIERS;
     SET_MODIFIERS(explicit_modifiers);
@@ -312,7 +312,9 @@ bool zmk_hid_keyboard_is_pressed(zmk_key_t code) {
     return check_keyboard_usage(code);
 }
 
-void zmk_hid_keyboard_clear() { memset(&keyboard_report.body, 0, sizeof(keyboard_report.body)); }
+void zmk_hid_keyboard_clear(void) {
+    memset(&keyboard_report.body, 0, sizeof(keyboard_report.body));
+}
 
 int zmk_hid_consumer_press(zmk_key_t code) {
     TOGGLE_CONSUMER(0U, code);
@@ -324,7 +326,9 @@ int zmk_hid_consumer_release(zmk_key_t code) {
     return 0;
 };
 
-void zmk_hid_consumer_clear() { memset(&consumer_report.body, 0, sizeof(consumer_report.body)); }
+void zmk_hid_consumer_clear(void) {
+    memset(&consumer_report.body, 0, sizeof(consumer_report.body));
+}
 
 bool zmk_hid_consumer_is_pressed(zmk_key_t key) {
     for (int idx = 0; idx < CONFIG_ZMK_HID_CONSUMER_REPORT_SIZE; idx++) {
@@ -426,21 +430,21 @@ int zmk_hid_mouse_buttons_release(zmk_mouse_button_flags_t buttons) {
     }
     return 0;
 }
-void zmk_hid_mouse_clear() { memset(&mouse_report.body, 0, sizeof(mouse_report.body)); }
+void zmk_hid_mouse_clear(void) { memset(&mouse_report.body, 0, sizeof(mouse_report.body)); }
 
 #endif // IS_ENABLED(CONFIG_ZMK_MOUSE)
 
-struct zmk_hid_keyboard_report *zmk_hid_get_keyboard_report() {
+struct zmk_hid_keyboard_report *zmk_hid_get_keyboard_report(void) {
     return &keyboard_report;
 }
 
-struct zmk_hid_consumer_report *zmk_hid_get_consumer_report() {
+struct zmk_hid_consumer_report *zmk_hid_get_consumer_report(void) {
     return &consumer_report;
 }
 
 #if IS_ENABLED(CONFIG_ZMK_MOUSE)
 
-struct zmk_hid_mouse_report *zmk_hid_get_mouse_report() {
+struct zmk_hid_mouse_report *zmk_hid_get_mouse_report(void) {
     return &mouse_report;
 }
 

--- a/app/src/hog.c
+++ b/app/src/hog.c
@@ -220,7 +220,7 @@ BT_GATT_SERVICE_DEFINE(
     BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_CTRL_POINT, BT_GATT_CHRC_WRITE_WITHOUT_RESP,
                            BT_GATT_PERM_WRITE, NULL, write_ctrl_point, &ctrl_point));
 
-struct bt_conn *destination_connection() {
+struct bt_conn *destination_connection(void) {
     struct bt_conn *conn;
     bt_addr_le_t *addr = zmk_ble_active_profile_addr();
     LOG_DBG("Address pointer %p", addr);

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -96,9 +96,9 @@ static inline int set_layer_state(uint8_t layer, bool state) {
     return 0;
 }
 
-uint8_t zmk_keymap_layer_default() { return _zmk_keymap_layer_default; }
+uint8_t zmk_keymap_layer_default(void) { return _zmk_keymap_layer_default; }
 
-zmk_keymap_layers_state_t zmk_keymap_layer_state() { return _zmk_keymap_layer_state; }
+zmk_keymap_layers_state_t zmk_keymap_layer_state(void) { return _zmk_keymap_layer_state; }
 
 bool zmk_keymap_layer_active_with_state(uint8_t layer, zmk_keymap_layers_state_t state_to_test) {
     // The default layer is assumed to be ALWAYS ACTIVE so we include an || here to ensure nobody
@@ -110,7 +110,7 @@ bool zmk_keymap_layer_active(uint8_t layer) {
     return zmk_keymap_layer_active_with_state(layer, _zmk_keymap_layer_state);
 };
 
-uint8_t zmk_keymap_highest_layer_active() {
+uint8_t zmk_keymap_highest_layer_active(void) {
     for (uint8_t layer = ZMK_KEYMAP_LAYERS_LEN - 1; layer > 0; layer--) {
         if (zmk_keymap_layer_active(layer)) {
             return layer;

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -232,7 +232,7 @@ static int rgb_settings_set(const char *name, size_t len, settings_read_cb read_
 
 struct settings_handler rgb_conf = {.name = "rgb/underglow", .h_set = rgb_settings_set};
 
-static void zmk_rgb_underglow_save_state_work(void) {
+static void zmk_rgb_underglow_save_state_work(struct k_work *_work) {
     settings_save_one("rgb/underglow/state", &state, sizeof(state));
 }
 

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -130,13 +130,13 @@ static struct led_rgb hsb_to_rgb(struct zmk_led_hsb hsb) {
     return rgb;
 }
 
-static void zmk_rgb_underglow_effect_solid() {
+static void zmk_rgb_underglow_effect_solid(void) {
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
         pixels[i] = hsb_to_rgb(hsb_scale_min_max(state.color));
     }
 }
 
-static void zmk_rgb_underglow_effect_breathe() {
+static void zmk_rgb_underglow_effect_breathe(void) {
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
         struct zmk_led_hsb hsb = state.color;
         hsb.b = abs(state.animation_step - 1200) / 12;
@@ -151,7 +151,7 @@ static void zmk_rgb_underglow_effect_breathe() {
     }
 }
 
-static void zmk_rgb_underglow_effect_spectrum() {
+static void zmk_rgb_underglow_effect_spectrum(void) {
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
         struct zmk_led_hsb hsb = state.color;
         hsb.h = state.animation_step;
@@ -163,7 +163,7 @@ static void zmk_rgb_underglow_effect_spectrum() {
     state.animation_step = state.animation_step % HUE_MAX;
 }
 
-static void zmk_rgb_underglow_effect_swirl() {
+static void zmk_rgb_underglow_effect_swirl(void) {
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
         struct zmk_led_hsb hsb = state.color;
         hsb.h = (HUE_MAX / STRIP_NUM_PIXELS * i + state.animation_step) % HUE_MAX;
@@ -232,7 +232,7 @@ static int rgb_settings_set(const char *name, size_t len, settings_read_cb read_
 
 struct settings_handler rgb_conf = {.name = "rgb/underglow", .h_set = rgb_settings_set};
 
-static void zmk_rgb_underglow_save_state_work() {
+static void zmk_rgb_underglow_save_state_work(void) {
     settings_save_one("rgb/underglow/state", &state, sizeof(state));
 }
 
@@ -286,7 +286,7 @@ static int zmk_rgb_underglow_init(const struct device *_arg) {
     return 0;
 }
 
-int zmk_rgb_underglow_save_state() {
+int zmk_rgb_underglow_save_state(void) {
 #if IS_ENABLED(CONFIG_SETTINGS)
     int ret = k_work_reschedule(&underglow_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
     return MIN(ret, 0);
@@ -303,7 +303,7 @@ int zmk_rgb_underglow_get_state(bool *on_off) {
     return 0;
 }
 
-int zmk_rgb_underglow_on() {
+int zmk_rgb_underglow_on(void) {
     if (!led_strip)
         return -ENODEV;
 
@@ -333,7 +333,7 @@ static void zmk_rgb_underglow_off_handler(struct k_work *work) {
 
 K_WORK_DEFINE(underglow_off_work, zmk_rgb_underglow_off_handler);
 
-int zmk_rgb_underglow_off() {
+int zmk_rgb_underglow_off(void) {
     if (!led_strip)
         return -ENODEV;
 
@@ -376,7 +376,7 @@ int zmk_rgb_underglow_cycle_effect(int direction) {
     return zmk_rgb_underglow_select_effect(zmk_rgb_underglow_calc_effect(direction));
 }
 
-int zmk_rgb_underglow_toggle() {
+int zmk_rgb_underglow_toggle(void) {
     return state.on ? zmk_rgb_underglow_off() : zmk_rgb_underglow_on();
 }
 

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -436,7 +436,7 @@ static void split_central_process_connection(struct bt_conn *conn) {
     start_scanning();
 }
 
-static int stop_scanning() {
+static int stop_scanning(void) {
     LOG_DBG("Stopping peripheral scanning");
     is_scanning = false;
 

--- a/app/src/split/bluetooth/peripheral.c
+++ b/app/src/split/bluetooth/peripheral.c
@@ -142,9 +142,9 @@ static struct bt_conn_auth_info_cb zmk_peripheral_ble_auth_info_cb = {
     .pairing_complete = auth_pairing_complete,
 };
 
-bool zmk_split_bt_peripheral_is_connected() { return is_connected; }
+bool zmk_split_bt_peripheral_is_connected(void) { return is_connected; }
 
-bool zmk_split_bt_peripheral_is_bonded() { return is_bonded; }
+bool zmk_split_bt_peripheral_is_bonded(void) { return is_bonded; }
 
 static int zmk_peripheral_ble_init(const struct device *_arg) {
     int err = bt_enable(NULL);

--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -28,9 +28,9 @@ static void raise_usb_status_changed_event(struct k_work *_work) {
 
 K_WORK_DEFINE(usb_status_notifier_work, raise_usb_status_changed_event);
 
-enum usb_dc_status_code zmk_usb_get_status() { return usb_status; }
+enum usb_dc_status_code zmk_usb_get_status(void) { return usb_status; }
 
-enum zmk_usb_conn_state zmk_usb_get_conn_state() {
+enum zmk_usb_conn_state zmk_usb_get_conn_state(void) {
     LOG_DBG("state: %d", usb_status);
     switch (usb_status) {
     case USB_DC_SUSPEND:

--- a/app/src/usb_hid.c
+++ b/app/src/usb_hid.c
@@ -147,13 +147,13 @@ static int zmk_usb_hid_send_report(const uint8_t *report, size_t len) {
     }
 }
 
-int zmk_usb_hid_send_keyboard_report() {
+int zmk_usb_hid_send_keyboard_report(void) {
     size_t len;
     uint8_t *report = get_keyboard_report(&len);
     return zmk_usb_hid_send_report(report, len);
 }
 
-int zmk_usb_hid_send_consumer_report() {
+int zmk_usb_hid_send_consumer_report(void) {
 #if IS_ENABLED(CONFIG_ZMK_USB_BOOT)
     if (hid_protocol == HID_PROTOCOL_BOOT) {
         return -ENOTSUP;

--- a/app/src/workqueue.c
+++ b/app/src/workqueue.c
@@ -13,11 +13,11 @@ K_THREAD_STACK_DEFINE(lowprio_q_stack, CONFIG_ZMK_LOW_PRIORITY_THREAD_STACK_SIZE
 
 static struct k_work_q lowprio_work_q;
 
-struct k_work_q *zmk_workqueue_lowprio_work_q() {
+struct k_work_q *zmk_workqueue_lowprio_work_q(void) {
     return &lowprio_work_q;
 }
 
-static int workqueue_init() {
+static int workqueue_init(void) {
     static const struct k_work_queue_config queue_config = {.name = "Low Priority Work Queue"};
     k_work_queue_start(&lowprio_work_q, lowprio_q_stack, K_THREAD_STACK_SIZEOF(lowprio_q_stack),
                        CONFIG_ZMK_LOW_PRIORITY_THREAD_PRIORITY, &queue_config);

--- a/app/src/workqueue.c
+++ b/app/src/workqueue.c
@@ -17,7 +17,7 @@ struct k_work_q *zmk_workqueue_lowprio_work_q(void) {
     return &lowprio_work_q;
 }
 
-static int workqueue_init(void) {
+static int workqueue_init(const struct device *_device) {
     static const struct k_work_queue_config queue_config = {.name = "Low Priority Work Queue"};
     k_work_queue_start(&lowprio_work_q, lowprio_q_stack, K_THREAD_STACK_SIZEOF(lowprio_q_stack),
                        CONFIG_ZMK_LOW_PRIORITY_THREAD_PRIORITY, &queue_config);

--- a/app/src/wpm.c
+++ b/app/src/wpm.c
@@ -32,7 +32,7 @@ static uint8_t last_wpm_state;
 static uint8_t wpm_update_counter;
 static uint32_t key_pressed_count;
 
-int zmk_wpm_get_state() { return wpm_state; }
+int zmk_wpm_get_state(void) { return wpm_state; }
 
 int wpm_event_listener(const zmk_event_t *eh) {
     const struct zmk_keycode_state_changed *ev = as_zmk_keycode_state_changed(eh);
@@ -68,11 +68,11 @@ void wpm_work_handler(struct k_work *work) {
 
 K_WORK_DEFINE(wpm_work, wpm_work_handler);
 
-void wpm_expiry_function() { k_work_submit(&wpm_work); }
+void wpm_expiry_function(void) { k_work_submit(&wpm_work); }
 
 K_TIMER_DEFINE(wpm_timer, wpm_expiry_function, NULL);
 
-int wpm_init() {
+int wpm_init(void) {
     wpm_state = 0;
     wpm_update_counter = 0;
     k_timer_start(&wpm_timer, K_SECONDS(WPM_UPDATE_INTERVAL_SECONDS),

--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -12,8 +12,8 @@ computer/laptop/keyboard should receive the keyboard input; many of the commands
 :::note Connection Management
 When pairing to a host device ZMK saves bond information to the selected
 profile. It will not replace this when you initiate pairing with another device.
-To pair with a new device select an unused profile with `BT_SEL`, `BT_NXT` or
-`BT_PRV` bindings, or by clearing an existing profile using `BT_CLR` or `BT_CLR_ALL`.
+To pair with a new device, select a profile that doesn't have a pairing with `BT_SEL`, `BT_NXT` or
+`BT_PRV` bindings, or clear an already paired profile using `BT_CLR` or `BT_CLR_ALL`.
 
 A ZMK device may show as "connected" on multiple hosts at the same time. This is working as intended, and only the host associated with the active profile will receive keystrokes.
 

--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -10,7 +10,10 @@ between the keyboard and the host. By default, ZMK supports five "profiles" for 
 computer/laptop/keyboard should receive the keyboard input; many of the commands here operate on those profiles.
 
 :::note Connection Management
-When pairing to a host device ZMK saves bond information to the selected profile. It will not replace this when you initiate pairing with another device. To pair with a new device select an unused profile with `BT_SEL`, `BT_NXT` or `BT_PRV` bindings, or by clearing an existing profile using `BT_CLR`.
+When pairing to a host device ZMK saves bond information to the selected
+profile. It will not replace this when you initiate pairing with another device.
+To pair with a new device select an unused profile with `BT_SEL`, `BT_NXT` or
+`BT_PRV` bindings, or by clearing an existing profile using `BT_CLR` or `BT_CLR_ALL`.
 
 A ZMK device may show as "connected" on multiple hosts at the same time. This is working as intended, and only the host associated with the active profile will receive keystrokes.
 
@@ -35,13 +38,14 @@ This will allow you to reference the actions defined in this header such as `BT_
 
 Here is a table describing the command for each define:
 
-| Define    | Action                                                                                                                                                                             |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `BT_CLR`  | Clear bond information between the keyboard and host for the selected profile.                                                                                                     |
-| `BT_NXT`  | Switch to the next profile, cycling through to the first one when the end is reached.                                                                                              |
-| `BT_PRV`  | Switch to the previous profile, cycling through to the last one when the beginning is reached.                                                                                     |
-| `BT_SEL`  | Select the 0-indexed profile by number; must include a number as an argument in the keymap to work correctly, e.g. `BT_SEL 0`.                                                     |
-| `BT_DISC` | Disconnect from the 0-indexed profile by number, if it's currently connected and inactive; must include a number as an argument in the keymap to work correctly, e.g. `BT_DISC 0`. |
+| Define       | Action                                                                                                                                                                             |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BT_CLR`     | Clear bond information between the keyboard and host for the selected profile.                                                                                                     |
+| `BT_CLR_ALL` | Clear bond information between the keyboard and host for all profiles.                                                                                                             |
+| `BT_NXT`     | Switch to the next profile, cycling through to the first one when the end is reached.                                                                                              |
+| `BT_PRV`     | Switch to the previous profile, cycling through to the last one when the beginning is reached.                                                                                     |
+| `BT_SEL`     | Select the 0-indexed profile by number; must include a number as an argument in the keymap to work correctly, e.g. `BT_SEL 0`.                                                     |
+| `BT_DISC`    | Disconnect from the 0-indexed profile by number, if it's currently connected and inactive; must include a number as an argument in the keymap to work correctly, e.g. `BT_DISC 0`. |
 
 :::note Selected profile persistence
 The profile that is selected by the `BT_SEL`/`BT_PRV`/`BT_NXT` actions will be saved to flash storage and hence persist across restarts and firmware flashes.


### PR DESCRIPTION
Defines a new behavior to clear all paired Bluetooth profiles.

Implementation question: is it appropriate for this to subsume the (commented out) `BT_FULL_RESET`?