### PR TITLE
Build CI fixes/improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -413,7 +413,9 @@ jobs:
       board-changes: ${{ steps.board-changes.outputs.result }}
       core-changes: ${{ steps.core-changes.outputs.result }}
     steps:
-      - uses: tj-actions/changed-files@v42
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@v44
         id: changed-files
         with:
           json: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
   schedule:
     - cron: "22 4 * * *"
 
+permissions: {}
+
 jobs:
   build:
     if: ${{ always() }}
@@ -25,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Cache west modules
         uses: actions/cache@v4
         env:
@@ -179,6 +183,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -335,6 +341,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -415,6 +423,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: tj-actions/changed-files@v44
         id: changed-files
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
   schedule:
     - cron: "22 4 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -135,7 +139,7 @@ jobs:
               throw new Error('Failed to build one or more configurations');
             }
   compile-matrix:
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     needs: [core-coverage, board-changes, nightly]
     outputs:
@@ -290,7 +294,7 @@ jobs:
               });
             }))).flat();
   nightly:
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' && github.repository_owner == 'zmkfirmware' }}
     runs-on: ubuntu-latest
     needs: get-grouped-hardware
     outputs:


### PR DESCRIPTION
[All `push` event runs of the Build action since 2024-01-25 have failed](https://github.com/zmkfirmware/zmk/actions/workflows/build.yml?query=event%3Apush+is%3Afailure) in part[^1] because `actions/checkout` is not being run prior to `tj-actions/changed-files`.

~~This primarily presents a problem for novice end-users looking for `settings_reset` firmware [as linked from the documentation](https://zmk.dev/docs/troubleshooting#option-2-download-reset-uf2-from-zmks-workflow). The outdated binaries appear to be entirely ineffective on Zephyr 3.5 firmware[^2].~~ All artifacts containing the outdated firmware have now expired.

<details>
<summary>Remaining commits are general improvements to security and efficiency:</summary>

### `concurrency`

Group builds by workflow and [github ref](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).
> The fully-formed ref of the branch or tag that triggered the workflow run. For workflows triggered by `push`, this is the branch or tag ref that was pushed. For workflows triggered by `pull_request`, this is the pull request merge branch. 

`ref_name` is another possibility, but could collide with any eventual tags.

These groupings allow us to...

### `cancel-in-progress`

...cancel workflow runs which are subsequently obsoleted by later pushes.

In an ideal world, anyway. Unfortunately, the way ZMK currently handles the final `Build` and `Upload Artifact` steps means the cancellation of those particular steps is not immediate. If the five-minute post-cancellation timeout passes, something will error out. If not: the job will grind on to completion and display as "Cancelled".

This is something worth examining as part of a re-evaluation of CI generally, but it's out of scope for now. Any kind of "stop doing unnecessary work" constitutes improvement.

### `permissions`

Given what this workflow currently does, its `GITHUB_TOKEN` doesn't need anything more than read-only access to metadata.

### `persist-credentials`

It also doesn't need to keep the  `zmkfirmware` credentials handy.

### etc

- If the `compile-matrix` job has no inputs because the previous jobs were canceled, might as well cancel it.
- I don't see why forks should run nightly builds.
</details>

Suggestions welcome. I have been testing these changes [in my own fork](https://github.com/lesshonor/zmk/actions/workflows/build.yml).

[^1]: It might be "in total"; I haven't checked every run.
[^2]: #2210, [discord](https://discord.com/channels/719497620560543766/1221880567373496433/1221880567373496433), [discord](https://discord.com/channels/719497620560543766/1219493309429321728/1225906079393644626)