### PR TITLE
refactor: Improve keymap alignment

### DIFF
--- a/app/boards/shields/corne/corne.keymap
+++ b/app/boards/shields/corne/corne.keymap
@@ -9,48 +9,50 @@
 #include <dt-bindings/zmk/bt.h>
 
 / {
-        keymap {
-                compatible = "zmk,keymap";
-
-                default_layer {
-// -----------------------------------------------------------------------------------------
-// |  TAB |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  | BKSP |
-// | CTRL |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |  '   |
-// | SHFT |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | ESC  |
-//                    | GUI | LWR | SPC |   | ENT | RSE  | ALT |
-                        bindings = <
-   &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
-   &kp LCTRL &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
-   &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp ESC
-                  &kp LGUI &mo 1 &kp SPACE   &kp RET &mo 2 &kp RALT
-                        >;
-                };
-                lower_layer {
-// -----------------------------------------------------------------------------------------
-// |  TAB |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  | BKSP |
-// | BTCLR| BT1 | BT2 | BT3 | BT4 | BT5 |   | LFT | DWN |  UP | RGT |     |      |
-// | SHFT |     |     |     |     |     |   |     |     |     |     |     |      |
-//                    | GUI |     | SPC |   | ENT |     | ALT |
-                        bindings = <
-   &kp TAB    &kp N1       &kp N2       &kp N3       &kp N4       &kp N5         &kp N6   &kp N7   &kp N8 &kp N9    &kp N0 &kp BSPC
-   &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4   &kp LEFT &kp DOWN &kp UP &kp RIGHT &trans &trans
-   &kp LSHFT  &trans       &trans       &trans       &trans       &trans         &trans   &trans   &trans &trans    &trans &trans
-                                    &kp LGUI     &trans       &kp SPACE      &kp RET  &trans   &kp RALT
-                        >;
-                };
-
-                raise_layer {
-// -----------------------------------------------------------------------------------------
-// |  TAB |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  (  |  )  | BKSP |
-// | CTRL |     |     |     |     |     |   |  -  |  =  |  [  |  ]  |  \  |  `   |
-// | SHFT |     |     |     |     |     |   |  _  |  +  |  {  |  }  | "|" |  ~   |
-//                    | GUI |     | SPC |   | ENT |     | ALT |
-                        bindings = <
-   &kp  TAB  &kp EXCL &kp AT &kp HASH &kp DLLR &kp PRCNT   &kp CARET &kp AMPS  &kp ASTRK &kp LPAR &kp RPAR &kp BSPC
-   &kp LCTRL &trans   &trans &trans   &trans   &trans      &kp MINUS &kp EQUAL &kp LBKT  &kp RBKT &kp BSLH &kp GRAVE
-   &kp LSHFT &trans   &trans &trans   &trans   &trans      &kp UNDER &kp PLUS  &kp LBRC  &kp RBRC &kp PIPE &kp TILDE
-                             &kp LGUI &trans   &kp SPACE   &kp RET   &trans    &kp RALT
-                        >;
-                };
+    keymap {
+        compatible = "zmk,keymap";
+        default_layer {
+            bindings = <
+    //╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮   ╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮
+    //│  TAB       │  Q         │  W         │  E         │  R         │  T         │   │  Y         │  U         │  I         │  O         │  P         │  BSPC      │
+        &kp TAB      &kp Q        &kp W        &kp E        &kp R        &kp T            &kp Y        &kp U         &kp I       &kp O        &kp P        &kp BSPC
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤   ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+    //│ CONTROL    │  A         │  S         │  D         │  F         │  G         │   │  H         │  J         │  K         │  L         │  ;         │  '         │
+        &kp LCTRL    &kp A        &kp S        &kp D        &kp F        &kp G            &kp H        &kp J        &kp K        &kp L        &kp SEMI     &kp SQT
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤   ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+    //│  SHIFT     │  Z         │  X         │  C         │  V         │  B         │   │  N         │  M         │  ,         │  .         │  /         │ ESC        │
+        &kp LSHFT    &kp Z        &kp X        &kp C        &kp V        &kp B            &kp N        &kp M        &kp COMMA    &kp DOT      &kp FSLH     &kp ESC
+    //╰────────────┴────────────┴────────────┼────────────┼────────────┼────────────┤   ├────────────┼────────────┼────────────┼─────────────┴───────────┴────────────╯
+                                               &kp LGUI     &mo 1        &kp SPACE        &kp RET      &mo 2        &kp RALT
+    //                                       ╰────────────┴────────────┴────────────╯   ╰────────────┴────────────┴────────────╯
+            >;
         };
+        lower_layer {
+            bindings = <
+    //╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮   ╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮
+        &kp TAB      &kp N1       &kp N2       &kp N3       &kp N4       &kp N5           &kp N6       &kp N7       &kp N8       &kp N9       &kp N0       &kp BSPC
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤   ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+       &bt BT_CLR   &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4      &kp LEFT     &kp DOWN     &kp UP       &kp RIGHT    &trans       &trans
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤   ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+        &kp LSHFT    &trans       &trans       &trans       &trans       &bootloader      &bootloader  &trans       &trans       &trans       &trans       &trans
+    //╰────────────┴────────────┴────────────┼────────────┼────────────┼────────────┤   ├────────────┼────────────┼────────────┼─────────────┴───────────┴────────────╯
+                                               &kp LGUI     &trans       &kp SPACE        &kp RET      &trans       &kp RALT
+    //                                       ╰────────────┴────────────┴────────────╯   ╰────────────┴────────────┴────────────╯
+            >;
+        };
+        raise_layer {
+            bindings = <
+    //╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮   ╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮
+        &kp TAB      &kp EXCL     &kp AT       &kp HASH     &kp DLLR     &kp PRCNT        &kp CARET    &kp AMPS     &kp ASTRK    &kp LPAR     &kp RPAR     &kp BSPC
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤   ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+        &kp LCTRL    &trans       &trans       &trans       &trans       &trans           &kp MINUS    &kp EQUAL    &kp LBKT     &kp RBKT     &kp BSLH     &kp GRAVE
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤   ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+        &kp LSHFT    &trans       &trans       &trans       &trans       &trans           &kp UNDER    &kp PLUS     &kp LBRC     &kp RBRC     &kp PIPE     &kp TILDE
+    //╰────────────┴────────────┴────────────┼────────────┼────────────┼────────────┤   ├────────────┼────────────┼────────────┼─────────────┴───────────┴────────────╯
+                                               &kp LGUI     &trans       &kp SPACE        &kp RET      &trans       &kp RALT
+    //                                       ╰────────────┴────────────┴────────────╯   ╰────────────┴────────────┴────────────╯
+            >;
+        };
+
+    };
 };

--- a/app/boards/shields/lily58/lily58.keymap
+++ b/app/boards/shields/lily58/lily58.keymap
@@ -12,58 +12,56 @@
 / {
     keymap {
         compatible = "zmk,keymap";
-
         default_layer {
-// ------------------------------------------------------------------------------------------------------------
-// |  ESC  |  1  |  2  |  3   |  4   |  5   |                   |  6   |  7    |  8    |  9   |   0   |   `   |
-// |  TAB  |  Q  |  W  |  E   |  R   |  T   |                   |  Y   |  U    |  I    |  O   |   P   |   -   |
-// |  CTRL |  A  |  S  |  D   |  F   |  G   |                   |  H   |  J    |  K    |  L   |   ;   |   '   |
-// | SHIFT |  Z  |  X  |  C   |  V   |  B   |   "["  |  |  "]"  |  N   |  M    |  ,    |  .   |   /   | SHIFT |
-//                     | ALT  | GUI  | LOWER|  SPACE |  | ENTER | RAISE| BSPC  | GUI   |
             bindings = <
-&kp ESC   &kp N1 &kp N2 &kp N3   &kp N4   &kp N5                     &kp N6 &kp N7   &kp N8    &kp N9  &kp N0   &kp GRAVE
-&kp TAB   &kp Q  &kp W  &kp E    &kp R    &kp T                      &kp Y  &kp U    &kp I     &kp O   &kp P    &kp MINUS
-&kp LCTRL &kp A  &kp S  &kp D    &kp F    &kp G                      &kp H  &kp J    &kp K     &kp L   &kp SEMI &kp SQT
-&kp LSHFT &kp Z  &kp X  &kp C    &kp V    &kp B  &kp LBKT   &kp RBKT &kp N  &kp M    &kp COMMA &kp DOT &kp FSLH &kp RSHFT
-                        &kp LALT &kp LGUI &mo 1  &kp SPACE  &kp RET  &mo 2  &kp BSPC &kp RGUI
+    //╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮                            ╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮
+    //│  TAB       │  1         │  2         │  3         │  4         │  5         │                            │  6         │  7         │  8         │  9         │  0         │  `         │
+        &kp ESC      &kp N1       &kp N2       &kp N3        &kp N4      &kp N5                                    &kp N6       &kp N7       &kp N8       &kp N9       &kp N0       &kp GRAVE
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤                            ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+    //│  TAB       │  Q         │  W         │  E         │  R         │  T         │                            │  Y         │  U         │  I         │  O         │  P         │  BSPC      │
+        &kp TAB      &kp Q        &kp W        &kp E         &kp R       &kp T                                     &kp Y        &kp U        &kp I        &kp O        &kp P        &kp MINUS
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤                            ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+    //│ CONTROL    │  A         │  S         │  D         │  F         │  G         │                            │  H         │  J         │  K         │  L         │  ;         │  '         │
+        &kp LCTRL    &kp A        &kp S        &kp D         &kp F       &kp G                                     &kp H        &kp J        &kp K        &kp L        &kp SEMI     &kp SQT
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────╮  ╭────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+    //│  LSHIFT    │  Z         │  X         │  C         │  V         │  B         │  (         │  │  )         │  N         │  M         │  ,         │  .         │  /         │ RSHIFT     │
+        &kp LSHFT    &kp Z        &kp X        &kp C        &kp V        &kp B        &kp LBKT        &kp RBKT     &kp N        &kp M        &kp COMMA    &kp DOT      &kp FSLH     &kp RSHFT
+    //╰────────────┴────────────┴────────────┼────────────┼────────────┼────────────┼────────────┤  ├────────────┼────────────┼────────────┼────────────┼────────────┴────────────┴────────────╯
+                                               &kp LALT     &kp LGUI     &mo 1        &kp SPACE       &kp RET      &mo 2        &kp BSPC     &kp RGUI
+    //                                       ╰────────────┴────────────┴────────────┴────────────╯  ╰────────────┴────────────┴────────────┴────────────╯
             >;
-
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
-
         lower_layer {
-// ------------------------------------------------------------------------------------------------------------
-// | BTCLR | BT1 | BT2 |  BT3 |  BT4 |  BT5 |                   |      |       |       |      |       |       |
-// |  F1   |  F2 |  F3 |  F4  |  F5  |  F6  |                   |  F7  |  F8   |  F9   |  F10 |  F11  |  F12  |
-// |   `   |  !  |  @  |  #   |  $   |  %   |                   |  ^   |  &    |  *    |  (   |   )   |   ~   |
-// |       |     |     |      |      |      |        |  |       |      |  _    |  +    |  {   |   }   |  "|"  |
-//                     |      |      |      |        |  |       |      |       |       |
             bindings = <
-&bt BT_CLR &bt BT_SEL 0     &bt BT_SEL 1      &bt BT_SEL 2      &bt BT_SEL 3 &bt BT_SEL 4                 &trans    &trans    &trans    &trans    &trans    &trans
-&kp F1     &kp F2           &kp F3            &kp F4            &kp F5       &kp F6                       &kp F7    &kp F8    &kp F9    &kp F10   &kp F11   &kp F12
-&kp GRAVE  &kp EXCL         &kp AT            &kp HASH          &kp DOLLAR   &kp PRCNT                    &kp CARET &kp AMPS  &kp ASTRK &kp LPAR  &kp RPAR  &kp TILDE
-&trans     &ext_power EP_ON &ext_power EP_OFF &ext_power EP_TOG &trans       &trans    &trans   &trans    &trans    &kp MINUS &kp PLUS  &kp LBRC  &kp RBRC  &kp PIPE
-                                              &trans            &trans       &trans    &trans   &trans    &trans    &trans    &trans
+    //╭────────────┬────────────────┬─────────────────┬─────────────────┬────────────┬────────────╮                            ╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮
+        &bt BT_CLR   &bt BT_SEL 0     &bt BT_SEL 1      &bt BT_SEL 2     &bt BT_SEL 3 &bt BT_SEL 4                               &trans       &trans       &trans       &trans       &trans       &trans
+    //├────────────┼────────────────┼─────────────────┼─────────────────┼────────────┼────────────┤                            ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+        &kp F1       &kp F2           &kp F3            &kp F4            &kp F5        &kp F6                                   &kp F7       &kp F8       &kp F9       &kp F10      &kp F11      &kp F12
+    //├────────────┼────────────────┼─────────────────┼─────────────────┼────────────┼────────────┤                            ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+        &kp GRAVE    &kp EXCL         &kp AT            &kp HASH          &kp DOLLAR   &kp PRCNT                                 &kp CARET    &kp AMPS     &kp ASTRK    &kp LPAR     &kp RPAR     &kp TILDE
+    //├────────────┼────────────────┼─────────────────┼─────────────────┼────────────┼────────────┼────────────╮  ╭────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+        &trans      &ext_power EP_ON &ext_power EP_OFF &ext_power EP_TOG  &trans       &trans       &bootloader     &bootloader  &trans       &kp MINUS    &kp KP_PLUS  &kp LBRC     &kp RBRC     &kp PIPE
+    //╰────────────┴────────────────┴─────────────────┼─────────────────┼────────────┼────────────┼────────────┤  ├────────────┼────────────┼────────────┼────────────┼────────────┴────────────┴────────────╯
+                                                        &trans            &trans       &trans       &trans          &trans       &trans       &trans       &trans
+    //                                                ╰─────────────────┴────────────┴────────────┴────────────╯  ╰────────────┴────────────┴────────────┴────────────╯
             >;
-
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
-
         raise_layer {
-// ------------------------------------------------------------------------------------------------------------
-// |       |     |     |      |      |      |                   |      |       |       |      |       |       |
-// |   `   |  1  |  2  |  3   |  4   |  5   |                   |  6   |   7   |   8   |  9   |   0   |       |
-// |   F1  |  F2 |  F3 |  F4  |  F5  |  F6  |                   |      |   <-  |   v   |  ^   |  ->   |       |
-// |   F7  |  F8 |  F9 |  F10 |  F11 |  F12 |        |  |       |  +   |   -   |   =   |  [   |   ]   |   \   |
-//                     |      |      |      |        |  |       |      |       |       |
             bindings = <
-&trans    &trans &trans &trans  &trans  &trans                       &trans      &trans    &trans    &trans   &trans    &trans
-&kp GRAVE &kp N1 &kp N2 &kp N3  &kp N4  &kp N5                       &kp N6      &kp N7    &kp N8    &kp N9   &kp N0    &trans
-&kp F1    &kp F2 &kp F3 &kp F4  &kp F5  &kp F6                       &trans      &kp LEFT  &kp DOWN  &kp UP   &kp RIGHT &trans
-&kp F7    &kp F8 &kp F9 &kp F10 &kp F11 &kp F12   &trans   &trans    &kp KP_PLUS &kp MINUS &kp EQUAL &kp LBKT &kp RBKT  &kp BSLH
-                        &trans  &trans  &trans    &trans   &trans    &trans      &trans    &trans
+    //╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮                            ╭────────────┬────────────┬────────────┬────────────┬────────────┬────────────╮
+        &trans       &trans       &trans       &trans       &trans       &trans                                    &trans       &trans       &trans       &trans       &trans       &trans
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤                            ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+        &kp GRAVE    &kp N1       &kp N2       &kp N3       &kp N4       &kp N5                                    &kp N6       &kp N7       &kp N8       &kp N9       &kp N0       &trans
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤                            ├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+        &kp F1       &kp F2       &kp F3       &kp F4       &kp F5       &kp F6                                    &trans       &kp LEFT     &kp DOWN     &kp UP       &kp RIGHT    &trans
+    //├────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────╮  ╭────────────┼────────────┼────────────┼────────────┼────────────┼────────────┼────────────┤
+        &kp F7       &kp F8       &kp F9       &kp F10       &kp F11     &kp F12      &trans          &trans       &kp KP_PLUS  &kp MINUS    &kp EQUAL    &kp LBKT     &kp RBKT     &kp BSLH
+    //╰────────────┴────────────┴────────────┼────────────┼────────────┼────────────┼────────────┤  ├────────────┼────────────┼────────────┼────────────┼────────────┴────────────┴────────────╯
+                                                &trans       &trans      &trans       &trans          &trans       &trans       &trans       &trans
+    //                                       ╰────────────┴────────────┴────────────┴────────────╯  ╰────────────┴────────────┴────────────┴────────────╯
             >;
-
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
     };


### PR DESCRIPTION
Refactor Corne and Lily58 keymaps to reduce editing errors:
* Align codes with consistent indentation
* Add grid lines for guidance