### PR TITLE
nice!view: individual profile status

### DIFF
--- a/app/boards/shields/nice_view/README.md
+++ b/app/boards/shields/nice_view/README.md
@@ -4,9 +4,21 @@ The nice!view is a low-power, high refresh rate display meant to replace I2C OLE
 
 This shield requires that an `&nice_view_spi` labeled SPI bus is provided with _at least_ MOSI, SCK, and CS pins defined.
 
+## Custom widget
+
+The nice!view shield includes a custom vertical widget.
+
+Profile indicators show the status of the first five BLE profiles using numbers from 1 to 5.
+The number corresponding to the currently selected profile is drawn in a filled disk
+and the circle outline around each profile number correspond to the following states:
+
+- solid outline: connected
+- dashed outline: not connected
+- no outline: not bound
+
 ## Disable custom widget
 
-The nice!view shield includes a custom vertical widget. To use the built-in ZMK one, add the following item to your `.conf` file:
+To use the built-in ZMK widget instead of the custom nice!view one, add the following item to your `.conf` file:
 
 ```
 CONFIG_ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN=y

--- a/app/boards/shields/nice_view/widgets/util.h
+++ b/app/boards/shields/nice_view/widgets/util.h
@@ -1,12 +1,14 @@
 /*
  *
- * Copyright (c) 2023 The ZMK Contributors
+ * Copyright (c) 2025 The ZMK Contributors
  * SPDX-License-Identifier: MIT
  *
  */
 
 #include <lvgl.h>
 #include <zmk/endpoints.h>
+
+#define NICEVIEW_PROFILE_COUNT 5
 
 #define CANVAS_SIZE 68
 
@@ -23,6 +25,8 @@ struct status_state {
     int active_profile_index;
     bool active_profile_connected;
     bool active_profile_bonded;
+    bool profiles_connected[NICEVIEW_PROFILE_COUNT];
+    bool profiles_bonded[NICEVIEW_PROFILE_COUNT];
     uint8_t layer_index;
     const char *layer_label;
     uint8_t wpm[10];


### PR DESCRIPTION
Allow the nice!view widget to display the status of each profile by:
- not adding a circle around the number if the profile is not bound
- drawing a dashed circle around the number if a profile is bound but not connected (device not live, explicitly disconnected with `BT_DISC`, ...)

Example:
![niceview-profiles](https://github.com/zmkfirmware/zmk/assets/489715/32fd5652-8f61-48f4-b0ea-d18bd4ee6058)

- solid circle: connected
- dashed circle: not connected
- no circle: not bound
- filled circle: selected

---

This requires minor refactoring in BLE code to expose state methods by profile address rather than only by the current profile.

One issue I can see so far is that event's are indeed raised when the current profile changes but not when other profiles change from what I can tell (eg. a device other that the selected one disconnects).

I have tried addressing the `BT_DISC` case by adding a `raise_profile_changed_event();` in `zmk_ble_prof_disconnect()` and that seems to work but I'm pretty sure that's not the proper way to do it (if there is a proper way to do it currently, see comment). Maybe that needs to be addressed separately from this PR?
