### PR TITLE
feat: adding separate settings for automatic saving of the selected endpoint / ext_power state

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -635,6 +635,16 @@ config ZMK_SETTINGS_SAVE_DEBOUNCE
     int "Milliseconds to debounce settings saves"
     default 60000
 
+config ZMK_SETTINGS_SAVE_ENDPOINTS
+    bool "save endpoints configuration"
+    depends on CONFIG_SETTINGS
+    default y
+
+config ZMK_SETTINGS_SAVE_EXT_POWER
+    bool "save ext power state"
+    depends on CONFIG_SETTINGS
+    default y
+
 #SETTINGS
 endif
 

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -41,7 +41,7 @@ static struct k_work_delayable endpoints_save_work;
 #endif
 
 static int endpoints_save_preferred(void) {
-#if IS_ENABLED(CONFIG_SETTINGS)
+#if IS_ENABLED(CONFIG_ZMK_SETTINGS_SAVE_ENDPOINTS)
     return k_work_reschedule(&endpoints_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
 #else
     return 0;

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -47,7 +47,7 @@ static struct k_work_delayable ext_power_save_work;
 #endif
 
 int ext_power_save_state(void) {
-#if IS_ENABLED(CONFIG_SETTINGS)
+#if IS_ENABLED(CONFIG_ZMK_SETTINGS_SAVE_EXT_POWER)
     int ret = k_work_reschedule(&ext_power_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
     return MIN(ret, 0);
 #else

--- a/docs/docs/behaviors/outputs.md
+++ b/docs/docs/behaviors/outputs.md
@@ -47,6 +47,7 @@ The output selection behavior changes the preferred output on press.
 :::note[Output selection persistence]
 The endpoint that is selected by the `&out` behavior will be saved to flash storage and hence persist across restarts and firmware flashes.
 However it will only be saved after [`CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`](../config/system.md#general) milliseconds in order to reduce potential wear on the flash memory.
+This can be disabled by unsetting [`CONFIG_ZMK_SETTINGS_SAVE_ENDPOINTS`](../config/system.md#general)
 :::
 
 ### Examples

--- a/docs/docs/behaviors/power.md
+++ b/docs/docs/behaviors/power.md
@@ -46,6 +46,7 @@ Here is a table describing the command for each define:
 :::note[External power state persistence]
 The on/off state that is set by the `&ext_power` behavior will be saved to flash storage and hence persist across restarts and firmware flashes.
 However it will only be saved after [`CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`](../config/system.md#general) milliseconds in order to reduce potential wear on the flash memory.
+This can be disabled by unsetting [`CONFIG_ZMK_SETTINGS_SAVE_EXT_POWER`](../config/system.md#general)
 :::
 
 ### Example:

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -20,6 +20,8 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 | `CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE`  | int    | Milliseconds to wait after a setting change before writing it to flash memory | 60000   |
 | `CONFIG_ZMK_WPM`                     | bool   | Enable calculating words per minute                                           | n       |
 | `CONFIG_HEAP_MEM_POOL_SIZE`          | int    | Size of the heap memory pool                                                  | 8192    |
+| `CONFIG_ZMK_SETTINGS_SAVE_ENDPOINTS` | bool   | Enable automatic saving of the selected endpoint (USB / BT)                   | y       |
+| `CONFIG_ZMK_SETTINGS_SAVE_EXT_POWER` | bool   | Enable automatic saving of the selected ext_power persistance state           | y       |
 
 ### HID
 


### PR DESCRIPTION
Hello,

it's my first pull request so I hope I did everything right :)

This adds two new config values for en-/disabling the automatic saving of the selected endpoint / ext_power state. (#1599)

Per default both are set to `y` to keep the default behaviour the same.

I tested it on my own keyboard and as far as I can tell it works, but I'd be grateful if also other people could test it for their boards.