### PR TITLE
feat(docs): Update behaviors config page

### DIFF
--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -183,6 +183,27 @@ You can use the following nodes to tweak the default behaviors:
 | -------- | ----------------------------------------- |
 | `&gresc` | [Grave escape](../behaviors/mod-morph.md) |
 
+## Sensor Rotation
+
+Creates a custom behavior which sends a tap of other behaviors when a sensor is rotated.
+Has two variants: with `compatible = "zmk,behavior-sensor-rotate"` it accepts no parameters when used, whereas with `compatible = "zmk,behavior-sensor-rotate-var"` it accepts two parameters.
+
+See the [sensor rotation behavior](../behaviors/sensor-rotate.md) documentation for more details and examples.
+
+### Devicetree
+
+Definition files:
+
+- [zmk/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-sensor-rotate.yaml)
+- [zmk/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate-var.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-sensor-rotate-var.yaml)
+
+| Property                | Type          | Description                                                                                                                                                                        | Default |
+| ----------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `compatible`            | string        | Sensor rotation type, **must be _one_ of**:<br/>• `"zmk,behavior-sensor-rotate"`<br/>• `"zmk,behavior-sensor-rotate-var"`                                                          |         |
+| `#sensor-binding-cells` | int           | Number of params accepted (depends on `compatible` property), **must be _one_ of**:<br/>• `<0>`<br/>• `<2>`                                                                        |         |
+| `bindings`              | phandle array | A list of two behaviors to trigger for each rotation direction, must include parameters for `"zmk,behavior-sensor-rotate"` and exclude them for `"zmk,behavior-sensor-rotate-var"` |         |
+| `tap-ms`                | int           | The tap duration (between press and release events) in milliseconds for behaviors in `bindings`                                                                                    | 5       |
+
 ## Sticky Key
 
 Creates a custom behavior that triggers a behavior and keeps it pressed it until another key is pressed and released.

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -126,7 +126,11 @@ See the [macro behavior](../behaviors/macros.md) documentation for more details 
 
 ### Devicetree
 
-Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-macro.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-macro.yaml)
+Definition files:
+
+- [zmk/app/dts/bindings/behaviors/zmk,behavior-macro.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-macro.yaml)
+- [zmk/app/dts/bindings/behaviors/zmk,behavior-macro-one-param.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-macro-one-param.yaml)
+- [zmk/app/dts/bindings/behaviors/zmk,behavior-macro-two-param.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-macro-two-param.yaml)
 
 | Property         | Type          | Description                                                                                                                                  | Default                            |
 | ---------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -193,7 +193,7 @@ Applies to: `compatible = "zmk,behavior-sticky-key"`
 
 | Property           | Type          | Description                                                              | Default |
 | ------------------ | ------------- | ------------------------------------------------------------------------ | ------- |
-| `#binding-cells`   | int           | Must match the number of parameters the `bindings` behavior uses         |         |
+| `#binding-cells`   | int           | Must be `<1>`                                                            |         |
 | `bindings`         | phandle array | A behavior (without parameters) to trigger                               |         |
 | `release-after-ms` | int           | Releases the key after this many milliseconds if no other key is pressed | 1000    |
 | `quick-release`    | bool          | Release the sticky key on the next key press instead of release          | false   |

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -134,13 +134,13 @@ Definition files:
 - [zmk/app/dts/bindings/behaviors/zmk,behavior-macro-one-param.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-macro-one-param.yaml)
 - [zmk/app/dts/bindings/behaviors/zmk,behavior-macro-two-param.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-macro-two-param.yaml)
 
-| Property         | Type          | Description                                                                                                                                  | Default                            |
-| ---------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `compatible`     | string        | Macro type, **must be _one_ of**:<br/>• `"zmk,behavior-macro"`<br/>• `"zmk,behavior-macro-one-param"`<br/>• `"zmk,behavior-macro-two-param"` |                                    |
-| `#binding-cells` | int           | Number of params accepted (depends on `compatible` property), **must be _one_ of**:<br/>• `<0>`<br/>• `<1>`<br/>• `<2>`                      |                                    |
-| `bindings`       | phandle array | List of behaviors to trigger                                                                                                                 |                                    |
-| `wait-ms`        | int           | The default time to wait (in milliseconds) before triggering the next behavior.                                                              | `CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS` |
-| `tap-ms`         | int           | The default time to wait (in milliseconds) between the press and release events of a tapped behavior.                                        | `CONFIG_ZMK_MACRO_DEFAULT_TAP_MS`  |
+| Property         | Type          | Description                                                                                                                                                                                          | Default                            |
+| ---------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `compatible`     | string        | Macro type, **must be _one_ of**:<ul><li>`"zmk,behavior-macro"`</li><li>`"zmk,behavior-macro-one-param"`</li><li>`"zmk,behavior-macro-two-param"`</li></ul>                                          |                                    |
+| `#binding-cells` | int           | Must be <ul><li>`<0>` if `compatible = "zmk,behavior-macro"`</li><li>`<1>` if `compatible = "zmk,behavior-macro-one-param"`</li><li>`<2>` if `compatible = "zmk,behavior-macro-two-param"`</li></ul> |                                    |
+| `bindings`       | phandle array | List of behaviors to trigger                                                                                                                                                                         |                                    |
+| `wait-ms`        | int           | The default time to wait (in milliseconds) before triggering the next behavior.                                                                                                                      | `CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS` |
+| `tap-ms`         | int           | The default time to wait (in milliseconds) between the press and release events of a tapped behavior.                                                                                                | `CONFIG_ZMK_MACRO_DEFAULT_TAP_MS`  |
 
 With `compatible = "zmk,behavior-macro-one-param"` or `compatible = "zmk,behavior-macro-two-param"`, this behavior forwards the parameters it receives according to the `&macro_param_*` control behaviors noted below.
 
@@ -203,8 +203,8 @@ Definition files:
 
 | Property                | Type          | Description                                                                                                                                                                        | Default |
 | ----------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `compatible`            | string        | Sensor rotation type, **must be _one_ of**:<br/>• `"zmk,behavior-sensor-rotate"`<br/>• `"zmk,behavior-sensor-rotate-var"`                                                          |         |
-| `#sensor-binding-cells` | int           | Number of params accepted (depends on `compatible` property), **must be _one_ of**:<br/>• `<0>`<br/>• `<2>`                                                                        |         |
+| `compatible`            | string        | Sensor rotation type, **must be _one_ of**: <ul><li>`"zmk,behavior-sensor-rotate"`</li><li>`"zmk,behavior-sensor-rotate-var"`</li></ul>                                            |         |
+| `#sensor-binding-cells` | int           | Must be <ul><li>`<0>` if `compatible = "zmk,behavior-sensor-rotate"`</li><li>`<2>` if `compatible = "zmk,behavior-sensor-rotate-var"`</li></ul>                                    |         |
 | `bindings`              | phandle array | A list of two behaviors to trigger for each rotation direction, must include parameters for `"zmk,behavior-sensor-rotate"` and exclude them for `"zmk,behavior-sensor-rotate-var"` |         |
 | `tap-ms`                | int           | The tap duration (between press and release events) in milliseconds for behaviors in `bindings`                                                                                    | 5       |
 

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -49,7 +49,7 @@ You can use the following nodes to tweak the default behaviors:
 
 Creates a custom behavior that triggers one behavior when a key is held or a different one when the key is tapped.
 
-See the [hold-tap behavior documentation](../behaviors/hold-tap.md) for more details and examples.
+See the [hold-tap behavior](../behaviors/hold-tap.md) documentation for more details and examples.
 
 ### Devicetree
 
@@ -157,6 +157,8 @@ The following macro-specific behaviors can be added at any point in the `binding
 
 Creates a custom behavior that triggers one of two behaviors depending on whether certain modifiers are held.
 
+See the [mod-morph behavior](../behaviors/mod-morph.md) documentation for more details and examples.
+
 ### Devicetree
 
 Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-mod-morph.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-mod-morph.yaml)
@@ -207,6 +209,8 @@ You can use the following nodes to tweak the default behaviors:
 ## Tap Dance
 
 Creates a custom behavior that triggers a different behavior corresponding to the number of times the key is tapped.
+
+See the [tap dance behavior](../behaviors/tap-dance.md) documentation for more details and examples.
 
 ### Devicetree
 

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -68,6 +68,8 @@ Applies to: `compatible = "zmk,behavior-hold-tap"`
 | `retro-tap`                  | bool          | Triggers the tap behavior on release if no other key was pressed during a hold                                 | false              |
 | `hold-trigger-key-positions` | array         | If set, pressing the hold-tap and then any key position _not_ in the list triggers a tap.                      |                    |
 
+This behavior forwards the first parameter it receives to the parameter of the first behavior specified in `bindings`, and second parameter to the parameter of the second behavior.
+
 The `flavor` property may be one of:
 
 - `"hold-preferred"`
@@ -140,6 +142,8 @@ Definition files:
 | `wait-ms`        | int           | The default time to wait (in milliseconds) before triggering the next behavior.                                                              | `CONFIG_ZMK_MACRO_DEFAULT_WAIT_MS` |
 | `tap-ms`         | int           | The default time to wait (in milliseconds) between the press and release events of a tapped behavior.                                        | `CONFIG_ZMK_MACRO_DEFAULT_TAP_MS`  |
 
+With `compatible = "zmk,behavior-macro-one-param"` or `compatible = "zmk,behavior-macro-two-param"`, this behavior forwards the parameters it receives according to the `&macro_param_*` control behaviors noted below.
+
 ### Macro Control Behaviors
 
 The following macro-specific behaviors can be added at any point in the `bindings` list to change how the macro triggers subsequent behaviors.
@@ -204,6 +208,8 @@ Definition files:
 | `bindings`              | phandle array | A list of two behaviors to trigger for each rotation direction, must include parameters for `"zmk,behavior-sensor-rotate"` and exclude them for `"zmk,behavior-sensor-rotate-var"` |         |
 | `tap-ms`                | int           | The tap duration (between press and release events) in milliseconds for behaviors in `bindings`                                                                                    | 5       |
 
+With `compatible = "zmk,behavior-sensor-rotate-var"`, this behavior forwards the first parameter it receives to the parameter of the first behavior specified in `bindings`, and second parameter to the parameter of the second behavior.
+
 ## Sticky Key
 
 Creates a custom behavior that triggers a behavior and keeps it pressed it until another key is pressed and released.
@@ -223,6 +229,8 @@ Applies to: `compatible = "zmk,behavior-sticky-key"`
 | `release-after-ms` | int           | Releases the key after this many milliseconds if no other key is pressed | 1000    |
 | `quick-release`    | bool          | Release the sticky key on the next key press instead of release          | false   |
 | `ignore-modifiers` | bool          | If enabled, pressing a modifier key does not cancel the sticky key       | true    |
+
+This behavior forwards the one parameter it receives to the parameter of the behavior specified in `bindings`.
 
 You can use the following nodes to tweak the default behaviors:
 


### PR DESCRIPTION
This PR updates the behaviors config page to do the following, split into separate commits:
- Add a couple missing links to behavior docs
- Fix `#binding-cells` for sticky keys to `<1>`
- Add missing definition file links for parametrized macro variants
- Add sensor rotation behaviors that were missing
- Note how behaviors forward the parameters they receive to the behaviors they invoke

Mouse key press behavior is not documented here, but similar to key press, it has no options to tweak so IMO it doesn't seem necessary. However move/scroll behaviors will likely need to be documented in the future.