### PR TITLE
docs: Document adding USB logging to a standalone board

### DIFF
--- a/docs/docs/development/usb-logging.md
+++ b/docs/docs/development/usb-logging.md
@@ -83,3 +83,32 @@ You should see tio printing `Disconnected` or `Connected` when you disconnect or
 </Tabs>
 
 From there, you should see the various log messages from ZMK and Zephyr, depending on which systems you have set to what log levels.
+
+## Adding USB logging to a board
+
+Standard boards such as the nice!nano and Seeeduinoo XIAO family have logging already added, however if you are developing your own standalone board you may wish to add the ability to use USB logging in the future.
+
+To add USB logging to a board you need to define the USB CDC ACM device that the serial output gets piped to as well as adding the console in the `chosen` node inside `<board>.dts`
+
+Inside the USB device (`&usbd`), add the CDC ACM node:
+
+```dts
+&usbd {
+  status = "okay";
+  cdc_acm_uart: cdc_acm_uart {
+    compatible = "zephyr,cdc-acm-uart";
+  };
+};
+```
+
+Then you can add the `zephyr,console` binding in the `chosen` node
+
+```dts
+/ {
+  chosen {
+    ...
+    zephyr,console = &cdc_acm_uart;
+  };
+  ...
+};
+```

--- a/docs/docs/development/usb-logging.md
+++ b/docs/docs/development/usb-logging.md
@@ -86,29 +86,29 @@ From there, you should see the various log messages from ZMK and Zephyr, dependi
 
 ## Adding USB logging to a board
 
-Standard boards such as the nice!nano and Seeeduinoo XIAO family have logging already added, however if you are developing your own standalone board you may wish to add the ability to use USB logging in the future.
+Standard boards such as the nice!nano and Seeeduino XIAO family have the necessary configuration for logging already added, however if you are developing your own standalone board you may wish to add the ability to use USB logging in the future.
 
-To add USB logging to a board you need to define the USB CDC ACM device that the serial output gets piped to as well as adding the console in the `chosen` node inside `<board>.dts`
+To add USB logging to a board you need to define the USB CDC ACM device that the serial output gets piped to, as well as adding the console in the `chosen` node inside `<board>.dts`.
 
 Inside the USB device (`&usbd`), add the CDC ACM node:
 
 ```dts
 &usbd {
-  status = "okay";
-  cdc_acm_uart: cdc_acm_uart {
-    compatible = "zephyr,cdc-acm-uart";
-  };
+    status = "okay";
+    cdc_acm_uart: cdc_acm_uart {
+        compatible = "zephyr,cdc-acm-uart";
+    };
 };
 ```
 
-Then you can add the `zephyr,console` binding in the `chosen` node
+Then you can add the `zephyr,console` binding in the `chosen` node:
 
 ```dts
 / {
-  chosen {
+    chosen {
+        ...
+        zephyr,console = &cdc_acm_uart;
+    };
     ...
-    zephyr,console = &cdc_acm_uart;
-  };
-  ...
 };
 ```

--- a/docs/docs/development/usb-logging.md
+++ b/docs/docs/development/usb-logging.md
@@ -84,7 +84,7 @@ You should see tio printing `Disconnected` or `Connected` when you disconnect or
 
 From there, you should see the various log messages from ZMK and Zephyr, depending on which systems you have set to what log levels.
 
-## Adding USB logging to a board
+## Adding USB Logging to a Board
 
 Standard boards such as the nice!nano and Seeeduino XIAO family have the necessary configuration for logging already added, however if you are developing your own standalone board you may wish to add the ability to use USB logging in the future.
 


### PR DESCRIPTION
Currently, this is only documented in the zephyr 3.0 upgrade blog. This explicitly documents it as well as when it doesn't need to be applied (i.e. when a mcu board is already in use) 