### PR TITLE
refactor(blog): Add global authors file and truncate markers

### DIFF
--- a/docs/blog/2020-05-24-wip.md
+++ b/docs/blog/2020-05-24-wip.md
@@ -1,9 +1,6 @@
 ---
 title: WIP
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [keyboards, firmware, oss, ble]
 ---
 

--- a/docs/blog/2020-05-24-wip.md
+++ b/docs/blog/2020-05-24-wip.md
@@ -8,3 +8,5 @@ This blog is a work-in-progress as I work on basic docs + blog on this nascent k
 
 As is, there are more features _missing_ from ZMK than features it has. As always with pre-alpha software,
 if something breaks, you get to keep both halves! (especially if it is a split KB)
+
+<!-- truncate -->

--- a/docs/blog/2020-08-12-zmk-sotf-1.md
+++ b/docs/blog/2020-08-12-zmk-sotf-1.md
@@ -8,6 +8,8 @@ Welcome to the first ZMK "State Of The Firmware"!
 
 With interest and Discord activity growing, it seemed important to lay out the progress made recently, current major bugs/showstoppers, and planned next steps.
 
+<!-- truncate -->
+
 ## Recent Activity
 
 There's been lots of various activity in ZMK land!

--- a/docs/blog/2020-08-12-zmk-sotf-1.md
+++ b/docs/blog/2020-08-12-zmk-sotf-1.md
@@ -1,9 +1,6 @@
 ---
 title: "ZMK State Of The Firmware #1"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [SOTF, keyboards, firmware, oss, ble]
 ---
 

--- a/docs/blog/2020-09-21-zmk-sotf-2.md
+++ b/docs/blog/2020-09-21-zmk-sotf-2.md
@@ -1,9 +1,6 @@
 ---
 title: "ZMK State Of The Firmware #2"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [SOTF, keyboards, firmware, oss, ble]
 ---
 

--- a/docs/blog/2020-09-21-zmk-sotf-2.md
+++ b/docs/blog/2020-09-21-zmk-sotf-2.md
@@ -9,6 +9,8 @@ Welcome to the second ZMK "State Of The Firmware" (SOTF)!
 This update will cover all the major activity since [SOTF #1](/blog/2020/08/12/zmk-sotf-1), preparations for the upcoming
 Hacktoberfest activity, and a current open call for community feedback on a ZMK mascot.
 
+<!-- truncate -->
+
 ## Recent Activity
 
 So much going on in ZMK!

--- a/docs/blog/2020-10-03-bootloader-fix.md
+++ b/docs/blog/2020-10-03-bootloader-fix.md
@@ -9,6 +9,8 @@ Recently I was able to fix the "stuck in the bootloader" issue in
 for quite some time. I want to go over what the issue was, how the issue was
 diagnosed, and how it was fixed.
 
+<!-- truncate -->
+
 ## Background
 
 What exactly is the "stuck in the bootloader" issue? Seemingly randomly, users'

--- a/docs/blog/2020-10-03-bootloader-fix.md
+++ b/docs/blog/2020-10-03-bootloader-fix.md
@@ -1,9 +1,6 @@
 ---
 title: Fixing the Mysterious Broken Bootloader
-author: Nick Winans
-author_title: Contributor
-author_url: https://github.com/Nicell
-author_image_url: https://avatars1.githubusercontent.com/u/9439650
+authors: nickwinans
 tags: [bootloader, keyboards, firmware, oss, ble]
 ---
 

--- a/docs/blog/2020-11-09-zmk-sotf-3.md
+++ b/docs/blog/2020-11-09-zmk-sotf-3.md
@@ -1,9 +1,6 @@
 ---
 title: "ZMK State Of The Firmware #3"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [SOTF, keyboards, firmware, oss, ble]
 ---
 

--- a/docs/blog/2020-11-09-zmk-sotf-3.md
+++ b/docs/blog/2020-11-09-zmk-sotf-3.md
@@ -8,6 +8,8 @@ Welcome to the third ZMK "State Of The Firmware" (SOTF)!
 
 This update will cover all the major activity since [SOTF #2](/blog/2020/09/21/zmk-sotf-2). This edition comes a bit later than planned, but the amount of features and changes will hopefully make it worth it!
 
+<!-- truncate -->
+
 ## Recent Activity
 
 Here's a summary of the various major changes since last time, broken down by theme:

--- a/docs/blog/2021-01-27-zmk-sotf-4.md
+++ b/docs/blog/2021-01-27-zmk-sotf-4.md
@@ -1,9 +1,6 @@
 ---
 title: "ZMK State Of The Firmware #4"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [SOTF, keyboards, firmware, oss, ble]
 ---
 

--- a/docs/blog/2021-01-27-zmk-sotf-4.md
+++ b/docs/blog/2021-01-27-zmk-sotf-4.md
@@ -8,6 +8,8 @@ Welcome to the fourth ZMK "State Of The Firmware" (SOTF)!
 
 This update will cover all the major activity since [SOTF #3](/blog/2020/11/09/zmk-sotf-3).
 
+<!-- truncate -->
+
 ## Recent Activity
 
 Here's a summary of the various major changes since last time, broken down by theme:

--- a/docs/blog/2021-07-17-zephyr-2-5.md
+++ b/docs/blog/2021-07-17-zephyr-2-5.md
@@ -6,6 +6,8 @@ tags: [firmware, zephyr, core]
 
 I'm happy to announce that we have completed the [work](https://github.com/zmkfirmware/zmk/pull/736/) to upgrade ZMK to [Zephyr 2.5](https://docs.zephyrproject.org/2.5.0/releases/release-notes-2.5.html)!
 
+<!-- truncate -->
+
 A big part of this work was some _major_ refactors and improvements by [innovaker] to our [zmk-docker](https://github.com/zmkfirmware/zmk-docker/) Docker image and GH Actions automation.
 
 - Faster build times with improved caching.

--- a/docs/blog/2021-07-17-zephyr-2-5.md
+++ b/docs/blog/2021-07-17-zephyr-2-5.md
@@ -1,9 +1,6 @@
 ---
 title: "Zephyr 2.5 Update"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [firmware, zephyr, core]
 ---
 

--- a/docs/blog/2022-03-08-zephyr-3-0-upgrade-prep.md
+++ b/docs/blog/2022-03-08-zephyr-3-0-upgrade-prep.md
@@ -1,9 +1,6 @@
 ---
 title: "Zephyr 3.0 Update Preparation"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [firmware, zephyr, core]
 ---
 

--- a/docs/blog/2022-03-08-zephyr-3-0-upgrade-prep.md
+++ b/docs/blog/2022-03-08-zephyr-3-0-upgrade-prep.md
@@ -7,6 +7,8 @@ tags: [firmware, zephyr, core]
 As preparation for completing the [work](https://github.com/zmkfirmware/zmk/pull/1143) to upgrade ZMK to [Zephyr 3.0](https://docs.zephyrproject.org/3.0.0/releases/release-notes-3.0.html), users with user config repositories who wish to avoid future build failures with their GitHub Actions workflows can take steps to adjust
 their repositories now.
 
+<!-- truncate -->
+
 GitHub Actions needs to use our latest Docker image to ensure continued compatibility with the ZMK codebase on Zephyr 3.0 (and beyond). You should:
 
 - Open `.github/workflows/build.yml` in your editor/IDE

--- a/docs/blog/2022-04-02-zephyr-3-0.md
+++ b/docs/blog/2022-04-02-zephyr-3-0.md
@@ -1,9 +1,6 @@
 ---
 title: "Zephyr 3.0 Update"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [firmware, zephyr, core]
 ---
 

--- a/docs/blog/2022-04-02-zephyr-3-0.md
+++ b/docs/blog/2022-04-02-zephyr-3-0.md
@@ -6,6 +6,8 @@ tags: [firmware, zephyr, core]
 
 I'm happy to announce that we have completed the [work](https://github.com/zmkfirmware/zmk/pull/1143) to upgrade ZMK to [Zephyr 3.0](https://docs.zephyrproject.org/3.0.0/releases/release-notes-3.0.html)!
 
+<!-- truncate -->
+
 [petejohanson] did the upgrade work to adjust ZMK for the Zephyr changes.
 
 - Moving to Zephyr's UF2 build integration that was submitted upstream by [petejohanson]

--- a/docs/blog/2022-04-10-zmk-sotf-5.md
+++ b/docs/blog/2022-04-10-zmk-sotf-5.md
@@ -8,6 +8,8 @@ Welcome to the fifth ZMK "State Of The Firmware" (SOTF)!
 
 This update will cover all the major activity since [SOTF #4](/blog/2021/01/27/zmk-sotf-4). That was over a year ago, so lots to cover!
 
+<!-- truncate -->
+
 ## Recent Activity
 
 Here's a summary of the various major changes since last time, broken down by theme:

--- a/docs/blog/2022-04-10-zmk-sotf-5.md
+++ b/docs/blog/2022-04-10-zmk-sotf-5.md
@@ -1,9 +1,6 @@
 ---
 title: "ZMK State Of The Firmware #5"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [SOTF, keyboards, firmware, oss, ble]
 ---
 

--- a/docs/blog/2022-04-21-zmk-2yo.md
+++ b/docs/blog/2022-04-21-zmk-2yo.md
@@ -6,6 +6,8 @@ tags: [keyboards, firmware, oss]
 
 Two years ago, today, I minted the first ever commit for ZMK:
 
+<!-- truncate -->
+
 ```
 commit 85c8be89dea8f7a00e8efb06d38e2b32f3459935
 Author: Pete Johanson <peter@peterjohanson.com>

--- a/docs/blog/2022-04-21-zmk-2yo.md
+++ b/docs/blog/2022-04-21-zmk-2yo.md
@@ -1,9 +1,6 @@
 ---
 title: "ZMK's Second Birthday"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [keyboards, firmware, oss]
 ---
 

--- a/docs/blog/2023-04-06-zephyr-3-2.md
+++ b/docs/blog/2023-04-06-zephyr-3-2.md
@@ -1,9 +1,6 @@
 ---
 title: "Zephyr 3.2 Update"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [firmware, zephyr, core]
 ---
 

--- a/docs/blog/2023-04-06-zephyr-3-2.md
+++ b/docs/blog/2023-04-06-zephyr-3-2.md
@@ -6,6 +6,8 @@ tags: [firmware, zephyr, core]
 
 I'm happy to announce that we have completed the [work](https://github.com/zmkfirmware/zmk/pull/1499) to upgrade ZMK to [Zephyr 3.2](https://docs.zephyrproject.org/3.2.0/releases/release-notes-3.2.html)!
 
+<!-- truncate -->
+
 [petejohanson] did the upgrade work to adjust ZMK for the Zephyr changes, with help from [Nicell] on the LVGL pieces.
 
 - Upgrade to LVGL 8.x API, and move to the new Kconfig settings.

--- a/docs/blog/2023-06-18-encoder-refactors.md
+++ b/docs/blog/2023-06-18-encoder-refactors.md
@@ -1,9 +1,6 @@
 ---
 title: "Major Encoder Refactor"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [firmware, zephyr, sensors, encoders]
 ---
 

--- a/docs/blog/2023-06-18-encoder-refactors.md
+++ b/docs/blog/2023-06-18-encoder-refactors.md
@@ -8,6 +8,8 @@ Today, we merged a significant change to the low level sensor code that is used 
 this paves the way for completing the work on supporting split peripheral sensors/encoders, and other future sensors
 like pointing devices.
 
+<!-- truncate -->
+
 As part of the work, backwards compatibility for existing shields has been retained, but only for a grace period to allow out-of-tree shields to move to the new approach for encoders.
 
 Special thanks to [joelspadin] for the _thorough_ code review and testing throughout the development of the refactor.

--- a/docs/blog/2023-10-05-zmk-sotf-6.md
+++ b/docs/blog/2023-10-05-zmk-sotf-6.md
@@ -1,9 +1,6 @@
 ---
 title: "ZMK State Of The Firmware #6"
-author: Cem Aksoylar
-author_title: Documentation maintainer
-author_url: https://github.com/caksoylar
-author_image_url: https://avatars.githubusercontent.com/u/7876996
+authors: caksoylar
 tags: [SOTF, keyboards, firmware, oss, ble]
 ---
 

--- a/docs/blog/2023-10-05-zmk-sotf-6.md
+++ b/docs/blog/2023-10-05-zmk-sotf-6.md
@@ -8,6 +8,8 @@ Welcome to the sixth ZMK "State Of The Firmware" (SOTF)!
 
 This update will cover all the major activity since [SOTF #5](/blog/2022/04/10/zmk-sotf-5). That was over a year ago (again!), so there are many new exciting features and plenty of improvements to cover!
 
+<!-- truncate -->
+
 ## Recent Activity
 
 Here's a summary of the various major changes since last time, broken down by theme:

--- a/docs/blog/2023-11-09-keymap-editor.mdx
+++ b/docs/blog/2023-11-09-keymap-editor.mdx
@@ -6,6 +6,10 @@ tags: [keyboards, firmware, community]
 
 import ThemedImage from "@theme/ThemedImage";
 
+This blog post is the first in a series of posts where we highlight projects within the ZMK ecosystem that we think are cool and that the users might benefit from knowing about them. We are starting the series with a big one, [Keymap Editor](http://nickcoutsos.github.io/keymap-editor) by [Nick Coutsos](https://github.com/nickcoutsos)!
+
+{/* truncate */}
+
 <ThemedImage
   alt="Shows a screenshot of the Keymap Editor application featuring a graphical layout of the Corne Keyboard with a keymap loaded from the nickcoutsos/keymap-editor-demo-crkbd GitHub repository."
   sources={{
@@ -16,8 +20,6 @@ import ThemedImage from "@theme/ThemedImage";
       .default,
   }}
 />
-
-This blog post is the first in a series of posts where we highlight projects within the ZMK ecosystem that we think are cool and that the users might benefit from knowing about them. We are starting the series with a big one, [Keymap Editor] by [Nick Coutsos](https://github.com/nickcoutsos)!
 
 In the rest of the post we leave it to Nick himself to introduce the project, detail his goals and motivation in developing such a tool, and talk about the future of the project. Stay tuned for future installments in the series!
 

--- a/docs/blog/2023-11-09-keymap-editor.mdx
+++ b/docs/blog/2023-11-09-keymap-editor.mdx
@@ -1,9 +1,6 @@
 ---
 title: "Community Spotlight Series #1: Keymap Editor"
-author: Cem Aksoylar
-author_title: Documentation maintainer
-author_url: https://github.com/caksoylar
-author_image_url: https://avatars.githubusercontent.com/u/7876996
+authors: caksoylar
 tags: [keyboards, firmware, community]
 ---
 

--- a/docs/blog/2023-12-17-nodefree-config.md
+++ b/docs/blog/2023-12-17-nodefree-config.md
@@ -1,9 +1,6 @@
 ---
 title: "Community Spotlight Series #2: Node-free Config"
-author: Cem Aksoylar
-author_title: Documentation maintainer
-author_url: https://github.com/caksoylar
-author_image_url: https://avatars.githubusercontent.com/u/7876996
+authors: caksoylar
 tags: [keyboards, firmware, community]
 ---
 

--- a/docs/blog/2023-12-17-nodefree-config.md
+++ b/docs/blog/2023-12-17-nodefree-config.md
@@ -14,6 +14,8 @@ by [urob](https://github.com/urob) that contains helper methods that utilizes th
 for users who prefer editing and maintaining their ZMK config directly using the Devicetree
 syntax format.
 
+<!-- truncate -->
+
 In the rest of the post we leave it to urob to introduce and explain the motivations of the
 project, and various ways it can be used to help maintain ZMK keymaps. Stay tuned for future
 installments in the series!

--- a/docs/blog/2024-01-05-zmk-tools.md
+++ b/docs/blog/2024-01-05-zmk-tools.md
@@ -9,6 +9,9 @@ that we think are interesting and that the users might benefit from knowing abou
 
 In this installment, we are highlighting two projects (and a bonus one!) from [Joel Spadin](https://github.com/joelspadin),
 a member of the core ZMK team.
+
+<!-- truncate -->
+
 The first one is [ZMK Tools](#zmk-tools), a handy Visual Studio Code extension to ease working with ZMK configurations, and the second is [ZMK Locale Generator](#zmk-locale-generator), a tool to help users that use non-US English keyboard locales in their operating systems.
 
 In the rest of the post we leave it to Joel to introduce and explain the motivations of his ZMK-related projects.

--- a/docs/blog/2024-01-05-zmk-tools.md
+++ b/docs/blog/2024-01-05-zmk-tools.md
@@ -1,9 +1,6 @@
 ---
 title: "Community Spotlight Series #3: ZMK Tools and ZMK Locale Generator"
-author: Cem Aksoylar
-author_title: Documentation maintainer
-author_url: https://github.com/caksoylar
-author_image_url: https://avatars.githubusercontent.com/u/7876996
+authors: caksoylar
 tags: [keyboards, firmware, community]
 ---
 

--- a/docs/blog/2024-02-09-zephyr-3-5.md
+++ b/docs/blog/2024-02-09-zephyr-3-5.md
@@ -6,6 +6,8 @@ tags: [firmware, zephyr, core]
 
 I'm happy to announce that we have completed the [work](https://github.com/zmkfirmware/zmk/pull/1995) to upgrade ZMK to [Zephyr 3.5](https://docs.zephyrproject.org/3.5.0/releases/release-notes-3.5.html)!
 
+<!-- truncate -->
+
 [petejohanson] did the upgrade work to adjust ZMK for the Zephyr changes:
 
 - Add `west flash` support to all UF2 capable boards.

--- a/docs/blog/2024-02-09-zephyr-3-5.md
+++ b/docs/blog/2024-02-09-zephyr-3-5.md
@@ -1,9 +1,6 @@
 ---
 title: "Zephyr 3.5 Update"
-author: Pete Johanson
-author_title: Project Creator
-author_url: https://gitlab.com/petejohanson
-author_image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+authors: petejohanson
 tags: [firmware, zephyr, core]
 ---
 

--- a/docs/blog/authors.yml
+++ b/docs/blog/authors.yml
@@ -1,0 +1,17 @@
+petejohanson:
+  name: Pete Johanson
+  title: Project Creator
+  url: https://gitlab.com/petejohanson
+  image_url: https://www.gravatar.com/avatar/2001ceff7e9dc753cf96fcb2e6f41110
+
+nickwinans:
+  name: Nick Winans
+  title: Contributor
+  url: https://github.com/Nicell
+  image_url: https://avatars1.githubusercontent.com/u/9439650
+
+caksoylar:
+  name: Cem Aksoylar
+  title: Documentation maintainer
+  url: https://github.com/caksoylar
+  image_url: https://avatars.githubusercontent.com/u/7876996

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -165,6 +165,7 @@ module.exports = {
     ],
   ],
   markdown: {
+    format: "detect",
     mermaid: true,
     mdx1Compat: {
       comments: false,


### PR DESCRIPTION
Build now complains about two things related to the blog:
- not using global authors with `authors.yml`
- not putting truncate markers in blog posts so they can be truncated in the main page

While both behaviors can be disabled, I think it's nicer to follow the recommendation in these cases.

When putting truncate markers I ran into the issue that `.md` files are also considered mdx by default, in Docusaurus 3. This causes an issue: We can't use `<!-- ... -->` in .md files because that's invalid mdx. But if we use the mdx format `{/* ... */}` instead, then prettier tries to fix it to `{/_ ... _/}` thinking it's markdown. 

The [`format` config](https://docusaurus.io/docs/api/docusaurus-config#markdown) controls this and can be set to `detect` to fix this, so I did that. The alternative would be to try to configure prettier instead but I think assuming the extension is correct is the better approach.