### PR TITLE
feat(ble): Fast switching between two recent profiles

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
+  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,6 @@ name: pre-commit
 on:
   pull_request:
   push:
-  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -268,7 +268,6 @@ static int ble_save_profile(void) {
 int zmk_ble_prof_select(uint8_t index) {
     if (index == 255) {
         index = last_profile;
-        last_profile = active_profile;
     }
 
     if (index >= ZMK_BLE_PROFILE_COUNT) {
@@ -280,6 +279,7 @@ int zmk_ble_prof_select(uint8_t index) {
         return 0;
     }
 
+    last_profile = active_profile;
     active_profile = index;
     ble_save_profile();
 

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -61,6 +61,7 @@ enum advertising_type {
 
 static struct zmk_ble_profile profiles[ZMK_BLE_PROFILE_COUNT];
 static uint8_t active_profile;
+static uint8_t last_profile;
 
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)
@@ -265,6 +266,11 @@ static int ble_save_profile(void) {
 }
 
 int zmk_ble_prof_select(uint8_t index) {
+    if (index == 255) {
+        index = last_profile;
+        last_profile = active_profile;
+    }
+
     if (index >= ZMK_BLE_PROFILE_COUNT) {
         return -ERANGE;
     }
@@ -625,7 +631,7 @@ static void zmk_ble_ready(int err) {
         LOG_ERR("Bluetooth init failed (err %d)", err);
         return;
     }
-
+    last_profile = active_profile;
     update_advertising();
 }
 


### PR DESCRIPTION
related to #767 

I'm not a developer, so this implementation is quite basic, but it works perfectly for me.

This update introduces the ability to switch back to the previously active bluetooth profile by passing index 255 to the profile selection function.  This feature facilitates quick toggling between two frequently used Bluetooth devices. 