### PR TITLE
refactor: replace zmk,matrix_transform with zmk,matrix-transform

### DIFF
--- a/app/boards/arm/adv360pro/adv360pro.dtsi
+++ b/app/boards/arm/adv360pro/adv360pro.dtsi
@@ -25,7 +25,7 @@
         zmk,kscan = &kscan0;
         zmk,backlight = &backlight;
         zmk,battery = &vbatt;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
         zmk,underglow = &led_strip;
     };
 

--- a/app/boards/arm/bt60/bt60.dtsi
+++ b/app/boards/arm/bt60/bt60.dtsi
@@ -19,7 +19,7 @@
         zephyr,console = &cdc_acm_uart;
         zmk,battery = &vbatt;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     sensors: sensors {

--- a/app/boards/arm/bt60/bt60_v1.dts
+++ b/app/boards/arm/bt60/bt60_v1.dts
@@ -11,7 +11,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &ansi_transform;
+        zmk,matrix-transform = &ansi_transform;
     };
 
     ansi_transform: keymap_transform_0 {

--- a/app/boards/arm/bt60/bt60_v1.keymap
+++ b/app/boards/arm/bt60/bt60_v1.keymap
@@ -13,15 +13,15 @@
 / {
     chosen {
     #ifdef ANSI
-        zmk,matrix_transform = &ansi_transform;
+        zmk,matrix-transform = &ansi_transform;
     #elif defined(HHKB)
-        zmk,matrix_transform = &hhkb_transform;
+        zmk,matrix-transform = &hhkb_transform;
     #elif defined(ISO)
-        zmk,matrix_transform = &iso_transform;
+        zmk,matrix-transform = &iso_transform;
     #elif defined(ALL_1U)
-        zmk,matrix_transform = &all_1u_transform;
+        zmk,matrix-transform = &all_1u_transform;
     #else
-        zmk,matrix_transform = &split_transform;
+        zmk,matrix-transform = &split_transform;
     #endif
     };
 

--- a/app/boards/arm/bt60/bt60_v1_hs.dts
+++ b/app/boards/arm/bt60/bt60_v1_hs.dts
@@ -11,7 +11,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/arm/ckp/bt60_v2.dts
+++ b/app/boards/arm/ckp/bt60_v2.dts
@@ -13,7 +13,7 @@
   compatible = "polarityworks,bt60_v2";
 
   chosen {
-    zmk,matrix_transform = &ansi_transform;
+    zmk,matrix-transform = &ansi_transform;
   };
 
 

--- a/app/boards/arm/ckp/bt60_v2.keymap
+++ b/app/boards/arm/ckp/bt60_v2.keymap
@@ -12,13 +12,13 @@
 / {
   chosen {
   #ifdef ANSI
-    zmk,matrix_transform = &ansi_transform;
+    zmk,matrix-transform = &ansi_transform;
   #elif defined(ISO)
-    zmk,matrix_transform = &iso_transform;
+    zmk,matrix-transform = &iso_transform;
   #elif defined(ALL_1U)
-    zmk,matrix_transform = &all_1u_transform;
+    zmk,matrix-transform = &all_1u_transform;
   #elif defined(HHKB)
-    zmk,matrix_transform = &hhkb_transform;
+    zmk,matrix-transform = &hhkb_transform;
   #else
   #error "Layout not defined, please define a layout by uncommenting the appropriate line in bt60_v2.keymap"
   #endif

--- a/app/boards/arm/ckp/bt65_v1.dts
+++ b/app/boards/arm/ckp/bt65_v1.dts
@@ -13,7 +13,7 @@
   compatible = "polarityworks,bt65_v1";
 
   chosen {
-    zmk,matrix_transform = &ansi_transform;
+    zmk,matrix-transform = &ansi_transform;
   };
 
 

--- a/app/boards/arm/ckp/bt65_v1.keymap
+++ b/app/boards/arm/ckp/bt65_v1.keymap
@@ -12,13 +12,13 @@
 / {
   chosen {
   #ifdef ANSI
-    zmk,matrix_transform = &ansi_transform;
+    zmk,matrix-transform = &ansi_transform;
   #elif defined(ISO)
-    zmk,matrix_transform = &iso_transform;
+    zmk,matrix-transform = &iso_transform;
   #elif defined(ALL_1U)
-    zmk,matrix_transform = &all_1u_transform;
+    zmk,matrix-transform = &all_1u_transform;
   #elif defined(HHKB)
-    zmk,matrix_transform = &hhkb_transform;
+    zmk,matrix-transform = &hhkb_transform;
   #else
   #error "Layout not defined, please define a layout by uncommenting the appropriate line in bt65_v1.keymap"
   #endif

--- a/app/boards/arm/ckp/bt75_v1.dts
+++ b/app/boards/arm/ckp/bt75_v1.dts
@@ -13,7 +13,7 @@
   compatible = "polarityworks,bt75_v1";
 
   chosen {
-    zmk,matrix_transform = &ansi_transform;
+    zmk,matrix-transform = &ansi_transform;
   };
 
 

--- a/app/boards/arm/ckp/bt75_v1.keymap
+++ b/app/boards/arm/ckp/bt75_v1.keymap
@@ -11,11 +11,11 @@
 / {
   chosen {
   #ifdef ANSI
-    zmk,matrix_transform = &ansi_transform;
+    zmk,matrix-transform = &ansi_transform;
   #elif defined(ISO)
-    zmk,matrix_transform = &iso_transform;
+    zmk,matrix-transform = &iso_transform;
   #elif defined(ALL_1U)
-    zmk,matrix_transform = &all_1u_transform;
+    zmk,matrix-transform = &all_1u_transform;
   #else
   #error "Layout not defined, please define a layout using by uncommenting the appropriate line in bt75_v1.keymap"
   #endif

--- a/app/boards/arm/corneish_zen/corneish_zen.dtsi
+++ b/app/boards/arm/corneish_zen/corneish_zen.dtsi
@@ -21,7 +21,7 @@
         zmk,kscan = &kscan0;
         zmk,display = &epd;
         zephyr,console = &cdc_acm_uart;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/arm/corneish_zen/corneish_zen.keymap
+++ b/app/boards/arm/corneish_zen/corneish_zen.keymap
@@ -11,8 +11,8 @@
 
 / {
     chosen {
-        zmk,matrix_transform = &default_transform;
-        // zmk,matrix_transform = &five_column_transform;
+        zmk,matrix-transform = &default_transform;
+        // zmk,matrix-transform = &five_column_transform;
     };
 };
 

--- a/app/boards/arm/dz60rgb/dz60rgb_rev1.dts
+++ b/app/boards/arm/dz60rgb/dz60rgb_rev1.dts
@@ -18,7 +18,7 @@
         zephyr,flash = &flash0;
         zephyr,console = &cdc_acm_uart;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/arm/ferris/ferris_rev02.dts
+++ b/app/boards/arm/ferris/ferris_rev02.dts
@@ -19,7 +19,7 @@
         zephyr,flash = &flash0;
         zephyr,console = &cdc_acm_uart;
         zmk,kscan = &kscan;
-        zmk,matrix_transform = &transform;
+        zmk,matrix-transform = &transform;
         /* TODO: Enable once we support the IC for underglow
         zmk,underglow = &led_strip;
          */

--- a/app/boards/arm/glove80/glove80.dtsi
+++ b/app/boards/arm/glove80/glove80.dtsi
@@ -11,7 +11,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
         zephyr,code-partition = &code_partition;
         zephyr,sram = &sram0;
         zephyr,flash = &flash0;

--- a/app/boards/arm/kbdfans_tofu65/kbdfans_tofu65_v2.dts
+++ b/app/boards/arm/kbdfans_tofu65/kbdfans_tofu65_v2.dts
@@ -17,7 +17,7 @@
         zephyr,shell-uart = &cdc_acm_uart;
         zephyr,code-partition = &code_partition;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     xtal_clk: xtal-clk {

--- a/app/boards/arm/nice60/nice60.dts
+++ b/app/boards/arm/nice60/nice60.dts
@@ -23,7 +23,7 @@
         zephyr,console = &cdc_acm_uart;
         zmk,battery = &vbatt;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
         zmk,underglow = &led_strip;
     };
 

--- a/app/boards/arm/planck/planck_rev6.dts
+++ b/app/boards/arm/planck/planck_rev6.dts
@@ -18,7 +18,7 @@
         zephyr,flash = &flash0;
         zephyr,console = &cdc_acm_uart;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &layout_grid_transform;
+        zmk,matrix-transform = &layout_grid_transform;
     };
 
     kscan0: kscan {

--- a/app/boards/arm/preonic/preonic_rev3.dts
+++ b/app/boards/arm/preonic/preonic_rev3.dts
@@ -18,7 +18,7 @@
         zephyr,sram = &sram0;
         zephyr,flash = &flash0;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &layout_grid_transform;
+        zmk,matrix-transform = &layout_grid_transform;
     };
 
     kscan0: kscan_0 {

--- a/app/boards/arm/preonic/preonic_rev3.keymap
+++ b/app/boards/arm/preonic/preonic_rev3.keymap
@@ -13,7 +13,7 @@
 #define RAISE   2
 
 / {
-    chosen { zmk,matrix_transform = &layout_grid_transform; };
+    chosen { zmk,matrix-transform = &layout_grid_transform; };
     keymap {
         compatible = "zmk,keymap";
         default_layer {

--- a/app/boards/arm/s40nc/s40nc.dts
+++ b/app/boards/arm/s40nc/s40nc.dts
@@ -19,7 +19,7 @@
         zephyr,console = &cdc_acm_uart;
         zmk,battery = &vbatt;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/a_dux/a_dux.dtsi
+++ b/app/boards/shields/a_dux/a_dux.dtsi
@@ -10,7 +10,7 @@
 
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/bat43/bat43.overlay
+++ b/app/boards/shields/bat43/bat43.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/bfo9000/bfo9000.dtsi
+++ b/app/boards/shields/bfo9000/bfo9000.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/chalice/chalice.overlay
+++ b/app/boards/shields/chalice/chalice.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
 

--- a/app/boards/shields/clog/clog.dtsi
+++ b/app/boards/shields/clog/clog.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/corne/corne.dtsi
+++ b/app/boards/shields/corne/corne.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/cradio/cradio.dtsi
+++ b/app/boards/shields/cradio/cradio.dtsi
@@ -10,7 +10,7 @@
 
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/eek/eek.overlay
+++ b/app/boards/shields/eek/eek.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/elephant42/elephant42.dtsi
+++ b/app/boards/shields/elephant42/elephant42.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/ergodash/ergodash.dtsi
+++ b/app/boards/shields/ergodash/ergodash.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/eternal_keypad/eternal_keypad.dtsi
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.dtsi
@@ -9,7 +9,7 @@
 / {
   chosen {
     zmk,kscan = &kscan0;
-    zmk,matrix_transform = &default_transform;
+    zmk,matrix-transform = &default_transform;
   };
 
   kscan0: kscan {

--- a/app/boards/shields/eternal_keypad/eternal_keypad.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.keymap
@@ -17,7 +17,7 @@
 / {
   chosen {
       zmk,kscan = &kscan0;
-      zmk,matrix_transform = &default_transform;
+      zmk,matrix-transform = &default_transform;
   };
 
   keymap {

--- a/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
@@ -17,7 +17,7 @@
 / {
   chosen {
       zmk,kscan = &kscan0;
-      zmk,matrix_transform = &default_transform;
+      zmk,matrix-transform = &default_transform;
   };
 
   keymap {

--- a/app/boards/shields/fourier/fourier.dtsi
+++ b/app/boards/shields/fourier/fourier.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     /*

--- a/app/boards/shields/helix/helix.dtsi
+++ b/app/boards/shields/helix/helix.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/hummingbird/hummingbird.overlay
+++ b/app/boards/shields/hummingbird/hummingbird.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     /delete-property/ zephyr,console;
     /delete-property/ zephyr,shell-uart;
     };

--- a/app/boards/shields/iris/iris.dtsi
+++ b/app/boards/shields/iris/iris.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/jian/jian.dtsi
+++ b/app/boards/shields/jian/jian.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/jiran/jiran.dtsi
+++ b/app/boards/shields/jiran/jiran.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/jorne/jorne.dtsi
+++ b/app/boards/shields/jorne/jorne.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/kyria/kyria.dtsi
+++ b/app/boards/shields/kyria/kyria.dtsi
@@ -8,7 +8,7 @@
 
 / {
     chosen {
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/kyria/kyria_common.dtsi
+++ b/app/boards/shields/kyria/kyria_common.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     kscan0: kscan {

--- a/app/boards/shields/kyria/kyria_rev2.dtsi
+++ b/app/boards/shields/kyria/kyria_rev2.dtsi
@@ -8,7 +8,7 @@
 
 / {
     chosen {
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/kyria/kyria_rev3.dtsi
+++ b/app/boards/shields/kyria/kyria_rev3.dtsi
@@ -8,7 +8,7 @@
 
 / {
     chosen {
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/leeloo/leeloo_common.dtsi
+++ b/app/boards/shields/leeloo/leeloo_common.dtsi
@@ -9,7 +9,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/leeloo_micro/leeloo_micro.dtsi
+++ b/app/boards/shields/leeloo_micro/leeloo_micro.dtsi
@@ -9,7 +9,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/lily58/lily58.dtsi
+++ b/app/boards/shields/lily58/lily58.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/lotus58/lotus58.dtsi
+++ b/app/boards/shields/lotus58/lotus58.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/m60/m60.overlay
+++ b/app/boards/shields/m60/m60.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     kscan0: kscan {

--- a/app/boards/shields/microdox/microdox_common.dtsi
+++ b/app/boards/shields/microdox/microdox_common.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
 
     };
 

--- a/app/boards/shields/nibble/nibble.overlay
+++ b/app/boards/shields/nibble/nibble.overlay
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     encoder_1: encoder_1 {

--- a/app/boards/shields/osprette/osprette.overlay
+++ b/app/boards/shields/osprette/osprette.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/qaz/qaz.overlay
+++ b/app/boards/shields/qaz/qaz.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/quefrency/quefrency.dtsi
+++ b/app/boards/shields/quefrency/quefrency.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zmk,kscan = &kscan0;
 
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     /*

--- a/app/boards/shields/redox/redox.dtsi
+++ b/app/boards/shields/redox/redox.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/reviung34/README.md
+++ b/app/boards/shields/reviung34/README.md
@@ -7,7 +7,7 @@ By default, the 2x1u layout is used. To use to the 1x2u layout, add the followin
 ```
 / {
     chosen {
-        zmk,matrix_transform = &single_2u_transform;
+        zmk,matrix-transform = &single_2u_transform;
     };
 };
 ```

--- a/app/boards/shields/reviung34/reviung34.keymap
+++ b/app/boards/shields/reviung34/reviung34.keymap
@@ -12,11 +12,11 @@
 / {
     chosen {
         // 34 keys.
-        zmk,matrix_transform = &dual_1u_transform;
+        zmk,matrix-transform = &dual_1u_transform;
 
         // 33 keys. Center two thumb keys replaced by a single 2u key. Remember to adjust your
         // keymap accordingly!
-        // zmk,matrix_transform = &single_2u_transform;
+        // zmk,matrix-transform = &single_2u_transform;
     };
 };
 

--- a/app/boards/shields/reviung34/reviung34.overlay
+++ b/app/boards/shields/reviung34/reviung34.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &dual_1u_transform;
+        zmk,matrix-transform = &dual_1u_transform;
     };
 
     dual_1u_transform: keymap_transform_0 {

--- a/app/boards/shields/reviung41/reviung41.overlay
+++ b/app/boards/shields/reviung41/reviung41.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/reviung5/reviung5.overlay
+++ b/app/boards/shields/reviung5/reviung5.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
             zmk,kscan = &kscan0;
-            zmk,matrix_transform = &default_transform;
+            zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/reviung53/reviung53.overlay
+++ b/app/boards/shields/reviung53/reviung53.overlay
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/romac_plus/romac_plus.dtsi
+++ b/app/boards/shields/romac_plus/romac_plus.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/snap/snap.dtsi
+++ b/app/boards/shields/snap/snap.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan_composite;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     left_encoder: encoder_left {

--- a/app/boards/shields/sofle/sofle.dtsi
+++ b/app/boards/shields/sofle/sofle.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.dtsi
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.dtsi
@@ -10,7 +10,7 @@
 
     chosen {
         zephyr,display = &oled;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.dtsi
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.dtsi
@@ -10,7 +10,7 @@
 
     chosen {
         zephyr,display = &oled;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58.dtsi
+++ b/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58.dtsi
@@ -10,7 +10,7 @@
 
     chosen {
         zephyr,display = &oled;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.dtsi
+++ b/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.dtsi
@@ -10,7 +10,7 @@
 
     chosen {
         zephyr,display = &oled;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.dtsi
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.dtsi
@@ -10,7 +10,7 @@
 
     chosen {
         zephyr,display = &oled;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/splitreus62/splitreus62.dtsi
+++ b/app/boards/shields/splitreus62/splitreus62.dtsi
@@ -9,7 +9,7 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/tg4x/tg4x.overlay
+++ b/app/boards/shields/tg4x/tg4x.overlay
@@ -49,6 +49,6 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,4)                                 RC(3,5) RC(7,1) 
 
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 };

--- a/app/boards/shields/tidbit/tidbit.dtsi
+++ b/app/boards/shields/tidbit/tidbit.dtsi
@@ -86,7 +86,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 };
 

--- a/app/boards/shields/waterfowl/waterfowl.dtsi
+++ b/app/boards/shields/waterfowl/waterfowl.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/app/boards/shields/zodiark/zodiark.dtsi
+++ b/app/boards/shields/zodiark/zodiark.dtsi
@@ -10,7 +10,7 @@
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -30,7 +30,7 @@ Applies to: [`/chosen` node](https://docs.zephyrproject.org/latest/guides/dts/in
 | Property               | Type | Description                                                   |
 | ---------------------- | ---- | ------------------------------------------------------------- |
 | `zmk,kscan`            | path | The node for the keyboard scan driver to use                  |
-| `zmk,matrix_transform` | path | The node for the [matrix transform](#matrix-transform) to use |
+| `zmk,matrix-transform` | path | The node for the [matrix transform](#matrix-transform) to use |
 
 ## Demux Driver
 
@@ -347,7 +347,7 @@ Any keyboard which is not a grid of 1 unit keys will likely have some unused pos
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     kscan0: kscan {
@@ -407,7 +407,7 @@ Consider a keyboard with a [duplex matrix](https://wiki.ai03.com/books/pcb-desig
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     kscan0: kscan {
@@ -446,7 +446,7 @@ Note that the entire addressable space does not need to be mapped.
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     kscan0: kscan {

--- a/docs/docs/development/boards-shields-keymaps.md
+++ b/docs/docs/development/boards-shields-keymaps.md
@@ -6,7 +6,7 @@ title: Boards, Shields, and Keymaps
 
 The foundational elements needed to get a specific keyboard working with ZMK can be broken down into:
 
-- A [KSCAN driver](https://docs.zephyrproject.org/2.5.0/reference/peripherals/kscan.html), which uses `compatible="zmk,kscan-gpio-matrix"` for GPIO matrix based keyboards, or uses `compatible="zmk,kscan-gpio-direct"` for small direct wires.
+- A [KSCAN driver](https://docs.zephyrproject.org/3.2.0/reference/peripherals/kscan.html), which uses `compatible="zmk,kscan-gpio-matrix"` for GPIO matrix based keyboards, or uses `compatible="zmk,kscan-gpio-direct"` for small direct wires.
 - An optional matrix transform, which defines how the KSCAN row/column events are translated into logical "key positions". This is required for non-rectangular keyboards/matrices, where the key positions don't naturally follow the row/columns from the GPIO matrix.
 - A keymap, which binds each key position to a behavior, e.g. key press, mod-tap, momentary layer, in a set of layers.
 
@@ -27,8 +27,8 @@ in the `app/boards/${arch}/${board_name}` directory, e.g. `app/boards/arm/planck
 - A `${board_name}_defconfig` file that forces specific Kconfig settings that are specific to this hardware configuration. Mostly this is SoC settings around the specific hardware configuration.
 - `${board_name}.dts` which contains all the devicetree definitions, including:
   - An `#include` line that pulls in the specific microprocessor that is used, e.g. `#include <st/f3/stm32f303Xc.dtsi>`.
-  - A [chosen](https://docs.zephyrproject.org/2.5.0/guides/dts/intro.html#aliases-and-chosen-nodes) node named `zmk,kscan` which references the configured KSCAN driver (usually a GPIO matrix)
-  - (Optional) A [chosen](https://docs.zephyrproject.org/2.5.0/guides/dts/intro.html#aliases-and-chosen-nodes) node named `zmk,matrix_transform` that defines the mapping from KSCAN row/column values to the logical key position for the keyboard.
+  - A [chosen](https://docs.zephyrproject.org/3.2.0/guides/dts/intro.html#aliases-and-chosen-nodes) node named `zmk,kscan` which references the configured KSCAN driver (usually a GPIO matrix)
+  - (Optional) A [chosen](https://docs.zephyrproject.org/3.2.0/guides/dts/intro.html#aliases-and-chosen-nodes) node named `zmk,matrix-transform` that defines the mapping from KSCAN row/column values to the logical key position for the keyboard.
 - A `board.cmake` file with CMake directives for how to flash to the device.
 - A `${board_name}.keymap` file that includes the default keymap for that keyboard. Users will be able to override this keymap in their user configs.
 
@@ -47,6 +47,6 @@ in the `app/boards/shields/${board_name}` directory, e.g. `app/boards/shields/cl
 - A `Kconfig.shield` that defines the toplevel Kconfig value for the shield, which uses a supplied utility to function to default the value based on the shield list, e.g. `def_bool $(shields_list_contains,clueboard_california)`.
 - A `Kconfig.defconfig` file to set default values for things like `ZMK_KEYBOARD_NAME`
 - A `${shield_name}.overlay` file, which is a devicetree overlay file, that includes:
-  - A [chosen](https://docs.zephyrproject.org/2.5.0/guides/dts/intro.html#aliases-and-chosen-nodes) node named `zmk,kscan` which references the configured KSCAN driver (usually a GPIO matrix). For these keyboards, to be compatible with any Pro Micro compatible boards, the KSCAN configuration should reference the [nexus node](https://docs.zephyrproject.org/2.5.0/guides/porting/shields.html#gpio-nexus-nodes) that ZMK has standardized on. In particular, the `&pro_micro` aliases can be used to reference the standard digital pins of a Pro Micro for shields.
-  - (Optional) A [chosen](https://docs.zephyrproject.org/2.5.0/guides/dts/intro.html#aliases-and-chosen-nodes) node named `zmk,matrix_transform` that defines the mapping from KSCAN row/column values to the logical key position for the keyboard.
+  - A [chosen](https://docs.zephyrproject.org/3.2.0/guides/dts/intro.html#aliases-and-chosen-nodes) node named `zmk,kscan` which references the configured KSCAN driver (usually a GPIO matrix). For these keyboards, to be compatible with any Pro Micro compatible boards, the KSCAN configuration should reference the [nexus node](https://docs.zephyrproject.org/3.2.0/guides/porting/shields.html#gpio-nexus-nodes) that ZMK has standardized on. In particular, the `&pro_micro` aliases can be used to reference the standard digital pins of a Pro Micro for shields.
+  - (Optional) A [chosen](https://docs.zephyrproject.org/3.2.0/guides/dts/intro.html#aliases-and-chosen-nodes) node named `zmk,matrix-transform` that defines the mapping from KSCAN row/column values to the logical key position for the keyboard.
 - A `keymap/keymap.overlay` file that includes the default keymap for that keyboard. Users will be able to override this keymap in their user configs.

--- a/docs/docs/development/build-flash.mdx
+++ b/docs/docs/development/build-flash.mdx
@@ -16,7 +16,7 @@ an onboard MCU, or one that uses an MCU board addon.
 
 ### Keyboard (Shield) + MCU Board
 
-ZMK treats keyboards that take an MCU addon board as [shields](https://docs.zephyrproject.org/2.5.0/guides/porting/shields.html), and treats the smaller MCU board as the true [board](https://docs.zephyrproject.org/2.5.0/guides/porting/board_porting.html)
+ZMK treats keyboards that take an MCU addon board as [shields](https://docs.zephyrproject.org/3.2.0/guides/porting/shields.html), and treats the smaller MCU board as the true [board](https://docs.zephyrproject.org/3.2.0/guides/porting/board_porting.html)
 
 Given the following:
 
@@ -32,7 +32,7 @@ west build -b proton_c -- -DSHIELD=kyria_left
 
 ### Keyboard With Onboard MCU
 
-Keyboards with onboard MCU chips are simply treated as the [board](https://docs.zephyrproject.org/2.5.0/guides/porting/board_porting.html) as far as Zephyr™ is concerned.
+Keyboards with onboard MCU chips are simply treated as the [board](https://docs.zephyrproject.org/3.2.0/guides/porting/board_porting.html) as far as Zephyr™ is concerned.
 
 Given the following:
 

--- a/docs/docs/development/new-shield.mdx
+++ b/docs/docs/development/new-shield.mdx
@@ -201,7 +201,7 @@ For `col2row` directed boards like the iris, the shared .dtsi file may look like
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {
@@ -336,7 +336,7 @@ Here is an example for the [nice60](https://github.com/Nicell/nice60), which use
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        zmk,matrix-transform = &default_transform;
     };
 
     default_transform: keymap_transform_0 {
@@ -362,7 +362,7 @@ Some important things to note:
 
 - The `#include <dt-bindings/zmk/matrix_transform.h>` is critical. The `RC` macro is used to generate the internal storage in the matrix transform, and is actually replaced by a C preprocessor before the final devicetree is compiled into ZMK.
 - `RC(row, column)` is placed sequentially to define what row and column values that position corresponds to.
-- If you have a keyboard with options for `2u` keys in certain positions, or break away portions, it is a good idea to set the chosen `zmk,matrix_transform` to the default arrangement, and include _other_ possible matrix transform nodes in the devicetree that users can select in their user config by overriding the chosen node.
+- If you have a keyboard with options for `2u` keys in certain positions, or break away portions, it is a good idea to set the chosen `zmk,matrix-transform` to the default arrangement, and include _other_ possible matrix transform nodes in the devicetree that users can select in their user config by overriding the chosen node.
 
 See the [matrix transform section](../config/kscan.md#matrix-transform) in the Keyboard Scan configuration documentation for details and more examples of matrix transforms.
 


### PR DESCRIPTION
* While functionally equivalent, the hyphenated form of this property is more consistent with other ZMK properties and adheres to [DTS style guidelines](https://buildmedia.readthedocs.org/media/pdf/devicetree-specification/latest/devicetree-specification.pdf).
* ...Since I'm already touching a number of files, might as well update links to use Zephyr 3.2 documentation instead of 2.5 where appropriate.

---

~~This PR intentionally refrains from updating any boards or shields to minimize disruption, as some forks and/or utilities may currently expect/require the underscore form ([Keymap Editor](https://nickcoutsos.github.io/keymap-editor/) being one).~~