### PR TITLE
  fix(display): widgets: increase buffer size for symbols

### DIFF
--- a/app/src/display/widgets/layer_status.c
+++ b/app/src/display/widgets/layer_status.c
@@ -24,13 +24,13 @@ struct layer_status_state {
 
 static void set_layer_symbol(lv_obj_t *label, struct layer_status_state state) {
     if (state.label == NULL) {
-        char text[7] = {};
+        char text[8] = {};
 
-        sprintf(text, LV_SYMBOL_KEYBOARD " %i", state.index);
+        snprintf(text, sizeof(text), LV_SYMBOL_KEYBOARD " %i", state.index);
 
         lv_label_set_text(label, text);
     } else {
-        char text[13] = {};
+        char text[14] = {};
 
         snprintf(text, sizeof(text), LV_SYMBOL_KEYBOARD " %s", state.label);
 

--- a/app/src/display/widgets/output_status.c
+++ b/app/src/display/widgets/output_status.c
@@ -35,7 +35,7 @@ static struct output_status_state get_state(const zmk_event_t *_eh) {
 }
 
 static void set_status_symbol(lv_obj_t *label, struct output_status_state state) {
-    char text[10] = {};
+    char text[20] = {};
 
     switch (state.selected_endpoint.transport) {
     case ZMK_TRANSPORT_USB:


### PR DESCRIPTION
Increase buffer size used for placing LVGL symbols on displays. This prevents array overflow warnings as discussed in #2444.

Also convert one sprintf to snprintf to ensure the buffers are always null terminated and never overflow.

Resolves #2444