### PR TITLE
fix(usb): Ensure USB init is last

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -490,7 +490,11 @@ if USB_DEVICE_STACK
 
 config ZMK_USB_INIT_PRIORITY
     int "USB Init Priority"
-    default 50
+    default 94
+
+config ZMK_USB_HID_INIT_PRIORITY
+    int "USB HID Init Priority"
+    default 95
 
 #USB
 endif

--- a/app/src/usb_hid.c
+++ b/app/src/usb_hid.c
@@ -195,4 +195,4 @@ static int zmk_usb_hid_init(void) {
     return 0;
 }
 
-SYS_INIT(zmk_usb_hid_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+SYS_INIT(zmk_usb_hid_init, APPLICATION, CONFIG_ZMK_USB_HID_INIT_PRIORITY);


### PR DESCRIPTION
* To avoid USB init issues due to other initialization disrupting USB setup, move USB setup to a lower priority.

Hit this as part of the Studio work... that adds just enough additional init time that splitting up the USB and USB HID earlier in init levels caused failures on my host, so defer USB until the very end of startup.