### PR TITLE
refactor: remove/replace deprecated properties

### DIFF
--- a/app/boards/arm/ferris/ferris_rev02.keymap
+++ b/app/boards/arm/ferris/ferris_rev02.keymap
@@ -21,7 +21,7 @@
         hm: homerow_mods {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
-            tapping_term_ms = <200>;
+            tapping-term-ms = <200>;
             flavor = "tap-preferred";
             bindings = <&kp>, <&kp>;
         };

--- a/app/boards/arm/ferris/ferris_rev02.keymap
+++ b/app/boards/arm/ferris/ferris_rev02.keymap
@@ -14,7 +14,7 @@
 #define SYM_L 4
 
 // Using layer taps on thumbs, having quick tap as well helps w/ repeating space/backspace
-&lt { quick_tap_ms = <200>; };
+&lt { quick-tap-ms = <200>; };
 
 / {
     behaviors {

--- a/app/boards/shields/clog/clog.keymap
+++ b/app/boards/shields/clog/clog.keymap
@@ -15,7 +15,7 @@
 
 &mt {
     flavor = "tap-preferred";
-    tapping_term_ms = <140>;
+    tapping-term-ms = <140>;
 };
 
 / {

--- a/app/boards/shields/hummingbird/hummingbird.keymap
+++ b/app/boards/shields/hummingbird/hummingbird.keymap
@@ -20,7 +20,7 @@
         hm: homerow_mods {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
-            tapping_term_ms = <225>;
+            tapping-term-ms = <225>;
             flavor = "tap-preferred";
             bindings = <&kp>, <&kp>;
         };

--- a/app/boards/shields/hummingbird/hummingbird.keymap
+++ b/app/boards/shields/hummingbird/hummingbird.keymap
@@ -13,7 +13,7 @@
 #define SYM_L 3
 
 // Using layer taps on thumbs, having quick tap as well helps w/ repeating space/backspace
-&lt { quick_tap_ms = <200>; };
+&lt { quick-tap-ms = <200>; };
 
 / {
     behaviors {

--- a/app/boards/shields/jian/jian.keymap
+++ b/app/boards/shields/jian/jian.keymap
@@ -13,8 +13,8 @@
 #define RSE 2
 #define ADJ 3
 
-&lt { quick_tap_ms = <200>; };
-&mt { quick_tap_ms = <200>; };
+&lt { quick-tap-ms = <200>; };
+&mt { quick-tap-ms = <200>; };
 
 / {
         keymap {

--- a/app/boards/shields/osprette/osprette.keymap
+++ b/app/boards/shields/osprette/osprette.keymap
@@ -15,7 +15,7 @@
 
 &mt {
     flavor = "tap-preferred";
-    tapping_term_ms = <140>;
+    tapping-term-ms = <140>;
 };
 
 / {

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.keymap
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.keymap
@@ -11,7 +11,7 @@
 
 &mt {
   //  flavor = "tap-preferred";
-   // tapping_term_ms = <200>;
+   // tapping-term-ms = <200>;
 };
 
 / {

--- a/app/tests/hold-tap/balanced/6-retro-tap/native_posix_64.keymap
+++ b/app/tests/hold-tap/balanced/6-retro-tap/native_posix_64.keymap
@@ -8,7 +8,7 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "balanced";
-            tapping_term_ms = <300>;
+            tapping-term-ms = <300>;
             bindings = <&kp>, <&kp>;
             retro-tap;
         };

--- a/app/tests/hold-tap/hold-preferred/6-retro-tap/native_posix_64.keymap
+++ b/app/tests/hold-tap/hold-preferred/6-retro-tap/native_posix_64.keymap
@@ -8,7 +8,7 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "hold-preferred";
-            tapping_term_ms = <300>;
+            tapping-term-ms = <300>;
             bindings = <&kp>, <&kp>;
             retro-tap;
         };

--- a/app/tests/tap-dance/behavior_keymap.dtsi
+++ b/app/tests/tap-dance/behavior_keymap.dtsi
@@ -8,7 +8,7 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             tapping-term-ms = <200>;
-            quick_tap_ms = <0>;
+            quick-tap-ms = <0>;
             flavor = "tap-preferred";
             bindings = <&kp>, <&kp>;
         };


### PR DESCRIPTION
A few overlays scattered across boards, shields and tests appear to have been missed when updating/upgrading these properties.

~~Tagging @ReFil who may or may not be `crbn`'s maintainer: `resolution` was replaced with sane defaults for `steps` and `triggers-per-rotation`, but I am unfamiliar with this shield. If there are specific known values that should go here, please suggest.~~ Handled in #2143.