### PR TITLE
chore(ci): Bump to 3.5 Docker images.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/zmkfirmware/zmk-dev-arm:3.2
+FROM docker.io/zmkfirmware/zmk-dev-arm:3.5
 
 COPY .bashrc tmp
 RUN mv /tmp/.bashrc ~/.bashrc

--- a/.github/workflows/ble-test.yml
+++ b/.github/workflows/ble-test.yml
@@ -35,7 +35,7 @@ jobs:
         test: ${{ fromJSON(needs.collect-tests.outputs.test-dirs) }}
     runs-on: ubuntu-latest
     container:
-      image: docker.io/zmkfirmware/zmk-build-arm:3.2
+      image: docker.io/zmkfirmware/zmk-build-arm:3.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -45,7 +45,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: zmkfirmware/zmk-build-arm:stable
+      image: zmkfirmware/zmk-build-arm:3.5
     needs: matrix
     name: Build
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     container:
-      image: docker.io/zmkfirmware/zmk-build-arm:3.2
+      image: docker.io/zmkfirmware/zmk-build-arm:3.5
     needs: compile-matrix
     strategy:
       matrix:

--- a/.github/workflows/hardware-metadata-validation.yml
+++ b/.github/workflows/hardware-metadata-validation.yml
@@ -18,7 +18,7 @@ jobs:
   validate-metadata:
     runs-on: ubuntu-latest
     container:
-      image: docker.io/zmkfirmware/zmk-dev-arm:3.2
+      image: docker.io/zmkfirmware/zmk-dev-arm:3.5
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         test: ${{ fromJSON(needs.collect-tests.outputs.test-dirs) }}
     runs-on: ubuntu-latest
     container:
-      image: docker.io/zmkfirmware/zmk-build-arm:3.2
+      image: docker.io/zmkfirmware/zmk-build-arm:3.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Ignore me, just testing the new docker images with the current codebase to be sure we could bump our `stable` tag.