### PR TITLE
fix: Add settings reset on start init priority.

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -568,6 +568,19 @@ if SETTINGS
 config ZMK_SETTINGS_RESET_ON_START
     bool "Delete all persistent settings when the keyboard boots"
 
+if ZMK_SETTINGS_RESET_ON_START
+
+config ZMK_SETTINGS_RESET_ON_START_INIT_PRIORITY
+    int "Settings Reset ON Start Initialization Priority"
+    default 60
+    help
+      Initialization priority for the settings reset on start. Must be lower priority/
+      higher value than FLASH_INIT_PRIORITY if using the NVS/Flash settings backend.
+
+
+endif
+
+
 config ZMK_SETTINGS_SAVE_DEBOUNCE
     int "Milliseconds to debounce settings saves"
     default 60000

--- a/app/src/settings/reset_settings_on_start.c
+++ b/app/src/settings/reset_settings_on_start.c
@@ -10,4 +10,4 @@
 
 // Reset after the kernel is initialized but before any application code to
 // ensure settings are cleared before anything tries to use them.
-SYS_INIT(zmk_settings_erase, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(zmk_settings_erase, POST_KERNEL, CONFIG_ZMK_SETTINGS_RESET_ON_START_INIT_PRIORITY);


### PR DESCRIPTION
* Add a dedicated settings reset on start init priority and default it to lower priority (high number) than default FLASH_INIT_PRIORITY to be sure flash is initialized before we open the area.

## Testing

I haven't had a chance to test this on hardware yet, but this likely is the issue with reported settings reset:

```
[00:00:00.309,143] <inf> zmk: Erasing settings flash partition
[00:00:00.309,143] <err> zmk: Failed to open settings flash: -19
[00:00:00.316,070] <inf> fs_nvs: 8 Sectors of 4096 bytes
[00:00:00.316,070] <inf> fs_nvs: alloc wra: 0, fd8
[00:00:00.316,070] <inf> fs_nvs: data wra: 0, 18
```