### PR TITLE
fix: Improve startup time with proper settings loading.

### DIFF
--- a/app/Kconfig.behaviors
+++ b/app/Kconfig.behaviors
@@ -12,12 +12,16 @@ config ZMK_BEHAVIOR_LOCAL_IDS
 
 if ZMK_BEHAVIOR_LOCAL_IDS
 
+config ZMK_BEHAVIOR_LOCAL_IDS_IN_BINDINGS
+    bool "Track in behavior bindings"
+
 choice ZMK_BEHAVIOR_LOCAL_ID_TYPE
     prompt "Local ID Type"
 
 config ZMK_BEHAVIOR_LOCAL_ID_TYPE_SETTINGS_TABLE
     bool "Settings Table"
     depends on SETTINGS
+    select ZMK_BEHAVIOR_LOCAL_IDS_IN_BINDINGS
     help
       Use persistent entries in the settings subsystem to identify
       behaviors by local ID, which uses the device name to generate

--- a/app/include/zmk/behavior.h
+++ b/app/include/zmk/behavior.h
@@ -11,7 +11,12 @@
 #define ZMK_BEHAVIOR_OPAQUE 0
 #define ZMK_BEHAVIOR_TRANSPARENT 1
 
+typedef uint16_t zmk_behavior_local_id_t;
+
 struct zmk_behavior_binding {
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_LOCAL_IDS_IN_BINDINGS)
+    zmk_behavior_local_id_t local_id;
+#endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_LOCAL_IDS_IN_BINDINGS)
     const char *behavior_dev;
     uint32_t param1;
     uint32_t param2;
@@ -22,8 +27,6 @@ struct zmk_behavior_binding_event {
     uint32_t position;
     int64_t timestamp;
 };
-
-typedef uint16_t zmk_behavior_local_id_t;
 
 /**
  * @brief Get a const struct device* for a behavior from its @p name field.

--- a/app/src/behavior.c
+++ b/app/src/behavior.c
@@ -229,6 +229,8 @@ static int behavior_local_id_init(void) {
     return 0;
 }
 
+SYS_INIT(behavior_local_id_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+
 #elif IS_ENABLED(CONFIG_ZMK_BEHAVIOR_LOCAL_ID_TYPE_SETTINGS_TABLE)
 
 static zmk_behavior_local_id_t largest_local_id = 0;
@@ -239,7 +241,7 @@ static int behavior_handle_set(const char *name, size_t len, settings_read_cb re
 
     if (settings_name_steq(name, "local_id", &next) && next) {
         char *endptr;
-        uint8_t local_id = strtoul(next, &endptr, 10);
+        zmk_behavior_local_id_t local_id = strtoul(next, &endptr, 10);
         if (*endptr != '\0') {
             LOG_WRN("Invalid behavior local ID: %s with endptr %s", next, endptr);
             return -EINVAL;
@@ -302,21 +304,11 @@ static int behavior_handle_commit(void) {
 SETTINGS_STATIC_HANDLER_DEFINE(behavior, "behavior", NULL, behavior_handle_set,
                                behavior_handle_commit, NULL);
 
-static int behavior_local_id_init(void) {
-    settings_subsys_init();
-
-    settings_load_subtree("behavior");
-
-    return 0;
-}
-
 #else
 
 #error "A behavior local ID mechanism must be selected"
 
 #endif
-
-SYS_INIT(behavior_local_id_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
 
 #endif
 

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -445,7 +445,11 @@ static int ble_profiles_handle_set(const char *name, size_t len, settings_read_c
     return 0;
 };
 
-struct settings_handler profiles_handler = {.name = "ble", .h_set = ble_profiles_handle_set};
+static int zmk_ble_complete_startup(void);
+
+static struct settings_handler profiles_handler = {
+    .name = "ble", .h_set = ble_profiles_handle_set, .h_commit = zmk_ble_complete_startup};
+
 #endif /* IS_ENABLED(CONFIG_SETTINGS) */
 
 static bool is_conn_active_profile(const struct bt_conn *conn) {
@@ -644,29 +648,7 @@ static void zmk_ble_ready(int err) {
     update_advertising();
 }
 
-static int zmk_ble_init(void) {
-    int err = bt_enable(NULL);
-
-    if (err) {
-        LOG_ERR("BLUETOOTH FAILED (%d)", err);
-        return err;
-    }
-
-#if IS_ENABLED(CONFIG_SETTINGS)
-    settings_subsys_init();
-
-    err = settings_register(&profiles_handler);
-    if (err) {
-        LOG_ERR("Failed to setup the profile settings handler (err %d)", err);
-        return err;
-    }
-
-    k_work_init_delayable(&ble_save_work, ble_save_profile_work);
-
-    settings_load_subtree("ble");
-    settings_load_subtree("bt");
-
-#endif
+static int zmk_ble_complete_startup(void) {
 
 #if IS_ENABLED(CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START)
     LOG_WRN("Clearing all existing BLE bond information from the keyboard");
@@ -702,6 +684,24 @@ static int zmk_ble_init(void) {
     bt_conn_auth_info_cb_register(&zmk_ble_auth_info_cb_display);
 
     zmk_ble_ready(0);
+
+    return 0;
+}
+
+static int zmk_ble_init(void) {
+    int err = bt_enable(NULL);
+
+    if (err < 0 && err != -EALREADY) {
+        LOG_ERR("BLUETOOTH FAILED (%d)", err);
+        return err;
+    }
+
+#if IS_ENABLED(CONFIG_SETTINGS)
+    settings_register(&profiles_handler);
+    k_work_init_delayable(&ble_save_work, ble_save_profile_work);
+#else
+    zmk_ble_complete_startup();
+#endif
 
     return 0;
 }

--- a/app/src/endpoints.c
+++ b/app/src/endpoints.c
@@ -263,7 +263,8 @@ static int endpoints_handle_set(const char *name, size_t len, settings_read_cb r
     return 0;
 }
 
-struct settings_handler endpoints_handler = {.name = "endpoints", .h_set = endpoints_handle_set};
+SETTINGS_STATIC_HANDLER_DEFINE(endpoints, "endpoints", NULL, endpoints_handle_set, NULL, NULL);
+
 #endif /* IS_ENABLED(CONFIG_SETTINGS) */
 
 static bool is_usb_ready(void) {
@@ -322,17 +323,7 @@ static struct zmk_endpoint_instance get_selected_instance(void) {
 
 static int zmk_endpoints_init(void) {
 #if IS_ENABLED(CONFIG_SETTINGS)
-    settings_subsys_init();
-
-    int err = settings_register(&endpoints_handler);
-    if (err) {
-        LOG_ERR("Failed to register the endpoints settings handler (err %d)", err);
-        return err;
-    }
-
     k_work_init_delayable(&endpoints_save_work, endpoints_save_preferred_work);
-
-    settings_load_subtree("endpoints");
 #endif
 
     current_instance = get_selected_instance();

--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -121,12 +121,27 @@ static int ext_power_settings_set(const char *name, size_t len, settings_read_cb
     return -ENOENT;
 }
 
-struct settings_handler ext_power_conf = {.name = "ext_power/state",
-                                          .h_set = ext_power_settings_set};
+static int ext_power_settings_commit() {
+    const struct device *dev = DEVICE_DT_GET(DT_DRV_INST(0));
+    struct ext_power_generic_data *data = dev->data;
+
+    if (!data->settings_init) {
+
+        data->status = true;
+        k_work_schedule(&ext_power_save_work, K_NO_WAIT);
+
+        ext_power_enable(dev);
+    }
+
+    return 0;
+}
+
+SETTINGS_STATIC_HANDLER_DEFINE(ext_power, "ext_power/state", NULL, ext_power_settings_set,
+                               ext_power_settings_commit, NULL);
+
 #endif
 
 static int ext_power_generic_init(const struct device *dev) {
-    struct ext_power_generic_data *data = dev->data;
     const struct ext_power_generic_config *config = dev->config;
 
     if (gpio_pin_configure_dt(&config->control, GPIO_OUTPUT_INACTIVE)) {
@@ -135,25 +150,7 @@ static int ext_power_generic_init(const struct device *dev) {
     }
 
 #if IS_ENABLED(CONFIG_SETTINGS)
-    settings_subsys_init();
-
-    int err = settings_register(&ext_power_conf);
-    if (err) {
-        LOG_ERR("Failed to register the ext_power settings handler (err %d)", err);
-        return err;
-    }
-
     k_work_init_delayable(&ext_power_save_work, ext_power_save_state_work);
-
-    // Set default value (on) if settings isn't set
-    settings_load_subtree("ext_power");
-    if (!data->settings_init) {
-
-        data->status = true;
-        k_work_schedule(&ext_power_save_work, K_NO_WAIT);
-
-        ext_power_enable(dev);
-    }
 #else
     // Default to the ext_power being open when no settings
     ext_power_enable(dev);

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -24,6 +24,11 @@ int main(void) {
         return -ENOTSUP;
     }
 
+#if IS_ENABLED(CONFIG_SETTINGS)
+    settings_subsys_init();
+    settings_load();
+#endif
+
 #ifdef CONFIG_ZMK_DISPLAY
     zmk_display_init();
 #endif /* CONFIG_ZMK_DISPLAY */


### PR DESCRIPTION
* Avoid doing duplicate calls to setings_load_subtree, which iterates NVS fully each time under the hood, and instead use on settings_load later in the lifecycle.


Found this during Studio work, after we ended up with many more settings entries. Pinned it down to the many calls to `settings_load_subtree` which under the hood was actually loading the full NVS data each time, doing a ton of duplicate work. This refactor moves away from duplicate subtree loads. Doing so requires a bit of care to make timing work and have the right things loaded when needed, especially for BT initialization.