### PR TITLE
feat(docs): Document Karabiner interference with Mod-Morphs

### DIFF
--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -86,3 +86,10 @@ For example, the following configuration morphs `LEFT_SHIFT` + `BACKSPACE` into 
     };
 };
 ```
+
+:::note Karabiner-Elements (macOS) and interference with Mod-Morph
+
+If the first modified keypress sends the modifier along with the morphed keycode and [Karabiner-Elements](https://karabiner-elements.pqrs.org/) is running, disable `Modify Events` from Karabiners "Devices" settings page for the keyboard running ZMK.
+
+:::
+

--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -87,9 +87,9 @@ For example, the following configuration morphs `LEFT_SHIFT` + `BACKSPACE` into 
 };
 ```
 
-:::note Karabiner-Elements (macOS) and interference with Mod-Morph
+:::note[Karabiner-Elements (macOS) interfering with mod-morphs]
 
-If the first modified keypress sends the modifier along with the morphed keycode and [Karabiner-Elements](https://karabiner-elements.pqrs.org/) is running, disable `Modify Events` from Karabiners "Devices" settings page for the keyboard running ZMK.
+If the first modified key press sends the modifier along with the morphed keycode and [Karabiner-Elements](https://karabiner-elements.pqrs.org/) is running, disable the "Modify Events" toggle from Karabiner's "Devices" settings page for the keyboard running ZMK.
 
 :::
 


### PR DESCRIPTION
Small docs change to document the issues caused by having Karabiner running and Modify Events on for a keyboard sending morphed keypresses.