### PR TITLE
fix: Initialize sideband kscan in APPLICATION.

### DIFF
--- a/app/src/kscan_sideband_behaviors.c
+++ b/app/src/kscan_sideband_behaviors.c
@@ -173,7 +173,7 @@ static int ksbb_pm_action(const struct device *dev, enum pm_device_action action
     struct ksbb_data ksbb_data_##n = {};                                                           \
     PM_DEVICE_DT_INST_DEFINE(n, ksbb_pm_action);                                                   \
     DEVICE_DT_INST_DEFINE(n, ksbb_init, PM_DEVICE_DT_INST_GET(n), &ksbb_data_##n,                  \
-                          &ksbb_config_##n, POST_KERNEL,                                           \
+                          &ksbb_config_##n, APPLICATION,                                           \
                           CONFIG_ZMK_KSCAN_SIDEBAND_BEHAVIORS_INIT_PRIORITY, &ksbb_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KSBB_INST)


### PR DESCRIPTION
* In order to be sure the rest of the system is fully ready before initializing, because init may result in immediate events being triggered when used with toggle direct kscan inner devices.

Hit this with problems with the ZMK Uno shield after the soft off refactor. Without this change, the code attempts to schedule work items before that's allowed by Zephyr, leading to unexpected crashes.