### PR TITLE
charlieplex fix interrupt and documentation for pull down config

### DIFF
--- a/app/module/drivers/kscan/kscan_gpio_charlieplex.c
+++ b/app/module/drivers/kscan/kscan_gpio_charlieplex.c
@@ -47,14 +47,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #define USES_POLLING DT_INST_FOREACH_STATUS_OKAY(WITHOUT_INTR) > 0
 #define USES_INTERRUPT DT_INST_FOREACH_STATUS_OKAY(WITH_INTR) > 0
 
-#if USES_POLLING && USES_INTERRUPT
-#define USES_POLL_AND_INTR 1
-#else
-#define USES_POLL_AND_INTR 0
-#endif
-
 #define COND_ANY_POLLING(code) COND_CODE_1(USES_POLLING, code, ())
-#define COND_POLL_AND_INTR(code) COND_CODE_1(USES_POLL_AND_INTR, code, ())
 #define COND_THIS_INTERRUPT(n, code) COND_CODE_1(INST_INTR_DEFINED(n), code, ())
 
 #define KSCAN_INTR_CFG_INIT(inst_idx) GPIO_DT_SPEC_GET(DT_DRV_INST(inst_idx), interrupt_gpios)
@@ -410,7 +403,7 @@ static const struct kscan_driver_api kscan_charlieplex_api = {
             },                                                                                     \
         .debounce_scan_period_ms = DT_INST_PROP(n, debounce_scan_period_ms),                       \
         COND_ANY_POLLING((.poll_period_ms = DT_INST_PROP(n, poll_period_ms), ))                    \
-            COND_POLL_AND_INTR((.use_interrupt = INST_INTR_DEFINED(n), ))                          \
+            COND_THIS_INTERRUPT(n, (.use_interrupt = INST_INTR_DEFINED(n), ))                      \
                 COND_THIS_INTERRUPT(n, (.interrupt = KSCAN_INTR_CFG_INIT(n), ))};                  \
                                                                                                    \
     DEVICE_DT_INST_DEFINE(n, &kscan_charlieplex_init, NULL, &kscan_charlieplex_data_##n,           \

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -182,6 +182,8 @@ Define the transform with a [matrix transform](#matrix-transform). The row is al
 For example, in `RC(5,0)` power flows from the 6th pin in `gpios` to the 1st pin in `gpios`.
 Exclude all positions where the row and column are the same as these pairs will never be triggered, since no pin can be both input and output at the same time.
 
+The [GPIO flags](https://docs.zephyrproject.org/3.5.0/hardware/peripherals/gpio.html#api-reference) for the elements in `gpios` should be `GPIO_ACTIVE_HIGH`, and interrupt pins set in `interrupt-gpios` should have the flags `(GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)`.
+
 ## Composite Driver
 
 Keyboard scan driver which combines multiple other keyboard scan drivers.
@@ -454,11 +456,11 @@ Note that the entire addressable space does not need to be mapped.
 
         interrupt-gpios = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN) >;
         gpios
-          = <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN) >
-          , <&pro_micro 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN) >
-          , <&pro_micro 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN) >
-          , <&pro_micro 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN) >
-          , <&pro_micro 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN) >
+          = <&pro_micro 16 GPIO_ACTIVE_HIGH>
+          , <&pro_micro 17 GPIO_ACTIVE_HIGH>
+          , <&pro_micro 18 GPIO_ACTIVE_HIGH>
+          , <&pro_micro 19 GPIO_ACTIVE_HIGH>
+          , <&pro_micro 20 GPIO_ACTIVE_HIGH>
           ; // addressable space is 5x5, (minus paired values)
     };
 


### PR DESCRIPTION
This PR has a fix for the issue with interrupt not being enabled if just one compatible device is configured (see [issue](https://github.com/zmkfirmware/zmk/issues/2201)).

Further in the current documentation, in the example the pins used for scanning the matrix are configured with `GPIO_PULL_DOWN`. This results of a current draw of 260mAh per configured pin during sleep. This is not necessary as the pull flags are set as needed during the scan.