### PR TITLE
Update preonic_rev3.dts

### DIFF
--- a/app/boards/arm/preonic/preonic_rev3.dts
+++ b/app/boards/arm/preonic/preonic_rev3.dts
@@ -17,6 +17,7 @@
     chosen {
         zephyr,sram = &sram0;
         zephyr,flash = &flash0;
+        zephyr,console = &cdc_acm_uart;
         zmk,kscan = &kscan0;
         zmk,matrix-transform = &layout_grid_transform;
     };


### PR DESCRIPTION
Quick fix to make USB-logging compile and work on the Preonic. Tested on my keyboard.