### PR TITLE
fix(build): Modify function return type to remove compiler warning

### DIFF
--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -121,7 +121,7 @@ static inline int release_sticky_key_behavior(struct active_sticky_key *sticky_k
     return behavior_keymap_binding_released(&binding, event);
 }
 
-static inline int on_sticky_key_timeout(struct active_sticky_key *sticky_key) {
+static inline void on_sticky_key_timeout(struct active_sticky_key *sticky_key) {
     // If the key is lazy, a release is not needed on timeout
     if (sticky_key->config->lazy) {
         clear_sticky_key(sticky_key);


### PR DESCRIPTION
Function [sticky_key_timeout](https://github.com/zmkfirmware/zmk/blob/main/app/src/behaviors/behavior_sticky_key.c#L124) is defined with return type `int`, yet it is not returning any value. Both calls to this function also ignore the return value. Therefore the return type is modified to `void` to remove this warning.