### PR TITLE
fix: Fix hardware metadata validation after image changes.

### DIFF
--- a/.github/workflows/hardware-metadata-validation.yml
+++ b/.github/workflows/hardware-metadata-validation.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: pip install -r app/scripts/requirements.txt
+        run: pip install --break-system-packages -r app/scripts/requirements.txt
       - name: West init
         run: west init -l app
       - name: Update modules (west update)


### PR DESCRIPTION
* Newer Docker image requires --break-system-packages for pip.
