### PR TITLE
Fix max brightness in backlight metadata

### DIFF
--- a/app/src/behaviors/behavior_backlight.c
+++ b/app/src/behaviors/behavior_backlight.c
@@ -68,7 +68,7 @@ static const struct behavior_parameter_value_metadata one_arg_p2_values[] = {
         .range =
             {
                 .min = 0,
-                .max = 255,
+                .max = 100,
             },
     },
 };


### PR DESCRIPTION
Spotted this whilst working on a custom backlight behavior. The set brightness function in the backlighting code has a max of 100, as does the zephyr led-pwm driver https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/led/led_pwm.c

The range for the set brightness function should reflect this max, otherwise ~2/3rds of the possible brightness range will set the leds to the same brightness