### PR TITLE
fix(docs): Fix bindings types in behaviors config page

### DIFF
--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -203,12 +203,21 @@ Definition files:
 - [zmk/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-sensor-rotate.yaml)
 - [zmk/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate-var.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-sensor-rotate-var.yaml)
 
-| Property                | Type                                                                                              | Description                                                                                                                                                                        | Default |
-| ----------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `compatible`            | string                                                                                            | Sensor rotation type, **must be _one_ of**: <ul><li>`"zmk,behavior-sensor-rotate"`</li><li>`"zmk,behavior-sensor-rotate-var"`</li></ul>                                            |         |
-| `#sensor-binding-cells` | int                                                                                               | Must be <ul><li>`<0>` if `compatible = "zmk,behavior-sensor-rotate"`</li><li>`<2>` if `compatible = "zmk,behavior-sensor-rotate-var"`</li></ul>                                    |         |
-| `bindings`              | phandles for `"zmk,behavior-sensor-rotate"`, phandle array for `"zmk,behavior-sensor-rotate-var"` | A list of two behaviors to trigger for each rotation direction, must include parameters for `"zmk,behavior-sensor-rotate"` and exclude them for `"zmk,behavior-sensor-rotate-var"` |         |
-| `tap-ms`                | int                                                                                               | The tap duration (between press and release events) in milliseconds for behaviors in `bindings`                                                                                    | 5       |
+Applies to: `compatible = "zmk,behavior-sensor-rotate"`
+
+| Property                | Type     | Description                                                                                            | Default |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------------------------ | ------- |
+| `#sensor-binding-cells` | int      | Must be `<0>`                                                                                          |         |
+| `bindings`              | phandles | A list of two behaviors to trigger for each rotation direction, must _include_ any behavior parameters |         |
+| `tap-ms`                | int      | The tap duration (between press and release events) in milliseconds for behaviors in `bindings`        | 5       |
+
+Applies to: `compatible = "zmk,behavior-sensor-rotate-var"`
+
+| Property                | Type          | Description                                                                                            | Default |
+| ----------------------- | ------------- | ------------------------------------------------------------------------------------------------------ | ------- |
+| `#sensor-binding-cells` | int           | Must be `<2>`                                                                                          |         |
+| `bindings`              | phandle array | A list of two behaviors to trigger for each rotation direction, must _exclude_ any behavior parameters |         |
+| `tap-ms`                | int           | The tap duration (between press and release events) in milliseconds for behaviors in `bindings`        | 5       |
 
 With `compatible = "zmk,behavior-sensor-rotate-var"`, this behavior forwards the first parameter it receives to the parameter of the first behavior specified in `bindings`, and second parameter to the parameter of the second behavior.
 

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -57,18 +57,18 @@ Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml](htt
 
 Applies to: `compatible = "zmk,behavior-hold-tap"`
 
-| Property                      | Type          | Description                                                                                                    | Default            |
-| ----------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `#binding-cells`              | int           | Must be `<2>`                                                                                                  |                    |
-| `bindings`                    | phandle array | A list of two behaviors (without parameters): one for hold and one for tap                                     |                    |
-| `flavor`                      | string        | Adjusts how the behavior chooses between hold and tap                                                          | `"hold-preferred"` |
-| `tapping-term-ms`             | int           | How long in milliseconds the key must be held to trigger a hold                                                |                    |
-| `quick-tap-ms`                | int           | Tap twice within this period (in milliseconds) to trigger a tap, even when held                                | -1 (disabled)      |
-| `require-prior-idle-ms`       | int           | Triggers a tap immediately if any non-modifier key was pressed within `require-prior-idle-ms` of the hold-tap. | -1 (disabled)      |
-| `retro-tap`                   | bool          | Triggers the tap behavior on release if no other key was pressed during a hold                                 | false              |
-| `hold-while-undecided`        | bool          | Triggers the hold behavior immediately on press and releases before a tap                                      | false              |
-| `hold-while-undecided-linger` | bool          | Continues to hold the hold behavior until after the tap is released                                            | false              |
-| `hold-trigger-key-positions`  | array         | If set, pressing the hold-tap and then any key position _not_ in the list triggers a tap.                      |                    |
+| Property                      | Type     | Description                                                                                                    | Default            |
+| ----------------------------- | -------- | -------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `#binding-cells`              | int      | Must be `<2>`                                                                                                  |                    |
+| `bindings`                    | phandles | A list of two behaviors (without parameters): one for hold and one for tap                                     |                    |
+| `flavor`                      | string   | Adjusts how the behavior chooses between hold and tap                                                          | `"hold-preferred"` |
+| `tapping-term-ms`             | int      | How long in milliseconds the key must be held to trigger a hold                                                |                    |
+| `quick-tap-ms`                | int      | Tap twice within this period (in milliseconds) to trigger a tap, even when held                                | -1 (disabled)      |
+| `require-prior-idle-ms`       | int      | Triggers a tap immediately if any non-modifier key was pressed within `require-prior-idle-ms` of the hold-tap. | -1 (disabled)      |
+| `retro-tap`                   | bool     | Triggers the tap behavior on release if no other key was pressed during a hold                                 | false              |
+| `hold-while-undecided`        | bool     | Triggers the hold behavior immediately on press and releases before a tap                                      | false              |
+| `hold-while-undecided-linger` | bool     | Continues to hold the hold behavior until after the tap is released                                            | false              |
+| `hold-trigger-key-positions`  | array    | If set, pressing the hold-tap and then any key position _not_ in the list triggers a tap.                      |                    |
 
 This behavior forwards the first parameter it receives to the parameter of the first behavior specified in `bindings`, and second parameter to the parameter of the second behavior.
 
@@ -203,12 +203,12 @@ Definition files:
 - [zmk/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-sensor-rotate.yaml)
 - [zmk/app/dts/bindings/behaviors/zmk,behavior-sensor-rotate-var.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/behaviors/zmk%2Cbehavior-sensor-rotate-var.yaml)
 
-| Property                | Type          | Description                                                                                                                                                                        | Default |
-| ----------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `compatible`            | string        | Sensor rotation type, **must be _one_ of**: <ul><li>`"zmk,behavior-sensor-rotate"`</li><li>`"zmk,behavior-sensor-rotate-var"`</li></ul>                                            |         |
-| `#sensor-binding-cells` | int           | Must be <ul><li>`<0>` if `compatible = "zmk,behavior-sensor-rotate"`</li><li>`<2>` if `compatible = "zmk,behavior-sensor-rotate-var"`</li></ul>                                    |         |
-| `bindings`              | phandle array | A list of two behaviors to trigger for each rotation direction, must include parameters for `"zmk,behavior-sensor-rotate"` and exclude them for `"zmk,behavior-sensor-rotate-var"` |         |
-| `tap-ms`                | int           | The tap duration (between press and release events) in milliseconds for behaviors in `bindings`                                                                                    | 5       |
+| Property                | Type                                                                                              | Description                                                                                                                                                                        | Default |
+| ----------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `compatible`            | string                                                                                            | Sensor rotation type, **must be _one_ of**: <ul><li>`"zmk,behavior-sensor-rotate"`</li><li>`"zmk,behavior-sensor-rotate-var"`</li></ul>                                            |         |
+| `#sensor-binding-cells` | int                                                                                               | Must be <ul><li>`<0>` if `compatible = "zmk,behavior-sensor-rotate"`</li><li>`<2>` if `compatible = "zmk,behavior-sensor-rotate-var"`</li></ul>                                    |         |
+| `bindings`              | phandles for `"zmk,behavior-sensor-rotate"`, phandle array for `"zmk,behavior-sensor-rotate-var"` | A list of two behaviors to trigger for each rotation direction, must include parameters for `"zmk,behavior-sensor-rotate"` and exclude them for `"zmk,behavior-sensor-rotate-var"` |         |
+| `tap-ms`                | int                                                                                               | The tap duration (between press and release events) in milliseconds for behaviors in `bindings`                                                                                    | 5       |
 
 With `compatible = "zmk,behavior-sensor-rotate-var"`, this behavior forwards the first parameter it receives to the parameter of the first behavior specified in `bindings`, and second parameter to the parameter of the second behavior.
 
@@ -224,14 +224,14 @@ Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-sticky-key.yaml](h
 
 Applies to: `compatible = "zmk,behavior-sticky-key"`
 
-| Property           | Type          | Description                                                              | Default |
-| ------------------ | ------------- | ------------------------------------------------------------------------ | ------- |
-| `#binding-cells`   | int           | Must be `<1>`                                                            |         |
-| `bindings`         | phandle array | A behavior (without parameters) to trigger                               |         |
-| `release-after-ms` | int           | Releases the key after this many milliseconds if no other key is pressed | 1000    |
-| `quick-release`    | bool          | Release the sticky key on the next key press instead of release          | false   |
-| `lazy`             | bool          | Wait until the next key press to activate the sticky key behavior        | false   |
-| `ignore-modifiers` | bool          | If enabled, pressing a modifier key does not cancel the sticky key       | true    |
+| Property           | Type     | Description                                                              | Default |
+| ------------------ | -------- | ------------------------------------------------------------------------ | ------- |
+| `#binding-cells`   | int      | Must be `<1>`                                                            |         |
+| `bindings`         | phandles | A behavior (without parameters) to trigger                               |         |
+| `release-after-ms` | int      | Releases the key after this many milliseconds if no other key is pressed | 1000    |
+| `quick-release`    | bool     | Release the sticky key on the next key press instead of release          | false   |
+| `lazy`             | bool     | Wait until the next key press to activate the sticky key behavior        | false   |
+| `ignore-modifiers` | bool     | If enabled, pressing a modifier key does not cancel the sticky key       | true    |
 
 This behavior forwards the one parameter it receives to the parameter of the behavior specified in `bindings`.
 


### PR DESCRIPTION
Fixes the incorrect types for `bindings` prop in `docs/config/behaviors`, for hold-tap, sticky key and sensor rotate behaviors.

In a separate commit, I split the sensor rotate table into two separate tables for `sensor-rotate` and `sensor-rotate-var` since there didn't seem to be enough common properties anymore to make the single table worth it.