### PR TITLE
feat(docs): Add warning to new shield docs how Kconfig treats whitspaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,12 @@ documentation to areas not currently covered are greatly appreciated.
 ZMK uses `prettier` to format documentation files. You can run prettier with `npm run prettier:format`.
 You can setup git to run prettier automatically when you commit by installing the pre-commit hooks: `pip3 install pre-commit`, `pre-commit install`.
 
+### Linting
+
+This repository utilizes ESLint for code linting to ensure consistent code style and identify potential errors or bugs early in the development process.
+
+You can run ESLint with `npm run lint` to verify your changes.
+
 ## Code Contributions
 
 ### Development Setup

--- a/docs/docs/development/new-shield.mdx
+++ b/docs/docs/development/new-shield.mdx
@@ -79,6 +79,10 @@ config SHIELD_MY_BOARD
     def_bool $(shields_list_contains,my_board)
 ```
 
+:::warning
+Kconfig uses only commas for delimiters, and keeps all whitespaces in the function call. Therefore do not add a whitespace after the comma when configuring your shield as this would be treated as <code>&nbsp;my_board</code> (with a leading whitespace) and will cause issues.
+:::
+
 This will make sure that a new configuration value named `SHIELD_MY_BOARD` is set to true whenever `my_board` is used as the shield name, either as the `SHIELD` variable [in a local build](build-flash.mdx) or in your `build.yaml` file [when using Github Actions](../customization). Note that this configuration value will be used in `Kconfig.defconfig` to set other properties about your shield, so make sure that they match.
 
 **For split boards**, you will need to add configurations for the left and right sides. For example, if your split halves are named `my_board_left` and `my_board_right`, it would look like this:


### PR DESCRIPTION
Resolves #2183

Added a warning to the shield section explaining that Kconfig does not ignore whitespaces on function calls and therefore adding whitespaces after the comma will break functionality.