### PR TITLE
refactor(hog): Cleanup ble message sending

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -648,6 +648,15 @@ config ZMK_SETTINGS_SAVE_DEBOUNCE
 #SETTINGS
 endif
 
+config ZMK_WORKAROUND_COPY_USB_TX_DATA_BUFFER
+    bool "Enable workaround for USB driver not copying data before transmit"
+    help
+      Work around some hardware USB drivers not copying the passed USB TX buffer
+      contents before beginning a transaction, causing corruption of the USB
+      message, by copying the TX data into a temporary buffer first. For
+      example, the NRFx family of Zephyr drivers suffer this issue.
+    default y if SOC_SERIES_NRF52X
+
 config ZMK_BATTERY_REPORT_INTERVAL
     depends on ZMK_BATTERY_REPORTING
     int "Battery level report interval in seconds"

--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -254,6 +254,30 @@ struct zmk_hid_mouse_report {
 
 #endif // IS_ENABLED(CONFIG_ZMK_MOUSE)
 
+struct zmk_hid_report_body {
+    union {
+#if IS_ENABLED(CONFIG_ZMK_MOUSE)
+        struct zmk_hid_mouse_report_body mouse;
+#endif
+
+        struct zmk_hid_keyboard_report_body keyboard;
+        struct zmk_hid_consumer_report_body consumer;
+    } __packed;
+} __packed;
+
+struct zmk_hid_report {
+    union {
+#if IS_ENABLED(CONFIG_ZMK_USB_BOOT)
+        zmk_hid_boot_report_t boot;
+#endif
+
+        struct {
+            uint8_t report_id;
+            struct zmk_hid_report_body body;
+        } __packed;
+    } __packed;
+} __packed;
+
 zmk_mod_flags_t zmk_hid_get_explicit_mods(void);
 int zmk_hid_register_mod(zmk_mod_t modifier);
 int zmk_hid_unregister_mod(zmk_mod_t modifier);

--- a/app/src/usb_hid.c
+++ b/app/src/usb_hid.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <zephyr/sys/util.h>
+
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 
@@ -23,6 +25,17 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 static const struct device *hid_dev;
 
 static K_SEM_DEFINE(hid_sem, 1, 1);
+
+#if IS_ENABLED(CONFIG_ZMK_WORKAROUND_COPY_USB_TX_DATA_BUFFER)
+static uint8_t hid_ep_write_buf[sizeof(struct zmk_hid_report)];
+
+static const uint8_t *prepare_report_buf(const uint8_t *report, size_t len) {
+    memcpy(hid_ep_write_buf, report, len);
+    return hid_ep_write_buf;
+}
+#else
+static const uint8_t *prepare_report_buf(const uint8_t *report, size_t len) { return report; }
+#endif
 
 static void in_ready_cb(const struct device *dev) { k_sem_give(&hid_sem); }
 
@@ -137,7 +150,8 @@ static int zmk_usb_hid_send_report(const uint8_t *report, size_t len) {
         return -ENODEV;
     default:
         k_sem_take(&hid_sem, K_MSEC(30));
-        int err = hid_int_ep_write(hid_dev, report, len, NULL);
+        const uint8_t *buf = prepare_report_buf(report, len);
+        int err = hid_int_ep_write(hid_dev, buf, len, NULL);
 
         if (err) {
             k_sem_give(&hid_sem);


### PR DESCRIPTION
We deduplicate a bunch of code removing about 80 lines (not clear from the diff due to dependence on other PR), fixing a very minor copy-paste typo in the process. No functional change.

Stacked on top of https://github.com/zmkfirmware/zmk/pull/2257 since we use a struct from there. Tested on an Adv360.