### PR TITLE
Fix path to `run-test.sh` when ZMK is used as a module

### DIFF
--- a/app/scripts/west_commands/test.py
+++ b/app/scripts/west_commands/test.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 """Test runner for ZMK."""
 
-import os
 import subprocess
+from pathlib import Path
 
-from west.commands import WestCommand
 from west import log  # use this for user output
+from west.commands import WestCommand
 
 
 class Test(WestCommand):
@@ -16,6 +16,8 @@ class Test(WestCommand):
             help="run ZMK testsuite",
             description="Run the ZMK testsuite.",
         )
+
+        self.appdir = Path(__file__).resolve().parents[2]
 
     def do_add_parser(self, parser_adder):
         parser = parser_adder.add_parser(
@@ -34,8 +36,7 @@ class Test(WestCommand):
 
     def do_run(self, args, unknown_args):
         # the run-test script assumes the app directory is the current dir.
-        os.chdir(f"{self.topdir}/app")
         completed_process = subprocess.run(
-            [f"{self.topdir}/app/run-test.sh", args.test_path]
+            ["./run-test.sh", args.test_path], cwd=self.appdir
         )
         exit(completed_process.returncode)


### PR DESCRIPTION
Fixes #2421 