### PR TITLE
feat(docs): Document HID report descriptor refresh

### DIFF
--- a/docs/docs/behaviors/mouse-emulation.md
+++ b/docs/docs/behaviors/mouse-emulation.md
@@ -8,7 +8,12 @@ sidebar_label: Mouse Emulation
 Mouse emulation behaviors send mouse events. Currently, only mouse button presses are supported, but movement
 and scroll action support is planned for the future.
 
-Whenever the Mouse Emulation feature is turned on or off, the HID protocol used to communicate events to hosts changes. Unfortunately, those changes are not always detected automatically, and might require re-pairing your keyboard to your devices to work over bluetooth. If mouse behaviors are still not recognized by your device after doing that, you can try [these troubleshooting steps](../features/bluetooth.md#windows-connected-but-not-working).
+:::warning[Refreshing the HID descriptor]
+
+Enabling or disabling the mouse emulation feature modifies the HID report descriptor and requires it to be [refreshed](../features/bluetooth.md#refreshing-the-hid-descriptor).
+The mouse functionality will not work over BLE until that is done.
+
+:::
 
 ## Configuration Option
 

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -22,6 +22,12 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 
 ### HID
 
+:::warning[Refreshing the HID descriptor]
+
+Making changes to any of the settings in this section modifies the HID report descriptor and requires it to be [refreshed](../features/bluetooth.md#refreshing-the-hid-descriptor).
+
+:::
+
 | Config                                | Type | Description                                                    | Default |
 | ------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
 | `CONFIG_ZMK_HID_INDICATORS`           | bool | Enable reciept of HID/LED indicator state from connected hosts | n       |

--- a/docs/docs/features/bluetooth.md
+++ b/docs/docs/features/bluetooth.md
@@ -56,18 +56,6 @@ This setting can also improve the connection strength between the keyboard halve
 
 If you want to test bluetooth output on your keyboard and are powering it through the USB connection rather than a battery, you will be able to pair with a host device but may not see keystrokes sent. In this case you need to use the [output selection behavior](../behaviors/outputs.md) to prefer sending keystrokes over bluetooth rather than USB. This might be necessary even if you are not powering from a device capable of receiving USB inputs, such as a USB charger.
 
-## Known Issues
-
-There are a few known issues related to BLE and ZMK:
-
-### Windows Battery Reporting
-
-There is a known issue with Windows failing to update the battery information after connecting to a ZMK keyboard. You can work around this Windows bug by overriding a [Bluetooth config variable](../config/bluetooth.md) to force battery notifications even if a host neglects to subscribe to them:
-
-```ini
-CONFIG_BT_GATT_ENFORCE_SUBSCRIPTION=n
-```
-
 ### macOS Connected But Not Working
 
 If you attempt to pair a ZMK keyboard from macOS in a way that causes a bonding issue, macOS may report the keyboard as connected, but fail to actually work. If this occurs:

--- a/docs/docs/features/bluetooth.md
+++ b/docs/docs/features/bluetooth.md
@@ -36,6 +36,19 @@ Failure to manage the profiles can result in unexpected/broken behavior with hos
 
 Management of the bluetooth in ZMK is accomplished using the [`&bt` behavior](../behaviors/bluetooth.md). Be sure to refer to that documentation to learn how to manage profiles, switch between connected hosts, etc.
 
+## Refreshing the HID Descriptor
+
+Enabling certain features or behaviors in ZMK changes the data structure that ZMK sends over USB or BLE to host devices.
+This in turn requires [HID report descriptors](https://docs.kernel.org/hid/hidintro.html) to be modified for the reports to be parsed correctly.
+Firmware changes that would modify the descriptor include the following:
+
+- Changing any of the settings under the [HID category](../config/system.md#hid), including enabling/disabling NKRO or HID indicators
+- Enabling mouse features, such as adding [mouse keys](../behaviors/mouse-emulation.md) to your keymap
+
+While the descriptor refresh happens on boot for USB, hosts will frequently cache this descriptor for BLE devices.
+In order to refresh this cache, you need to remove the keyboard from the host device, clear the profile associated with the host on the keyboard, then pair again.
+For Windows systems you might need to follow the instructions in [this troubleshooting section](#windows-connected-but-not-working) below.
+
 ## Troubleshooting
 
 ### Connectivity Issues


### PR DESCRIPTION
Added a section under the BT features page that describes when it might be necessary, and how to do it. This will be a more common ask with more mouse functionality getting integrated in the future.

Also took the opportunity to remove the guidance on Windows battery refresh Kconfig. This doesn't seem to be necessary anymore in W10/W11, according to reports.