### PR TITLE
feat(docs): Add troubleshooting section for empty_file error

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -56,6 +56,14 @@ A `devicetree error` followed by a reference to the line number on `<keyboard>.k
 devicetree error: /__w/zmk-config/zmk-config/config/cradio.keymap:109 (column 4): parse error: expected ';' or ','
 ```
 
+A `devicetree error` followed by an `empty_file.c` reference with `lacks #binding-cells` string indicates possible problems with improper parameters for specific bindings:
+
+```
+devicetree error: <Node /soc/gpio@50000300 in '/tmp/tmp.vJq9sMwkcY/zephyr/misc/empty_file.c'> lacks #binding-cells
+```
+
+This error can be triggered by incorrect binding syntax such as `&kp BT_SEL 0` instead of `&bt BT_SEL 0`.
+
 #### devicetree_unfixed.h error
 
 A `devicetree_unfixed.h` error that follows with an "undeclared here" string indicates a problem with key bindings, like behavior nodes (e.g. `&kp` or `&mt`) with incorrect number of parameters:


### PR DESCRIPTION
Add a troubleshooting section for `empty_file.c` `lacks #binding-cells` error
