### PR TITLE
fix(boards): Fix up EXT_POWER naming for adv360pro;

### DIFF
--- a/app/boards/arm/adv360pro/adv360pro.dtsi
+++ b/app/boards/arm/adv360pro/adv360pro.dtsi
@@ -44,7 +44,9 @@
 
         >;
     };
-    ext-power {
+
+    // Node name must match original "EXT_POWER" label to preserve user settings.
+    EXT_POWER {
         compatible = "zmk,ext-power-generic";
         control-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
     };


### PR DESCRIPTION
* Restore setting loading by preserving old device name for the external power node.
