### PR TITLE
fix(docs): Fix table for BT_DISC

### DIFF
--- a/docs/docs/behaviors/bluetooth.md
+++ b/docs/docs/behaviors/bluetooth.md
@@ -35,14 +35,13 @@ This will allow you to reference the actions defined in this header such as `BT_
 
 Here is a table describing the command for each define:
 
-| Define    | Action                                                                                                                                                    |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `BT_CLR`  | Clear bond information between the keyboard and host for the selected profile.                                                                            |
-| `BT_NXT`  | Switch to the next profile, cycling through to the first one when the end is reached.                                                                     |
-| `BT_PRV`  | Switch to the previous profile, cycling through to the last one when the beginning is reached.                                                            |
-| `BT_SEL`  | Select the 0-indexed profile by number. Please note: this definition must include a number as an argument in the keymap to work correctly. eg. `BT_SEL 0` |
-| `BT_DISC` | Disconnect from the 0-indexed profile by number, if it's currently connected and inactive. Please note: this definition must include a number as an       |
-|           | argument in the keymap to work correctly. eg. `BT_DISC 0`                                                                                                 |
+| Define    | Action                                                                                                                                                                             |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BT_CLR`  | Clear bond information between the keyboard and host for the selected profile.                                                                                                     |
+| `BT_NXT`  | Switch to the next profile, cycling through to the first one when the end is reached.                                                                                              |
+| `BT_PRV`  | Switch to the previous profile, cycling through to the last one when the beginning is reached.                                                                                     |
+| `BT_SEL`  | Select the 0-indexed profile by number; must include a number as an argument in the keymap to work correctly, e.g. `BT_SEL 0`.                                                     |
+| `BT_DISC` | Disconnect from the 0-indexed profile by number, if it's currently connected and inactive; must include a number as an argument in the keymap to work correctly, e.g. `BT_DISC 0`. |
 
 :::note Selected profile persistence
 The profile that is selected by the `BT_SEL`/`BT_PRV`/`BT_NXT` actions will be saved to flash storage and hence persist across restarts and firmware flashes.


### PR DESCRIPTION
Fix the double row for `BT_DISC` entry in Bluetooth behavior page. While touching, clean up the wording a bit on that and `BT_SEL`.
