### PR TITLE
fix(bt): Passkey entry pairing fixes.

### DIFF
--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -696,9 +696,9 @@ static int zmk_ble_handle_key_user(struct zmk_keycode_state_changed *event) {
         return ZMK_EV_EVENT_BUBBLE;
     }
 
-    if (!event->state) {
-        LOG_DBG("Key released, ignoring");
-        return ZMK_EV_EVENT_BUBBLE;
+    if (event->state) {
+        LOG_DBG("Key press, ignoring");
+        return ZMK_EV_EVENT_HANDLED;
     }
 
     if (key == HID_USAGE_KEY_KEYBOARD_ESCAPE) {
@@ -728,7 +728,7 @@ static int zmk_ble_handle_key_user(struct zmk_keycode_state_changed *event) {
           zmk_ble_numeric_usage_to_value(key, HID_USAGE_KEY_KEYPAD_1_AND_END,
                                          HID_USAGE_KEY_KEYPAD_0_AND_INSERT, &val))) {
         LOG_DBG("Key not a number, ignoring");
-        return ZMK_EV_EVENT_BUBBLE;
+        return ZMK_EV_EVENT_HANDLED;
     }
 
     if (ring_buf_space_get(&passkey_entries) <= 0) {


### PR DESCRIPTION
* Don't propogate any key press events while in the
  middle of passkey entry, avoid funky state on hosts.
* Handle passkey on release, not press, to ensure key *releases*
  are not accidentally sent, especially the Enter release
  at the very end of passkey entry, which can trigger
  cancel in the dialog if the keyboard is connected
  via USB to the same host.


I know @joelspadin has a bigger refactor coming for this, but a few minor improvements to this feature in the meantime to make the current passkey support actually usable.