### PR TITLE
fix(displays, battery): fix initial display of battery status on displays

### DIFF
--- a/app/boards/arm/corneish_zen/widgets/battery_status.c
+++ b/app/boards/arm/corneish_zen/widgets/battery_status.c
@@ -66,8 +66,16 @@ void battery_status_update_cb(struct battery_status_state state) {
 }
 
 static struct battery_status_state battery_status_get_state(const zmk_event_t *eh) {
-    return (struct battery_status_state) {
-        .level = zmk_battery_state_of_charge(),
+    const struct zmk_battery_state_changed *ev = as_zmk_battery_state_changed(eh);
+    uint8_t soc;
+    if (ev != NULL) {
+        soc = ev->state_of_charge;
+    } else {
+        soc = zmk_battery_state_of_charge();
+    }
+
+    return (struct battery_status_state){
+        .level = soc,
 #if IS_ENABLED(CONFIG_USB_DEVICE_STACK)
         .usb_present = zmk_usb_is_powered(),
 #endif /* IS_ENABLED(CONFIG_USB_DEVICE_STACK) */

--- a/app/boards/shields/nice_view/widgets/status.c
+++ b/app/boards/shields/nice_view/widgets/status.c
@@ -210,8 +210,16 @@ static void battery_status_update_cb(struct battery_status_state state) {
 }
 
 static struct battery_status_state battery_status_get_state(const zmk_event_t *eh) {
-    return (struct battery_status_state) {
-        .level = zmk_battery_state_of_charge(),
+    const struct zmk_battery_state_changed *ev = as_zmk_battery_state_changed(eh);
+    uint8_t soc;
+    if (ev != NULL) {
+        soc = ev->state_of_charge;
+    } else {
+        soc = zmk_battery_state_of_charge();
+    }
+
+    return (struct battery_status_state){
+        .level = soc,
 #if IS_ENABLED(CONFIG_USB_DEVICE_STACK)
         .usb_present = zmk_usb_is_powered(),
 #endif /* IS_ENABLED(CONFIG_USB_DEVICE_STACK) */

--- a/app/src/display/widgets/battery_status.c
+++ b/app/src/display/widgets/battery_status.c
@@ -9,6 +9,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
+#include <zmk/battery.h>
 #include <zmk/display.h>
 #include <zmk/display/widgets/battery_status.h>
 #include <zmk/usb.h>
@@ -63,8 +64,15 @@ void battery_status_update_cb(struct battery_status_state state) {
 
 static struct battery_status_state battery_status_get_state(const zmk_event_t *eh) {
     const struct zmk_battery_state_changed *ev = as_zmk_battery_state_changed(eh);
-    return (struct battery_status_state) {
-        .level = ev->state_of_charge,
+    uint8_t soc;
+    if (ev != NULL) {
+        soc = ev->state_of_charge;
+    } else {
+        soc = zmk_battery_state_of_charge();
+    }
+
+    return (struct battery_status_state){
+        .level = soc,
 #if IS_ENABLED(CONFIG_USB_DEVICE_STACK)
         .usb_present = zmk_usb_is_powered(),
 #endif /* IS_ENABLED(CONFIG_USB_DEVICE_STACK) */


### PR DESCRIPTION
Fix the issue where the battery status on displays would not be correct until *after* at least one update interval (typically 1 minute) had passed. This was caused by the display subsystem being initialised after the first battery event is raised.

Also fixed a null dereference issue in the default display battery widget.