### PR TITLE
Make settings_reset builds reset all settings

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -99,5 +99,6 @@ target_sources_ifdef(CONFIG_ZMK_LOW_PRIORITY_WORK_QUEUE app PRIVATE src/workqueu
 target_sources(app PRIVATE src/main.c)
 
 add_subdirectory(src/display/)
+add_subdirectory_ifdef(CONFIG_SETTINGS src/settings/)
 
 zephyr_cc_option(-Wfatal-errors)

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -565,6 +565,9 @@ endmenu
 
 if SETTINGS
 
+config ZMK_SETTINGS_RESET_ON_START
+    bool "Delete all persistent settings when the keyboard boots"
+
 config ZMK_SETTINGS_SAVE_DEBOUNCE
     int "Milliseconds to debounce settings saves"
     default 60000

--- a/app/boards/shields/settings_reset/settings_reset.conf
+++ b/app/boards/shields/settings_reset/settings_reset.conf
@@ -1,1 +1,4 @@
-CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START=y
+CONFIG_SETTINGS=y
+CONFIG_ZMK_SETTINGS_RESET_ON_START=y
+# Disable BLE so splits don't try to re-pair until normal firmware is flashed.
+CONFIG_ZMK_BLE=n

--- a/app/include/zmk/settings.h
+++ b/app/include/zmk/settings.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+/**
+ * Erases all saved settings.
+ *
+ * @note This does not automatically update any code using Zephyr's settings
+ * subsystem. This should typically be followed by a call to sys_reboot().
+ */
+int zmk_settings_erase(void);

--- a/app/src/settings/CMakeLists.txt
+++ b/app/src/settings/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+target_sources_ifdef(CONFIG_SETTINGS_NONE app PRIVATE reset_settings_none.c)
+target_sources_ifdef(CONFIG_SETTINGS_FCB app PRIVATE reset_settings_fcb.c)
+target_sources_ifdef(CONFIG_SETTINGS_FILE app PRIVATE reset_settings_file.c)
+target_sources_ifdef(CONFIG_SETTINGS_NVS app PRIVATE reset_settings_nvs.c)

--- a/app/src/settings/CMakeLists.txt
+++ b/app/src/settings/CMakeLists.txt
@@ -5,3 +5,5 @@ target_sources_ifdef(CONFIG_SETTINGS_NONE app PRIVATE reset_settings_none.c)
 target_sources_ifdef(CONFIG_SETTINGS_FCB app PRIVATE reset_settings_fcb.c)
 target_sources_ifdef(CONFIG_SETTINGS_FILE app PRIVATE reset_settings_file.c)
 target_sources_ifdef(CONFIG_SETTINGS_NVS app PRIVATE reset_settings_nvs.c)
+
+target_sources_ifdef(CONFIG_ZMK_SETTINGS_RESET_ON_START app PRIVATE reset_settings_on_start.c)

--- a/app/src/settings/reset_settings_fcb.c
+++ b/app/src/settings/reset_settings_fcb.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zmk/settings.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+int zmk_settings_erase(void) {
+    LOG_ERR("Settings reset is not implemented for deprecated FCB backend.");
+    return -ENOSYS;
+}

--- a/app/src/settings/reset_settings_file.c
+++ b/app/src/settings/reset_settings_file.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/fs/fs.h>
+
+#include <zmk/settings.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+int zmk_settings_erase(void) {
+    LOG_INF("Erasing settings file");
+
+    int rc = fs_unlink(CONFIG_SETTINGS_FS_FILE);
+    if (rc) {
+        LOG_ERR("Failed to unlink '%s': %d", CONFIG_SETTINGS_FS_FILE, rc);
+    }
+
+    return rc;
+}

--- a/app/src/settings/reset_settings_none.c
+++ b/app/src/settings/reset_settings_none.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zmk/settings.h>
+
+int zmk_settings_erase(void) {
+    // No storage backend; nothing to do
+    return 0;
+}

--- a/app/src/settings/reset_settings_nvs.c
+++ b/app/src/settings/reset_settings_nvs.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/storage/flash_map.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+// SETTINGS_PARTITION must match settings_nvs.c
+#if DT_HAS_CHOSEN(zephyr_settings_partition)
+#define SETTINGS_PARTITION DT_FIXED_PARTITION_ID(DT_CHOSEN(zephyr_settings_partition))
+#else
+#define SETTINGS_PARTITION FIXED_PARTITION_ID(storage_partition)
+#endif
+
+int zmk_settings_erase(void) {
+    LOG_INF("Erasing settings flash partition");
+
+    const struct flash_area *fa;
+    int rc = flash_area_open(SETTINGS_PARTITION, &fa);
+    if (rc) {
+        LOG_ERR("Failed to open settings flash: %d", rc);
+        return rc;
+    }
+
+    rc = flash_area_erase(fa, 0, fa->fa_size);
+    if (rc) {
+        LOG_ERR("Failed to erase settings flash: %d", rc);
+    }
+
+    flash_area_close(fa);
+
+    return rc;
+}

--- a/app/src/settings/reset_settings_on_start.c
+++ b/app/src/settings/reset_settings_on_start.c
@@ -4,16 +4,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <zephyr/device.h>
 #include <zephyr/init.h>
 
 #include <zmk/settings.h>
 
-static int reset_settings_init(const struct device *dev) {
-    ARG_UNUSED(dev);
-    return zmk_settings_erase();
-}
-
 // Reset after the kernel is initialized but before any application code to
 // ensure settings are cleared before anything tries to use them.
-SYS_INIT(reset_settings_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);
+SYS_INIT(zmk_settings_erase, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/app/src/settings/reset_settings_on_start.c
+++ b/app/src/settings/reset_settings_on_start.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+
+#include <zmk/settings.h>
+
+static int reset_settings_init(const struct device *dev) {
+    ARG_UNUSED(dev);
+    return zmk_settings_erase();
+}
+
+// Reset after the kernel is initialized but before any application code to
+// ensure settings are cleared before anything tries to use them.
+SYS_INIT(reset_settings_init, POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -13,12 +13,13 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 
 ### General
 
-| Config                              | Type   | Description                                                                   | Default |
-| ----------------------------------- | ------ | ----------------------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_KEYBOARD_NAME`          | string | The name of the keyboard (max 16 characters)                                  |         |
-| `CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE` | int    | Milliseconds to wait after a setting change before writing it to flash memory | 60000   |
-| `CONFIG_ZMK_WPM`                    | bool   | Enable calculating words per minute                                           | n       |
-| `CONFIG_HEAP_MEM_POOL_SIZE`         | int    | Size of the heap memory pool                                                  | 8192    |
+| Config                               | Type   | Description                                                                   | Default |
+| ------------------------------------ | ------ | ----------------------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_KEYBOARD_NAME`           | string | The name of the keyboard (max 16 characters)                                  |         |
+| `CONFIG_ZMK_SETTINGS_RESET_ON_START` | bool   | Clears all persistent settings from the keyboard at startup                   | n       |
+| `CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`  | int    | Milliseconds to wait after a setting change before writing it to flash memory | 60000   |
+| `CONFIG_ZMK_WPM`                     | bool   | Enable calculating words per minute                                           | n       |
+| `CONFIG_HEAP_MEM_POOL_SIZE`          | int    | Size of the heap memory pool                                                  | 8192    |
 
 ### HID
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -68,7 +68,20 @@ A common mistake that leads to this error is to use [key press keycodes](behavio
 
 ### Split Keyboard Halves Unable to Pair
 
-Split keyboard halves pairing issue can be resolved by flashing a settings reset firmware to both controllers. You will first need to acquire the reset UF2 image file with one of the following options:
+Split keyboard halves will automatically pair with one another, but there are some cases where this breaks, and the pairing needs to be reset, for example:
+
+- Switching which halves are the central/peripheral.
+- Replacing the controller for one of the halves.
+
+These issues can be resolved by flashing a settings reset firmware to both controllers.
+
+:::warning
+
+This procedure will erase all settings, such as Bluetooth profiles, output selection, RGB underglow color, etc.
+
+:::
+
+First, acquire the reset UF2 image file with one of the following options:
 
 #### Option 1: Build Reset UF2 in 'zmk-config'
 
@@ -101,8 +114,16 @@ Save the file, commit the changes and push them to GitHub. Download the new firm
 Perform the following steps to reset both halves of your split keyboard:
 
 1. Put each half of the split keyboard into bootloader mode.
-1. Flash one of the halves of the split with the downloaded settings reset UF2 image. Immediately after flashing the chosen half, put it into bootloader mode to avoid accidental bonding between the halves.
+1. Flash one of the halves of the split with the downloaded settings reset UF2 image.
 1. Repeat step 2 with the other half of the split keyboard.
 1. Flash the actual image for each half of the split keyboard (e.g `my_board_left.uf2` to the left half, `my_board_right.uf2` to the right half).
 
 After completing these steps, pair the halves of the split keyboard together by resetting them at the same time. Most commonly, this is done by grounding the reset pins for each of your keyboard's microcontrollers or pressing the reset buttons at the same time.
+
+Once this is done, you can remove/forget the keyboard on each host device and pair it again.
+
+:::info
+
+The settings reset firmware has Bluetooth disabled to prevent the two sides from automatically re-pairing until you are done resetting them both. You will not be able to pair your keyboard or see it in any Bluetooth device lists until you have flashed the normal firmware again.
+
+:::


### PR DESCRIPTION
- Added `zmk_settings_erase()`, which directly clears the backend data for settings.
- Changed the `settings_reset` shield to run this function on startup instead of using `CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START`, so it now resets all settings instead of just Bluetooth ones.
- Removed `CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START`, as it is no longer needed.

Future PRs can add additional ways to trigger `zmk_settings_erase()`.