### PR TITLE
chore(docs): fix hold-tap info callout

### DIFF
--- a/docs/docs/behaviors/hold-tap.mdx
+++ b/docs/docs/behaviors/hold-tap.mdx
@@ -87,7 +87,7 @@ For example, if you press `&mt LEFT_SHIFT A` and then release it without pressin
 
 If enabled, the hold behavior will immediately be held on hold-tap press, and will release before the behavior is sent in the event the hold-tap resolves into a tap. With most modifiers this will not affect typing, and is useful for using modifiers with the mouse.
 
-:::info
+:::info[Alt/Win/Cmd behavior]
 In some applications/desktop environments, pressing Alt keycodes by itself will have its own behavior like activate a menu and Gui keycodes will bring up the start menu or an application launcher.
 :::
 

--- a/docs/docs/behaviors/hold-tap.mdx
+++ b/docs/docs/behaviors/hold-tap.mdx
@@ -87,7 +87,7 @@ For example, if you press `&mt LEFT_SHIFT A` and then release it without pressin
 
 If enabled, the hold behavior will immediately be held on hold-tap press, and will release before the behavior is sent in the event the hold-tap resolves into a tap. With most modifiers this will not affect typing, and is useful for using modifiers with the mouse.
 
-:::note Alt/Win/Cmd behavior
+:::info
 In some applications/desktop environments, pressing Alt keycodes by itself will have its own behavior like activate a menu and Gui keycodes will bring up the start menu or an application launcher.
 :::
 


### PR DESCRIPTION
The hold-while-undecided callout does not properly render in the docs. This fixes it.