### PR TITLE
Add some python things to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /build
 *.DS_Store
 __pycache__
+.python-version
+.venv


### PR DESCRIPTION
As per title. (Zephyr docs recommend installing Python packages in a virtual environment)