### PR TITLE
Add zmk_usb_boot toggle to documentation

### DIFF
--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -74,8 +74,9 @@ Exactly zero or one of the following options may be set to `y`. The first is use
 
 :::note USB Boot protocol support
 
-By default USB Boot protocol support is disabled, however in certain situations such as the input of Bitlocker pins or FileVault passwords may require it to be enabled.
+By default USB Boot protocol support is disabled, however certain situations such as the input of Bitlocker pins or FileVault passwords may require it to be enabled.
 
+:::
 ### Bluetooth
 
 See [Zephyr's Bluetooth stack architecture documentation](https://docs.zephyrproject.org/latest/guides/bluetooth/bluetooth-arch.html)

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -69,6 +69,7 @@ Exactly zero or one of the following options may be set to `y`. The first is use
 | `CONFIG_USB_DEVICE_MANUFACTURER`  | string | The manufacturer name advertised to USB | `"ZMK Project"` |
 | `CONFIG_USB_HID_POLL_INTERVAL_MS` | int    | USB polling interval in milliseconds    | 1               |
 | `CONFIG_ZMK_USB`                  | bool   | Enable ZMK as a USB keyboard            |                 |
+| `CONFIG_ZMK_USB_BOOT`             | bool   | Enable ZMK Boot protocol                | n               |
 | `CONFIG_ZMK_USB_INIT_PRIORITY`    | int    | USB init priority                       | 50              |
 
 ### Bluetooth

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -72,6 +72,10 @@ Exactly zero or one of the following options may be set to `y`. The first is use
 | `CONFIG_ZMK_USB_BOOT`             | bool   | Enable USB Boot protocol support        | n               |
 | `CONFIG_ZMK_USB_INIT_PRIORITY`    | int    | USB init priority                       | 50              |
 
+:::note USB Boot protocol support
+
+By default USB Boot protocol support is disabled, however in certain situations such as the input of Bitlocker pins or FileVault passwords may require it to be enabled.
+
 ### Bluetooth
 
 See [Zephyr's Bluetooth stack architecture documentation](https://docs.zephyrproject.org/latest/guides/bluetooth/bluetooth-arch.html)

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -69,7 +69,7 @@ Exactly zero or one of the following options may be set to `y`. The first is use
 | `CONFIG_USB_DEVICE_MANUFACTURER`  | string | The manufacturer name advertised to USB | `"ZMK Project"` |
 | `CONFIG_USB_HID_POLL_INTERVAL_MS` | int    | USB polling interval in milliseconds    | 1               |
 | `CONFIG_ZMK_USB`                  | bool   | Enable ZMK as a USB keyboard            |                 |
-| `CONFIG_ZMK_USB_BOOT`             | bool   | Enable ZMK Boot protocol                | n               |
+| `CONFIG_ZMK_USB_BOOT`             | bool   | Enable USB Boot protocol support        | n               |
 | `CONFIG_ZMK_USB_INIT_PRIORITY`    | int    | USB init priority                       | 50              |
 
 ### Bluetooth

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -77,6 +77,7 @@ Exactly zero or one of the following options may be set to `y`. The first is use
 By default USB Boot protocol support is disabled, however certain situations such as the input of Bitlocker pins or FileVault passwords may require it to be enabled.
 
 :::
+
 ### Bluetooth
 
 See [Zephyr's Bluetooth stack architecture documentation](https://docs.zephyrproject.org/latest/guides/bluetooth/bluetooth-arch.html)


### PR DESCRIPTION
The |CONFIG_ZMK_USB_BOOT switch was missing from the documentation.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [ ] `.zmk.yml` metadata file added
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] General consistent formatting of DeviceTree files
- [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [ ] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
