### PR TITLE
pre-commit: use versioned clang-format hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,11 @@ repos:
     hooks:
       - id: remove-tabs
         exclude: "vendor-prefixes\\.txt$"
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8
     hooks:
       - id: clang-format
+        types_or: [c++, c]
         args:
           - -i
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/app/boards/arm/corneish_zen/widgets/battery_status.c
+++ b/app/boards/arm/corneish_zen/widgets/battery_status.c
@@ -68,7 +68,7 @@ void battery_status_update_cb(struct battery_status_state state) {
 static struct battery_status_state battery_status_get_state(const zmk_event_t *eh) {
     const struct zmk_battery_state_changed *ev = as_zmk_battery_state_changed(eh);
 
-    return (struct battery_status_state) {
+    return (struct battery_status_state){
         .level = (ev != NULL) ? ev->state_of_charge : zmk_battery_state_of_charge(),
 #if IS_ENABLED(CONFIG_USB_DEVICE_STACK)
         .usb_present = zmk_usb_is_powered(),

--- a/app/boards/shields/nice_view/widgets/peripheral_status.c
+++ b/app/boards/shields/nice_view/widgets/peripheral_status.c
@@ -71,7 +71,7 @@ static void battery_status_update_cb(struct battery_status_state state) {
 }
 
 static struct battery_status_state battery_status_get_state(const zmk_event_t *eh) {
-    return (struct battery_status_state) {
+    return (struct battery_status_state){
         .level = zmk_battery_state_of_charge(),
 #if IS_ENABLED(CONFIG_USB_DEVICE_STACK)
         .usb_present = zmk_usb_is_powered(),

--- a/app/boards/shields/nice_view/widgets/status.c
+++ b/app/boards/shields/nice_view/widgets/status.c
@@ -212,7 +212,7 @@ static void battery_status_update_cb(struct battery_status_state state) {
 static struct battery_status_state battery_status_get_state(const zmk_event_t *eh) {
     const struct zmk_battery_state_changed *ev = as_zmk_battery_state_changed(eh);
 
-    return (struct battery_status_state) {
+    return (struct battery_status_state){
         .level = (ev != NULL) ? ev->state_of_charge : zmk_battery_state_of_charge(),
 #if IS_ENABLED(CONFIG_USB_DEVICE_STACK)
         .usb_present = zmk_usb_is_powered(),

--- a/app/include/drivers/behavior.h
+++ b/app/include/drivers/behavior.h
@@ -122,7 +122,9 @@ struct zmk_behavior_local_id_map {
 #if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 
 #define ZMK_BEHAVIOR_METADATA_INITIALIZER(node_id)                                                 \
-    { .display_name = DT_PROP_OR(node_id, display_name, DEVICE_DT_NAME(node_id)), }
+    {                                                                                              \
+        .display_name = DT_PROP_OR(node_id, display_name, DEVICE_DT_NAME(node_id)),                \
+    }
 
 #else
 
@@ -132,10 +134,15 @@ struct zmk_behavior_local_id_map {
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 
 #define ZMK_BEHAVIOR_REF_INITIALIZER(node_id, _dev)                                                \
-    { .device = _dev, .metadata = ZMK_BEHAVIOR_METADATA_INITIALIZER(node_id), }
+    {                                                                                              \
+        .device = _dev,                                                                            \
+        .metadata = ZMK_BEHAVIOR_METADATA_INITIALIZER(node_id),                                    \
+    }
 
 #define ZMK_BEHAVIOR_LOCAL_ID_MAP_INITIALIZER(node_id, _dev)                                       \
-    { .device = _dev, }
+    {                                                                                              \
+        .device = _dev,                                                                            \
+    }
 
 #define ZMK_BEHAVIOR_REF_DEFINE(name, node_id, _dev)                                               \
     static const STRUCT_SECTION_ITERABLE(zmk_behavior_ref, name) =                                 \

--- a/app/include/zmk/virtual_key_position.h
+++ b/app/include/zmk/virtual_key_position.h
@@ -17,7 +17,7 @@
 /**
  * Gets the sensor number from the virtual key position.
  */
-#define ZMK_SENSOR_POSITION_FROM_VIRTUAL_KEY_POSITION(vkp) ((vkp)-ZMK_KEYMAP_LEN)
+#define ZMK_SENSOR_POSITION_FROM_VIRTUAL_KEY_POSITION(vkp) ((vkp) - ZMK_KEYMAP_LEN)
 
 /**
  * Gets the virtual key position to use for the combo with the given index.

--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -169,10 +169,7 @@ static int behavior_caps_word_init(const struct device *dev) {
 #define CAPS_WORD_LABEL(i, _n) DT_INST_LABEL(i)
 
 #define PARSE_BREAK(i)                                                                             \
-    {                                                                                              \
-        .page = ZMK_HID_USAGE_PAGE(i), .id = ZMK_HID_USAGE_ID(i),                                  \
-        .implicit_modifiers = SELECT_MODS(i)                                                       \
-    }
+    {.page = ZMK_HID_USAGE_PAGE(i), .id = ZMK_HID_USAGE_ID(i), .implicit_modifiers = SELECT_MODS(i)}
 
 #define BREAK_ITEM(i, n) PARSE_BREAK(DT_INST_PROP_BY_IDX(n, continue_list, i))
 

--- a/app/src/behaviors/behavior_tap_dance.c
+++ b/app/src/behaviors/behavior_tap_dance.c
@@ -245,7 +245,7 @@ static int behavior_tap_dance_init(const struct device *dev) {
 #define _TRANSFORM_ENTRY(idx, node) ZMK_KEYMAP_EXTRACT_BINDING(idx, node)
 
 #define TRANSFORMED_BINDINGS(node)                                                                 \
-    { LISTIFY(DT_INST_PROP_LEN(node, bindings), _TRANSFORM_ENTRY, (, ), DT_DRV_INST(node)) }
+    {LISTIFY(DT_INST_PROP_LEN(node, bindings), _TRANSFORM_ENTRY, (, ), DT_DRV_INST(node))}
 
 #define KP_INST(n)                                                                                 \
     static struct zmk_behavior_binding                                                             \

--- a/app/src/display/widgets/battery_status.c
+++ b/app/src/display/widgets/battery_status.c
@@ -65,7 +65,7 @@ void battery_status_update_cb(struct battery_status_state state) {
 static struct battery_status_state battery_status_get_state(const zmk_event_t *eh) {
     const struct zmk_battery_state_changed *ev = as_zmk_battery_state_changed(eh);
 
-    return (struct battery_status_state) {
+    return (struct battery_status_state){
         .level = (ev != NULL) ? ev->state_of_charge : zmk_battery_state_of_charge(),
 #if IS_ENABLED(CONFIG_USB_DEVICE_STACK)
         .usb_present = zmk_usb_is_powered(),

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -116,9 +116,7 @@ int zmk_endpoints_toggle_transport(void) {
     return zmk_endpoints_select_transport(new_transport);
 }
 
-struct zmk_endpoint_instance zmk_endpoints_selected(void) {
-    return current_instance;
-}
+struct zmk_endpoint_instance zmk_endpoints_selected(void) { return current_instance; }
 
 static int send_keyboard_report(void) {
     switch (current_instance.transport) {

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -435,18 +435,12 @@ void zmk_hid_mouse_clear(void) { memset(&mouse_report.body, 0, sizeof(mouse_repo
 
 #endif // IS_ENABLED(CONFIG_ZMK_MOUSE)
 
-struct zmk_hid_keyboard_report *zmk_hid_get_keyboard_report(void) {
-    return &keyboard_report;
-}
+struct zmk_hid_keyboard_report *zmk_hid_get_keyboard_report(void) { return &keyboard_report; }
 
-struct zmk_hid_consumer_report *zmk_hid_get_consumer_report(void) {
-    return &consumer_report;
-}
+struct zmk_hid_consumer_report *zmk_hid_get_consumer_report(void) { return &consumer_report; }
 
 #if IS_ENABLED(CONFIG_ZMK_MOUSE)
 
-struct zmk_hid_mouse_report *zmk_hid_get_mouse_report(void) {
-    return &mouse_report;
-}
+struct zmk_hid_mouse_report *zmk_hid_get_mouse_report(void) { return &mouse_report; }
 
 #endif // IS_ENABLED(CONFIG_ZMK_MOUSE)

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -40,11 +40,9 @@ static zmk_keymap_layer_id_t _zmk_keymap_layer_default = 0;
 #endif
 
 #define TRANSFORMED_LAYER(node)                                                                    \
-    {                                                                                              \
-        COND_CODE_1(                                                                               \
-            DT_NODE_HAS_PROP(node, bindings),                                                      \
-            (LISTIFY(DT_PROP_LEN(node, bindings), ZMK_KEYMAP_EXTRACT_BINDING, (, ), node)), ())    \
-    }
+    {COND_CODE_1(DT_NODE_HAS_PROP(node, bindings),                                                 \
+                 (LISTIFY(DT_PROP_LEN(node, bindings), ZMK_KEYMAP_EXTRACT_BINDING, (, ), node)),   \
+                 ())}
 
 #if ZMK_KEYMAP_HAS_SENSORS
 #define _TRANSFORM_SENSOR_ENTRY(idx, layer)                                                        \
@@ -841,11 +839,12 @@ static int keymap_handle_set(const char *name, size_t len, settings_read_cb read
                     binding_setting.behavior_local_id);
         }
 
-        zmk_keymap[layer][key_position] = (struct zmk_behavior_binding) {
+        zmk_keymap[layer][key_position] = (struct zmk_behavior_binding){
 #if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_LOCAL_IDS_IN_BINDINGS)
             .local_id = binding_setting.behavior_local_id,
 #endif
-            .behavior_dev = name, .param1 = binding_setting.param1,
+            .behavior_dev = name,
+            .param1 = binding_setting.param1,
             .param2 = binding_setting.param2,
         };
     }

--- a/app/src/kscan_sideband_behaviors.c
+++ b/app/src/kscan_sideband_behaviors.c
@@ -183,7 +183,8 @@ static const struct kscan_driver_api ksbb_api = {
 
 #define ENTRY(e)                                                                                   \
     {                                                                                              \
-        .row = DT_PROP(e, row), .column = DT_PROP(e, column),                                      \
+        .row = DT_PROP(e, row),                                                                    \
+        .column = DT_PROP(e, column),                                                              \
         .binding = ZMK_KEYMAP_EXTRACT_BINDING(0, e),                                               \
     }
 

--- a/app/src/physical_layouts.c
+++ b/app/src/physical_layouts.c
@@ -139,7 +139,9 @@ struct zmk_kscan_event {
     uint32_t state;
 };
 
-static struct zmk_kscan_msg_processor { struct k_work work; } msg_processor;
+static struct zmk_kscan_msg_processor {
+    struct k_work work;
+} msg_processor;
 
 K_MSGQ_DEFINE(physical_layouts_kscan_msgq, sizeof(struct zmk_kscan_event),
               CONFIG_ZMK_KSCAN_EVENT_QUEUE_SIZE, 4);

--- a/app/src/sensors.c
+++ b/app/src/sensors.c
@@ -26,28 +26,22 @@ struct sensors_item_cfg {
 };
 
 #define _SENSOR_ITEM(idx, node)                                                                    \
-    {                                                                                              \
-        .dev = DEVICE_DT_GET_OR_NULL(node),                                                        \
-        .trigger = {.type = SENSOR_TRIG_DATA_READY, .chan = SENSOR_CHAN_ROTATION},                 \
-        .config = &configs[idx], .sensor_index = idx                                               \
-    }
+    {.dev = DEVICE_DT_GET_OR_NULL(node),                                                           \
+     .trigger = {.type = SENSOR_TRIG_DATA_READY, .chan = SENSOR_CHAN_ROTATION},                    \
+     .config = &configs[idx],                                                                      \
+     .sensor_index = idx}
 #define SENSOR_ITEM(idx, _i) _SENSOR_ITEM(idx, ZMK_KEYMAP_SENSORS_BY_IDX(idx))
 
 #define PLUS_ONE(n) +1
 #define ZMK_KEYMAP_SENSORS_CHILD_COUNT (0 DT_FOREACH_CHILD(ZMK_KEYMAP_SENSORS_NODE, PLUS_ONE))
 #define SENSOR_CHILD_ITEM(node)                                                                    \
-    {                                                                                              \
-        .triggers_per_rotation =                                                                   \
-            DT_PROP_OR(node, triggers_per_rotation,                                                \
-                       DT_PROP_OR(ZMK_KEYMAP_SENSORS_NODE, triggers_per_rotation,                  \
-                                  CONFIG_ZMK_KEYMAP_SENSORS_DEFAULT_TRIGGERS_PER_ROTATION))        \
-    }
+    {.triggers_per_rotation =                                                                      \
+         DT_PROP_OR(node, triggers_per_rotation,                                                   \
+                    DT_PROP_OR(ZMK_KEYMAP_SENSORS_NODE, triggers_per_rotation,                     \
+                               CONFIG_ZMK_KEYMAP_SENSORS_DEFAULT_TRIGGERS_PER_ROTATION))}
 #define SENSOR_CHILD_DEFAULTS(idx, arg)                                                            \
-    {                                                                                              \
-        .triggers_per_rotation =                                                                   \
-            DT_PROP_OR(ZMK_KEYMAP_SENSORS_NODE, triggers_per_rotation,                             \
-                       CONFIG_ZMK_KEYMAP_SENSORS_DEFAULT_TRIGGERS_PER_ROTATION)                    \
-    }
+    {.triggers_per_rotation = DT_PROP_OR(ZMK_KEYMAP_SENSORS_NODE, triggers_per_rotation,           \
+                                         CONFIG_ZMK_KEYMAP_SENSORS_DEFAULT_TRIGGERS_PER_ROTATION)}
 
 static struct zmk_sensor_config configs[] = {
 #if ZMK_KEYMAP_SENSORS_CHILD_COUNT > 0

--- a/app/src/studio/rpc.c
+++ b/app/src/studio/rpc.c
@@ -77,9 +77,7 @@ static enum studio_framing_state rpc_framing_state;
 static K_MUTEX_DEFINE(rpc_transport_mutex);
 static struct zmk_rpc_transport *selected_transport;
 
-struct ring_buf *zmk_rpc_get_rx_buf(void) {
-    return &rpc_rx_buf;
-}
+struct ring_buf *zmk_rpc_get_rx_buf(void) { return &rpc_rx_buf; }
 
 void zmk_rpc_rx_notify(void) { k_sem_give(&rpc_rx_sem); }
 
@@ -118,9 +116,7 @@ static pb_istream_t pb_istream_for_rx_ring_buf() {
 
 RING_BUF_DECLARE(rpc_tx_buf, CONFIG_ZMK_STUDIO_RPC_TX_BUF_SIZE);
 
-struct ring_buf *zmk_rpc_get_tx_buf(void) {
-    return &rpc_tx_buf;
-}
+struct ring_buf *zmk_rpc_get_tx_buf(void) { return &rpc_tx_buf; }
 
 static bool rpc_tx_buffer_write(pb_ostream_t *stream, const uint8_t *buf, size_t count) {
     void *user_data = stream->state;

--- a/app/src/workqueue.c
+++ b/app/src/workqueue.c
@@ -13,9 +13,7 @@ K_THREAD_STACK_DEFINE(lowprio_q_stack, CONFIG_ZMK_LOW_PRIORITY_THREAD_STACK_SIZE
 
 static struct k_work_q lowprio_work_q;
 
-struct k_work_q *zmk_workqueue_lowprio_work_q(void) {
-    return &lowprio_work_q;
-}
+struct k_work_q *zmk_workqueue_lowprio_work_q(void) { return &lowprio_work_q; }
 
 static int workqueue_init(void) {
     static const struct k_work_queue_config queue_config = {.name = "Low Priority Work Queue"};


### PR DESCRIPTION
slight change to the `pre-commit` config.
the version of clang-format used determined the way the code is formatted.

I was having a lot of trouble because my local version of clang-format (Arch Linux) is more recent than the one running on Github Actions. Therefore, the pre-commit action would almost always fail because of difference in clang-format output.

Using this version of the `pre-commit` config, it specifies the exact version of `clang-format` to be used, which I believe matches what is currently using on Github.