### PR TITLE
Fix compile issue on zephyr 3.5 with ext_power and rgb_toggle

### DIFF
--- a/app/src/behaviors/behavior_ext_power.c
+++ b/app/src/behaviors/behavior_ext_power.c
@@ -75,6 +75,6 @@ static const struct behavior_driver_api behavior_ext_power_driver_api = {
 };
 
 BEHAVIOR_DT_INST_DEFINE(0, behavior_ext_power_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_APPLICATION_INIT_PRIORITY, &behavior_ext_power_driver_api);
+                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_ext_power_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */


### PR DESCRIPTION
After Zephyr 3.5 was merged, I got an error compiling with a board that used both rgb_toggle and ext_power behaviors:

`ERROR: /behaviors/rgb_toggle POST_KERNEL 5 < /behaviors/extpower POST_KERNEL 55`

This change fixes the compile error.