### PR TITLE
fix(split): Split peripherals should auto sec req still.

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -217,7 +217,7 @@ config BT_GATT_NOTIFY_MULTIPLE
     default n
 
 config BT_GATT_AUTO_SEC_REQ
-    default n
+    default (ZMK_SPLIT_BLE && !ZMK_SPLIT_ROLE_CENTRAL)
 
 config BT_DEVICE_APPEARANCE
     default 961


### PR DESCRIPTION
* Ensure split peripherals have `BT_GATT_AUTO_SEC_REQ` enabled so that
  reconnects to centrals are automatically encrypted.
