### PR TITLE
fix(ci): Update upload-artifact with merge step

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -157,7 +157,19 @@ jobs:
           fi
 
       - name: Archive (${{ env.display_name }})
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ env.artifact_name }}
+          path: ${{ env.build_dir }}/artifacts
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    name: Merge Output Artifacts
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
         with:
           name: ${{ inputs.archive_name }}
-          path: ${{ env.build_dir }}/artifacts
+          pattern: artifact-*
+          delete-merged: true


### PR DESCRIPTION
Another try at #2316, this time using unique artifact names then merging them using the `merge` action. Fixes #2139.

For reference, here is the migration guide section about merging: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts
Deleting artifacts after merge: https://github.com/actions/upload-artifact/blob/main/merge/README.md#deleting-artifacts-after-merge

To compare, build on `main`: https://github.com/caksoylar/zmk-config/actions/runs/7681083423
Build using this branch's workflow: https://github.com/caksoylar/zmk-config/actions/runs/7681160822
`firmware.zip` contents are identical after unzipping.