### PR TITLE
fix(battery): prevent bus fault when battery does not exist

### DIFF
--- a/app/src/battery.c
+++ b/app/src/battery.c
@@ -87,7 +87,9 @@ static void zmk_battery_timer(struct k_timer *timer) {
 K_TIMER_DEFINE(battery_timer, zmk_battery_timer, NULL);
 
 static void zmk_battery_start_reporting() {
-    k_timer_start(&battery_timer, K_NO_WAIT, K_SECONDS(CONFIG_ZMK_BATTERY_REPORT_INTERVAL));
+    if (device_is_ready(battery)) {
+        k_timer_start(&battery_timer, K_NO_WAIT, K_SECONDS(CONFIG_ZMK_BATTERY_REPORT_INTERVAL));
+    }
 }
 
 static int zmk_battery_init(const struct device *_arg) {


### PR DESCRIPTION
zmk_battery_start_reporting() may be called from battery_event_listener(), which will result in a bus fault when attempting to read a battery that does not exist such as on a dongle.
