### PR TITLE
shortening keymap_soft_off behavior label

### DIFF
--- a/app/dts/behaviors/soft_off.dtsi
+++ b/app/dts/behaviors/soft_off.dtsi
@@ -6,7 +6,7 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ soft_off: soft_off {
+        /omit-if-no-ref/ soft_off: z_so_off {
             compatible = "zmk,behavior-soft-off";
             #binding-cells = <0>;
             split-peripheral-off-on-press;

--- a/app/dts/behaviors/soft_off.dtsi
+++ b/app/dts/behaviors/soft_off.dtsi
@@ -6,7 +6,7 @@
 
 / {
     behaviors {
-        /omit-if-no-ref/ soft_off: keymap_soft_off {
+        /omit-if-no-ref/ soft_off: soft_off {
             compatible = "zmk,behavior-soft-off";
             #binding-cells = <0>;
             split-peripheral-off-on-press;


### PR DESCRIPTION
This PR is aiming to fix #2274 
The behavior label gets truncated because the len is 9, defined in app/include/zmk/split/bluetooth/service.h as ZMK_SPLIT_RUN_BEHAVIOR_DEV_LEN
Shortening the keymap_soft_off solves the issue. 
Thanks bravekarma (discord) for the advice.