### PR TITLE
fix(docs): Fix broken anchor in reset behaviors

### DIFF
--- a/docs/docs/behaviors/reset.md
+++ b/docs/docs/behaviors/reset.md
@@ -44,4 +44,4 @@ Example:
 
 ## Split Keyboards
 
-Both basic and bootloader reset behaviors are [source-specific](../features/split-keyboards.md##source-locality-behaviors): This means that it affects the side of the keyboard that contains the behavior binding for split keyboards. For example if you press a key with the `&sys_reset` binding on the left half of the keyboard, the left half will be reset. If you want to be able to reset both sides you can put the bindings on both sides of the keyboard and activate it on the side you would like to reset.
+Both basic and bootloader reset behaviors are [source-specific](../features/split-keyboards.md#source-locality-behaviors): This means that it affects the side of the keyboard that contains the behavior binding for split keyboards. For example if you press a key with the `&sys_reset` binding on the left half of the keyboard, the left half will be reset. If you want to be able to reset both sides you can put the bindings on both sides of the keyboard and activate it on the side you would like to reset.


### PR DESCRIPTION
Somehow a second `#` snuck in, breaking the link. `npm build` warns about these, note to self and others for the next time.