### PR TITLE
refactor(ble): Extract API to get active profile connection.

### DIFF
--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -29,7 +29,10 @@ int zmk_ble_prof_disconnect(uint8_t index);
 
 int zmk_ble_active_profile_index(void);
 int zmk_ble_profile_index(const bt_addr_le_t *addr);
+
 bt_addr_le_t *zmk_ble_active_profile_addr(void);
+struct bt_conn *zmk_ble_active_profile_conn(void);
+
 bool zmk_ble_active_profile_is_open(void);
 bool zmk_ble_active_profile_is_connected(void);
 char *zmk_ble_active_profile_name(void);

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -318,6 +318,21 @@ int zmk_ble_prof_disconnect(uint8_t index) {
 
 bt_addr_le_t *zmk_ble_active_profile_addr(void) { return &profiles[active_profile].peer; }
 
+struct bt_conn *zmk_ble_active_profile_conn(void) {
+    struct bt_conn *conn;
+    bt_addr_le_t *addr = zmk_ble_active_profile_addr();
+
+    if (!bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
+        LOG_WRN("Not sending, no active address for current profile");
+        return NULL;
+    } else if ((conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr)) == NULL) {
+        LOG_WRN("Not sending, not connected to active profile");
+        return NULL;
+    }
+
+    return conn;
+}
+
 char *zmk_ble_active_profile_name(void) { return profiles[active_profile].name; }
 
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)

--- a/app/src/hog.c
+++ b/app/src/hog.c
@@ -220,21 +220,6 @@ BT_GATT_SERVICE_DEFINE(
     BT_GATT_CHARACTERISTIC(BT_UUID_HIDS_CTRL_POINT, BT_GATT_CHRC_WRITE_WITHOUT_RESP,
                            BT_GATT_PERM_WRITE, NULL, write_ctrl_point, &ctrl_point));
 
-struct bt_conn *destination_connection(void) {
-    struct bt_conn *conn;
-    bt_addr_le_t *addr = zmk_ble_active_profile_addr();
-    LOG_DBG("Address pointer %p", addr);
-    if (!bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
-        LOG_WRN("Not sending, no active address for current profile");
-        return NULL;
-    } else if ((conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr)) == NULL) {
-        LOG_WRN("Not sending, not connected to active profile");
-        return NULL;
-    }
-
-    return conn;
-}
-
 K_THREAD_STACK_DEFINE(hog_q_stack, CONFIG_ZMK_BLE_THREAD_STACK_SIZE);
 
 struct k_work_q hog_work_q;
@@ -246,7 +231,7 @@ void send_keyboard_report_callback(struct k_work *work) {
     struct zmk_hid_keyboard_report_body report;
 
     while (k_msgq_get(&zmk_hog_keyboard_msgq, &report, K_NO_WAIT) == 0) {
-        struct bt_conn *conn = destination_connection();
+        struct bt_conn *conn = zmk_ble_active_profile_conn();
         if (conn == NULL) {
             return;
         }
@@ -298,7 +283,7 @@ void send_consumer_report_callback(struct k_work *work) {
     struct zmk_hid_consumer_report_body report;
 
     while (k_msgq_get(&zmk_hog_consumer_msgq, &report, K_NO_WAIT) == 0) {
-        struct bt_conn *conn = destination_connection();
+        struct bt_conn *conn = zmk_ble_active_profile_conn();
         if (conn == NULL) {
             return;
         }


### PR DESCRIPTION
Small refactor to make it easier to get a `struct bt_conn *` for the active profile, if we are connected.