### PR TITLE
chore: Add rp2040/USB logging core coverage.

### DIFF
--- a/app/core-coverage.yml
+++ b/app/core-coverage.yml
@@ -22,6 +22,9 @@ include:
     shield: kyria_left
     cmake-args: "-DCONFIG_ZMK_DISPLAY=y"
     nickname: "display"
+  - board: sparkfun_pro_micro_rp2040
+    shield: reviung41
+    cmake-args: "-DSNIPPET='zmk-usb-logging'"
   - board: nice_nano_v2
     shield: kyria_right
     cmake-args: "-DCONFIG_ZMK_DISPLAY=y"


### PR DESCRIPTION
* Include an rp2040 core build target, and include USB logging snippet for completeness.
