### PR TITLE
fix(boards): Fix pulls on ZMK uno toggle switch

### DIFF
--- a/app/boards/shields/zmk_uno/zmk_uno.dtsi
+++ b/app/boards/shields/zmk_uno/zmk_uno.dtsi
@@ -125,9 +125,9 @@ nice_view_spi: &arduino_spi {
         toggle-mode;
 
         input-gpios
-        = <&arduino_header 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-        , <&arduino_header 3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
-        , <&arduino_header 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+        = <&arduino_header 4 GPIO_ACTIVE_LOW>
+        , <&arduino_header 3 GPIO_ACTIVE_LOW>
+        , <&arduino_header 2 GPIO_ACTIVE_LOW>
         ;
     };
 


### PR DESCRIPTION
The devicetree pulls always add on to the extra pulls configured by toggle mode, so these should not have pulls defined in the devicetree. Saved ~200uA avg on another board with a 3t toggle switch.

AFAIK there are no other upstream board using `toggle-mode;` where this needs to be corrected