### PR TITLE
fix(usb): detect USB power mode to fallback to BLE

### DIFF
--- a/app/include/zmk/usb.h
+++ b/app/include/zmk/usb.h
@@ -24,6 +24,4 @@ enum zmk_usb_conn_state zmk_usb_get_conn_state(void);
 static inline bool zmk_usb_is_powered(void) {
     return zmk_usb_get_conn_state() != ZMK_USB_CONN_NONE;
 }
-static inline bool zmk_usb_is_hid_ready(void) {
-    return zmk_usb_get_conn_state() == ZMK_USB_CONN_HID;
-}
+bool zmk_usb_is_hid_ready(void);

--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -51,7 +51,6 @@ enum zmk_usb_conn_state zmk_usb_get_conn_state(void) {
 }
 
 bool zmk_usb_is_hid_ready(void) {
-    LOG_DBG("is_configured: %d", is_configured);
     return zmk_usb_get_conn_state() == ZMK_USB_CONN_HID && is_configured;
 }
 

--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -33,11 +33,8 @@ enum usb_dc_status_code zmk_usb_get_status(void) { return usb_status; }
 enum zmk_usb_conn_state zmk_usb_get_conn_state(void) {
     LOG_DBG("state: %d", usb_status);
     switch (usb_status) {
-    case USB_DC_SUSPEND:
     case USB_DC_CONFIGURED:
     case USB_DC_RESUME:
-    case USB_DC_CLEAR_HALT:
-    case USB_DC_SOF:
         return ZMK_USB_CONN_HID;
 
     case USB_DC_DISCONNECTED:

--- a/app/src/usb.c
+++ b/app/src/usb.c
@@ -20,7 +20,7 @@
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 static enum usb_dc_status_code usb_status = USB_DC_UNKNOWN;
-static bool is_configured = false;
+static bool is_configured;
 
 static void raise_usb_status_changed_event(struct k_work *_work) {
     raise_zmk_usb_conn_state_changed(

--- a/app/src/usb_hid.c
+++ b/app/src/usb_hid.c
@@ -127,6 +127,7 @@ static const struct hid_ops ops = {
 };
 
 static int zmk_usb_hid_send_report(const uint8_t *report, size_t len) {
+    LOG_ERR("Send report keyboard %d", zmk_usb_get_status());
     switch (zmk_usb_get_status()) {
     case USB_DC_SUSPEND:
         return usb_wakeup_request();

--- a/app/src/usb_hid.c
+++ b/app/src/usb_hid.c
@@ -127,7 +127,6 @@ static const struct hid_ops ops = {
 };
 
 static int zmk_usb_hid_send_report(const uint8_t *report, size_t len) {
-    LOG_ERR("Send report keyboard %d", zmk_usb_get_status());
     switch (zmk_usb_get_status()) {
     case USB_DC_SUSPEND:
         return usb_wakeup_request();


### PR DESCRIPTION
Update `zmk_usb_is_hid_ready` to check that HID configuration from the host has been done, before allowing the keyboard to be used as a HID device.

This is done by adding `bool is_configured` and toggling it off when the device is disconnected, and enabling it when `usb_status == USB_DC_CONFIGURED`.

This is a naive solution for https://github.com/zmkfirmware/zmk/issues/841, where having a USB-power cable without data driving the keyboard, like a power bank, still has the firmware thinking that it's connected to a host and futilely sending data over USB.

When the cable to a power source is plugged in, the USB DC status (from Zephyr) goes through the following states:
```
USB_DC_CONNECTED -> USB_DC_SUSPEND
```
While for cables to a host machine:
```
USB_DC_CONNECTED -> USB_DC_SUSPEND -> USB_DC_RESUME -> USB_DC_RESET -> USB_DC_CONFIGURED
```
The status code list can be found at https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/drivers/usb/usb_dc.h#L33-L58

In the case of a power bank being plugged in, the code changes above allow `zmk_usb_is_hid_ready` to declare that HID isn't ready yet, and thus allows `endpoints.c` to fallback to BLE connection. 

Steps to reproduce the original issue
---------------------------------
1. (Setup) Have ZMK keyboard with Bluetooth profile enabled
2. Set the keyboard to prefer sending to USB (`&out OUT_USB`)
3. Power on the keyboard via USB via a power bank
4. Type, text should not show up anywhere ('consumed' by power bank)

Testing
------
- Built and flashed the firmware with the commit changes, ran the same steps above, and text showed up on the expected device.
- Tested using 2 laptops (Ubuntu / Windows) using 2 different power banks.
- Tested for regression, keyboard still works as expected for waking up the host machine (`CONFIG_USB_DEVICE_REMOTE_WAKEUP=y`) and for boot protocol (`CONFIG_ZMK_USB_BOOT=y`).

Concerns
--------
- I can't find any USB or USB HID specifications that explicitly state that the host machine will do the USB configuration step before the USB HID connection is considered complete.
- It's my first time contributing to ZMK, please let me know how the pull request can be improved!