### PR TITLE
feat(power) Add additional idle options

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -163,8 +163,7 @@ config ZMK_BLE_EXPERIMENTAL_CONN
     bool "Experimental BLE connection changes"
     help
       Enables a combination of settings that are planned to be default in future versions of ZMK
-      to improve connection stability. This includes changes to timing on BLE pairing initiation,
-      restores use of the updated/new LLCP implementation, and disables 2M PHY support.
+      to improve connection stability. 
 
 config ZMK_BLE_EXPERIMENTAL_SEC
     bool "Experimental BLE security changes"
@@ -429,6 +428,10 @@ endif
 config ZMK_EXT_POWER
     bool "Enable support to control external power output"
     default y
+
+config ZMK_EXT_POWER_IDLE_OFF
+    bool "Turn off external power while idle"
+    depends on ZMK_EXT_POWER
 
 config ZMK_PM
     bool

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -406,6 +406,10 @@ config ZMK_IDLE_TIMEOUT
     int "Milliseconds of inactivity before entering idle state (OLED shutoff, etc)"
     default 30000
 
+config ZMK_IDLE_USB
+    bool "Allow idling while connected to USB"
+    default y
+
 config ZMK_SLEEP
     bool "Enable deep sleep support"
     depends on HAS_POWEROFF

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -163,7 +163,7 @@ config ZMK_BLE_EXPERIMENTAL_CONN
     bool "Experimental BLE connection changes"
     help
       Enables a combination of settings that are planned to be default in future versions of ZMK
-      to improve connection stability. 
+      to improve connection stability.
 
 config ZMK_BLE_EXPERIMENTAL_SEC
     bool "Experimental BLE security changes"

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -101,10 +101,9 @@ void activity_work_handler(struct k_work *work) {
             const struct device *ext_power = device_get_binding("EXT_POWER");
             if (ext_power == NULL) {
                 LOG_ERR("Unable to retrieve ext_power device on entering idle.");
-                return;
+            } else {
+                ext_power_disable(ext_power);
             }
-
-            ext_power_disable(ext_power);
 #endif /* IS_ENABLED(CONFIG_ZMK_EXT_POWER_IDLE_OFF) */
             set_state(ZMK_ACTIVITY_IDLE);
         }

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -21,7 +21,7 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 | Config                          | Type | Description                                           | Default |
 | ------------------------------- | ---- | ----------------------------------------------------- | ------- |
 | `CONFIG_ZMK_IDLE_TIMEOUT`       | int  | Milliseconds of inactivity before entering idle state | 30000   |
-| `CONFIG_ZMK_EXT_POWER_IDLE_OFF` | bool | Turn off external power while idle                    | n       |
+| `CONFIG_ZMK_IDLE_USB`           | bool | Enable idling while connected to USB power            | y       |
 | `CONFIG_ZMK_SLEEP`              | bool | Enable deep sleep support                             | n       |
 | `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT` | int  | Milliseconds of inactivity before entering deep sleep | 900000  |
 
@@ -45,9 +45,10 @@ Driver for enabling or disabling power to peripherals such as displays and light
 
 Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
 
-| Config                 | Type | Description                                     | Default |
-| ---------------------- | ---- | ----------------------------------------------- | ------- |
-| `CONFIG_ZMK_EXT_POWER` | bool | Enable support to control external power output | y       |
+| Config                          | Type | Description                                     | Default |
+| ------------------------------- | ---- | ----------------------------------------------- | ------- |
+| `CONFIG_ZMK_EXT_POWER`          | bool | Enable support to control external power output | y       |
+| `CONFIG_ZMK_EXT_POWER_IDLE_OFF` | bool | Turn off external power while idle              | n       |
 
 ### Devicetree
 

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -21,6 +21,7 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 | Config                          | Type | Description                                           | Default |
 | ------------------------------- | ---- | ----------------------------------------------------- | ------- |
 | `CONFIG_ZMK_IDLE_TIMEOUT`       | int  | Milliseconds of inactivity before entering idle state | 30000   |
+| `CONFIG_ZMK_EXT_POWER_IDLE_OFF` | bool | Turn off external power while idle                    | n       |
 | `CONFIG_ZMK_SLEEP`              | bool | Enable deep sleep support                             | n       |
 | `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT` | int  | Milliseconds of inactivity before entering deep sleep | 900000  |
 


### PR DESCRIPTION
Added two Kconfig flags:

- `ZMK_EXT_POWER_IDLE_OFF` (disabled by default) to turn off external power when the keyboard goes into idle, and enable it again when it exits idle. Seems like it would be particularly useful for trackpoint users.
- `ZMK_IDLE_USB` (enabled by default) which enables/disables idling while connected to USB power. I'd be expecting RGB lovers to request this.

First flag is tested and confirmed working. Unable to test second flag, implementation is trivial though. Unable to test whether the display re-init bug mentioned in #1300 is still present, would expect this to interact poorly if so.