### PR TITLE
fix(ci): Use unique artifact for test logs

### DIFF
--- a/.github/workflows/ble-test.yml
+++ b/.github/workflows/ble-test.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           cd app/tests/ble
           export TESTS=$(ls -d * | grep -v central | jq -R -s -c 'split("\n")[:-1]')
-          echo "::set-output name=test-dirs::${TESTS}"
+          echo "test-dirs=${TESTS}" > $GITHUB_OUTPUT
   run-tests:
     needs: collect-tests
     strategy:
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cache west modules
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3
         env:
           cache-name: cache-zephyr-modules
         with:
@@ -72,7 +72,7 @@ jobs:
         run: BSIM_COMPONENTS_PATH="${GITHUB_WORKSPACE}/tools/bsim/components/" BSIM_OUT_PATH="${GITHUB_WORKSPACE}/tools/bsim/" ./run-ble-test.sh tests/ble/${{ matrix.test }}
       - name: Archive artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: "log-files"
+          name: "${{ matrix.test }}-log-files"
           path: app/build/**/*.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           cd app/tests/
           export TESTS=$(ls -d * | grep -v ble | jq -R -s -c 'split("\n")[:-1]')
-          echo "::set-output name=test-dirs::${TESTS}"
+          echo "test-dirs=${TESTS}" >> $GITHUB_OUTPUT
   run-tests:
     needs: collect-tests
     strategy:
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cache west modules
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3
         env:
           cache-name: cache-zephyr-modules
         with:
@@ -65,7 +65,7 @@ jobs:
         run: west test tests/${{ matrix.test }}
       - name: Archive artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: "log-files"
+          name: "${{ matrix.test }}-log-files"
           path: app/build/**/*.log


### PR DESCRIPTION
* To address conflicts with identically named artifact uploads, include the
  test name in the artifact name.

Bit of a chore after seeing failure in the dependabot PR to bump our `actions/upload-artifact` dep.