### PR TITLE
feat(docs): Add pointer to shield folder in new shield guide

### DIFF
--- a/docs/docs/development/new-shield.mdx
+++ b/docs/docs/development/new-shield.mdx
@@ -348,6 +348,8 @@ Here is an example for the [nice60](https://github.com/Nicell/nice60), which use
         zmk,matrix-transform = &default_transform;
     };
 
+    /* define kscan node with label `kscan0`... */
+
     default_transform: keymap_transform_0 {
         compatible = "zmk,matrix-transform";
         columns = <8>;
@@ -365,6 +367,9 @@ RC(6,0)       RC(6,1) RC(6,2) RC(6,3) RC(5,3) RC(6,4) RC(5,4) RC(6,5) RC(5,5) RC
 RC(7,0)    RC(7,1)   RC(7,2)                     RC(7,3)                    RC(7,5)    RC(7,6)    RC(6,7)    RC(7,7)
         >;
     };
+
+    /* potentially other overlay nodes... */
+};
 ```
 
 Some important things to note:

--- a/docs/docs/development/new-shield.mdx
+++ b/docs/docs/development/new-shield.mdx
@@ -233,8 +233,9 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,2) RC(4,9) RC(3,6) RC(3,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
         diode-direction = "col2row";
+        wakeup-source;
+
         row-gpios
             = <&pro_micro 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row A from the schematic file
             , <&pro_micro 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row B from the schematic file

--- a/docs/docs/development/new-shield.mdx
+++ b/docs/docs/development/new-shield.mdx
@@ -67,6 +67,10 @@ mkdir boards/shields/<keyboard_name>
 
 ## Base Kconfig Files
 
+:::tip[Example shields]
+You can check out the [`shields` folder](https://github.com/zmkfirmware/zmk/tree/main/app/boards/shields) in the ZMK repo that houses [the in-tree supported shields](../hardware.mdx) in order to copy and modify as a starting point.
+:::
+
 There are two required Kconfig files that need to be created for your new keyboard
 shield to get it picked up for ZMK, `Kconfig.shield` and `Kconfig.defconfig`.
 


### PR DESCRIPTION
- Add a tip that links to ZMK shields folder for users to use as starting points
  - I think it's a good idea, but I am open to discussion if anyone has concerns.
- Add some comments in the matrix transform example to look less like a complete overlay, but also add the closing brace just in case.