### PR TITLE
fix(boards): Tweaks for Ferris rev0.2 for Zephyr.

### DIFF
--- a/app/boards/arm/ferris/ferris_rev02.dts
+++ b/app/boards/arm/ferris/ferris_rev02.dts
@@ -112,12 +112,19 @@
 
 &usb {
     status = "okay";
+
+    pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+    pinctrl-names = "default";
     cdc_acm_uart: cdc_acm_uart {
         compatible = "zephyr,cdc-acm-uart";
     };
 };
 
 &clk_hsi {
+    status = "okay";
+};
+
+&clk_hsi48 {
     status = "okay";
 };
 


### PR DESCRIPTION
* Enable missing clock and set up USB pinctrl.
