### PR TITLE
fix(hid): Eliminate data race in USB pathway causing dropped keys [ALTERNATIVE]

### DIFF
--- a/app/src/usb_hid.c
+++ b/app/src/usb_hid.c
@@ -22,7 +22,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 static const struct device *hid_dev;
 
-static K_SEM_DEFINE(hid_sem, 1, 1);
+static K_SEM_DEFINE(hid_sem, 0, 1);
 
 static void in_ready_cb(const struct device *dev) { k_sem_give(&hid_sem); }
 
@@ -136,11 +136,9 @@ static int zmk_usb_hid_send_report(const uint8_t *report, size_t len) {
     case USB_DC_UNKNOWN:
         return -ENODEV;
     default:
-        k_sem_take(&hid_sem, K_MSEC(30));
         int err = hid_int_ep_write(hid_dev, report, len, NULL);
-
-        if (err) {
-            k_sem_give(&hid_sem);
+        if (!err) {
+            k_sem_take(&hid_sem, K_MSEC(30));
         }
 
         return err;


### PR DESCRIPTION
Alternative to https://github.com/zmkfirmware/zmk/pull/2257, solving the same problem which happens there, perhaps more elegantly. We simply move the existing mutex to protect calls to `hid_int_ep_write()` as well as the passed buffer, causing `zmk_usb_hid_send_report()` to become synchronous on first invocation. (Subsequent invocations of `zmk_usb_hid_send_report()` while the first USB TX was pending also blocked previously.)

The cost of the introduced synchronous delay upon first invocation can be mitigated (and latency I imagine actually slightly improved in some applications) by wrapping `zmk_usb_hid_send_report()` in a work queue, but I doubt this is worth the memory + task switching penalty. After all, the whole reason the data race wasn't discovered for so long was because the USB TX transactions were completing so blazingly fast in the first place.

Tested working on real hardware (Adv360 Pro).

Closes #2253, closes #2257.