### PR TITLE
fix(ci): checkout repository for get-changed-files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -413,6 +413,8 @@ jobs:
       board-changes: ${{ steps.board-changes.outputs.result }}
       core-changes: ${{ steps.core-changes.outputs.result }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - uses: tj-actions/changed-files@v42
         id: changed-files
         with:


### PR DESCRIPTION
Not sure if/how this was working before without the checkout but all the recent commits that touch `app/src` seem to fail on `get-changed-files`.

A few recent examples:

- https://github.com/zmkfirmware/zmk/commit/7be955ff7285a1003455b4d573e843ef713ac584
- https://github.com/zmkfirmware/zmk/commit/a080b5287f9814d90166be523c3cd2969f4d69a3
- https://github.com/zmkfirmware/zmk/commit/2ee76be6fee671042d9740ac0271eb69e2558165

This fixes test failures such as https://github.com/zmkfirmware/zmk/actions/runs/9618851916/job/26533624945.