### PR TITLE
fix(hid): Correct off-by-one buffer overflow with NKRO

### DIFF
--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <zephyr/sys/util.h>
+
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/usb/class/usb_hid.h>
 
@@ -200,7 +202,7 @@ struct zmk_hid_keyboard_report_body {
     zmk_mod_flags_t modifiers;
     uint8_t _reserved;
 #if IS_ENABLED(CONFIG_ZMK_HID_REPORT_TYPE_NKRO)
-    uint8_t keys[(ZMK_HID_KEYBOARD_NKRO_MAX_USAGE + 1) / 8];
+    uint8_t keys[DIV_ROUND_UP(ZMK_HID_KEYBOARD_NKRO_MAX_USAGE + 1, 8)];
 #elif IS_ENABLED(CONFIG_ZMK_HID_REPORT_TYPE_HKRO)
     uint8_t keys[CONFIG_ZMK_HID_KEYBOARD_REPORT_SIZE];
 #endif

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -126,7 +126,7 @@ zmk_hid_boot_report_t *zmk_hid_get_boot_report(void) {
     memset(&boot_report.keys, 0, HID_BOOT_KEY_LEN);
     int ix = 0;
     uint8_t base_code = 0;
-    for (int i = 0; i < (ZMK_HID_KEYBOARD_NKRO_MAX_USAGE + 1) / 8; ++i) {
+    for (int i = 0; i < sizeof(keyboard_report.body.keys); ++i) {
         if (ix == keys_held) {
             break;
         }


### PR DESCRIPTION
We correct an off-by-one buffer overflow I found while diagnosing #2257. The problem is that we should be rounding up the computed key array length; consider the case where we want to show 10 keys, i.e. `ZMK_HID_KEYBOARD_NKRO_MAX_USAGE` is 9 and so we need 10 bits (because this range is inclusive); then we only use an array of length 1, which doesn't have enough space.

(An actual buffer overflow by one byte occurs e.g. here: https://github.com/zmkfirmware/zmk/blob/20df20009d6e38c55fc062fc449371b4470021b3/app/src/hid.c#L151 but in any case the `1` will not be observed because the number of bytes transmitted to the USB endpoint will be too small.)