### PR TITLE
Fix nrfMicro oled display

### DIFF
--- a/app/boards/arm/nrfmicro/nrfmicro_11.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11.dts
@@ -31,6 +31,7 @@
     EXT_POWER {
         compatible = "zmk,ext-power-generic";
         control-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+        init-delay-ms = <50>;
     };
 };
 

--- a/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
@@ -31,6 +31,7 @@
     EXT_POWER {
         compatible = "zmk,ext-power-generic";
         control-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+        init-delay-ms = <50>;
     };
 };
 

--- a/app/boards/arm/nrfmicro/nrfmicro_13.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13.dts
@@ -32,6 +32,7 @@
     EXT_POWER {
         compatible = "zmk,ext-power-generic";
         control-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+        init-delay-ms = <50>;
     };
 
     vbatt: vbatt {

--- a/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
@@ -32,6 +32,7 @@
     EXT_POWER {
         compatible = "zmk,ext-power-generic";
         control-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+        init-delay-ms = <50>;
     };
 
     vbatt: vbatt {


### PR DESCRIPTION
After Apr 6 2023(ae8299edb3d638f1332475b1da0fdf40afa43fe4), the nrfMicro can not driver oled, because of missing a line.