### PR TITLE
feat(docs): Added and modified docs to point users to the experimental zmk-cli.

### DIFF
--- a/docs/docs/user-setup-cli.mdx
+++ b/docs/docs/user-setup-cli.mdx
@@ -17,11 +17,9 @@ If you use this program, any bug reports are highly appreciated. We are happy to
 
 ### Preliminaries
 
-:::tip
-The below commands should print a version number if the program is installed.
-:::
-
 #### Make sure you have Git installed
+
+The below commands should print a version number if the program is installed.
 
 ```sh
 git --version
@@ -44,15 +42,13 @@ Re-open your terminal and test to make sure it is now installed.
 
 #### Make sure you have Python installed
 
-:::tip
-Some operating systems may use `python` in place of `python3`
-:::
+ZMK CLI requires Python 3.10 or newer.
 
 ```sh
 python3 --version
 ```
 
-ZMK CLI requires Python 3.10 or newer.
+Note that some operating systems may use `python` in place of `python3`.
 
 <details>
   <summary>I don't have Python 3.10 or newer installed.</summary>
@@ -88,9 +84,7 @@ Re-open your terminal and test to make sure it is now installed.
 
 #### (Recommended) Make sure you have pipx installed
 
-:::note
 ZMK CLI can be installed with pip, but using [pipx](https://github.com/pypa/pipx) is recommended to avoid conflicts between Python packages.
-:::
 
 ```sh
 pipx --version
@@ -167,7 +161,7 @@ Otherwise, leave this first prompt blank and press <kbd>Enter</kbd>, and it will
 
 Once you finish following all the instructions, you will have a copy of the repo stored on your computer. All `zmk` commands will run on this repo (unless the working directory is inside a different repo). If you ever forget where the repo is located, you can run `zmk cd` to find it.
 
-Now that you have a repo created, see the instructions below for how ZMK CLI can automate some common tasks, or see [Customizing ZMK](customization.md) for more hands-on customisation information.
+Now that you have a repo created, see the instructions below for how ZMK CLI can automate some common tasks, or see [Customizing ZMK](customization.md) for more hands-on customization information.
 
 ### Keyboard Management
 

--- a/docs/docs/user-setup-cli.mdx
+++ b/docs/docs/user-setup-cli.mdx
@@ -17,6 +17,10 @@ If you use this program, any bug reports are highly appreciated. We are happy to
 
 ### Preliminaries
 
+:::tip
+The below commands should print a version number if the program is installed.
+:::
+
 #### Make sure you have Git installed
 
 ```sh
@@ -40,8 +44,11 @@ Re-open your terminal and test to make sure it is now installed.
 
 #### Make sure you have Python installed
 
+:::tip
+Some operating systems may use `python` in place of `python3`
+:::
+
 ```sh
-python --version
 python3 --version
 ```
 
@@ -81,14 +88,16 @@ Re-open your terminal and test to make sure it is now installed.
 
 #### (Recommended) Make sure you have pipx installed
 
+:::note
+ZMK CLI can be installed with pip, but using [pipx](https://github.com/pypa/pipx) is recommended to avoid conflicts between Python packages.
+:::
+
 ```sh
 pipx --version
 ```
 
 <details>
   <summary>I don't have pipx installed.</summary>
-
-ZMK CLI can be installed with pip, but using [pipx](https://github.com/pypa/pipx) is recommended to avoid conflicts between Python packages.
 
 ### On Windows and Linux
 

--- a/docs/docs/user-setup-cli.mdx
+++ b/docs/docs/user-setup-cli.mdx
@@ -1,0 +1,278 @@
+---
+title: (EXPERIMENTAL) Installing ZMK
+sidebar_label: (EXPERIMENTAL) Installing ZMK
+---
+
+This is an **experimental** command line program to help set up ZMK. [Click here to return to the main documentation](user-setup.mdx).
+
+ZMK CLI walks you through installing ZMK and setting up a GitHub repository to store and build custom firmware. It also automates some common tasks such as adding new keyboards to your repository.
+
+The instructions below contain commands that need to be run in a terminal program. On Windows, use the [Windows Terminal](https://apps.microsoft.com/detail/9n0dx20hk701) or PowerShell. On other operating systems, the terminal program is usually just named "Terminal".
+
+:::info
+If you use this program, any bug reports are highly appreciated. We are happy to help you fix your setup if you encounter a bug through the usage of this program.
+:::
+
+## Installation
+
+### Preliminaries
+
+#### Make sure you have Git installed
+
+```sh
+git --version
+```
+
+<details>
+  <summary>I don't have Git installed.</summary>
+
+Install Git from https://git-scm.com/downloads.
+
+If you have Windows 11, you can instead open a terminal and run:
+
+```sh
+winget install git.git
+```
+
+Re-open your terminal and test to make sure it is now installed.
+
+</details>
+
+#### Make sure you have Python installed
+
+```sh
+python --version
+python3 --version
+```
+
+ZMK CLI requires Python 3.10 or newer.
+
+<details>
+  <summary>I don't have Python 3.10 or newer installed.</summary>
+
+##### On Windows and macOS
+
+Install the latest version of Python from https://www.python.org/downloads/.
+
+If you have Windows 11, you can instead open a terminal and run:
+
+```sh
+winget install python3
+```
+
+Re-open your terminal and test to make sure it is now installed.
+
+##### On Linux
+
+Install `python3` with your package manager.
+
+If the version is older than 3.10, you will need to find and install a package for a newer version of Python. On Ubuntu 20.04 and older, you can get Python 3.10 from the deadsnakes PPA with the following commands:
+
+```sh
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt install python3.10
+```
+
+You will then need to replace `python3` with `python3.10` in the rest of the installation instructions.
+
+Re-open your terminal and test to make sure it is now installed.
+
+</details>
+
+#### (Recommended) Make sure you have pipx installed
+
+```sh
+pipx --version
+```
+
+<details>
+  <summary>I don't have pipx installed.</summary>
+
+ZMK CLI can be installed with pip, but using [pipx](https://github.com/pypa/pipx) is recommended to avoid conflicts between Python packages.
+
+### On Windows and Linux
+
+Open a terminal and run:
+
+```sh
+python3 -m pip install --user pipx
+python3 -m pipx ensurepath
+```
+
+Some Linux distributions may disallow installing packages with pip. If this gives you an error, see the [install instructions](https://github.com/pypa/pipx?tab=readme-ov-file#on-linux) specific to your distribution.
+
+Re-open your terminal and test to make sure it is now installed.
+
+### On macOS
+
+Open Terminal and run:
+
+```sh
+brew install pipx
+pipx ensurepath
+```
+
+Re-open your terminal and test to make sure it is now installed.
+
+</details>
+
+### Install ZMK CLI
+
+Run the following commands:
+
+```sh
+pipx install git+https://github.com/joelspadin/zmk-cli.git
+zmk --help
+```
+
+It should print a help message if everything installed correctly.
+
+On Linux, you may get an error saying you need to install another package such as `python3.10-venv`. If so, follow the instructions in the error message, then try the above commands again.
+
+## Using ZMK CLI
+
+All ZMK CLI commands start with `zmk`. Run `zmk --help` for general usage instructions. For help with a specific subcommand, add `--help` after the subcommand, e.g. `zmk init --help`.
+
+### Initialize a Repository
+
+:::warning
+If you have already created a repo and cloned it to your computer, you do not need to run this command. Set the [user.home](#userhome) setting to point to the existing repo instead.
+:::
+
+The `zmk init` command walks you through creating a GitHub repository, then clones it to your computer so you can edit it.
+
+Open a terminal and use the `cd` command to move to a directory where you'd like to place the ZMK files, then run `zmk init`. For example:
+
+```sh
+cd ~/Documents
+zmk init
+```
+
+Follow the instructions it gives you. If you already have a ZMK config repo, you can enter its URL when prompted, for example:
+
+```
+Repository URL: https://github.com/myusername/zmk-config
+```
+
+Otherwise, leave this first prompt blank and press <kbd>Enter</kbd>, and it will walk you through creating a new repo.
+
+Once you finish following all the instructions, you will have a copy of the repo stored on your computer. All `zmk` commands will run on this repo (unless the working directory is inside a different repo). If you ever forget where the repo is located, you can run `zmk cd` to find it.
+
+Now that you have a repo created, see the instructions below for how ZMK CLI can automate some common tasks, or see [Customizing ZMK](customization.md) for more hands-on customisation information.
+
+### Keyboard Management
+
+#### Add a keyboard
+
+To start building firmware for a new keyboard, run `zmk keyboard add`. Follow the instructions to select a keyboard (and controller board if necessary), and it will add it to the list of firmware to build and copy a default keymap into your repo.
+
+You can then run `zmk code <keyboard>` to open the keymap in a text editor.
+
+This command reads from a local copy of ZMK to determine the supported keyboards. If the keyboard you want to use isn't listed, try running `zmk update` to update the local copy to the latest version of ZMK. If it still isn't listed, you may be able to find a [Zephyr module](#module-management) that provides it, you you may need to [create it yourself](#create-a-new-keyboard).
+
+#### Remove a keyboard
+
+To remove a keyboard from the build, run `zmk keyboard remove` and select the item to remove. For a split keyboard, you will need to run this twice and remove the left and right sides.
+
+This simply removes a keyboard from the `build.yaml` file. It does not delete any `.keymap` or `.conf` files.
+
+#### List supported keyboards
+
+Run `zmk keyboard list` to print a list of supported keyboard hardware.
+
+#### Create a new keyboard
+
+If ZMK doesn't support your keyboard yet, you can run `zmk keyboard new` to create a new keyboard from a template.
+
+This won't walk you through all of the details of adding support for a new keyboard, but it will generate most of the boilerplate for you. See the [New Keyboard Shield](development/new-shield.mdx) guide for how to finish writing the keyboard files.
+
+### Module Management
+
+[Modules](features/modules.mdx) can add support for new keyboards, behaviors, and other features to ZMK. Use the `zmk module` command to install modules into your repo:
+
+```sh
+zmk module add     # Add a module
+zmk module remove  # Remove an installed module
+zmk module list    # List the installed modules
+zmk update         # Update the local copies of ZMK and modules to their latest versions
+```
+
+### Edit Keymap and Config Files
+
+The `zmk code` command will open ZMK files in a text editor:
+
+```sh
+zmk code                    # Open the repo directory in an editor
+zmk code <keyboard>         # Open <keyboard>.keymap in an editor
+zmk code --conf <keyboard>  # Open <keyboard>.conf in an editor
+zmk code --build            # Open build.yaml in an editor
+```
+
+The first time you run this command, it will ask you which editor you want to use. If you want to change this choice later or use an editor that wasn't listed, see the [core.editor](#coreeditor) and [code.explorer](#coreexplorer) settings.
+
+### Push Changes to GitHub
+
+Run `zmk cd` to go to the repo directory. From here, you can run `git` commands manage the repo.
+
+For example, after adding a keyboard to your repo and editing its keymap, you can run the following commands to push your changes to GitHub and trigger a firmware build:
+
+```sh
+git add .
+git commit
+git push
+```
+
+You will need to [authenticate with GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#authenticating-with-the-command-line) before the `git push` command will work. The easiest way to do this is to install the [GitHub CLI](https://cli.github.com/) and run
+
+```sh
+gh auth login
+```
+
+but you can also use a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens). If using an access token, make sure you create it with the "workflow" scope option selected.
+
+### Download Firmware from GitHub
+
+After pushing changes, GitHub will automatically build the firmware for you. Run `zmk download` (or `zmk dl` for short) to open the GitHub actions page in your browser.
+
+From this page, you can click on a build (the latest is at the top) to view its status. If the build succeeded, you can download the firmware from the "Artifacts" section at the bottom of the build summary page.
+
+### Configuration
+
+The `zmk config` command manages settings for ZMK CLI:
+
+```sh
+zmk config                 # List all settings
+zmk config <name>          # Print the value of the setting <name>
+zmk config <name> <value>  # Set <name> to <value>
+zmk config --unset <name>  # Remove the setting <name>
+```
+
+By default, these settings are stored in a file in your user profile directory. Run `zmk config --path` to get the location of this file. You can change where the settings file is stored by setting a `ZMK_CLI_CONFIG` environment variable to the new path to use, or by adding a `--config-file=<path>` argument when running `zmk`.
+
+Other commands use the following settings:
+
+#### user.home
+
+The path to the repository to use whenever `zmk` is run and the working directory is not inside a ZMK config repository.
+
+For example, to point ZMK CLI to an existing repo at `~/Documents/zmk-config`, run:
+
+```sh
+zmk config user.home ~/Documents/zmk-config
+```
+
+#### core.editor
+
+Command line for a text editor to use with the `zmk code` command.
+
+For example, so set Visual Studio Code as the editor and make it always open a new window, run:
+
+```sh
+zmk config core.editor "code --new-window"
+```
+
+#### core.explorer
+
+Command line for a file explorer to use with the `zmk code` command when opening a directory.
+
+If this setting is not set, the `core.editor` tool will be run instead. Set this setting when using a text editor that does not support opening directories.

--- a/docs/docs/user-setup-cli.mdx
+++ b/docs/docs/user-setup-cli.mdx
@@ -168,7 +168,7 @@ To start building firmware for a new keyboard, run `zmk keyboard add`. Follow th
 
 You can then run `zmk code <keyboard>` to open the keymap in a text editor.
 
-This command reads from a local copy of ZMK to determine the supported keyboards. If the keyboard you want to use isn't listed, try running `zmk update` to update the local copy to the latest version of ZMK. If it still isn't listed, you may be able to find a [Zephyr module](#module-management) that provides it, you you may need to [create it yourself](#create-a-new-keyboard).
+This command reads from a local copy of ZMK to determine the supported keyboards. If the keyboard you want to use isn't listed, try running `zmk update` to update the local copy to the latest version of ZMK. If it still isn't listed, you may be able to find a [Zephyr module](#module-management) that provides it, or you may need to [create it yourself](#create-a-new-keyboard).
 
 #### Remove a keyboard
 

--- a/docs/docs/user-setup-cli.mdx
+++ b/docs/docs/user-setup-cli.mdx
@@ -121,7 +121,7 @@ Re-open your terminal and test to make sure it is now installed.
 Run the following commands:
 
 ```sh
-pipx install git+https://github.com/joelspadin/zmk-cli.git
+pipx install zmk
 zmk --help
 ```
 

--- a/docs/docs/user-setup.mdx
+++ b/docs/docs/user-setup.mdx
@@ -12,6 +12,10 @@ core ZMK Firmware source repository.
 
 In addition to this, most users will not need to install any complicated toolchains or tools to build ZMK. GitHub Actions is used instead to automatically build the user's configured firmware for them.
 
+:::info
+ZMK currently has an **experimental** command line program set to replace the below steps. It is designed to automate a number of steps for you, and be easier to use. [Give it a try by following the instructions found here](user-setup-cli.mdx). Feedback and bug reports are very much welcome.
+:::
+
 ## Summary
 
 The following steps can be taken to obtain an installable firmware image for your device, without the need

--- a/docs/docs/user-setup.mdx
+++ b/docs/docs/user-setup.mdx
@@ -13,7 +13,7 @@ core ZMK Firmware source repository.
 In addition to this, most users will not need to install any complicated toolchains or tools to build ZMK. GitHub Actions is used instead to automatically build the user's configured firmware for them.
 
 :::info
-ZMK currently has an **experimental** command line program set to replace the below steps. It is designed to automate a number of steps for you, and be easier to use. [Give it a try by following the instructions found here](user-setup-cli.mdx). Feedback and bug reports are very much welcome.
+ZMK currently has an **experimental** command line program set to replace the below steps. It is designed to automate a number of steps for you and be easier to use. Give it a try by following the instructions found [here](user-setup-cli.mdx). Feedback and bug reports are very much welcome.
 :::
 
 ## Summary


### PR DESCRIPTION
The page is hidden in the sidebar, and only accessible through a link in an `info` box under `user-setup.mdx`.

By making it publically available in this way while marking it as experimental repeatedly, we should be able to get some useful feedback on it prior to switching over to it officially.

Obviously, credit goes to @joelspadin for writing the tool and most of the doc page, I just reformatted it.