### PR TITLE
refactor(core): Make low priority queue optional.

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -88,7 +88,7 @@ target_sources_ifdef(CONFIG_USB_DEVICE_STACK app PRIVATE src/usb.c)
 target_sources_ifdef(CONFIG_ZMK_USB app PRIVATE src/usb_hid.c)
 target_sources_ifdef(CONFIG_ZMK_RGB_UNDERGLOW app PRIVATE src/rgb_underglow.c)
 target_sources_ifdef(CONFIG_ZMK_BACKLIGHT app PRIVATE src/backlight.c)
-target_sources(app PRIVATE src/workqueue.c)
+target_sources_ifdef(CONFIG_ZMK_LOW_PRIORITY_WORK_QUEUE app PRIVATE src/workqueue.c)
 target_sources(app PRIVATE src/main.c)
 
 add_subdirectory(src/display/)

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -256,6 +256,7 @@ rsource "src/display/Kconfig"
 menuconfig ZMK_RGB_UNDERGLOW
     bool "RGB Adressable LED Underglow"
     select LED_STRIP
+    select ZMK_LOW_PRIORITY_WORK_QUEUE
 
 if ZMK_RGB_UNDERGLOW
 
@@ -378,6 +379,7 @@ config ZMK_BATTERY_REPORTING
     bool "Battery level detection/reporting"
     default n
     select SENSOR
+    select ZMK_LOW_PRIORITY_WORK_QUEUE
     imply BT_BAS if ZMK_BLE
 
 config ZMK_IDLE_TIMEOUT
@@ -572,6 +574,11 @@ config ZMK_BATTERY_REPORT_INTERVAL
     int "Battery level report interval in seconds"
     default 60
 
+config ZMK_LOW_PRIORITY_WORK_QUEUE
+    bool "Work queue for low priority items"
+
+if ZMK_LOW_PRIORITY_WORK_QUEUE
+
 config ZMK_LOW_PRIORITY_THREAD_STACK_SIZE
     int "Low priority thread stack size"
     default 768
@@ -579,6 +586,8 @@ config ZMK_LOW_PRIORITY_THREAD_STACK_SIZE
 config ZMK_LOW_PRIORITY_THREAD_PRIORITY
     int "Low priority thread priority"
     default 10
+
+endif
 
 #Advanced
 endmenu


### PR DESCRIPTION
* Add a new Kconfig symbol to enable the low priority queue, and make the two features that depend on it `select` the symbol to turn it on. This helps ensure no wasted RAM/ROM on devices that don't need it.

This came up while working on more resource constrained devices like SAMD21 and stm32f072.