### PR TITLE
fix(boards): nrf boards missing SPI definitions for pro_micro pins at the board level

### DIFF
--- a/app/boards/arm/bluemicro840/arduino_pro_micro_pins.dtsi
+++ b/app/boards/arm/bluemicro840/arduino_pro_micro_pins.dtsi
@@ -53,5 +53,5 @@
 
 pro_micro_d: &pro_micro {};
 pro_micro_i2c: &i2c0 {};
-pro_micro_spi: &spi0 {};
+pro_micro_spi: &spi1 {};
 pro_micro_serial: &uart0 {};

--- a/app/boards/arm/bluemicro840/bluemicro840_v1-pinctrl.dtsi
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1-pinctrl.dtsi
@@ -36,4 +36,21 @@
             low-power-enable;
         };
     };
+
+    spi1_default: spi1_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 28)>,
+                <NRF_PSEL(SPIM_MISO, 0, 3)>;
+        };
+    };
+
+    spi1_sleep: spi1_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 28)>,
+                <NRF_PSEL(SPIM_MISO, 0, 3)>;
+            low-power-enable;
+        };
+    };
 };

--- a/app/boards/arm/bluemicro840/bluemicro840_v1.dts
+++ b/app/boards/arm/bluemicro840/bluemicro840_v1.dts
@@ -67,6 +67,13 @@
     pinctrl-names = "default", "sleep";
 };
 
+&spi1 {
+    compatible = "nordic,nrf-spim";
+    pinctrl-0 = <&spi1_default>;
+    pinctrl-1 = <&spi1_sleep>;
+    pinctrl-names = "default", "sleep";
+};
+
 &uart0 {
     compatible = "nordic,nrf-uarte";
     current-speed = <115200>;

--- a/app/boards/arm/mikoto/arduino_pro_micro_pins.dtsi
+++ b/app/boards/arm/mikoto/arduino_pro_micro_pins.dtsi
@@ -55,5 +55,5 @@
 
 pro_micro_d: &pro_micro {};
 pro_micro_i2c: &i2c0 {};
-pro_micro_spi: &spi0 {};
+pro_micro_spi: &spi1 {};
 pro_micro_serial: &uart0 {};

--- a/app/boards/arm/mikoto/mikoto_520-pinctrl.dtsi
+++ b/app/boards/arm/mikoto/mikoto_520-pinctrl.dtsi
@@ -36,4 +36,21 @@
             low-power-enable;
         };
     };
+
+    spi1_default: spi1_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 0, 2)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 10)>,
+                <NRF_PSEL(SPIM_MISO, 1, 13)>;
+        };
+    };
+
+    spi1_sleep: spi1_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 0, 2)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 10)>,
+                <NRF_PSEL(SPIM_MISO, 1, 13)>;
+            low-power-enable;
+        };
+    };
 };

--- a/app/boards/arm/mikoto/mikoto_520.dts
+++ b/app/boards/arm/mikoto/mikoto_520.dts
@@ -66,6 +66,13 @@
     pinctrl-names = "default", "sleep";
 };
 
+&spi1 {
+    compatible = "nordic,nrf-spim";
+    pinctrl-0 = <&spi1_default>;
+    pinctrl-1 = <&spi1_sleep>;
+    pinctrl-names = "default", "sleep";
+};
+
 &uart0 {
     compatible = "nordic,nrf-uarte";
     current-speed = <115200>;

--- a/app/boards/arm/nice_nano/arduino_pro_micro_pins.dtsi
+++ b/app/boards/arm/nice_nano/arduino_pro_micro_pins.dtsi
@@ -53,5 +53,5 @@
 
 pro_micro_d: &pro_micro {};
 pro_micro_i2c: &i2c0 {};
-pro_micro_spi: &spi0 {};
+pro_micro_spi: &spi1 {};
 pro_micro_serial: &uart0 {};

--- a/app/boards/arm/nice_nano/nice_nano-pinctrl.dtsi
+++ b/app/boards/arm/nice_nano/nice_nano-pinctrl.dtsi
@@ -36,4 +36,21 @@
             low-power-enable;
         };
     };
+
+    spi1_default: spi1_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 10)>,
+                <NRF_PSEL(SPIM_MISO, 1, 11)>;
+        };
+    };
+
+    spi1_sleep: spi1_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 10)>,
+                <NRF_PSEL(SPIM_MISO, 1, 11)>;
+            low-power-enable;
+        };
+    };
 };

--- a/app/boards/arm/nice_nano/nice_nano.dtsi
+++ b/app/boards/arm/nice_nano/nice_nano.dtsi
@@ -50,6 +50,13 @@
     pinctrl-names = "default", "sleep";
 };
 
+&spi1 {
+    compatible = "nordic,nrf-spim";
+    pinctrl-0 = <&spi1_default>;
+    pinctrl-1 = <&spi1_sleep>;
+    pinctrl-names = "default", "sleep";
+};
+
 &uart0 {
     compatible = "nordic,nrf-uarte";
     current-speed = <115200>;

--- a/app/boards/arm/nrfmicro/arduino_pro_micro_pins.dtsi
+++ b/app/boards/arm/nrfmicro/arduino_pro_micro_pins.dtsi
@@ -55,5 +55,5 @@
 
 pro_micro_d: &pro_micro {};
 pro_micro_i2c: &i2c0 {};
-pro_micro_spi: &spi0 {};
+pro_micro_spi: &spi1 {};
 pro_micro_serial: &uart0 {};

--- a/app/boards/arm/nrfmicro/arduino_pro_micro_pins_52833.dtsi
+++ b/app/boards/arm/nrfmicro/arduino_pro_micro_pins_52833.dtsi
@@ -55,5 +55,5 @@
 
 pro_micro_d: &pro_micro {};
 pro_micro_i2c: &i2c0 {};
-pro_micro_spi: &spi0 {};
+pro_micro_spi: &spi1 {};
 pro_micro_serial: &uart0 {};

--- a/app/boards/arm/nrfmicro/arduino_pro_micro_pins_flipped.dtsi
+++ b/app/boards/arm/nrfmicro/arduino_pro_micro_pins_flipped.dtsi
@@ -53,5 +53,5 @@
 
 pro_micro_d: &pro_micro {};
 pro_micro_i2c: &i2c0 {};
-pro_micro_spi: &spi0 {};
+pro_micro_spi: &spi1 {};
 pro_micro_serial: &uart0 {};

--- a/app/boards/arm/nrfmicro/nrfmicro-flipped-pinctrl.dtsi
+++ b/app/boards/arm/nrfmicro/nrfmicro-flipped-pinctrl.dtsi
@@ -36,4 +36,21 @@
             low-power-enable;
         };
     };
+
+    spi1_default: spi1_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 0, 9)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 10)>,
+                <NRF_PSEL(SPIM_MISO, 1, 6)>;
+        };
+    };
+
+    spi1_sleep: spi1_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 0, 9)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 10)>,
+                <NRF_PSEL(SPIM_MISO, 1, 6)>;
+            low-power-enable;
+        };
+    };
 };

--- a/app/boards/arm/nrfmicro/nrfmicro-pinctrl.dtsi
+++ b/app/boards/arm/nrfmicro/nrfmicro-pinctrl.dtsi
@@ -36,4 +36,21 @@
             low-power-enable;
         };
     };
+
+    spi1_default: spi1_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 28)>,
+                <NRF_PSEL(SPIM_MISO, 0, 3)>;
+        };
+    };
+
+    spi1_sleep: spi1_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 1, 13)>,
+                <NRF_PSEL(SPIM_MOSI, 0, 28)>,
+                <NRF_PSEL(SPIM_MISO, 0, 3)>;
+            low-power-enable;
+        };
+    };
 };

--- a/app/boards/arm/nrfmicro/nrfmicro_11.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11.dts
@@ -54,6 +54,13 @@
     pinctrl-names = "default", "sleep";
 };
 
+&spi1 {
+    compatible = "nordic,nrf-spim";
+    pinctrl-0 = <&spi1_default>;
+    pinctrl-1 = <&spi1_sleep>;
+    pinctrl-names = "default", "sleep";
+};
+
 &uart0 {
     compatible = "nordic,nrf-uarte";
     current-speed = <115200>;

--- a/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_11_flipped.dts
@@ -54,6 +54,13 @@
     pinctrl-names = "default", "sleep";
 };
 
+&spi1 {
+    compatible = "nordic,nrf-spim";
+    pinctrl-0 = <&spi1_default>;
+    pinctrl-1 = <&spi1_sleep>;
+    pinctrl-names = "default", "sleep";
+};
+
 &uart0 {
     compatible = "nordic,nrf-uarte";
     current-speed = <115200>;

--- a/app/boards/arm/nrfmicro/nrfmicro_13.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13.dts
@@ -66,6 +66,13 @@
     pinctrl-names = "default", "sleep";
 };
 
+&spi1 {
+    compatible = "nordic,nrf-spim";
+    pinctrl-0 = <&spi1_default>;
+    pinctrl-1 = <&spi1_sleep>;
+    pinctrl-names = "default", "sleep";
+};
+
 &uart0 {
     compatible = "nordic,nrf-uarte";
     current-speed = <115200>;

--- a/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
+++ b/app/boards/arm/nrfmicro/nrfmicro_13_52833.dts
@@ -66,6 +66,13 @@
     pinctrl-names = "default", "sleep";
 };
 
+&spi1 {
+    compatible = "nordic,nrf-spim";
+    pinctrl-0 = <&spi1_default>;
+    pinctrl-1 = <&spi1_sleep>;
+    pinctrl-names = "default", "sleep";
+};
+
 &uart0 {
     compatible = "nordic,nrf-uarte";
     current-speed = <115200>;


### PR DESCRIPTION
nice nano didn't have definitions for SPI in pinctrl and dtsi, requiring users to manually define in their shield definitions if they wanted to use SPI. This should be defined at the board level.
