### PR TITLE
fix: adding option to separate implicit mod release from key release

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -113,6 +113,12 @@ config ZMK_HID_INDICATORS
       Enable HID indicators, used for detecting state of Caps/Scroll/Num Lock,
       Kata, and Compose.
 
+config ZMK_HID_SEPARATE_MOD_RELEASE_REPORT
+    bool "Release Modifiers Separately"
+    help
+      Send a separate release event for the modifiers, to make sure the release
+      of the modifier doesn't get recognized before the actual key's release event.
+
 menu "Output Types"
 
 config ZMK_USB

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -29,10 +29,11 @@ Making changes to any of the settings in this section modifies the HID report de
 
 :::
 
-| Config                                | Type | Description                                                    | Default |
-| ------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_HID_INDICATORS`           | bool | Enable receipt of HID/LED indicator state from connected hosts | n       |
-| `CONFIG_ZMK_HID_CONSUMER_REPORT_SIZE` | int  | Number of consumer keys simultaneously reportable              | 6       |
+| Config                                       | Type | Description                                                    | Default |
+| -------------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_HID_INDICATORS`                  | bool | Enable receipt of HID/LED indicator state from connected hosts | n       |
+| `CONFIG_ZMK_HID_CONSUMER_REPORT_SIZE`        | int  | Number of consumer keys simultaneously reportable              | 6       |
+| `CONFIG_ZMK_HID_SEPARATE_MOD_RELEASE_REPORT` | bool | Release the Modifiers separate from and after the modified key | n       |
 
 Exactly zero or one of the following options may be set to `y`. The first is used if none are set.
 

--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -29,11 +29,11 @@ Making changes to any of the settings in this section modifies the HID report de
 
 :::
 
-| Config                                       | Type | Description                                                    | Default |
-| -------------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_HID_INDICATORS`                  | bool | Enable receipt of HID/LED indicator state from connected hosts | n       |
-| `CONFIG_ZMK_HID_CONSUMER_REPORT_SIZE`        | int  | Number of consumer keys simultaneously reportable              | 6       |
-| `CONFIG_ZMK_HID_SEPARATE_MOD_RELEASE_REPORT` | bool | Release the Modifiers separate from and after the modified key | n       |
+| Config                                       | Type | Description                                                      | Default |
+| -------------------------------------------- | ---- | ---------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_HID_INDICATORS`                  | bool | Enable receipt of HID/LED indicator state from connected hosts   | n       |
+| `CONFIG_ZMK_HID_CONSUMER_REPORT_SIZE`        | int  | Number of consumer keys simultaneously reportable                | 6       |
+| `CONFIG_ZMK_HID_SEPARATE_MOD_RELEASE_REPORT` | bool | Send modifier release event **after** non-modifier release event | n       |
 
 Exactly zero or one of the following options may be set to `y`. The first is used if none are set.
 


### PR DESCRIPTION
This adds a new config value `ZMK_HID_SEPARATE_MOD_RELEASE_REPORT` where, if enabled, the report for a key release is sent separately to the accompanying modifier release signals, which are then sent in a second report.

This fixes an issue where certain applications are unable to work with implicitly modified keys (e.g. colon) due to them registering the modifier release prior to the actual key release.

Have tested this on my personal keyboard and `wev` now shows the signals in the correct order.
=> **Previously:** ```LSHIFT (pressed) -> colon (pressed) -> LSHIFT (released) -> **semi**colon (released)```
=> **Now:** ```LSHIFT (pressed) -> colon (pressed) -> colon (released) -> LSHIFT (released)```