### PR TITLE
feat(keymap): create master header for dt-bindings imports

### DIFF
--- a/app/boards/shields/a_dux/a_dux.keymap
+++ b/app/boards/shields/a_dux/a_dux.keymap
@@ -5,7 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
 

--- a/app/boards/shields/bat43/bat43.keymap
+++ b/app/boards/shields/bat43/bat43.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 #define LOWER 1
 #define RAISE 2

--- a/app/boards/shields/bfo9000/bfo9000.keymap
+++ b/app/boards/shields/bfo9000/bfo9000.keymap
@@ -5,11 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/ext_power.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 #define DEFAULT 0
 #define LOWER   1

--- a/app/boards/shields/boardsource3x4/boardsource3x4.keymap
+++ b/app/boards/shields/boardsource3x4/boardsource3x4.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/boardsource5x12/boardsource5x12.keymap
+++ b/app/boards/shields/boardsource5x12/boardsource5x12.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 
 / {

--- a/app/boards/shields/chalice/chalice.keymap
+++ b/app/boards/shields/chalice/chalice.keymap
@@ -5,10 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/rgb.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
         keymap {

--- a/app/boards/shields/clog/clog.keymap
+++ b/app/boards/shields/clog/clog.keymap
@@ -5,8 +5,7 @@
 */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 #define MAIN 0
 #define SYM 1

--- a/app/boards/shields/clueboard_california/clueboard_california.keymap
+++ b/app/boards/shields/clueboard_california/clueboard_california.keymap
@@ -5,7 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap0: keymap {

--- a/app/boards/shields/contra/contra.keymap
+++ b/app/boards/shields/contra/contra.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 #define DEFAULT  0
 #define NUM_MODS 1

--- a/app/boards/shields/corne/corne.keymap
+++ b/app/boards/shields/corne/corne.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
         keymap {

--- a/app/boards/shields/cradio/cradio.keymap
+++ b/app/boards/shields/cradio/cradio.keymap
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 // Home row mods macro
 #define HRML(k1,k2,k3,k4) &ht LSHFT k1  &ht LALT k2  &ht LCTRL k3  &ht LGUI k4

--- a/app/boards/shields/crbn/crbn.keymap
+++ b/app/boards/shields/crbn/crbn.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/eek/eek.keymap
+++ b/app/boards/shields/eek/eek.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/elephant42/elephant42.keymap
+++ b/app/boards/shields/elephant42/elephant42.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 #define LOWR 1
 #define RAIS 2

--- a/app/boards/shields/ergodash/ergodash.keymap
+++ b/app/boards/shields/ergodash/ergodash.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 #define DEFAULT 0
 #define LOWER   1

--- a/app/boards/shields/eternal_keypad/eternal_keypad.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad.keymap
@@ -5,10 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 #define BASE        0
 #define ARROW       1

--- a/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
+++ b/app/boards/shields/eternal_keypad/eternal_keypad_lefty.keymap
@@ -5,10 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 #define BASE        0
 #define ARROW       1

--- a/app/boards/shields/fourier/fourier.keymap
+++ b/app/boards/shields/fourier/fourier.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/helix/helix.keymap
+++ b/app/boards/shields/helix/helix.keymap
@@ -5,11 +5,7 @@
  */
 
  #include <behaviors.dtsi>
- #include <dt-bindings/zmk/keys.h>
- #include <dt-bindings/zmk/bt.h>
- #include <dt-bindings/zmk/rgb.h>
- #include <dt-bindings/zmk/ext_power.h>
- #include <dt-bindings/zmk/outputs.h>
+ #include <dt-bindings/zmk/params.h>
 
  #define DEFAULT 0
  #define LOWER  1

--- a/app/boards/shields/hummingbird/hummingbird.keymap
+++ b/app/boards/shields/hummingbird/hummingbird.keymap
@@ -5,7 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 #define DEF_L 0
 #define NAV_L 1

--- a/app/boards/shields/iris/iris.keymap
+++ b/app/boards/shields/iris/iris.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/jian/jian.keymap
+++ b/app/boards/shields/jian/jian.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 #define DEF 0
 #define LWR 1

--- a/app/boards/shields/jiran/jiran.keymap
+++ b/app/boards/shields/jiran/jiran.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
         keymap {

--- a/app/boards/shields/jorne/jorne.keymap
+++ b/app/boards/shields/jorne/jorne.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 #define DEF 0
 #define LWR 1

--- a/app/boards/shields/knob_goblin/knob_goblin.keymap
+++ b/app/boards/shields/knob_goblin/knob_goblin.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/kyria/kyria.keymap
+++ b/app/boards/shields/kyria/kyria.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/kyria/kyria_rev2.keymap
+++ b/app/boards/shields/kyria/kyria_rev2.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/kyria/kyria_rev3.keymap
+++ b/app/boards/shields/kyria/kyria_rev3.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 /* Uncomment this block if using RGB
 &led_strip {

--- a/app/boards/shields/leeloo/leeloo.keymap
+++ b/app/boards/shields/leeloo/leeloo.keymap
@@ -4,9 +4,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 /*
  * Assign the cs-gpios pin to 4.

--- a/app/boards/shields/leeloo/leeloo_rev2.keymap
+++ b/app/boards/shields/leeloo/leeloo_rev2.keymap
@@ -4,10 +4,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 // Short versions
 #define RGBON   &rgb_ug RGB_ON

--- a/app/boards/shields/leeloo_micro/leeloo_micro.keymap
+++ b/app/boards/shields/leeloo_micro/leeloo_micro.keymap
@@ -4,10 +4,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 // Layers
 #define QW_M    0       // Main

--- a/app/boards/shields/lily58/lily58.keymap
+++ b/app/boards/shields/lily58/lily58.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/ext_power.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/lotus58/lotus58.keymap
+++ b/app/boards/shields/lotus58/lotus58.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     combos {

--- a/app/boards/shields/m60/m60.keymap
+++ b/app/boards/shields/m60/m60.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap0: keymap {

--- a/app/boards/shields/microdox/microdox.keymap
+++ b/app/boards/shields/microdox/microdox.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
         keymap {

--- a/app/boards/shields/murphpad/murphpad.keymap
+++ b/app/boards/shields/murphpad/murphpad.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 
 #define TIMEOUT 300

--- a/app/boards/shields/naked60/naked60.keymap
+++ b/app/boards/shields/naked60/naked60.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 
 / {

--- a/app/boards/shields/nibble/nibble.keymap
+++ b/app/boards/shields/nibble/nibble.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     sensors: sensors {

--- a/app/boards/shields/osprette/osprette.keymap
+++ b/app/boards/shields/osprette/osprette.keymap
@@ -5,8 +5,7 @@
 */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 #define MAIN 0
 #define SYM 1

--- a/app/boards/shields/pancake/pancake.keymap
+++ b/app/boards/shields/pancake/pancake.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 #define DEF 0
 #define LWR 1

--- a/app/boards/shields/qaz/qaz.keymap
+++ b/app/boards/shields/qaz/qaz.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 #define DEFAULT 0
 #define NUM_SYM 1

--- a/app/boards/shields/quefrency/quefrency.keymap
+++ b/app/boards/shields/quefrency/quefrency.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/redox/redox.keymap
+++ b/app/boards/shields/redox/redox.keymap
@@ -5,10 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/ext_power.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/reviung34/reviung34.keymap
+++ b/app/boards/shields/reviung34/reviung34.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     chosen {

--- a/app/boards/shields/reviung41/reviung41.keymap
+++ b/app/boards/shields/reviung41/reviung41.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
         keymap {

--- a/app/boards/shields/reviung5/reviung5.keymap
+++ b/app/boards/shields/reviung5/reviung5.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 #define BASE 0
 #define BLE 1

--- a/app/boards/shields/reviung53/reviung53.keymap
+++ b/app/boards/shields/reviung53/reviung53.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     conditional_layers {

--- a/app/boards/shields/romac/romac.keymap
+++ b/app/boards/shields/romac/romac.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/romac_plus/romac_plus.keymap
+++ b/app/boards/shields/romac_plus/romac_plus.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/settings_reset/settings_reset.keymap
+++ b/app/boards/shields/settings_reset/settings_reset.keymap
@@ -5,7 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/snap/snap.keymap
+++ b/app/boards/shields/snap/snap.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/rgb.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     sensors: sensors {

--- a/app/boards/shields/sofle/sofle.keymap
+++ b/app/boards/shields/sofle/sofle.keymap
@@ -5,10 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/rgb.h>
-#include <dt-bindings/zmk/ext_power.h>
+#include <dt-bindings/zmk/params.h>
 
 #define BASE 0
 #define LOWER 1

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.keymap
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
         keymap {

--- a/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.keymap
+++ b/app/boards/shields/splitkb_aurora_helix/splitkb_aurora_helix.keymap
@@ -5,11 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/rgb.h>
-#include <dt-bindings/zmk/ext_power.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 #define DEFAULT 0
 #define LOWER  1

--- a/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58.keymap
+++ b/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/ext_power.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.keymap
+++ b/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/ext_power.h>
+#include <dt-bindings/zmk/params.h>
 
 /* Uncomment this block if using RGB
 &led_strip {

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.keymap
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 
 &mt {

--- a/app/boards/shields/splitreus62/splitreus62.keymap
+++ b/app/boards/shields/splitreus62/splitreus62.keymap
@@ -6,7 +6,7 @@
 
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/tg4x/tg4x.keymap
+++ b/app/boards/shields/tg4x/tg4x.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     behaviors {

--- a/app/boards/shields/tidbit/tidbit.keymap
+++ b/app/boards/shields/tidbit/tidbit.keymap
@@ -5,9 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 &encoder_1_top_row {
     status = "okay";

--- a/app/boards/shields/tidbit/tidbit_19key.keymap
+++ b/app/boards/shields/tidbit/tidbit_19key.keymap
@@ -6,9 +6,7 @@
 
 #include "tidbit.dtsi"
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/params.h>
 
 &encoder_4 {
     status = "okay";

--- a/app/boards/shields/two_percent_milk/two_percent_milk.keymap
+++ b/app/boards/shields/two_percent_milk/two_percent_milk.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/waterfowl/waterfowl.keymap
+++ b/app/boards/shields/waterfowl/waterfowl.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/boards/shields/zmk_uno/zmk_uno.keymap
+++ b/app/boards/shields/zmk_uno/zmk_uno.keymap
@@ -5,11 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/backlight.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/ext_power.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 // Uncomment the following lines if using the "Direct Wire" jumper to switch the matrix to a direct wire.
 

--- a/app/boards/shields/zmk_uno/zmk_uno_split.keymap
+++ b/app/boards/shields/zmk_uno/zmk_uno_split.keymap
@@ -5,12 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/backlight.h>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/ext_power.h>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/params.h>
 
 // Uncomment the following lines if using the "Direct Wire" jumper to switch the matrix to a direct wire.
 

--- a/app/boards/shields/zodiark/zodiark.keymap
+++ b/app/boards/shields/zodiark/zodiark.keymap
@@ -5,8 +5,7 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/app/include/dt-bindings/zmk/params.h
+++ b/app/include/dt-bindings/zmk/params.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "backlight.h"
+#include "bt.h"
+#include "ext_power.h"
+#include "hid_usage.h"
+#include "hid_usage_pages.h"
+#include "keys.h"
+#include "matrix_transform.h"
+#include "modifiers.h"
+#include "mouse.h"
+#include "outputs.h"
+#include "reset.h"
+#include "rgb.h"

--- a/docs/docs/keymap-example-file.md
+++ b/docs/docs/keymap-example-file.md
@@ -1,6 +1,6 @@
 ```dts
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 
 / {
     keymap {

--- a/docs/docs/keymaps/behaviors/backlight.md
+++ b/docs/docs/keymaps/behaviors/backlight.md
@@ -9,6 +9,10 @@ This page contains [backlight](../../features/backlight.mdx) behaviors supported
 
 ## Backlight Action Defines
 
+:::info
+No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
+:::
+
 Backlight actions defines are provided through the [`dt-bindings/zmk/backlight.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/backlight.h) header,
 which is added at the top of the keymap file:
 

--- a/docs/docs/keymaps/behaviors/backlight.md
+++ b/docs/docs/keymaps/behaviors/backlight.md
@@ -9,21 +9,6 @@ This page contains [backlight](../../features/backlight.mdx) behaviors supported
 
 ## Backlight Action Defines
 
-:::info
-No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
-:::
-
-Backlight actions defines are provided through the [`dt-bindings/zmk/backlight.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/backlight.h) header,
-which is added at the top of the keymap file:
-
-```dts
-#include <dt-bindings/zmk/backlight.h>
-```
-
-This will allow you to reference the actions defined in this header such as `BL_TOG`.
-
-Here is a table describing the action for each define:
-
 | Define     | Action                      |
 | ---------- | --------------------------- |
 | `BL_ON`    | Turn on backlight           |

--- a/docs/docs/keymaps/behaviors/bluetooth.md
+++ b/docs/docs/keymaps/behaviors/bluetooth.md
@@ -27,6 +27,10 @@ even if OUT_USB is selected. To remain disconnected, another bluetooth profile m
 
 ## Bluetooth Command Defines
 
+:::info
+No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
+:::
+
 Bluetooth command defines are provided through the [`dt-bindings/zmk/bt.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/bt.h) header,
 which is added at the top of the keymap file:
 

--- a/docs/docs/keymaps/behaviors/bluetooth.md
+++ b/docs/docs/keymaps/behaviors/bluetooth.md
@@ -27,21 +27,6 @@ even if OUT_USB is selected. To remain disconnected, another bluetooth profile m
 
 ## Bluetooth Command Defines
 
-:::info
-No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
-:::
-
-Bluetooth command defines are provided through the [`dt-bindings/zmk/bt.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/bt.h) header,
-which is added at the top of the keymap file:
-
-```dts
-#include <dt-bindings/zmk/bt.h>
-```
-
-This will allow you to reference the actions defined in this header such as `BT_CLR`.
-
-Here is a table describing the command for each define:
-
 | Define       | Action                                                                                                                                                                             |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `BT_CLR`     | Clear bond information between the keyboard and host for the selected profile.                                                                                                     |

--- a/docs/docs/keymaps/behaviors/key-press.md
+++ b/docs/docs/keymaps/behaviors/key-press.md
@@ -24,11 +24,11 @@ For advanced users, user-defined HID usages are also supported but must be encod
 ## Keycode Defines
 
 To make it easier to encode the HID keycode numeric values, most keymaps include
-the [`dt-bindings/zmk/keys.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/keys.h) header
+the [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h) header
 provided by ZMK near the top:
 
 ```dts
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/params.h>
 ```
 
 Doing so makes a set of defines such as `A`, `N1`, etc. available for use with these behaviors

--- a/docs/docs/keymaps/behaviors/key-press.md
+++ b/docs/docs/keymaps/behaviors/key-press.md
@@ -24,7 +24,7 @@ For advanced users, user-defined HID usages are also supported but must be encod
 ## Keycode Defines
 
 To make it easier to encode the HID keycode numeric values, most keymaps include
-the [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h) header
+the [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/params.h) header
 provided by ZMK near the top:
 
 ```dts

--- a/docs/docs/keymaps/behaviors/mouse-emulation.md
+++ b/docs/docs/keymaps/behaviors/mouse-emulation.md
@@ -25,20 +25,6 @@ CONFIG_ZMK_MOUSE=y
 
 If you use the mouse key press behavior in your keymap, the feature will automatically be enabled for you.
 
-## Mouse Button Defines
-
-:::info
-No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
-:::
-
-To make it easier to encode the HID mouse button numeric values, include
-the [`dt-bindings/zmk/mouse.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/mouse.h) header
-provided by ZMK near the top:
-
-```
-#include <dt-bindings/zmk/mouse.h>
-```
-
 ## Mouse Button Press
 
 This behavior can press/release up to 5 mouse buttons.

--- a/docs/docs/keymaps/behaviors/mouse-emulation.md
+++ b/docs/docs/keymaps/behaviors/mouse-emulation.md
@@ -27,6 +27,10 @@ If you use the mouse key press behavior in your keymap, the feature will automat
 
 ## Mouse Button Defines
 
+:::info
+No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
+:::
+
 To make it easier to encode the HID mouse button numeric values, include
 the [`dt-bindings/zmk/mouse.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/mouse.h) header
 provided by ZMK near the top:

--- a/docs/docs/keymaps/behaviors/outputs.md
+++ b/docs/docs/keymaps/behaviors/outputs.md
@@ -20,19 +20,6 @@ to select the BLE output through below behavior to be able to send keystrokes to
 
 ## Output Command Defines
 
-:::info
-No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
-:::
-
-Output command defines are provided through the [`dt-bindings/zmk/outputs.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/outputs.h)
-header, which is added at the top of the keymap file:
-
-```dts
-#include <dt-bindings/zmk/outputs.h>
-```
-
-This allows you to reference the actions defined in this header:
-
 | Define    | Action                                          |
 | --------- | ----------------------------------------------- |
 | `OUT_USB` | Prefer sending to USB                           |

--- a/docs/docs/keymaps/behaviors/outputs.md
+++ b/docs/docs/keymaps/behaviors/outputs.md
@@ -20,6 +20,10 @@ to select the BLE output through below behavior to be able to send keystrokes to
 
 ## Output Command Defines
 
+:::info
+No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
+:::
+
 Output command defines are provided through the [`dt-bindings/zmk/outputs.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/outputs.h)
 header, which is added at the top of the keymap file:
 

--- a/docs/docs/keymaps/behaviors/power.md
+++ b/docs/docs/keymaps/behaviors/power.md
@@ -21,21 +21,6 @@ The following boards currently support this feature:
 
 ## External Power Control Command Defines
 
-:::info
-No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
-:::
-
-External power control command defines are provided through the [`dt-bindings/zmk/ext_power.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/ext_power.h) header,
-which is added at the top of the keymap file:
-
-```dts
-#include <dt-bindings/zmk/ext_power.h>
-```
-
-This will allow you to reference the actions defined in this header such as `EXT_POWER_OFF_CMD`.
-
-Here is a table describing the command for each define:
-
 | Define                 | Action                      | Alias    |
 | ---------------------- | --------------------------- | -------- |
 | `EXT_POWER_OFF_CMD`    | Disable the external power. | `EP_OFF` |

--- a/docs/docs/keymaps/behaviors/power.md
+++ b/docs/docs/keymaps/behaviors/power.md
@@ -21,6 +21,10 @@ The following boards currently support this feature:
 
 ## External Power Control Command Defines
 
+:::info
+No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
+:::
+
 External power control command defines are provided through the [`dt-bindings/zmk/ext_power.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/ext_power.h) header,
 which is added at the top of the keymap file:
 

--- a/docs/docs/keymaps/behaviors/underglow.md
+++ b/docs/docs/keymaps/behaviors/underglow.md
@@ -9,6 +9,10 @@ This page contains [RGB Underglow](../../features/underglow.md) behaviors suppor
 
 ## RGB Action Defines
 
+:::info
+No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
+:::
+
 RGB actions defines are provided through the [`dt-bindings/zmk/rgb.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/rgb.h) header,
 which is added at the top of the keymap file:
 

--- a/docs/docs/keymaps/behaviors/underglow.md
+++ b/docs/docs/keymaps/behaviors/underglow.md
@@ -9,21 +9,6 @@ This page contains [RGB Underglow](../../features/underglow.md) behaviors suppor
 
 ## RGB Action Defines
 
-:::info
-No longer required as long as your keymap includes [`dt-bindings/zmk/params.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/all.h).
-:::
-
-RGB actions defines are provided through the [`dt-bindings/zmk/rgb.h`](https://github.com/zmkfirmware/zmk/blob/main/app/include/dt-bindings/zmk/rgb.h) header,
-which is added at the top of the keymap file:
-
-```dts
-#include <dt-bindings/zmk/rgb.h>
-```
-
-This will allow you to reference the actions defined in this header such as `RGB_TOG`.
-
-Here is a table describing the action for each define:
-
 | Define          | Action                                                                                         |
 | --------------- | ---------------------------------------------------------------------------------------------- |
 | `RGB_ON`        | Turns the RGB feature on                                                                       |

--- a/docs/docs/keymaps/index.mdx
+++ b/docs/docs/keymaps/index.mdx
@@ -91,7 +91,7 @@ The top two lines of most keymaps should include:
 
 ```dts
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/all.h>
 ```
 
 The first defines the nodes for all the available behaviors in ZMK, which will be referenced in the behavior bindings. This is how bindings like `&kp` can reference the key press behavior defined with an anchor name of `kp`.

--- a/docs/docs/keymaps/index.mdx
+++ b/docs/docs/keymaps/index.mdx
@@ -91,7 +91,7 @@ The top two lines of most keymaps should include:
 
 ```dts
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/all.h>
+#include <dt-bindings/zmk/params.h>
 ```
 
 The first defines the nodes for all the available behaviors in ZMK, which will be referenced in the behavior bindings. This is how bindings like `&kp` can reference the key press behavior defined with an anchor name of `kp`.


### PR DESCRIPTION
Resolves #582

Create a single header file to include in `keymaps` to allow users to use any behavior without having to remember to add additional includes.

Open questions:

- Did I miss spots in the docs which should be adjusted?
- Should the include sections in the behavior docs be completely removed instead of having the info box?
- Should all existing keymap files be changed to use this new `#include <dt-bindings/zmk/all.h>`?