### PR TITLE
ci: fail slowly

### DIFF
--- a/.github/workflows/ble-test.yml
+++ b/.github/workflows/ble-test.yml
@@ -31,6 +31,7 @@ jobs:
   run-tests:
     needs: collect-tests
     strategy:
+      fail-fast: false
       matrix:
         test: ${{ fromJSON(needs.collect-tests.outputs.test-dirs) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       image: docker.io/zmkfirmware/zmk-build-arm:3.5
     needs: compile-matrix
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.compile-matrix.outputs.include-list) }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
   run-tests:
     needs: collect-tests
     strategy:
+      fail-fast: false
       matrix:
         test: ${{ fromJSON(needs.collect-tests.outputs.test-dirs) }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Instead of cancelling all jobs in the build or test matrices if one fails, allow remaining jobs to continue running.

This lowers the impact of [transient problems with CI actions/runners](https://github.com/zmkfirmware/zmk/actions/runs/9755038986), and provides more complete testing feedback on submissions. ([This test run](https://github.com/zmkfirmware/zmk/actions/runs/9812689840), for example, might have benefited from not being halted early.)