### PR TITLE
feat(underglow): add underglow for reviung5

### DIFF
--- a/app/boards/shields/reviung5/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/reviung5/boards/nice_nano_v2.overlay
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/led/led.h>
+
+&pinctrl {
+    spi3_default: spi3_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+        };
+    };
+
+    spi3_sleep: spi3_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 6)>;
+            low-power-enable;
+        };
+    };
+};
+
+&spi3 {
+    compatible = "nordic,nrf-spim";
+    status = "okay";
+
+    pinctrl-0 = <&spi3_default>;
+    pinctrl-1 = <&spi3_sleep>;
+    pinctrl-names = "default", "sleep";
+
+    led_strip: ws2812@0 {
+        compatible = "worldsemi,ws2812-spi";
+
+        /* SPI */
+        reg = <0>; /* ignored, but necessary for SPI bindings */
+        spi-max-frequency = <4000000>;
+
+        /* WS2812 */
+        chain-length = <4>;
+        spi-one-frame = <0x70>;
+        spi-zero-frame = <0x40>;
+
+        color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+    };
+};
+
+/ {
+    chosen {
+        zmk,underglow = &led_strip;
+    };
+};

--- a/app/boards/shields/reviung5/reviung5.conf
+++ b/app/boards/shields/reviung5/reviung5.conf
@@ -1,3 +1,7 @@
-# Encoder support. Uncomment to enable.
+# Uncomment the following two lines to add support for encoders
 # CONFIG_EC11=y
 # CONFIG_EC11_TRIGGER_GLOBAL_THREAD=y
+
+# Uncomment the following two lines to enable RGB underglow
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y

--- a/app/boards/shields/reviung5/reviung5.keymap
+++ b/app/boards/shields/reviung5/reviung5.keymap
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 The ZMK Contributors
+ * Copyright (c) 2024 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */
@@ -8,20 +8,31 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/rgb.h>
 
 #define BASE 0
 #define BLE 1
+#define RGB 2
 
 / {
+
+        behaviors {
+            rgb_encoder: rgb_encoder {
+              compatible = "zmk,behavior-sensor-rotate";
+              #sensor-binding-cells = <0>;
+              bindings = <&rgb_ug RGB_BRI>, <&rgb_ug RGB_BRD>;
+            };
+        };
+
         keymap {
             compatible = "zmk,keymap";
 
             base_layer {
               display-name = "BASE";
               bindings = <
-                // ╭─────────────┬──────────────┬──────────────────┬─────────────┬─────────────╮
-                     &mo BLE      &kp C_PREVIOUS  &kp C_PLAY_PAUSE    &kp C_NEXT   &kp C_MUTE
-                // ╰─────────────┴──────────────┴──────────────────┴─────────────┴─────────────╯
+                // ╭─────────┬────────────────┬──────────────────┬────────────┬────────────────╮
+                     &mo BLE   &kp C_PREVIOUS   &kp C_PLAY_PAUSE   &kp C_NEXT   &lt RGB C_MUTE
+                // ╰─────────┴────────────────┴──────────────────┴────────────┴────────────────╯
               >;
               sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
             };
@@ -29,10 +40,20 @@
             ble_layer {
               display-name = "BLE";
               bindings = <
-                // ╭─────────────┬─────────────┬─────────────┬─────────────┬─────────────╮
-                     &trans     &out OUT_TOG   &bt BT_PRV    &bt BT_NXT    &bt BT_CLR
-                // ╰─────────────┴─────────────┴─────────────┴─────────────┴─────────────╯
+                // ╭────────┬──────────────┬────────────┬────────────┬────────────╮
+                     &trans   &out OUT_TOG   &bt BT_PRV   &bt BT_NXT   &bt BT_CLR
+                // ╰────────┴──────────────┴────────────┴────────────┴────────────╯
               >;
+            };
+
+            rgb_layer {
+              display-name = "RGB";
+              bindings = <
+                // ╭──────────────────┬─────────────────┬─────────────────┬──────────────────────────────────┬────────╮
+                     &rgb_ug RGB_TOG    &rgb_ug RGB_EFR   &rgb_ug RGB_EFF   &rgb_ug RGB_COLOR_HSB(307,89,98)   &trans
+                // ╰──────────────────┴─────────────────┴─────────────────┴──────────────────────────────────┴────────╯
+              >;
+              sensor-bindings = <&rgb_encoder>;
             };
         };
 };

--- a/app/boards/shields/reviung5/reviung5.zmk.yml
+++ b/app/boards/shields/reviung5/reviung5.zmk.yml
@@ -7,3 +7,4 @@ requires: [pro_micro]
 features:
   - keys
   - encoder
+  - underglow


### PR DESCRIPTION
Adds underglow for the reviung5. Was just copying and adapting stuff from other reviungs. And created battery optimized keymap by toggling ext power off instead of just switching RGB on and off.

Looks nice :-D
![R0000581-01](https://github.com/zmkfirmware/zmk/assets/1927259/b6479fbb-112c-416f-9025-7582b513a630)
