### PR TITLE
Add encoder resolution fix to keymap upgrader

### DIFF
--- a/app/boards/shields/crbn/crbn.overlay
+++ b/app/boards/shields/crbn/crbn.overlay
@@ -42,12 +42,13 @@
         compatible = "alps,ec11";
         a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
         b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
-        resolution = <2>;
+        steps = <80>;
         status = "okay";
     };
 
     sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&encoder>;
+        triggers-per-rotation = <20>;
     };
 };

--- a/app/boards/shields/crbn/crbn.overlay
+++ b/app/boards/shields/crbn/crbn.overlay
@@ -46,7 +46,7 @@
         status = "okay";
     };
 
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&encoder>;
     };

--- a/app/boards/shields/kyria/kyria_rev3.dtsi
+++ b/app/boards/shields/kyria/kyria_rev3.dtsi
@@ -29,13 +29,11 @@
 };
 
 &left_encoder {
-    resolution = <2>;
     a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
     b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
 };
 
 &right_encoder {
-    resolution = <2>;
     a-gpios = <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
     b-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>;
 };

--- a/app/boards/shields/leeloo/leeloo_common.dtsi
+++ b/app/boards/shields/leeloo/leeloo_common.dtsi
@@ -60,7 +60,7 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
         status = "disabled";
     };
 
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&left_encoder &right_encoder>;
         triggers-per-rotation = <30>;

--- a/app/boards/shields/leeloo_micro/leeloo_micro.dtsi
+++ b/app/boards/shields/leeloo_micro/leeloo_micro.dtsi
@@ -58,7 +58,7 @@ RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(3,4) RC(3,5) RC(2,5) RC(2,6) RC(2,7) 
         steps = <60>;
     };
 
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&left_encoder &right_encoder>;
         triggers-per-rotation = <30>;

--- a/app/boards/shields/murphpad/murphpad.keymap
+++ b/app/boards/shields/murphpad/murphpad.keymap
@@ -45,7 +45,7 @@
         };
     };
 
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&encoder_1 &encoder_2>;
         triggers-per-rotation = <20>;

--- a/app/boards/shields/nibble/nibble.keymap
+++ b/app/boards/shields/nibble/nibble.keymap
@@ -9,7 +9,7 @@
 #include <dt-bindings/zmk/bt.h>
 
 / {
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&encoder_1>;
         triggers-per-rotation = <20>;

--- a/app/boards/shields/snap/snap.keymap
+++ b/app/boards/shields/snap/snap.keymap
@@ -10,7 +10,7 @@
 #include <dt-bindings/zmk/rgb.h>
 
 / {
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&left_encoder &right_encoder>;
         triggers-per-rotation = <20>;

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.dtsi
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.dtsi
@@ -49,7 +49,7 @@
         b-gpios = <&pro_micro 14 GPIO_PULL_UP>;
     };
 
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&left_encoder &right_encoder>;
         triggers-per-rotation = <36>;

--- a/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.dtsi
+++ b/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.dtsi
@@ -49,7 +49,7 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5) RC(4,6) RC(3,6) RC(3,7) 
         b-gpios = <&pro_micro 10 GPIO_PULL_UP>;
     };
 
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&left_encoder &right_encoder>;
         triggers-per-rotation = <36>;

--- a/app/boards/shields/tidbit/tidbit.keymap
+++ b/app/boards/shields/tidbit/tidbit.keymap
@@ -14,7 +14,7 @@
 };
 
 / {
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&encoder_1_top_row>;
         triggers-per-rotation = <20>;

--- a/app/boards/shields/tidbit/tidbit_19key.keymap
+++ b/app/boards/shields/tidbit/tidbit_19key.keymap
@@ -15,7 +15,7 @@
 };
 
 / {
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&encoder_4>;
     };

--- a/app/boards/shields/waterfowl/waterfowl.dtsi
+++ b/app/boards/shields/waterfowl/waterfowl.dtsi
@@ -73,7 +73,7 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4)                                 RC(3,5) 
         status = "disabled";
     };
 
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         triggers-per-rotation = <20>;
         sensors = <

--- a/app/boards/shields/zmk_uno/zmk_uno.overlay
+++ b/app/boards/shields/zmk_uno/zmk_uno.overlay
@@ -10,7 +10,7 @@
     chosen {
         zmk,matrix-transform = &matrix_transform;
     };
-    sensors {
+    sensors: sensors {
         compatible = "zmk,keymap-sensors";
         sensors = <&encoder>;
         triggers-per-rotation = <20>;

--- a/app/boards/shields/zmk_uno/zmk_uno_split.dtsi
+++ b/app/boards/shields/zmk_uno/zmk_uno_split.dtsi
@@ -53,9 +53,9 @@
         b-gpios = <&arduino_header 14 GPIO_PULL_UP>;
     };
 
-     sensors {
-         compatible = "zmk,keymap-sensors";
-         sensors = <&encoder &right_encoder>;
-         triggers-per-rotation = <20>;
-     };
+    sensors: sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&encoder &right_encoder>;
+        triggers-per-rotation = <20>;
+    };
  };

--- a/docs/src/keymap-upgrade/encoder.ts
+++ b/docs/src/keymap-upgrade/encoder.ts
@@ -1,0 +1,101 @@
+import type { SyntaxNode, Tree } from "web-tree-sitter";
+
+import {
+  getContainingDevicetreeNode,
+  getDevicetreeNodePath,
+  findDevicetreeProperty,
+} from "./parser";
+import { TextEdit } from "./textedit";
+
+const ALPS_EC11_COMPATIBLE = '"alps,ec11"';
+const DEFAULT_RESOLUTION = 4;
+const TRIGGERS_PER_ROTATION = 20;
+const TRIGGERS_PER_ROTATION_DT = `
+
+&sensors {
+    // Change this to your encoder's number of detents.
+    // If you have multiple encoders with different detents, see
+    // https://zmk.dev/docs/config/encoders#keymap-sensor-config
+    triggers-per-rotation = <${TRIGGERS_PER_ROTATION}>;
+};`;
+
+export function upgradeEncoderResolution(tree: Tree) {
+  const edits: TextEdit[] = [];
+
+  const resolutionProps = findEncoderResolution(tree);
+  edits.push(...resolutionProps.flatMap(upgradeResolutionProperty));
+
+  if (resolutionProps.length > 0) {
+    edits.push(...addTriggersPerRotation(tree));
+  }
+
+  return edits;
+}
+
+function findEncoderResolution(tree: Tree): SyntaxNode[] {
+  const props = findDevicetreeProperty(tree.rootNode, "resolution", {
+    recursive: true,
+  });
+
+  return props.filter((prop) => {
+    const node = getContainingDevicetreeNode(prop);
+    return node && isEncoderNode(node);
+  });
+}
+
+function isEncoderNode(node: SyntaxNode) {
+  // If a compatible property is set, then we know for sure if this is an encoder.
+  const compatible = findDevicetreeProperty(node, "compatible");
+  if (compatible) {
+    return compatible.childForFieldName("value")?.text === ALPS_EC11_COMPATIBLE;
+  }
+
+  // Compatible properties rarely appear in a keymap though, so just guess based
+  // on the node path/reference otherwise.
+  return getDevicetreeNodePath(node).toLowerCase().includes("encoder");
+}
+
+function upgradeResolutionProperty(prop: SyntaxNode): TextEdit[] {
+  const name = prop.childForFieldName("name");
+  const value = prop.childForFieldName("value");
+
+  if (!name || !value) {
+    return [];
+  }
+
+  // Try to set the new steps to be triggers-per-rotation * resolution, but fall
+  // back to a default if the value is something more complex than a single int.
+  const resolution = value.text.trim().replaceAll(/^<|>$/g, "");
+  const steps =
+    (parseInt(resolution) || DEFAULT_RESOLUTION) * TRIGGERS_PER_ROTATION;
+
+  const hint = `/* Change this to your encoder's number of detents times ${resolution} */`;
+
+  return [
+    TextEdit.fromNode(name, "steps"),
+    TextEdit.fromNode(value, `<${steps}> ${hint}`),
+  ];
+}
+
+function addTriggersPerRotation(tree: Tree): TextEdit[] {
+  // The keymap might already contain "triggers-per-rotation" for example if the
+  // user already upgraded some but not all "resolution" properties. Don't add
+  // another one if it already exists.
+  if (keymapHasTriggersPerRotation(tree)) {
+    return [];
+  }
+
+  // Inserting a new property into an existing node while keeping the code
+  // readable in all cases is hard, so just append a new &sensors node to the
+  // end of the keymap.
+  const end = tree.rootNode.endIndex;
+  return [new TextEdit(end, end, TRIGGERS_PER_ROTATION_DT)];
+}
+
+function keymapHasTriggersPerRotation(tree: Tree) {
+  const props = findDevicetreeProperty(tree.rootNode, "triggers-per-rotation", {
+    recursive: true,
+  });
+
+  return props.length > 0;
+}

--- a/docs/src/keymap-upgrade/index.ts
+++ b/docs/src/keymap-upgrade/index.ts
@@ -55,7 +55,11 @@ function getLineBreakPositions(text: string) {
 }
 
 function positionToLineNumber(position: number, lineBreaks: number[]) {
-  const line = lineBreaks.findIndex((lineBreak) => position <= lineBreak);
+  if (position >= lineBreaks[lineBreaks.length - 1]) {
+    return lineBreaks.length + 1;
+  }
+
+  const line = lineBreaks.findIndex((lineBreak) => position < lineBreak);
 
   return line < 0 ? 0 : line + 1;
 }

--- a/docs/src/keymap-upgrade/index.ts
+++ b/docs/src/keymap-upgrade/index.ts
@@ -2,6 +2,7 @@ import { createParser } from "./parser";
 import { applyEdits, Range } from "./textedit";
 
 import { upgradeBehaviors } from "./behaviors";
+import { upgradeEncoderResolution } from "./encoder";
 import { upgradeHeaders } from "./headers";
 import { upgradeKeycodes } from "./keycodes";
 import { upgradeNodeNames } from "./nodes";
@@ -11,6 +12,7 @@ export { initParser } from "./parser";
 
 const upgradeFunctions = [
   upgradeBehaviors,
+  upgradeEncoderResolution,
   upgradeHeaders,
   upgradeKeycodes,
   upgradeNodeNames,


### PR DESCRIPTION
Updated the keymap upgrader to upgrade the encoder `resolution` property to `steps` and `triggers-per-rotation`. 

The `steps` property will be set assuming triggers-per-rotation is 20. To simplify the code, it does not go looking for an existing triggers value since it's unlikely that you would have set `triggers-per-rotation` but not `steps`.

If `steps` is added and `triggers-per-rotation` is not present, a new `&sensors { ... }` block is added with the property set to 20. To simplify the code, it does not go looking for an existing sensors node to insert the property into.

Both added properties include a comment explaining how to fix the value to match your encoder.

Fixed an issue where appending text to the end of the file would highlight the wrong lines.

Also updated the shields that still had a `resolution` property, and fixed shields whose `/sensors` node did not have a `sensors` label, since the upgrader requires that label or it will generate broke code.