### PR TITLE
refactor(docs): Convert Codes and Setup index pages to category link

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -80,8 +80,14 @@ module.exports = {
       ],
     },
     {
-      Codes: [
-        "codes/index",
+      type: "category",
+      label: "Codes",
+      link: {
+        type: "doc",
+        id: "codes/index",
+      },
+      collapsed: true,
+      items: [
         "codes/keyboard-keypad",
         "codes/modifiers",
         "codes/editing",
@@ -122,12 +128,12 @@ module.exports = {
         {
           type: "category",
           label: "Setup",
+          link: {
+            type: "doc",
+            id: "development/setup/index",
+          },
           collapsed: true,
-          items: [
-            "development/setup/index",
-            "development/setup/docker",
-            "development/setup/native",
-          ],
+          items: ["development/setup/docker", "development/setup/native"],
         },
         "development/build-flash",
         "development/boards-shields-keymaps",


### PR DESCRIPTION
Following the linkification of Behaviors and Config category headers, doing the same for Setup (seems like a net positive) and Codes (might be more controversial since "Full List" isn't exactly like an index).