### PR TITLE
refactor: remove redundant Kconfig defaults

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -177,7 +177,6 @@ config ZMK_BLE_EXPERIMENTAL_FEATURES
 
 config ZMK_BLE_PASSKEY_ENTRY
     bool "Require passkey entry on the keyboard to complete pairing"
-    default n
     select RING_BUFFER
 
 config BT_SMP_ALLOW_UNAUTH_OVERWRITE
@@ -216,7 +215,6 @@ config ZMK_BLE_MOUSE_REPORT_QUEUE_SIZE
 
 config ZMK_BLE_CLEAR_BONDS_ON_START
     bool "Configuration that clears all bond information from the keyboard on startup."
-    default n
 
 # HID GATT notifications sent this way are *not* picked up by Linux, and possibly others.
 config BT_GATT_NOTIFY_MULTIPLE
@@ -373,7 +371,6 @@ menu "Mouse Options"
 
 config ZMK_MOUSE
     bool "Enable ZMK mouse emulation"
-    default n
 
 #Mouse Options
 endmenu
@@ -382,7 +379,6 @@ menu "Power Management"
 
 config ZMK_BATTERY_REPORTING
     bool "Battery level detection/reporting"
-    default n
     select SENSOR
     select ZMK_LOW_PRIORITY_WORK_QUEUE
     imply BT_BAS if ZMK_BLE
@@ -616,7 +612,6 @@ config FPU
 
 config ZMK_WPM
     bool "Calculate WPM"
-    default n
 
 config ZMK_KEYMAP_SENSORS
     bool "Enable Keymap Sensors support"

--- a/app/Kconfig.behaviors
+++ b/app/Kconfig.behaviors
@@ -14,7 +14,6 @@ config ZMK_BEHAVIOR_MOUSE_KEY_PRESS
 
 config ZMK_BEHAVIOR_SENSOR_ROTATE_COMMON
     bool
-    default n
 
 config ZMK_BEHAVIOR_SENSOR_ROTATE
     bool

--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -3,7 +3,6 @@
 
 menuconfig ZMK_DISPLAY
     bool "Enable ZMK Display"
-    default n
     select DISPLAY
     select LVGL
     select LV_CONF_MINIMAL


### PR DESCRIPTION
As discussed [on Discord](https://discord.com/channels/719497620560543766/1206391546090496060/1206398822675124254):
> **petejohanson:** We shouldn't ever explicitly set a default n
**petejohanson:** Because it causes the problem you describe
**petejohanson:** https://docs.zephyrproject.org/latest/build/kconfig/tips.html#redundant-defaults

Only ZMK symbols were modified; [`BT_GATT_NOTIFY_MULTIPLE`](https://github.com/zmkfirmware/zephyr/blob/1ae0eb5ce8adafcec993e6fb8f4eeb6f818a7772/subsys/bluetooth/host/Kconfig.gatt#L110) was intentionally omitted. While seemingly unlikely given the age of `git blame`...it's still *possible* that the default value of this symbol could be changed at some later date in Zephyr, so I left it alone.