### PR TITLE
Fix high idle/sleep current due to flash and use xiao-ble from upstream Zephyr

### DIFF
--- a/app/boards/seeeduino_xiao_ble.overlay
+++ b/app/boards/seeeduino_xiao_ble.overlay
@@ -31,5 +31,24 @@
 };
 
 &qspi {
-    status = "disabled";
+    status = "okay";
+    pinctrl-0 = <&qspi_default>;
+    pinctrl-1 = <&qspi_sleep>;
+    pinctrl-names = "default", "sleep";
+    p25q16h: p25q16h@0 {
+        compatible = "nordic,qspi-nor";
+        reg = <0>;
+        sck-frequency = <104000000>;
+        quad-enable-requirements = "S2B1v1";
+        jedec-id = [85 60 15];
+        sfdp-bfp = [
+            e5 20 f1 ff  ff ff ff 00  44 eb 08 6b  08 3b 80 bb
+            ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+            10 d8 08 81
+        ];
+        size = <16777216>;
+        has-dpd;
+        t-enter-dpd = <3000>;
+        t-exit-dpd = <8000>;
+    };
 };


### PR DESCRIPTION
I'm working a XIAO-BLE based keyboard and I noticed high idle and sleep currents, bearing in mind that my board:

- Uses matrix polling;
- has CA95xx gpio expander;

![image](https://github.com/zmkfirmware/zmk/assets/34199302/cc4fa6b2-6070-4fb6-ac37-f75f76da5d78)

The 500uA current is similar to reported here: https://forum.seeedstudio.com/t/low-power-with-xiao-nrf52840-on-zephyr-rtos/270491/6

Which led me to https://github.com/zmkfirmware/zmk/pull/1927. Even tho the PR seems to address the issue somehow, I find it strange that it does since the nRF driver puts the flash on Deep Power-Down (DPD) [drivers/flash/nrf_qspi_nor.c#L1324](https://github.com/zmkfirmware/zephyr/blob/1ae0eb5ce8adafcec993e6fb8f4eeb6f818a7772/drivers/flash/nrf_qspi_nor.c#L1324), the reason for DPD not properly working I believe to be related to the fact that the ZMK fork of Zephyr use what seems the incorrect [boards/arm/seeeduino_xiao_ble/seeeduino_xiao_ble.dts#L97](https://github.com/zmkfirmware/zephyr/blob/1ae0eb5ce8adafcec993e6fb8f4eeb6f818a7772/boards/arm/seeeduino_xiao_ble/seeeduino_xiao_ble.dts#L97) board configuration (which does not match the upstream Zephyr).

I noticed the `seeeduino_xiao_ble` was added on https://github.com/zmkfirmware/zephyr/commit/1f19b89c79fe4c451ba5cd9ff42deb3fd5c3be3f and I do not know the reason for adding since it is already available on [boards/arm/xiao_ble](https://github.com/zmkfirmware/zephyr/tree/v3.2.0%2Bzmk-fixes/boards/arm/xiao_ble) and also on Zephyr 3.2 and newer.

With that being said, this PR:
1. ~~Remove `seeeduino_xiao_ble` and use the `xiao_ble` from Zephyr~~
2. Put the Flash to Deep Power Down mode and reduce the idle/sleep current. ~~(To add measurement)~~

Note/Question:
1. Another PR can be made on `zmkfirmware/zephyr` to revert https://github.com/zmkfirmware/zephyr/commit/1f19b89c79fe4c451ba5cd9ff42deb3fd5c3be3f
2. If removing the board is not desireable, I can change everything on the `app/boards/seeeduino_xiao_ble.overlay`

