### PR TITLE
fix: Fix external power settings load issue.

### DIFF
--- a/app/src/ext_power_generic.c
+++ b/app/src/ext_power_generic.c
@@ -151,10 +151,10 @@ static int ext_power_generic_init(const struct device *dev) {
 
 #if IS_ENABLED(CONFIG_SETTINGS)
     k_work_init_delayable(&ext_power_save_work, ext_power_save_state_work);
-#else
-    // Default to the ext_power being open when no settings
-    ext_power_enable(dev);
 #endif
+
+    // Enable by default. We may get disabled again once settings load.
+    ext_power_enable(dev);
 
     if (config->init_delay_ms) {
         k_msleep(config->init_delay_ms);


### PR DESCRIPTION
* Because settings load is delayed now, enable external
  power on init, and let it be disabled on settings load
  later, to ensure power is on early for
  other peripheral initialization.

Fixes: #2361

