### PR TITLE
Correctly set underglow state when entering sleep

### DIFF
--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -492,7 +492,7 @@ static int rgb_underglow_auto_state(bool target_wake_state) {
             return zmk_rgb_underglow_off();
         }
     } else {
-        sleep_state.rgb_state_before_sleeping = sleep_state.on;
+        sleep_state.rgb_state_before_sleeping = state.on;
         return zmk_rgb_underglow_off();
     }
 }


### PR DESCRIPTION
This fixes a bug introduced in #2244