### PR TITLE
feat(ble): Add information to profile changed event

### DIFF
--- a/app/include/zmk/events/ble_active_profile_changed.h
+++ b/app/include/zmk/events/ble_active_profile_changed.h
@@ -15,6 +15,8 @@
 struct zmk_ble_active_profile_changed {
     uint8_t index;
     struct zmk_ble_profile *profile;
+    bool open;
+    bool connected;
 };
 
 ZMK_EVENT_DECLARE(zmk_ble_active_profile_changed);

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -86,7 +86,10 @@ static bt_addr_le_t peripheral_addrs[ZMK_SPLIT_BLE_PERIPHERAL_COUNT];
 
 static void raise_profile_changed_event(void) {
     raise_zmk_ble_active_profile_changed((struct zmk_ble_active_profile_changed){
-        .index = active_profile, .profile = &profiles[active_profile]});
+        .index = active_profile,
+        .profile = &profiles[active_profile],
+        .open = zmk_ble_active_profile_is_open(),
+        .connected = zmk_ble_active_profile_is_connected()});
 }
 
 static void raise_profile_changed_event_callback(struct k_work *work) {


### PR DESCRIPTION
Currently the `ble_active_profile_changed` event will trigger if a profile is cleared or disconnected but it's up on the individual event handlers to call `zmk_ble_active_profile_is_open()` and `zmk_ble_active_profile_is_connected()` to actually retrieve that information, integrating all this inside the event streamlines downstream implementations as all they need to do is retrieve this information from the event rather than each event handler call the getter functions