### PR TITLE
fix(boards): add sleep pinctrl node for nice!60

### DIFF
--- a/app/boards/arm/nice60/nice60-pinctrl.dtsi
+++ b/app/boards/arm/nice60/nice60-pinctrl.dtsi
@@ -9,4 +9,11 @@
             psels = <NRF_PSEL(SPIM_MOSI, 0, 27)>;
         };
     };
+
+    spi3_sleep: spi3_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_MOSI, 0, 27)>;
+            low-power-enable;
+        };
+    };
 };

--- a/app/boards/arm/nice60/nice60.dts
+++ b/app/boards/arm/nice60/nice60.dts
@@ -110,7 +110,8 @@ RC(4,0)   RC(4,1)   RC(4,2)                      RC(4,5)                       R
     compatible = "nordic,nrf-spim";
 
     pinctrl-0 = <&spi3_default>;
-    pinctrl-names = "default";
+    pinctrl-1 = <&spi3_sleep>;
+    pinctrl-names = "default", "sleep";
     status = "okay";
 
     led_strip: ws2812@0 {


### PR DESCRIPTION
Add spi3_sleep pinctrl node to fix nice!60 builds with both RGB underglow and sleep enabled.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [x] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [x] `.zmk.yml` metadata file added
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] General consistent formatting of DeviceTree files
- [x] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [x] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [x] If split, no name added for the right/peripheral half
- [x] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [x] `.conf` file has optional extra features commented out
- [x] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
