### PR TITLE
fix(docs): Fix mod-morph terms from keycodes to bindings

### DIFF
--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -86,6 +86,34 @@ For example, the following configuration morphs `LEFT_SHIFT` + `BACKSPACE` into 
 };
 ```
 
+#### Trigger conditions with multiple modifiers
+
+Any modifier used in the `mods` property will activate a mod-morph; it isn't possible to require that multiple modifiers are held _together_ in order to activate it.
+However, you can nest multiple mod-morph behaviors to achieve more complex decision logic, where you use one (or two) mod-morph behaviors in the `bindings` fields of another mod-morph.
+
+As an example, consider the following two mod-morphs:
+
+```dts
+/ {
+    behaviors {
+        morph_BC: morph_BC {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp B>, <&kp C>;
+            mods = <(MOD_LCTL|MOD_RCTL)>;
+        };
+        morph_ABC: morph_ABC {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp A>, <&morph_BC>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+        };
+    };
+};
+```
+
+When you assign `&morph_ABC` to a key position and press it, it will output `A` by default. If you press it while a shift modifier is held it will output `B`, and if you are also holding a control modifier it will output `C` instead.
+
 :::note[Karabiner-Elements (macOS) interfering with mod-morphs]
 
 If the first modified key press sends the modifier along with the morphed keycode and [Karabiner-Elements](https://karabiner-elements.pqrs.org/) is running, disable the "Modify Events" toggle from Karabiner's "Devices" settings page for the keyboard running ZMK.

--- a/docs/docs/behaviors/mod-morph.md
+++ b/docs/docs/behaviors/mod-morph.md
@@ -5,18 +5,17 @@ sidebar_label: Mod-Morph
 
 ## Summary
 
-The Mod-Morph behavior sends a different keypress, depending on whether a specified modifier is being held during the keypress.
+The mod-morph behavior invokes a different behavior depending on whether any of the specified modifiers are being held during the key press.
 
-- If you tap the key by itself, the first keycode is sent.
-- If you tap the key while holding the specified modifier, the second keycode is sent.
+- If you tap the key by itself, the first behavior binding is activated.
+- If you tap the key while holding (any of) the specified modifier(s), the second behavior binding is activated.
 
 ## Mod-Morph
 
-The Mod-Morph behavior acts as one of two keycodes, depending on if the required modifier is being held during the keypress.
-
 ### Configuration
 
-An example of how to implement the mod-morph "Grave Escape":
+Below is an example of how to implement the mod-morph "Grave Escape". When assigned to a key, pressing the key on its own will send an
+Escape keycode but pressing it while a shift or GUI modifier is held sends the grave `` ` `` keycode instead:
 
 ```dts
 / {
@@ -31,7 +30,7 @@ An example of how to implement the mod-morph "Grave Escape":
 };
 ```
 
-Note that this specific mod-morph exists in ZMK by default using code `&gresc`.
+Note that this specific mod-morph exists in ZMK by default using the binding `&gresc`.
 
 ### Behavior Binding
 
@@ -67,7 +66,7 @@ mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
 
 ### Advanced Configuration
 
-`keep-mods`
+#### `keep-mods`
 
 When a modifier specified in `mods` is being held, it won't be sent along with the morphed keycode unless it is also specified in `keep-mods`. By default `keep-mods` equals `0`, which means no modifier specified in `mods` will be sent along with the morphed keycode.
 


### PR DESCRIPTION
Added more precision to docs, where we don't want to conflate keycodes vs behavior bindings. Also elaborated on the grave escape behavior just in case it isn't clear from the definition.

As an aside, I want to do a pass on all the behavior pages to make them more consistent. Currently the header levels, overall organization, examples etc. are different across many of them.