### PR TITLE
fix(devcontainer): Add packages required by grpcio

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,3 +2,4 @@ FROM docker.io/zmkfirmware/zmk-dev-arm:3.5
 
 COPY .bashrc tmp
 RUN mv /tmp/.bashrc ~/.bashrc
+RUN apt-get update && apt-get install -y build-essential


### PR DESCRIPTION
When running `pip3 install --user -r zephyr/scripts/requirements.txt` (last step on https://zmk.dev/docs/development/setup), grpcio install fails with the following error:

    FileNotFoundError: [Errno 2] No such file or directory: c++: c++

This happens due to missing dev tooling in the container.
