### PR TITLE
feat(ble): Make it possible to use BT_GATT_AUTO_SEC_REQ

### DIFF
--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -445,9 +445,11 @@ static void connected(struct bt_conn *conn, uint8_t err) {
 
     LOG_DBG("Connected %s", addr);
 
+#if !IS_ENABLED(CONFIG_BT_GATT_AUTO_SEC_REQ)
     if (bt_conn_set_security(conn, BT_SECURITY_L2)) {
         LOG_ERR("Failed to set security");
     }
+#endif // !IS_ENABLED(CONFIG_BT_GATT_AUTO_SEC_REQ)
 
     update_advertising();
 


### PR DESCRIPTION
* Only upgrade security of new connections if BT_GATT_AUTO_SEC_REQ
  is not enabled.

This is something @joelspadin was discussing recently as possibly improving our compatibility with some OSes, so making it easy for folks to test by not automatically setting security on new connections unless needed.