### PR TITLE
feat(boards): add encoder support to planck

### DIFF
--- a/app/boards/arm/planck/planck_rev6.dts
+++ b/app/boards/arm/planck/planck_rev6.dts
@@ -44,6 +44,20 @@
             ;
     };
 
+    encoder: encoder {
+        compatible = "alps,ec11";
+        a-gpios = <&gpiob 12 GPIO_PULL_UP>;
+        b-gpios = <&gpiob 13 GPIO_PULL_UP>;
+        steps = <80>;
+        status = "disabled";
+    };
+
+    sensors: sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&encoder>;
+        triggers-per-rotation = <20>;
+    };
+
 layout_grid_transform:
     keymap_transform_0 {
         compatible = "zmk,matrix-transform";

--- a/app/boards/arm/planck/planck_rev6.keymap
+++ b/app/boards/arm/planck/planck_rev6.keymap
@@ -7,6 +7,11 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 
+/* Uncomment this block if using an encoder */
+//&encoder {
+//    status = "okay";
+//};
+
 / {
     keymap {
         compatible = "zmk,keymap";
@@ -23,6 +28,7 @@
                 &kp LSHFT &kp Z    &kp X &kp C &kp V &kp B  &kp N   &kp M  &kp COMMA &kp DOT &kp SLASH &kp RET
                 &trans   &kp LCTL &kp LALT &kp LGUI &mo 1 &trans &kp SPACE &mo 2 &kp LEFT &kp DOWN &kp UP &kp RIGHT
             >;
+            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
 
         lower {

--- a/app/boards/arm/planck/planck_rev6.zmk.yml
+++ b/app/boards/arm/planck/planck_rev6.zmk.yml
@@ -5,6 +5,7 @@ type: board
 arch: arm
 features:
   - keys
+  - encoder
 outputs:
   - usb
 url: https://olkb.com/collections/planck

--- a/app/boards/arm/planck/planck_rev6_defconfig
+++ b/app/boards/arm/planck/planck_rev6_defconfig
@@ -14,3 +14,7 @@ CONFIG_GPIO=y
 CONFIG_CLOCK_CONTROL=y
 
 CONFIG_ZMK_USB=y
+
+# Uncomment these two lines to add support for encoder to your firmware
+#CONFIG_EC11=y
+#CONFIG_EC11_TRIGGER_OWN_THREAD=y


### PR DESCRIPTION
This adds support for an optional rotary encoder in the leftmost column of the Planck rev6. All positions for the encoder map to the same pins on the board, so this ought to work regardless of which position is chosen.

I have been using this regularly for the last week without any issues. FWIW, my encoder is in the bottom row.