### PR TITLE
feat: default layer setter

### DIFF
--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -15,6 +15,7 @@
 typedef uint32_t zmk_keymap_layers_state_t;
 
 uint8_t zmk_keymap_layer_default(void);
+int zmk_keymap_layer_set_default(uint8_t layer);
 zmk_keymap_layers_state_t zmk_keymap_layer_state(void);
 bool zmk_keymap_layer_active(uint8_t layer);
 uint8_t zmk_keymap_highest_layer_active(void);

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -108,6 +108,29 @@ static inline int set_layer_state(uint8_t layer, bool state) {
 
 uint8_t zmk_keymap_layer_default(void) { return _zmk_keymap_layer_default; }
 
+int zmk_keymap_layer_set_default(uint8_t layer) {
+    int ret = 0;
+    uint8_t prev_default = _zmk_keymap_layer_default;
+
+    ret = set_layer_state(layer, true);
+    if (ret < 0) {
+        LOG_WRN("Could not turn on the new default layer, bailing out.");
+        return ret;
+    }
+
+    _zmk_keymap_layer_default = layer;
+    ret = set_layer_state(prev_default, false);
+    if (ret < 0) {
+        LOG_WRN("Could not disable current default layer, undoing changes.");
+        _zmk_keymap_layer_default = prev_default;
+        set_layer_state(layer, false);
+        return ret;
+    }
+
+    LOG_DBG("default_layer_changed: %d", layer);
+    return 0;
+}
+
 zmk_keymap_layers_state_t zmk_keymap_layer_state(void) { return _zmk_keymap_layer_state; }
 
 bool zmk_keymap_layer_active_with_state(uint8_t layer, zmk_keymap_layers_state_t state_to_test) {


### PR DESCRIPTION
I plan to do a PR to *persistently* change the default layer, for multi-layout uses (eg win/mac or qwerty/dvorak)

However, while activating the layer or to'ing into it is similar, it wouldn't mimic the behavior of default layer. Thus, the follow-up PR needs an API of this kind.

 Notes:
- New event for **default** layer changes?
- I dont quite like the function's name and log texts, ideas are welcome.