### PR TITLE
feat(boards): Support board revisions

### DIFF
--- a/docs/src/templates/setup.ps1.mustache
+++ b/docs/src/templates/setup.ps1.mustache
@@ -131,6 +131,19 @@ if ($keyboard_type -eq "shield") {
         {{/boards}}
     }
 
+    $boards_revisions = [ordered]@{
+        {{#boards}}
+        {{id}} = @({{#revisions}}
+            "{{.}}"{{/revisions}});
+        {{/boards}}
+    }
+
+    $boards_default_revision=[ordered]@{
+        {{#boards}}
+        {{id}} = "{{{default_revision}}}";
+        {{/boards}}
+    }
+
     Write-Host "$title"
     Write-Host ""
     Write-Host "MCU Board Selection:"
@@ -145,6 +158,20 @@ if ($keyboard_type -eq "shield") {
     $shields = $keyboard_siblings
     $board = $($($boards.keys)[$choice])
     $boards = ( $board )
+
+    if ($($($boards_revisions.values)[$choice]).count -gt 0) {
+        $valid_revisions = $($($boards_revisions.values)[$choice])
+        for ($i = 0; $i -lt $valid_revisions.count; $i += 1) {
+            if ($valid_revisions[$i] -eq $($($boards_default_revision.values)[$choice])) {
+                $valid_revisions[$i] += " (default)"
+            }
+        }
+
+        $revision_choice = Get-Choice-From-Options -Options $valid_revisions -Prompt $prompt
+        $board = $board + "@" + $valid_revisions[$revision_choice]
+        $boards = ( $board )
+    }
+
 } else {
     $boards = ( $keyboard_siblings )
     $shields = @( )

--- a/docs/src/templates/setup.ps1.mustache
+++ b/docs/src/templates/setup.ps1.mustache
@@ -161,13 +161,15 @@ if ($keyboard_type -eq "shield") {
 
     if ($($($boards_revisions.values)[$choice]).count -gt 0) {
         $valid_revisions = $($($boards_revisions.values)[$choice])
+        $revision_choices = @() + $valid_revisions
+
         for ($i = 0; $i -lt $valid_revisions.count; $i += 1) {
             if ($valid_revisions[$i] -eq $($($boards_default_revision.values)[$choice])) {
-                $valid_revisions[$i] += " (default)"
+                $revision_choices[$i] += " (default)"
             }
         }
 
-        $revision_choice = Get-Choice-From-Options -Options $valid_revisions -Prompt $prompt
+        $revision_choice = Get-Choice-From-Options -Options $revision_choices -Prompt $prompt
         $board = $board + "@" + $valid_revisions[$revision_choice]
         $boards = ( $board )
     }

--- a/docs/src/templates/setup.sh.mustache
+++ b/docs/src/templates/setup.sh.mustache
@@ -157,15 +157,17 @@ if [ "$keyboard_shield" == "y" ]; then
 
     if [ -n "${boards_revisions[$board_index]}" ]; then
         read -a _valid_revisions <<< "${boards_revisions[$board_index]}"
+
+        _rev_choices=("${_valid_revisions[@]}")
         for (( _i=0; _i<${#_valid_revisions}; _i++ )); do
             if [ "${boards_default_revision[board_index]}" = "${_valid_revisions[_i]}" ]; then
-                _valid_revisions[_i]+=" (default)"
+                _rev_choices[_i]+=" (default)"
             fi
         done
 
         echo ""
         echo "MCU Board Revision:"
-        select opt in "${_valid_revisions[@]}" "Quit"; do
+        select opt in "${_rev_choices[@]}" "Quit"; do
             case "$REPLY" in
                 ''|*[!0-9]*) echo "Invalid option. Try another one."; continue;;
 

--- a/docs/src/templates/setup.sh.mustache
+++ b/docs/src/templates/setup.sh.mustache
@@ -122,6 +122,9 @@ if [ "$keyboard_shield" == "y" ]; then
     board_ids=({{#boards}}"{{id}}" {{/boards}})
     boards_usb_only=({{#boards}}"{{#usb_only}}y{{/usb_only}}{{^usb_only}}n{{/usb_only}}" {{/boards}})
 
+    boards_revisions=({{#boards}}"{{#revisions}}{{.}} {{/revisions}}" {{/boards}})
+    boards_default_revision=({{#boards}}"{{{default_revision}}}" {{/boards}})
+
     echo ""
     echo "MCU Board Selection:"
     PS3="$prompt "
@@ -151,6 +154,34 @@ if [ "$keyboard_shield" == "y" ]; then
 
         esac
     done
+
+    if [ -n "${boards_revisions[$board_index]}" ]; then
+        read -a _valid_revisions <<< "${boards_revisions[$board_index]}"
+        for (( _i=0; _i<${#_valid_revisions}; _i++ )); do
+            if [ "${boards_default_revision[board_index]}" = "${_valid_revisions[_i]}" ]; then
+                _valid_revisions[_i]+=" (default)"
+            fi
+        done
+
+        echo ""
+        echo "MCU Board Revision:"
+        select opt in "${_valid_revisions[@]}" "Quit"; do
+            ''|*[!0-9]*) echo "Invalid option. Try another one."; continue;;
+
+            $(( ${#_valid_revisions[@]}+1 )) ) echo "Goodbye!"; exit 1;;
+            *)
+                if [ $REPLY -gt $(( ${#_valid_revisions[@]}+1 )) ] || [ $REPLY -lt 0 ]; then
+                    echo "Invalid option. Try another one."
+                    continue
+                fi
+
+                _rev_index=$(( $REPLY-1 ))
+                board="${board_ids[$board_index]}@${_valid_revisions[_rev_index]}"
+                boards=( "${board}" )
+                break
+            ;;
+        done
+    fi
 else
     board=${keyboard}
     boards=$keyboard_siblings

--- a/docs/src/templates/setup.sh.mustache
+++ b/docs/src/templates/setup.sh.mustache
@@ -166,20 +166,22 @@ if [ "$keyboard_shield" == "y" ]; then
         echo ""
         echo "MCU Board Revision:"
         select opt in "${_valid_revisions[@]}" "Quit"; do
-            ''|*[!0-9]*) echo "Invalid option. Try another one."; continue;;
+            case "$REPLY" in
+                ''|*[!0-9]*) echo "Invalid option. Try another one."; continue;;
 
-            $(( ${#_valid_revisions[@]}+1 )) ) echo "Goodbye!"; exit 1;;
-            *)
-                if [ $REPLY -gt $(( ${#_valid_revisions[@]}+1 )) ] || [ $REPLY -lt 0 ]; then
-                    echo "Invalid option. Try another one."
-                    continue
-                fi
+                $(( ${#_valid_revisions[@]}+1 )) ) echo "Goodbye!"; exit 1;;
+                *)
+                    if [ $REPLY -gt $(( ${#_valid_revisions[@]}+1 )) ] || [ $REPLY -lt 0 ]; then
+                        echo "Invalid option. Try another one."
+                        continue
+                    fi
 
-                _rev_index=$(( $REPLY-1 ))
-                board="${board_ids[$board_index]}@${_valid_revisions[_rev_index]}"
-                boards=( "${board}" )
-                break
-            ;;
+                    _rev_index=$(( $REPLY-1 ))
+                    board="${board_ids[$board_index]}@${_valid_revisions[_rev_index]}"
+                    boards=( "${board}" )
+                    break
+                ;;
+            esac
         done
     fi
 else

--- a/schema/hardware-metadata.schema.json
+++ b/schema/hardware-metadata.schema.json
@@ -137,15 +137,6 @@
         "type": {
           "type": "string",
           "const": "interconnect"
-        },
-        "revisions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/revision"
-          }
-        },
-        "default_revision": {
-          "$ref": "#/$defs/revision"
         }
       }
     },
@@ -277,15 +268,6 @@
         },
         "exposes": {
           "$ref": "#/$defs/interconnects"
-        },
-        "revisions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/revision"
-          }
-        },
-        "default_revision": {
-          "$ref": "#/$defs/revision"
         }
       }
     }

--- a/schema/hardware-metadata.schema.json
+++ b/schema/hardware-metadata.schema.json
@@ -18,6 +18,15 @@
       "type": "string",
       "pattern": "^[a-z0-9_]+$"
     },
+    "revisions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "default_revision": {
+      "type": "string"
+    },
     "keyboard_siblings": {
       "type": "array",
       "items": {
@@ -133,6 +142,12 @@
         "type": {
           "type": "string",
           "const": "interconnect"
+        },
+        "revisions": {
+          "type": "#/$defs/revisions"
+        },
+        "default_revision": {
+          "type": "#/$defs/default_revision"
         }
       }
     },
@@ -202,6 +217,12 @@
         },
         "exposes": {
           "$ref": "#/$defs/interconnects"
+        },
+        "revisions": {
+          "type": "#/$defs/revisions"
+        },
+        "default_revision": {
+          "type": "#/$defs/default_revision"
         }
       }
     },
@@ -255,6 +276,12 @@
         },
         "exposes": {
           "$ref": "#/$defs/interconnects"
+        },
+        "revisions": {
+          "type": "#/$defs/revisions"
+        },
+        "default_revision": {
+          "type": "#/$defs/default_revision"
         }
       }
     }

--- a/schema/hardware-metadata.schema.json
+++ b/schema/hardware-metadata.schema.json
@@ -16,10 +16,11 @@
   "$defs": {
     "id": {
       "type": "string",
-      "pattern": "^[a-z0-9_]+$"
+      "pattern": "^[a-z0-9_]+(@([A-Z]|[0-9]+|([0-9]+(\\.[0-9]+){1,2})))?$"
     },
     "revision": {
-      "type": "string"
+      "type": "string",
+      "pattern": "[A-Z]|[0-9]+|([0-9]+(\\.[0-9]+){1,2})"
     },
     "keyboard_siblings": {
       "type": "array",

--- a/schema/hardware-metadata.schema.json
+++ b/schema/hardware-metadata.schema.json
@@ -18,13 +18,7 @@
       "type": "string",
       "pattern": "^[a-z0-9_]+$"
     },
-    "revisions": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "default_revision": {
+    "revision": {
       "type": "string"
     },
     "keyboard_siblings": {
@@ -144,10 +138,13 @@
           "const": "interconnect"
         },
         "revisions": {
-          "type": "#/$defs/revisions"
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/revision"
+          }
         },
         "default_revision": {
-          "type": "#/$defs/default_revision"
+          "$ref": "#/$defs/revision"
         }
       }
     },
@@ -219,10 +216,13 @@
           "$ref": "#/$defs/interconnects"
         },
         "revisions": {
-          "type": "#/$defs/revisions"
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/revision"
+          }
         },
         "default_revision": {
-          "type": "#/$defs/default_revision"
+          "$ref": "#/$defs/revision"
         }
       }
     },
@@ -278,10 +278,13 @@
           "$ref": "#/$defs/interconnects"
         },
         "revisions": {
-          "type": "#/$defs/revisions"
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/revision"
+          }
         },
         "default_revision": {
-          "type": "#/$defs/default_revision"
+          "$ref": "#/$defs/revision"
         }
       }
     }


### PR DESCRIPTION
Split off from #1946; this is just the zmk infrastructure part to support board revisions.

Changes:
1. Updated schema to support a list of revisions, as well as a default revision
2. Updated `setup.sh` to prompt the user for revisions if the board yml defines revisions (and will also say which one is the default — if any)
3. `setup.sh` will append `@revision` to the board name.

The script doesn't support revisions for shields yet, but if the approach is sound I'll add that as well as fix up the powershell script.

I've set up a repo to test: https://github.com/zhiayang/zmk-test, but this depends on #1946.