### PR TITLE
fix(split): Make locality work for nested behaviors

### DIFF
--- a/app/include/zmk/behavior.h
+++ b/app/include/zmk/behavior.h
@@ -26,6 +26,7 @@ struct zmk_behavior_binding_event {
     int layer;
     uint32_t position;
     int64_t timestamp;
+    uint8_t source;
 };
 
 /**
@@ -41,6 +42,19 @@ struct zmk_behavior_binding_event {
  * unrelated node which shares the same name as a behavior.
  */
 const struct device *zmk_behavior_get_binding(const char *name);
+
+/**
+ * @brief Invoke a behavior given its binding and invoking event details.
+ *
+ * @param src_binding Behavior binding to invoke.
+ * @param event The binding event struct containing details of the event that invoked it.
+ * @param pressed Whether the binding is pressed or released.
+ *
+ * @retval 0 If successful.
+ * @retval Negative errno code if failure.
+ */
+int zmk_behavior_invoke_binding(const struct zmk_behavior_binding *src_binding,
+                                struct zmk_behavior_binding_event event, bool pressed);
 
 /**
  * @brief Get a local ID for a behavior from its @p name field.

--- a/app/include/zmk/behavior.h
+++ b/app/include/zmk/behavior.h
@@ -26,7 +26,9 @@ struct zmk_behavior_binding_event {
     int layer;
     uint32_t position;
     int64_t timestamp;
+#if IS_ENABLED(CONFIG_ZMK_SPLIT)
     uint8_t source;
+#endif
 };
 
 /**

--- a/app/include/zmk/behavior_queue.h
+++ b/app/include/zmk/behavior_queue.h
@@ -10,5 +10,5 @@
 #include <stdint.h>
 #include <zmk/behavior.h>
 
-int zmk_behavior_queue_add(uint32_t position, const struct zmk_behavior_binding behavior,
-                           bool press, uint32_t wait);
+int zmk_behavior_queue_add(uint32_t position, uint8_t source,
+                           const struct zmk_behavior_binding behavior, bool press, uint32_t wait);

--- a/app/include/zmk/behavior_queue.h
+++ b/app/include/zmk/behavior_queue.h
@@ -10,5 +10,5 @@
 #include <stdint.h>
 #include <zmk/behavior.h>
 
-int zmk_behavior_queue_add(uint32_t position, uint8_t source,
+int zmk_behavior_queue_add(const struct zmk_behavior_binding_event *event,
                            const struct zmk_behavior_binding behavior, bool press, uint32_t wait);

--- a/app/include/zmk/split/bluetooth/service.h
+++ b/app/include/zmk/split/bluetooth/service.h
@@ -20,6 +20,7 @@ struct sensor_event {
 
 struct zmk_split_run_behavior_data {
     uint8_t position;
+    uint8_t source;
     uint8_t state;
     uint32_t param1;
     uint32_t param2;

--- a/app/src/behavior.c
+++ b/app/src/behavior.c
@@ -95,7 +95,7 @@ int zmk_behavior_invoke_binding(const struct zmk_behavior_binding *src_binding,
     case BEHAVIOR_LOCALITY_CENTRAL:
         return invoke_locally(&binding, event, pressed);
     case BEHAVIOR_LOCALITY_EVENT_SOURCE:
-#if ZMK_BLE_IS_CENTRAL
+#if ZMK_BLE_IS_CENTRAL // source is a member of event because CONFIG_ZMK_SPLIT is enabled
         if (event.source == ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL) {
             return invoke_locally(&binding, event, pressed);
         } else {

--- a/app/src/behavior.c
+++ b/app/src/behavior.c
@@ -17,10 +17,17 @@
 
 #endif
 
+#include <zmk/ble.h>
+#if ZMK_BLE_IS_CENTRAL
+#include <zmk/split/bluetooth/central.h>
+#endif
+
 #include <drivers/behavior.h>
 #include <zmk/behavior.h>
 #include <zmk/hid.h>
 #include <zmk/matrix.h>
+
+#include <zmk/events/position_state_changed.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
@@ -47,6 +54,66 @@ const struct device *z_impl_behavior_get_binding(const char *name) {
     }
 
     return NULL;
+}
+
+static int invoke_locally(struct zmk_behavior_binding *binding,
+                          struct zmk_behavior_binding_event event, bool pressed) {
+    if (pressed) {
+        return behavior_keymap_binding_pressed(binding, event);
+    } else {
+        return behavior_keymap_binding_released(binding, event);
+    }
+}
+
+int zmk_behavior_invoke_binding(const struct zmk_behavior_binding *src_binding,
+                                struct zmk_behavior_binding_event event, bool pressed) {
+    // We want to make a copy of this, since it may be converted from
+    // relative to absolute before being invoked
+    struct zmk_behavior_binding binding = *src_binding;
+
+    const struct device *behavior = zmk_behavior_get_binding(binding.behavior_dev);
+
+    if (!behavior) {
+        LOG_WRN("No behavior assigned to %d on layer %d", event.position, event.layer);
+        return 1;
+    }
+
+    int err = behavior_keymap_binding_convert_central_state_dependent_params(&binding, event);
+    if (err) {
+        LOG_ERR("Failed to convert relative to absolute behavior binding (err %d)", err);
+        return err;
+    }
+
+    enum behavior_locality locality = BEHAVIOR_LOCALITY_CENTRAL;
+    err = behavior_get_locality(behavior, &locality);
+    if (err) {
+        LOG_ERR("Failed to get behavior locality %d", err);
+        return err;
+    }
+
+    switch (locality) {
+    case BEHAVIOR_LOCALITY_CENTRAL:
+        return invoke_locally(&binding, event, pressed);
+    case BEHAVIOR_LOCALITY_EVENT_SOURCE:
+#if ZMK_BLE_IS_CENTRAL
+        if (event.source == ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL) {
+            return invoke_locally(&binding, event, pressed);
+        } else {
+            return zmk_split_bt_invoke_behavior(event.source, &binding, event, pressed);
+        }
+#else
+        return invoke_locally(&binding, event, pressed);
+#endif
+    case BEHAVIOR_LOCALITY_GLOBAL:
+#if ZMK_BLE_IS_CENTRAL
+        for (int i = 0; i < ZMK_SPLIT_BLE_PERIPHERAL_COUNT; i++) {
+            zmk_split_bt_invoke_behavior(i, &binding, event, pressed);
+        }
+#endif
+        return invoke_locally(&binding, event, pressed);
+    }
+
+    return -ENOTSUP;
 }
 
 #if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)

--- a/app/src/behavior_queue.c
+++ b/app/src/behavior_queue.c
@@ -15,7 +15,9 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 struct q_item {
     uint32_t position;
+#if IS_ENABLED(CONFIG_ZMK_SPLIT)
     uint8_t source;
+#endif
     struct zmk_behavior_binding binding;
     bool press : 1;
     uint32_t wait : 31;
@@ -34,7 +36,12 @@ static void behavior_queue_process_next(struct k_work *work) {
                 item.binding.param2);
 
         struct zmk_behavior_binding_event event = {
-            .position = item.position, .timestamp = k_uptime_get(), .source = item.source};
+            .position = item.position,
+            .timestamp = k_uptime_get(),
+#if IS_ENABLED(CONFIG_ZMK_SPLIT)
+            .source = item.source
+#endif
+        };
 
         if (item.press) {
             zmk_behavior_invoke_binding(&item.binding, event, true);
@@ -51,10 +58,17 @@ static void behavior_queue_process_next(struct k_work *work) {
     }
 }
 
-int zmk_behavior_queue_add(uint32_t position, uint8_t source,
+int zmk_behavior_queue_add(const struct zmk_behavior_binding_event *event,
                            const struct zmk_behavior_binding binding, bool press, uint32_t wait) {
     struct q_item item = {
-        .press = press, .binding = binding, .wait = wait, .position = position, .source = source};
+        .press = press,
+        .binding = binding,
+        .wait = wait,
+        .position = event->position,
+#if IS_ENABLED(CONFIG_ZMK_SPLIT)
+        .source = event->source,
+#endif
+    };
 
     const int ret = k_msgq_put(&zmk_behavior_queue_msgq, &item, K_NO_WAIT);
     if (ret < 0) {

--- a/app/src/behaviors/behavior_macro.c
+++ b/app/src/behaviors/behavior_macro.c
@@ -158,7 +158,7 @@ static void replace_params(struct behavior_macro_trigger_state *state,
     state->param2_source = PARAM_SOURCE_BINDING;
 }
 
-static void queue_macro(uint32_t position, uint8_t source,
+static void queue_macro(struct zmk_behavior_binding_event *event,
                         const struct zmk_behavior_binding bindings[],
                         struct behavior_macro_trigger_state state,
                         const struct zmk_behavior_binding *macro_binding) {
@@ -170,14 +170,14 @@ static void queue_macro(uint32_t position, uint8_t source,
 
             switch (state.mode) {
             case MACRO_MODE_TAP:
-                zmk_behavior_queue_add(position, source, binding, true, state.tap_ms);
-                zmk_behavior_queue_add(position, source, binding, false, state.wait_ms);
+                zmk_behavior_queue_add(event, binding, true, state.tap_ms);
+                zmk_behavior_queue_add(event, binding, false, state.wait_ms);
                 break;
             case MACRO_MODE_PRESS:
-                zmk_behavior_queue_add(position, source, binding, true, state.wait_ms);
+                zmk_behavior_queue_add(event, binding, true, state.wait_ms);
                 break;
             case MACRO_MODE_RELEASE:
-                zmk_behavior_queue_add(position, source, binding, false, state.wait_ms);
+                zmk_behavior_queue_add(event, binding, false, state.wait_ms);
                 break;
             default:
                 LOG_ERR("Unknown macro mode: %d", state.mode);
@@ -198,7 +198,7 @@ static int on_macro_binding_pressed(struct zmk_behavior_binding *binding,
                                                          .start_index = 0,
                                                          .count = state->press_bindings_count};
 
-    queue_macro(event.position, event.source, cfg->bindings, trigger_state, binding);
+    queue_macro(&event, cfg->bindings, trigger_state, binding);
 
     return ZMK_BEHAVIOR_OPAQUE;
 }
@@ -209,7 +209,7 @@ static int on_macro_binding_released(struct zmk_behavior_binding *binding,
     const struct behavior_macro_config *cfg = dev->config;
     struct behavior_macro_state *state = dev->data;
 
-    queue_macro(event.position, event.source, cfg->bindings, state->release_state, binding);
+    queue_macro(&event, cfg->bindings, state->release_state, binding);
 
     return ZMK_BEHAVIOR_OPAQUE;
 }

--- a/app/src/behaviors/behavior_macro.c
+++ b/app/src/behaviors/behavior_macro.c
@@ -158,7 +158,8 @@ static void replace_params(struct behavior_macro_trigger_state *state,
     state->param2_source = PARAM_SOURCE_BINDING;
 }
 
-static void queue_macro(uint32_t position, const struct zmk_behavior_binding bindings[],
+static void queue_macro(uint32_t position, uint8_t source,
+                        const struct zmk_behavior_binding bindings[],
                         struct behavior_macro_trigger_state state,
                         const struct zmk_behavior_binding *macro_binding) {
     LOG_DBG("Iterating macro bindings - starting: %d, count: %d", state.start_index, state.count);
@@ -169,14 +170,14 @@ static void queue_macro(uint32_t position, const struct zmk_behavior_binding bin
 
             switch (state.mode) {
             case MACRO_MODE_TAP:
-                zmk_behavior_queue_add(position, binding, true, state.tap_ms);
-                zmk_behavior_queue_add(position, binding, false, state.wait_ms);
+                zmk_behavior_queue_add(position, source, binding, true, state.tap_ms);
+                zmk_behavior_queue_add(position, source, binding, false, state.wait_ms);
                 break;
             case MACRO_MODE_PRESS:
-                zmk_behavior_queue_add(position, binding, true, state.wait_ms);
+                zmk_behavior_queue_add(position, source, binding, true, state.wait_ms);
                 break;
             case MACRO_MODE_RELEASE:
-                zmk_behavior_queue_add(position, binding, false, state.wait_ms);
+                zmk_behavior_queue_add(position, source, binding, false, state.wait_ms);
                 break;
             default:
                 LOG_ERR("Unknown macro mode: %d", state.mode);
@@ -197,7 +198,7 @@ static int on_macro_binding_pressed(struct zmk_behavior_binding *binding,
                                                          .start_index = 0,
                                                          .count = state->press_bindings_count};
 
-    queue_macro(event.position, cfg->bindings, trigger_state, binding);
+    queue_macro(event.position, event.source, cfg->bindings, trigger_state, binding);
 
     return ZMK_BEHAVIOR_OPAQUE;
 }
@@ -208,7 +209,7 @@ static int on_macro_binding_released(struct zmk_behavior_binding *binding,
     const struct behavior_macro_config *cfg = dev->config;
     struct behavior_macro_state *state = dev->data;
 
-    queue_macro(event.position, cfg->bindings, state->release_state, binding);
+    queue_macro(event.position, event.source, cfg->bindings, state->release_state, binding);
 
     return ZMK_BEHAVIOR_OPAQUE;
 }

--- a/app/src/behaviors/behavior_mod_morph.c
+++ b/app/src/behaviors/behavior_mod_morph.c
@@ -51,7 +51,7 @@ static int on_mod_morph_binding_pressed(struct zmk_behavior_binding *binding,
     } else {
         data->pressed_binding = (struct zmk_behavior_binding *)&cfg->normal_binding;
     }
-    return behavior_keymap_binding_pressed(data->pressed_binding, event);
+    return zmk_behavior_invoke_binding(data->pressed_binding, event, true);
 }
 
 static int on_mod_morph_binding_released(struct zmk_behavior_binding *binding,
@@ -67,7 +67,7 @@ static int on_mod_morph_binding_released(struct zmk_behavior_binding *binding,
     struct zmk_behavior_binding *pressed_binding = data->pressed_binding;
     data->pressed_binding = NULL;
     int err;
-    err = behavior_keymap_binding_released(pressed_binding, event);
+    err = zmk_behavior_invoke_binding(pressed_binding, event, false);
     zmk_hid_masked_modifiers_clear();
     return err;
 }

--- a/app/src/behaviors/behavior_sensor_rotate_common.c
+++ b/app/src/behaviors/behavior_sensor_rotate_common.c
@@ -90,8 +90,8 @@ int zmk_behavior_sensor_rotate_common_process(struct zmk_behavior_binding *bindi
     LOG_DBG("Sensor binding: %s", binding->behavior_dev);
 
     for (int i = 0; i < triggers; i++) {
-        zmk_behavior_queue_add(event.position, triggered_binding, true, cfg->tap_ms);
-        zmk_behavior_queue_add(event.position, triggered_binding, false, 0);
+        zmk_behavior_queue_add(event.position, event.source, triggered_binding, true, cfg->tap_ms);
+        zmk_behavior_queue_add(event.position, event.source, triggered_binding, false, 0);
     }
 
     return ZMK_BEHAVIOR_OPAQUE;

--- a/app/src/behaviors/behavior_sensor_rotate_common.c
+++ b/app/src/behaviors/behavior_sensor_rotate_common.c
@@ -90,11 +90,14 @@ int zmk_behavior_sensor_rotate_common_process(struct zmk_behavior_binding *bindi
 
     LOG_DBG("Sensor binding: %s", binding->behavior_dev);
 
+#if IS_ENABLED(CONFIG_ZMK_SPLIT)
+    // set this value so that it always triggers on central, can be handled more properly later
+    event.source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL;
+#endif
+
     for (int i = 0; i < triggers; i++) {
-        zmk_behavior_queue_add(event.position, ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
-                               triggered_binding, true, cfg->tap_ms);
-        zmk_behavior_queue_add(event.position, ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
-                               triggered_binding, false, 0);
+        zmk_behavior_queue_add(&event, triggered_binding, true, cfg->tap_ms);
+        zmk_behavior_queue_add(&event, triggered_binding, false, 0);
     }
 
     return ZMK_BEHAVIOR_OPAQUE;

--- a/app/src/behaviors/behavior_sensor_rotate_common.c
+++ b/app/src/behaviors/behavior_sensor_rotate_common.c
@@ -6,6 +6,7 @@
 
 #include <zmk/behavior_queue.h>
 #include <zmk/virtual_key_position.h>
+#include <zmk/events/position_state_changed.h>
 
 #include "behavior_sensor_rotate_common.h"
 
@@ -90,8 +91,10 @@ int zmk_behavior_sensor_rotate_common_process(struct zmk_behavior_binding *bindi
     LOG_DBG("Sensor binding: %s", binding->behavior_dev);
 
     for (int i = 0; i < triggers; i++) {
-        zmk_behavior_queue_add(event.position, event.source, triggered_binding, true, cfg->tap_ms);
-        zmk_behavior_queue_add(event.position, event.source, triggered_binding, false, 0);
+        zmk_behavior_queue_add(event.position, ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
+                               triggered_binding, true, cfg->tap_ms);
+        zmk_behavior_queue_add(event.position, ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
+                               triggered_binding, false, 0);
     }
 
     return ZMK_BEHAVIOR_OPAQUE;

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -40,6 +40,7 @@ struct behavior_sticky_key_config {
 
 struct active_sticky_key {
     uint32_t position;
+    uint8_t source;
     uint32_t param1;
     uint32_t param2;
     const struct behavior_sticky_key_config *config;
@@ -55,8 +56,8 @@ struct active_sticky_key {
 
 struct active_sticky_key active_sticky_keys[ZMK_BHV_STICKY_KEY_MAX_HELD] = {};
 
-static struct active_sticky_key *store_sticky_key(uint32_t position, uint32_t param1,
-                                                  uint32_t param2,
+static struct active_sticky_key *store_sticky_key(uint32_t position, uint8_t source,
+                                                  uint32_t param1, uint32_t param2,
                                                   const struct behavior_sticky_key_config *config) {
     for (int i = 0; i < ZMK_BHV_STICKY_KEY_MAX_HELD; i++) {
         struct active_sticky_key *const sticky_key = &active_sticky_keys[i];
@@ -65,6 +66,7 @@ static struct active_sticky_key *store_sticky_key(uint32_t position, uint32_t pa
             continue;
         }
         sticky_key->position = position;
+        sticky_key->source = source;
         sticky_key->param1 = param1;
         sticky_key->param2 = param2;
         sticky_key->config = config;
@@ -101,8 +103,9 @@ static inline int press_sticky_key_behavior(struct active_sticky_key *sticky_key
     struct zmk_behavior_binding_event event = {
         .position = sticky_key->position,
         .timestamp = timestamp,
+        .source = sticky_key->source,
     };
-    return behavior_keymap_binding_pressed(&binding, event);
+    return zmk_behavior_invoke_binding(&binding, event, true);
 }
 
 static inline int release_sticky_key_behavior(struct active_sticky_key *sticky_key,
@@ -115,10 +118,11 @@ static inline int release_sticky_key_behavior(struct active_sticky_key *sticky_k
     struct zmk_behavior_binding_event event = {
         .position = sticky_key->position,
         .timestamp = timestamp,
+        .source = sticky_key->source,
     };
 
     clear_sticky_key(sticky_key);
-    return behavior_keymap_binding_released(&binding, event);
+    return zmk_behavior_invoke_binding(&binding, event, false);
 }
 
 static inline void on_sticky_key_timeout(struct active_sticky_key *sticky_key) {
@@ -149,7 +153,8 @@ static int on_sticky_key_binding_pressed(struct zmk_behavior_binding *binding,
         stop_timer(sticky_key);
         release_sticky_key_behavior(sticky_key, event.timestamp);
     }
-    sticky_key = store_sticky_key(event.position, binding->param1, binding->param2, cfg);
+    sticky_key =
+        store_sticky_key(event.position, event.source, binding->param1, binding->param2, cfg);
     if (sticky_key == NULL) {
         LOG_ERR("unable to store sticky key, did you press more than %d sticky_key?",
                 ZMK_BHV_STICKY_KEY_MAX_HELD);

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -291,8 +291,10 @@ static int release_pressed_keys() {
 static inline int press_combo_behavior(struct combo_cfg *combo, int32_t timestamp) {
     struct zmk_behavior_binding_event event = {
         .position = combo->virtual_key_position,
-        .source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
         .timestamp = timestamp,
+#if IS_ENABLED(CONFIG_ZMK_SPLIT)
+        .source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
+#endif
     };
 
     last_combo_timestamp = timestamp;
@@ -303,8 +305,10 @@ static inline int press_combo_behavior(struct combo_cfg *combo, int32_t timestam
 static inline int release_combo_behavior(struct combo_cfg *combo, int32_t timestamp) {
     struct zmk_behavior_binding_event event = {
         .position = combo->virtual_key_position,
-        .source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
         .timestamp = timestamp,
+#if IS_ENABLED(CONFIG_ZMK_SPLIT)
+        .source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
+#endif
     };
 
     return zmk_behavior_invoke_binding(&combo->behavior, event, false);

--- a/app/src/combo.c
+++ b/app/src/combo.c
@@ -291,21 +291,23 @@ static int release_pressed_keys() {
 static inline int press_combo_behavior(struct combo_cfg *combo, int32_t timestamp) {
     struct zmk_behavior_binding_event event = {
         .position = combo->virtual_key_position,
+        .source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
         .timestamp = timestamp,
     };
 
     last_combo_timestamp = timestamp;
 
-    return behavior_keymap_binding_pressed(&combo->behavior, event);
+    return zmk_behavior_invoke_binding(&combo->behavior, event, true);
 }
 
 static inline int release_combo_behavior(struct combo_cfg *combo, int32_t timestamp) {
     struct zmk_behavior_binding_event event = {
         .position = combo->virtual_key_position,
+        .source = ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL,
         .timestamp = timestamp,
     };
 
-    return behavior_keymap_binding_released(&combo->behavior, event);
+    return zmk_behavior_invoke_binding(&combo->behavior, event, false);
 }
 
 static void move_pressed_keys_to_active_combo(struct active_combo *active_combo) {

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -7,7 +7,6 @@
 #include <drivers/behavior.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/settings/settings.h>
-#include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
@@ -17,11 +16,6 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/matrix.h>
 #include <zmk/sensors.h>
 #include <zmk/virtual_key_position.h>
-
-#include <zmk/ble.h>
-#if ZMK_BLE_IS_CENTRAL
-#include <zmk/split/bluetooth/central.h>
-#endif
 
 #include <zmk/event_manager.h>
 #include <zmk/events/position_state_changed.h>
@@ -576,76 +570,20 @@ int zmk_keymap_reset_settings(void) { return -ENOTSUP; }
 
 #endif // IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE)
 
-int invoke_locally(struct zmk_behavior_binding *binding, struct zmk_behavior_binding_event event,
-                   bool pressed) {
-    if (pressed) {
-        return behavior_keymap_binding_pressed(binding, event);
-    } else {
-        return behavior_keymap_binding_released(binding, event);
-    }
-}
-
 int zmk_keymap_apply_position_state(uint8_t source, zmk_keymap_layer_id_t layer_id,
                                     uint32_t position, bool pressed, int64_t timestamp) {
-    // We want to make a copy of this, since it may be converted from
-    // relative to absolute before being invoked
-
-    ASSERT_LAYER_VAL(layer_id, -EINVAL);
-
-    struct zmk_behavior_binding binding = zmk_keymap[layer_id][position];
-    const struct device *behavior;
+    struct zmk_behavior_binding *binding = &zmk_keymap[layer_id][position];
     struct zmk_behavior_binding_event event = {
         .layer = layer_id,
         .position = position,
         .timestamp = timestamp,
+        .source = source,
     };
 
     LOG_DBG("layer_id: %d position: %d, binding name: %s", layer_id, position,
-            binding.behavior_dev);
+            binding->behavior_dev);
 
-    behavior = zmk_behavior_get_binding(binding.behavior_dev);
-
-    if (!behavior) {
-        LOG_WRN("No behavior assigned to %d on layer %d", position, layer_id);
-        return 1;
-    }
-
-    int err = behavior_keymap_binding_convert_central_state_dependent_params(&binding, event);
-    if (err) {
-        LOG_ERR("Failed to convert relative to absolute behavior binding (err %d)", err);
-        return err;
-    }
-
-    enum behavior_locality locality = BEHAVIOR_LOCALITY_CENTRAL;
-    err = behavior_get_locality(behavior, &locality);
-    if (err) {
-        LOG_ERR("Failed to get behavior locality %d", err);
-        return err;
-    }
-
-    switch (locality) {
-    case BEHAVIOR_LOCALITY_CENTRAL:
-        return invoke_locally(&binding, event, pressed);
-    case BEHAVIOR_LOCALITY_EVENT_SOURCE:
-#if ZMK_BLE_IS_CENTRAL
-        if (source == ZMK_POSITION_STATE_CHANGE_SOURCE_LOCAL) {
-            return invoke_locally(&binding, event, pressed);
-        } else {
-            return zmk_split_bt_invoke_behavior(source, &binding, event, pressed);
-        }
-#else
-        return invoke_locally(&binding, event, pressed);
-#endif
-    case BEHAVIOR_LOCALITY_GLOBAL:
-#if ZMK_BLE_IS_CENTRAL
-        for (int i = 0; i < ZMK_SPLIT_BLE_PERIPHERAL_COUNT; i++) {
-            zmk_split_bt_invoke_behavior(i, &binding, event, pressed);
-        }
-#endif
-        return invoke_locally(&binding, event, pressed);
-    }
-
-    return -ENOTSUP;
+    return zmk_behavior_invoke_binding(binding, event, pressed);
 }
 
 int zmk_keymap_position_state_changed(uint8_t source, uint32_t position, bool pressed,

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -577,7 +577,9 @@ int zmk_keymap_apply_position_state(uint8_t source, zmk_keymap_layer_id_t layer_
         .layer = layer_id,
         .position = position,
         .timestamp = timestamp,
+#if IS_ENABLED(CONFIG_ZMK_SPLIT)
         .source = source,
+#endif
     };
 
     LOG_DBG("layer_id: %d position: %d, binding name: %s", layer_id, position,

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -816,6 +816,7 @@ int zmk_split_bt_invoke_behavior(uint8_t source, struct zmk_behavior_binding *bi
                                                          .param1 = binding->param1,
                                                          .param2 = binding->param2,
                                                          .position = event.position,
+                                                         .source = event.source,
                                                          .state = state ? 1 : 0,
                                                      }};
     const size_t payload_dev_size = sizeof(payload.behavior_dev);

--- a/docs/docs/features/split-keyboards.md
+++ b/docs/docs/features/split-keyboards.md
@@ -86,11 +86,6 @@ These behaviors only affect the keyboard part that they are invoked from:
 
 - [Reset behaviors](../keymaps/behaviors/reset.md)
 
-:::warning[Nesting behaviors with locality]
-Currently there is [an issue](https://github.com/zmkfirmware/zmk/issues/1494) preventing both global and source locality behaviors from working as expected if they are invoked from another behavior, such as a hold-tap, tap dance or a mod-morph.
-For this reason it is recommended that these behaviors are placed directly on a keymap layer.
-:::
-
 :::note[Peripheral invocation]
 Peripherals must be paired and connected to the central in order to be able to activate these behaviors, even if it is possible to trigger the behavior using only keys on a particular peripheral.
 This is because the key bindings are processed on the central side which would then instruct the peripheral side to run the behavior's effect.


### PR DESCRIPTION
This is another attempt to solve #1494. My understanding is that #1630 only covers the case of macros invoking global behaviors. I incorporated the changes in it and attempted to address the existing comments.

In addition to the other PR, this should cover sticky keys, hold-taps, mod-morphs and work with source+global locality behaviors. I tested the reset behaviors with hold-taps and tap dances so far.

I am not familiar with these parts of the code; so far I stuck an extra field `source` wherever I saw a `position` and passed it around. Specifically, it is a new field in `zmk_behavior_binding_event`. Any recommendations are welcome on how better to do it.

TODO:
- [x] Test source local behaviors (reset)
  - [x] macros
  - [x] mod-morphs
  - [x] hold-taps
  - [x] tap dances
  - [x] sticky keys
- [x] Test global behaviors (backlight)
  - [x] macros
  - [x] mod-morphs
  - [x] hold-taps
  - [x] tap dances
  - [x] sticky keys
- [x] Handle combos (at least get them working with global behaviors)
