### PR TITLE
fix(docs): Document number of peripherals Kconfig

### DIFF
--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -125,6 +125,7 @@ Following split keyboard settings are defined in [zmk/app/src/split/Kconfig](htt
 | `CONFIG_ZMK_SPLIT_ROLE_CENTRAL`                         | bool | `y` for central device, `n` for peripheral                                 |                                            |
 | `CONFIG_ZMK_SPLIT_PERIPHERAL_HID_INDICATORS`            | bool | Enable split keyboard support for passing indicator state to peripherals   | n                                          |
 | `CONFIG_ZMK_SPLIT_BLE`                                  | bool | Use BLE to communicate between split keyboard halves                       | y                                          |
+| `CONFIG_ZMK_SPLIT_BLE_CENTRAL_PERIPHERALS`              | int  | Number of peripherals that will connect to the central                     | 1                                          |
 | `CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING`   | bool | Enable fetching split peripheral battery levels to the central side        | n                                          |
 | `CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_PROXY`      | bool | Enable central reporting of split battery levels to hosts                  | n                                          |
 | `CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_QUEUE_SIZE` | int  | Max number of battery level events to queue when received from peripherals | `CONFIG_ZMK_SPLIT_BLE_CENTRAL_PERIPHERALS` |


### PR DESCRIPTION
Just documenting the Kconfig option, not addressing the general issue on "dongle" documentation.

Fixes #2373.