### PR TITLE
Helix OLED support

### DIFF
--- a/app/boards/shields/helix/Kconfig.defconfig
+++ b/app/boards/shields/helix/Kconfig.defconfig
@@ -17,3 +17,31 @@ config ZMK_SPLIT
     default y
 
 endif
+
+
+if ZMK_DISPLAY
+
+config I2C
+    default y
+
+config SSD1306
+    default y
+
+endif # ZMK_DISPLAY
+
+if LVGL
+
+config LV_Z_VDB_SIZE
+    default 64
+
+config LV_DPI_DEF
+    default 148
+
+config LV_Z_BITS_PER_PIXEL
+    default 1
+
+choice LV_COLOR_DEPTH
+    default LV_COLOR_DEPTH_1
+endchoice
+
+endif # LVGL

--- a/app/boards/shields/helix/README.md
+++ b/app/boards/shields/helix/README.md
@@ -2,7 +2,6 @@
 
 - If desired, RGB underglow must be manually enabled before building and flashing. Check 'helix.conf' to do so.
 - Peripheral RGB function is impaired until full support is implemented in the master branch.
-- OLED displays are not currently included in this shield. This will be updated after OLED support is live.
 - 'KANA' and 'EISUU' input is currently utilized under the 'LANG1' and 'LANG2' keycodes respectively.
 
 ---

--- a/app/boards/shields/helix/helix.conf
+++ b/app/boards/shields/helix/helix.conf
@@ -4,3 +4,6 @@
 # Enables RGB functionality (Uncomment lines below to enable.)
 # CONFIG_ZMK_RGB_UNDERGLOW=y
 # CONFIG_WS2812_STRIP=y
+
+# Uncomment the following line to enable the Helix OLED Display
+# CONFIG_ZMK_DISPLAY=y

--- a/app/boards/shields/helix/helix.dtsi
+++ b/app/boards/shields/helix/helix.dtsi
@@ -8,6 +8,7 @@
 
 / {
     chosen {
+        zephyr,display = &oled;
         zmk,kscan = &kscan0;
         zmk,matrix-transform = &default_transform;
     };
@@ -42,5 +43,26 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(4,6)   RC(4,7) RC(4,8) RC(4,9
             , <&pro_micro 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
 
+    };
+};
+
+
+&pro_micro_i2c {
+    status = "okay";
+
+    oled: ssd1306@3c {
+        compatible = "solomon,ssd1306fb";
+        reg = <0x3c>;
+        label = "DISPLAY";
+        width = <128>;
+        height = <32>;
+        segment-offset = <0>;
+        page-offset = <0>;
+        display-offset = <0>;
+        multiplex-ratio = <31>;
+        segment-remap;
+        com-invdir;
+        com-sequential;
+        prechargep = <0x22>;
     };
 };


### PR DESCRIPTION
Added OLED support to the Helix shield. Followed the example set for the Sofle.