### PR TITLE
Fix: Use a lookup table & interpolation to better estimate remaining battery capacity

### DIFF
--- a/app/module/drivers/sensor/battery/battery_common.c
+++ b/app/module/drivers/sensor/battery/battery_common.c
@@ -29,15 +29,37 @@ int battery_channel_get(const struct battery_value *value, enum sensor_channel c
     return 0;
 }
 
-uint8_t lithium_ion_mv_to_pct(int16_t bat_mv) {
-    // Simple linear approximation of a battery based off adafruit's discharge graph:
-    // https://learn.adafruit.com/li-ion-and-lipoly-batteries/voltages
+uint8_t lithium_ion_mv_to_pct(int16_t batt_mv) {
+    // Lookup table of slope formulas for calculating remaining battery capacity.
+    //
+    // The current set of values acheives the same as: bat_mv * 2 / 15 - 459;
+    //
+    // Future updates sould include more complete lookup tables for different
+    // battery types slectable through config flags.
+    struct lookup_point {
+        int16_t millivolts;
+        int16_t percent;
+    };
 
-    if (bat_mv >= 4200) {
-        return 100;
-    } else if (bat_mv <= 3450) {
-        return 0;
+    static const struct lookup_point battery_lookup[] = {
+        {.millivolts = 4200, .percent = 100},
+        {.millivolts = 3450, .percent = 0},
+    };
+
+    if (batt_mv > battery_lookup[0].millivolts) {
+        return battery_lookup[0].percent;
     }
 
-    return bat_mv * 2 / 15 - 459;
+    for (int i = 1; i < ARRAY_SIZE(battery_lookup); i++) {
+        struct lookup_point one = battery_lookup[i - 1];
+        struct lookup_point two = battery_lookup[i];
+        if (batt_mv >= two.millivolts) {
+            const int t = batt_mv - one.millivolts;
+            const int dx = two.millivolts - one.millivolts;
+            const int dy = two.percent - one.percent;
+            return one.percent + dy * t / dx;
+        }
+    }
+
+    return battery_lookup[ARRAY_SIZE(battery_lookup) - 1].percent;
 }


### PR DESCRIPTION
The current battery capacity estimate uses a linear approximation to estimate the remaining battery capacity. This is computationally very efficient, however, the estimate is very inaccurate once below 60%.

This PR uses a small table of bounded functions to provide a more accurate estimate of remaining capacity.

The original data to create the estimate was taken from here: https://blog.ampow.com/lipo-voltage-chart/

The accuracy of the functions (in relation to the lookup chart least) can be seen below:

![Screenshot 2023-12-11 at 17 23 23](https://github.com/zmkfirmware/zmk/assets/137600636/beecde23-1dd6-4bd1-a517-0bc98c142afb)

In terms of testing I've used a Python version of the algorithm to validate the behaviour. I am also running the change on my daily driver keyboard.

Adding a little to the data/numbers on this: If a search is done for "lipo discharge lookup chart" in Goole/DuckDuckGo image search these numbers keep coming up or numbers that are within a few millivolts of those that I've used. So long as the discharge rate is substantially below C (most charts show 0.2C) then the shape and values are very consistent.