### PR TITLE
feat(build): Explicit keymap node error

### DIFF
--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -31,6 +31,12 @@ static uint8_t _zmk_keymap_layer_default = 0;
 
 #define DT_DRV_COMPAT zmk_keymap
 
+#if !DT_NODE_EXISTS(DT_DRV_INST(0))
+
+#error "Keymap node not found, check a keymap is available and is has compatible = "zmk,keymap" set"
+
+#endif
+
 #define TRANSFORMED_LAYER(node)                                                                    \
     { LISTIFY(DT_PROP_LEN(node, bindings), ZMK_KEYMAP_EXTRACT_BINDING, (, ), node) }
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -40,6 +40,10 @@ West build errors usually indicate syntax problems in the `<keyboard>.keymap` fi
 If you are reviewing these errors in the GitHub Actions tab, they can be found in the `West Build` step of the build process.
 :::
 
+#### Keymap error
+
+If you get an error stating `Keymap node not found, check a keymap is available and is has compatible = "zmk,keymap" set` this is an indication that the build process cannot find the keymap. Double check that the `<keyboard>.keymap` file is present and has been discovered by the build process. This can be checked by looking for a line in the build log stating `-- Using keymap file: /path/to/keymap/file/<keyboard>.keymap`. Inside the keymap file ensure the keymap node has `compatible = zmk,keymap` and it's not misspelled. For more information see the [Keymap](features/keymaps.mdx) documentation.
+
 #### devicetree error
 
 A `devicetree error` followed by a reference to the line number on `<keyboard>.keymap` refers to an issue at the exact line position in that file. For example, below error message indicates a missing `;` at line 109 of the `cradio.keymap` file:

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -42,7 +42,7 @@ If you are reviewing these errors in the GitHub Actions tab, they can be found i
 
 #### Keymap error
 
-If you get an error stating `Keymap node not found, check a keymap is available and is has compatible = "zmk,keymap" set` this is an indication that the build process cannot find the keymap. Double check that the `<keyboard>.keymap` file is present and has been discovered by the build process. This can be checked by looking for a line in the build log stating `-- Using keymap file: /path/to/keymap/file/<keyboard>.keymap`. Inside the keymap file ensure the keymap node has `compatible = zmk,keymap` and it's not misspelled. For more information see the [Keymap](features/keymaps.mdx) and [Config](config) documentation.
+If you get an error stating `Keymap node not found, check a keymap is available and is has compatible = "zmk,keymap" set` this is an indication that the build process cannot find the keymap. Double check that the `<keyboard>.keymap` file is present and has been discovered by the build process. This can be checked by looking for a line in the build log stating `-- Using keymap file: /path/to/keymap/file/<keyboard>.keymap`. Inside the keymap file ensure the keymap node has `compatible = zmk,keymap` and it's not misspelled. For more information see the [Keymap](features/keymaps.mdx) and [Config](config/index.md) documentation.
 
 #### devicetree error
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -42,7 +42,7 @@ If you are reviewing these errors in the GitHub Actions tab, they can be found i
 
 #### Keymap error
 
-If you get an error stating `Keymap node not found, check a keymap is available and is has compatible = "zmk,keymap" set` this is an indication that the build process cannot find the keymap. Double check that the `<keyboard>.keymap` file is present and has been discovered by the build process. This can be checked by looking for a line in the build log stating `-- Using keymap file: /path/to/keymap/file/<keyboard>.keymap`. Inside the keymap file ensure the keymap node has `compatible = zmk,keymap` and it's not misspelled. For more information see the [Keymap](features/keymaps.mdx) documentation.
+If you get an error stating `Keymap node not found, check a keymap is available and is has compatible = "zmk,keymap" set` this is an indication that the build process cannot find the keymap. Double check that the `<keyboard>.keymap` file is present and has been discovered by the build process. This can be checked by looking for a line in the build log stating `-- Using keymap file: /path/to/keymap/file/<keyboard>.keymap`. Inside the keymap file ensure the keymap node has `compatible = zmk,keymap` and it's not misspelled. For more information see the [Keymap](features/keymaps.mdx) and [Config](config) documentation.
 
 #### devicetree error
 


### PR DESCRIPTION
Little fix to address #1416 to throw an explicit error if a node with `compatible = zmk,keymap` is not set. In testing, the `ZMK_KEYMAP_LAYERS_LEN` error is still present but the explicit error gets presented as well, which should still help users diagnose problems.

Some documentation on the error has also been added to the troubleshooting section of the docs.