### PR TITLE
fix(docs) removing "to to" typos

### DIFF
--- a/docs/blog/2023-04-06-zephyr-3-2.md
+++ b/docs/blog/2023-04-06-zephyr-3-2.md
@@ -57,7 +57,7 @@ and then update it as appropriate to build the right shields/boards for your con
 
 ### Upgrade a manual script
 
-If you have a custom GitHub Actions workflow you need to maintain for some reason, you can update the workflow to to use the `stable` Docker image tag for the build:
+If you have a custom GitHub Actions workflow you need to maintain for some reason, you can update the workflow to use the `stable` Docker image tag for the build:
 
 - Open `.github/workflows/build.yml` in your editor/IDE
 - Change `zmkfirmware/zmk-build-arm:2.5` to `zmkfirmware/zmk-build-arm:stable` wherever it is found

--- a/docs/docs/behaviors/caps-word.md
+++ b/docs/docs/behaviors/caps-word.md
@@ -7,7 +7,7 @@ sidebar_label: Caps Word
 
 The caps word behavior behaves similar to a caps lock, but will automatically deactivate when any key not in a continue list is pressed, or if the caps word key is pressed again. For smaller keyboards using [mod-taps](/docs/behaviors/mod-tap), this can help avoid repeated alternating holds when typing words in all caps.
 
-The modifiers are applied only to to the alphabetic (`A` to `Z`) keycodes, to avoid automatically applying them to numeric values, etc.
+The modifiers are applied only to the alphabetic (`A` to `Z`) keycodes, to avoid automatically applying them to numeric values, etc.
 
 ### Behavior Binding
 

--- a/docs/docs/features/backlight.mdx
+++ b/docs/docs/features/backlight.mdx
@@ -58,7 +58,7 @@ config LED_PWM
 endif # ZMK_BACKLIGHT
 ```
 
-Create a `<board>-pinctrl.dtsi` file if it does not already exist, and include it at the beginning of the `<board>.dts` file. `CONFIG_PINCTRL=y` must be added to to `<board>_defconfig` if it isn't already enabled.
+Create a `<board>-pinctrl.dtsi` file if it does not already exist, and include it at the beginning of the `<board>.dts` file. `CONFIG_PINCTRL=y` must be added to `<board>_defconfig` if it isn't already enabled.
 
 The pinctrl file has a `&pinctrl` node that encompasses all pinctrl settings, including I2C or SPI peripherals (e.g. WS2812 LEDs, Battery fuel gauges):
 


### PR DESCRIPTION
Credit for noticing these typos go to [slashfoo on discord](https://discord.com/channels/719497620560543766/883452966114324550/1231473298538496121), I happened to have a spare moment to sort it.