### PR TITLE
feat(boards): Generic 40%, 50%, 60%, 65%, 75% and tkl physical layouts

### DIFF
--- a/app/boards/arm/bt60/bt60.dtsi
+++ b/app/boards/arm/bt60/bt60.dtsi
@@ -17,8 +17,6 @@
         zephyr,sram = &sram0;
         zephyr,flash = &flash0;
         zmk,battery = &vbatt;
-        zmk,kscan = &kscan0;
-        zmk,matrix-transform = &default_transform;
     };
 
     sensors: sensors {

--- a/app/boards/arm/bt60/bt60_v1.dts
+++ b/app/boards/arm/bt60/bt60_v1.dts
@@ -6,12 +6,13 @@
 
 /dts-v1/;
 #include "bt60.dtsi"
+#include <layouts/common/60percent/60percent.dtsi>
 
 
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix-transform = &ansi_transform;
+        zmk,physical-layout = &layout_60_ansi;
     };
 
     ansi_transform: keymap_transform_0 {
@@ -66,19 +67,6 @@
         >;
     };
 
-    split_transform: keymap_transform_4 {
-        compatible = "zmk,matrix-transform";
-        columns = <15>;
-        rows = <5>;
-        map = <
-            RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12)     RC(0,13) RC(0,14)
-            RC(1,0)   RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12)   RC(1,13)
-            RC(2,0)     RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11)          RC(2,13)
-            RC(3,0)   RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10)       RC(3,11)     RC(3,12) RC(3,14)
-            RC(4,0)   RC(4,1)   RC(4,2)                          RC(4,6)                  RC(4,10)  RC(4,11)   RC(4,12)    RC(4,13)
-        >;
-    };
-
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";
         wakeup-source;
@@ -111,4 +99,24 @@
             , <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };
+};
+
+&layout_60_ansi {
+    status = "okay";
+    transform = <&ansi_transform>;
+};
+
+&layout_60_iso {
+    status = "okay";
+    transform = <&iso_transform>;
+};
+
+&layout_60_all1u {
+    status = "okay";
+    transform = <&all_1u_transform>;
+};
+
+&layout_60_hhkb {
+    status = "okay";
+    transform = <&hhkb_transform>;
 };

--- a/app/boards/arm/bt60/bt60_v1.keymap
+++ b/app/boards/arm/bt60/bt60_v1.keymap
@@ -2,26 +2,25 @@
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
 
-#define ANSI true
-//#define HHKB true
-//#define ISO true
-//#define ALL_1U true
-//#define SPLIT_BKSP_RSHFT true
+#define ANSI
+//#define HHKB
+//#define ISO
+//#define ALL_1U
 
 
 
 / {
     chosen {
     #ifdef ANSI
-        zmk,matrix-transform = &ansi_transform;
-    #elif defined(HHKB)
-        zmk,matrix-transform = &hhkb_transform;
+        zmk,physical-layout = &layout_60_ansi;
     #elif defined(ISO)
-        zmk,matrix-transform = &iso_transform;
+        zmk,physical-layout = &layout_60_iso;
     #elif defined(ALL_1U)
-        zmk,matrix-transform = &all_1u_transform;
+        zmk,physical-layout = &layout_60_all1u;
+    #elif defined(HHKB)
+        zmk,physical-layout = &layout_60_hhkb;
     #else
-        zmk,matrix-transform = &split_transform;
+    #error "Layout not defined, please define a layout by uncommenting the appropriate line in bt60_v1.keymap"
     #endif
     };
 
@@ -148,33 +147,7 @@
             sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
         };
         #else
-        default_layer {
-                // ------------------------------------------------------------------------------------------
-                // | ESC |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  0  |  -  |  =  |BSPC| DEL |
-                // | TAB  |  Q  |  W  |  E  |  R  |  T  |  Y  |  U  |  I  |  O  |  P  |  [  |  ]  |    \    |
-                // | CAPS  |  A  |  S  |  D  |  F  |  G  |  H  |  J  |  K  |  L  |  ;  |  '  |     ENTER    |
-                // |  SHIFT    |  Z  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  | /   |   SHIFT  |  1  |
-                // |  CTL  |  WIN  |  ALT  |                     SPACE               |   ALT   |  1  | CTRL |
-                // ------------------------------------------------------------------------------------------
-            bindings = <
-                &kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp  N8   &kp  N9 &kp  N0  &kp MINUS &kp EQUAL &kp BSPC &kp DEL
-                &kp TAB  &kp Q  &kp W  &kp E  &kp R  &kp T  &kp Y  &kp U  &kp  I    &kp  O  &kp  P   &kp LBKT &kp RBKT  &kp BSLH
-                &kp CLCK  &kp A  &kp S  &kp D  &kp F  &kp G  &kp H  &kp J  &kp  K    &kp  L  &kp SEMI &kp SQT           &kp RET
-                &kp LSHFT  &kp Z  &kp X  &kp C  &kp V  &kp B  &kp N  &kp M  &kp COMMA &kp DOT &kp FSLH    &kp RSHFT    &mo 1
-                &kp LCTRL &kp LGUI &kp LALT            &kp SPACE                          &kp RALT &kp RGUI &kp C_MENU &kp RCTRL
-            >;
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
-        };
-        raise {
-            bindings = <
-                &kp GRAVE &kp F1 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6 &kp F7 &kp  F8   &kp  F9 &kp  F10  &kp F11 &kp F12   &kp DEL &trans
-                &trans &trans &kp UP &trans &trans &trans &trans &trans &kp INS &trans &kp PSCRN &kp SLCK &kp PAUSE_BREAK &sys_reset
-                &trans    &kp LEFT &kp DOWN &kp RIGHT &trans &trans &trans &trans &trans &trans &kp HOME  &kp PG_UP   &bootloader
-                &kp C_PREV &kp C_VOL_DN &kp C_VOL_UP &kp C_MUTE &trans &trans &trans &trans &trans &kp END &kp PG_DN  &kp C_NEXT &trans
-                &bt BT_PRV &bt BT_NXT  &trans                       &trans                            &trans  &trans &trans &bt BT_CLR
-            >;
-            sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
-        };
+        #error "Layout not defined, please define a layout by uncommenting the appropriate line in bt60_v2.keymap"
         #endif
     };
 };

--- a/app/boards/arm/bt60/bt60_v1_hs.dts
+++ b/app/boards/arm/bt60/bt60_v1_hs.dts
@@ -6,12 +6,12 @@
 
 /dts-v1/;
 #include "bt60.dtsi"
-
+#include <layouts/common/60percent/ansi.dtsi>
 
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix-transform = &default_transform;
+        zmk,physical-layout = &layout_60_ansi;
     };
 
     default_transform: keymap_transform_0 {
@@ -59,4 +59,8 @@
             , <&gpio0 23 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };
+};
+
+&layout_60_ansi {
+    transform = <&default_transform>;
 };

--- a/app/boards/arm/bt60/bt60_v1_hs.keymap
+++ b/app/boards/arm/bt60/bt60_v1_hs.keymap
@@ -8,14 +8,14 @@
 
         default_layer {
                 // ------------------------------------------------------------------------------------------
-                // | ESC |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  0  |  -  |  =  |   BSPC   | DEL
-                // | TAB  |  Q  |  W  |  E  |  R  |  T  |  Y  |  U  |  I  |  O  |  P  |  [  |  ]  |   |    |
+                // | ESC |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  0  |  -  |  =  |   BSPC   |
+                // | TAB  |  Q  |  W  |  E  |  R  |  T  |  Y  |  U  |  I  |  O  |  P  |  [  |  ]  |    |    |
                 // | CAPS  |  A  |  S  |  D  |  F  |  G  |  H  |  J  |  K  |  L  |  ;  |  '  |     ENTER    |
                 // |  SHIFT    |  Z  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  | /   |      SHIFT     |
-                // |  CTL  |  WIN  |  ALT  |            SPACE               | ALT | 1    |  MENU    |  CTRL    |
+                // |  CTL  |  WIN  |  ALT  |            SPACE               | ALT | 1    |  MENU    |  CTRL |
                 // ------------------------------------------------------------------------------------------
             bindings = <
-                &kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp  N8   &kp  N9 &kp  N0  &kp MINUS &kp EQUAL &kp BSPC &bt BT_CLR
+                &kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp  N8   &kp  N9 &kp  N0  &kp MINUS &kp EQUAL &kp BSPC
                 &kp TAB  &kp Q  &kp W  &kp E  &kp R  &kp T  &kp Y  &kp U  &kp  I    &kp  O  &kp  P   &kp LBKT &kp RBKT  &kp BSLH
                 &kp CLCK  &kp A  &kp S  &kp D  &kp F  &kp G  &kp H  &kp J  &kp  K    &kp  L  &kp SEMI &kp SQT           &kp RET
                 &kp LSHFT  &kp Z  &kp X  &kp C  &kp V  &kp B  &kp N  &kp M  &kp COMMA &kp DOT &kp FSLH             &kp RSHFT
@@ -25,7 +25,7 @@
         };
         raise {
             bindings = <
-                &kp GRAVE &kp F1 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6 &kp F7 &kp  F8   &kp  F9 &kp  F10  &kp F11 &kp F12   &kp DEL &trans
+                &kp GRAVE &kp F1 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6 &kp F7 &kp  F8   &kp  F9 &kp  F10  &kp F11 &kp F12   &kp DEL
                 &trans &trans &kp UP &trans &trans &trans &trans &trans &kp INS &trans &kp PSCRN &kp SLCK &kp PAUSE_BREAK &sys_reset
                 &trans    &kp LEFT &kp DOWN &kp RIGHT &trans &trans &trans &trans &trans &trans &kp HOME  &kp PG_UP   &bootloader
                 &kp C_PREV &kp C_VOL_DN &kp C_VOL_UP &kp C_MUTE &trans &trans &trans &trans &trans &kp END &kp PG_DN  &kp C_NEXT

--- a/app/boards/arm/ckp/bt60_v2.dts
+++ b/app/boards/arm/ckp/bt60_v2.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include "ckp.dtsi"
+#include <layouts/common/60percent/60percent.dtsi>
 
 
 / {
@@ -13,7 +14,7 @@
   compatible = "polarityworks,bt60_v2";
 
   chosen {
-    zmk,matrix-transform = &ansi_transform;
+    zmk,physical-layout = &layout_60_ansi;
   };
 
 
@@ -68,4 +69,24 @@
       RC(5,0)    RC(5,1)    RC(5,2)                       RC(5,6)                     RC(5,11)      RC(5,12)       RC(5,13)
     >;
   };
+};
+
+&layout_60_ansi {
+  status = "okay";
+  transform = <&ansi_transform>;
+};
+
+&layout_60_iso {
+  status = "okay";
+  transform = <&iso_transform>;
+};
+
+&layout_60_all1u {
+  status = "okay";
+  transform = <&all_1u_transform>;
+};
+
+&layout_60_hhkb {
+  status = "okay";
+  transform = <&hhkb_transform>;
 };

--- a/app/boards/arm/ckp/bt60_v2.keymap
+++ b/app/boards/arm/ckp/bt60_v2.keymap
@@ -12,13 +12,13 @@
 / {
   chosen {
   #ifdef ANSI
-    zmk,matrix-transform = &ansi_transform;
+    zmk,physical-layout = &layout_60_ansi;
   #elif defined(ISO)
-    zmk,matrix-transform = &iso_transform;
+    zmk,physical-layout = &layout_60_iso;
   #elif defined(ALL_1U)
-    zmk,matrix-transform = &all_1u_transform;
+    zmk,physical-layout = &layout_60_all1u;
   #elif defined(HHKB)
-    zmk,matrix-transform = &hhkb_transform;
+    zmk,physical-layout = &layout_60_hhkb;
   #else
   #error "Layout not defined, please define a layout by uncommenting the appropriate line in bt60_v2.keymap"
   #endif

--- a/app/boards/arm/ckp/bt65_v1.dts
+++ b/app/boards/arm/ckp/bt65_v1.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include "ckp.dtsi"
+#include <layouts/common/65percent/65percent.dtsi>
 
 
 / {
@@ -13,7 +14,7 @@
   compatible = "polarityworks,bt65_v1";
 
   chosen {
-    zmk,matrix-transform = &ansi_transform;
+    zmk,physical-layout = &layout_65_ansi;
   };
 
 
@@ -68,4 +69,24 @@
       RC(5,0)   RC(5,1)   RC(5,2)                         RC(5,6)                           RC(5,11)     RC(5,12)     RC(5,13)     RC(5,15)
     >;
   };
+};
+
+&layout_65_ansi {
+  status = "okay";
+  transform = <&ansi_transform>;
+};
+
+&layout_65_iso {
+  status = "okay";
+  transform = <&iso_transform>;
+};
+
+&layout_65_all1u {
+  status = "okay";
+  transform = <&all_1u_transform>;
+};
+
+&layout_65_hhkb {
+  status = "okay";
+  transform = <&hhkb_transform>;
 };

--- a/app/boards/arm/ckp/bt65_v1.keymap
+++ b/app/boards/arm/ckp/bt65_v1.keymap
@@ -12,13 +12,13 @@
 / {
   chosen {
   #ifdef ANSI
-    zmk,matrix-transform = &ansi_transform;
+    zmk,physical-layout = &layout_65_ansi;
   #elif defined(ISO)
-    zmk,matrix-transform = &iso_transform;
+    zmk,physical-layout = &layout_65_iso;
   #elif defined(ALL_1U)
-    zmk,matrix-transform = &all_1u_transform;
+    zmk,physical-layout = &layout_65_all1u;
   #elif defined(HHKB)
-    zmk,matrix-transform = &hhkb_transform;
+    zmk,physical-layout = &layout_65_hhkb;
   #else
   #error "Layout not defined, please define a layout by uncommenting the appropriate line in bt65_v1.keymap"
   #endif

--- a/app/boards/arm/ckp/bt75_v1.dts
+++ b/app/boards/arm/ckp/bt75_v1.dts
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 #include "ckp.dtsi"
+#include <layouts/common/75percent/75percent.dtsi>
 
 
 / {
@@ -13,7 +14,7 @@
   compatible = "polarityworks,bt75_v1";
 
   chosen {
-    zmk,matrix-transform = &ansi_transform;
+    zmk,physical-layout = &layout_75_ansi;
   };
 
 
@@ -58,4 +59,19 @@
       RC(5,0)   RC(5,1)   RC(5,2)                        RC(5,6)                      RC(5,10) RC(5,11) RC(5,12) RC(5,13) RC(5,14) RC(5,15)
     >;
   };
+};
+
+&layout_75_ansi {
+  status = "okay";
+  transform = <&ansi_transform>;
+};
+
+&layout_75_iso {
+  status = "okay";
+  transform = <&iso_transform>;
+};
+
+&layout_75_all1u {
+  status = "okay";
+  transform = <&all_1u_transform>;
 };

--- a/app/boards/arm/ckp/bt75_v1.keymap
+++ b/app/boards/arm/ckp/bt75_v1.keymap
@@ -11,11 +11,11 @@
 / {
   chosen {
   #ifdef ANSI
-    zmk,matrix-transform = &ansi_transform;
+    zmk,physical-layout = &layout_75_ansi;
   #elif defined(ISO)
-    zmk,matrix-transform = &iso_transform;
+    zmk,physical-layout = &layout_75_iso;
   #elif defined(ALL_1U)
-    zmk,matrix-transform = &all_1u_transform;
+    zmk,physical-layout = &layout_75_all1u;
   #else
   #error "Layout not defined, please define a layout using by uncommenting the appropriate line in bt75_v1.keymap"
   #endif

--- a/app/boards/arm/kbdfans_tofu65/kbdfans_tofu65_v2.dts
+++ b/app/boards/arm/kbdfans_tofu65/kbdfans_tofu65_v2.dts
@@ -8,6 +8,8 @@
 #include <rpi_pico/rp2040.dtsi>
 #include <dt-bindings/zmk/matrix_transform.h>
 
+#include <layouts/common/65percent/ansi.dtsi>
+
 / {
 
     chosen {
@@ -15,7 +17,7 @@
         zephyr,flash = &flash0;
         zephyr,code-partition = &code_partition;
         zmk,kscan = &kscan0;
-        zmk,matrix-transform = &default_transform;
+        zmk,physical-layout = &layout_65_ansi;
     };
 
     xtal_clk: xtal-clk {
@@ -115,3 +117,6 @@ zephyr_udc0: &usbd {
     status = "okay";
 };
 
+&layout_65_ansi {
+    transform = <&default_transform>;
+};

--- a/app/boards/arm/nice60/nice60.dts
+++ b/app/boards/arm/nice60/nice60.dts
@@ -10,6 +10,8 @@
 #include <dt-bindings/led/led.h>
 #include <dt-bindings/zmk/matrix_transform.h>
 
+#include <layouts/common/60percent/ansi.dtsi>
+
 #include "nice60-pinctrl.dtsi"
 
 / {
@@ -22,7 +24,7 @@
         zephyr,flash = &flash0;
         zmk,battery = &vbatt;
         zmk,kscan = &kscan0;
-        zmk,matrix-transform = &default_transform;
+        zmk,physical-layout = &layout_60_ansi;
         zmk,underglow = &led_strip;
     };
 
@@ -168,4 +170,8 @@ zephyr_udc0: &usbd {
             reg = <0x000f4000 0x0000c000>;
         };
     };
+};
+
+&layout_60_ansi {
+    transform = <&default_transform>;
 };

--- a/app/boards/arm/planck/planck_rev6.dts
+++ b/app/boards/arm/planck/planck_rev6.dts
@@ -9,6 +9,9 @@
 #include <st/f3/stm32f303c(b-c)tx-pinctrl.dtsi>
 #include <dt-bindings/zmk/matrix_transform.h>
 
+#include <layouts/common/ortho_4x12/ortho_4x12.dtsi>
+
+
 / {
     model = "Plack PCD, rev6";
     compatible = "planck,rev6", "st,stm32f303";
@@ -17,7 +20,7 @@
         zephyr,sram = &sram0;
         zephyr,flash = &flash0;
         zmk,kscan = &kscan0;
-        zmk,matrix-transform = &layout_grid_transform;
+        zmk,physical-layout = &layout_ortho_4x12_all1u;
     };
 
     kscan0: kscan {
@@ -136,4 +139,19 @@ zephyr_udc0: &usb {
             reg = <0x0003e800 0x00001800>;
         };
     };
+};
+
+&layout_ortho_4x12_all1u {
+    status = "okay";
+    transform = <&layout_grid_transform>;
+};
+
+&layout_ortho_4x12_1x2u {
+    status = "okay";
+    transform = <&layout_mit_transform>;
+};
+
+&layout_ortho_4x12_2x2u {
+    status = "okay";
+    transform = <&layout_2x2u_transform>;
 };

--- a/app/boards/arm/preonic/preonic_rev3.dts
+++ b/app/boards/arm/preonic/preonic_rev3.dts
@@ -9,6 +9,7 @@
 #include <st/f3/stm32f303c(b-c)tx-pinctrl.dtsi>
 #include <dt-bindings/zmk/matrix_transform.h>
 
+#include <layouts/common/ortho_5x12/ortho_5x12.dtsi>
 
 / {
     model = "Preonic PCD, rev3";
@@ -18,7 +19,7 @@
         zephyr,sram = &sram0;
         zephyr,flash = &flash0;
         zmk,kscan = &kscan0;
-        zmk,matrix-transform = &layout_grid_transform;
+        zmk,physical-layout = &layout_ortho_5x12_all1u;
     };
 
     kscan0: kscan_0 {
@@ -130,4 +131,19 @@ zephyr_udc0: &usb {
             reg = <0x0003e800 0x00001800>;
         };
     };
+};
+
+&layout_ortho_5x12_all1u {
+    status = "okay";
+    transform = <&layout_grid_transform>;
+};
+
+&layout_ortho_5x12_1x2u {
+    status = "okay";
+    transform = <&layout_mit_transform>;
+};
+
+&layout_ortho_5x12_2x2u {
+    status = "okay";
+    transform = <&layout_2x2u_transform>;
 };

--- a/app/boards/arm/preonic/preonic_rev3.keymap
+++ b/app/boards/arm/preonic/preonic_rev3.keymap
@@ -13,7 +13,6 @@
 #define RAISE   2
 
 / {
-    chosen { zmk,matrix-transform = &layout_grid_transform; };
     keymap {
         compatible = "zmk,keymap";
         default_layer {

--- a/app/boards/shields/boardsource5x12/boardsource5x12.overlay
+++ b/app/boards/shields/boardsource5x12/boardsource5x12.overlay
@@ -6,9 +6,25 @@
 
 #include <dt-bindings/zmk/matrix_transform.h>
 
+#include <layouts/common/ortho_5x12/all1u.dtsi>
+
 / {
     chosen {
         zmk,kscan = &kscan0;
+        zmk,physical-layout = &layout_ortho_5x12_all1u;
+    };
+
+    matrix_transform_50_all1u: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <12>;
+        rows = <5>;
+        map = <
+            RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11)
+            RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11)
+            RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11)
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11)
+            RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10) RC(4,11)
+            >;
     };
 
     kscan0: kscan {
@@ -40,4 +56,8 @@
             , <&pro_micro 6 GPIO_ACTIVE_HIGH>
             ;
     };
+};
+
+&layout_ortho_5x12_all1u {
+    transform = <&matrix_transform_50_all1u>;
 };

--- a/app/boards/shields/contra/contra.overlay
+++ b/app/boards/shields/contra/contra.overlay
@@ -4,9 +4,26 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <dt-bindings/zmk/matrix_transform.h>
+
+#include <layouts/common/ortho_4x12/all1u.dtsi>
+
 / {
     chosen {
         zmk,kscan = &kscan0;
+        zmk,physical-layout = &layout_ortho_4x12_all1u;
+    };
+
+    matrix_transform_40_all1u: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <12>;
+        rows = <4>;
+        map = <
+            RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11)
+            RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11)
+            RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11)
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11)
+            >;
     };
 
     kscan0: kscan_0 {
@@ -37,4 +54,8 @@
             , <&pro_micro 10 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };
+};
+
+&layout_ortho_4x12_all1u {
+    transform = <&matrix_transform_40_all1u>;
 };

--- a/app/boards/shields/crbn/crbn.overlay
+++ b/app/boards/shields/crbn/crbn.overlay
@@ -6,9 +6,24 @@
 
 #include <dt-bindings/zmk/matrix_transform.h>
 
+#include <layouts/common/ortho_4x12/all1u.dtsi>
+
 / {
     chosen {
         zmk,kscan = &kscan0;
+        zmk,physical-layout = &layout_ortho_4x12_all1u;
+    };
+
+    matrix_transform_40_all1u: keymap_transform_0 {
+        compatible = "zmk,matrix-transform";
+        columns = <12>;
+        rows = <4>;
+        map = <
+            RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11)
+            RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11)
+            RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11)
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11)
+            >;
     };
 
     kscan0: kscan_0 {
@@ -53,4 +68,8 @@
         sensors = <&encoder>;
         triggers-per-rotation = <20>;
     };
+};
+
+&layout_ortho_4x12_all1u {
+    transform = <&matrix_transform_40_all1u>;
 };

--- a/app/boards/shields/m60/m60.overlay
+++ b/app/boards/shields/m60/m60.overlay
@@ -6,10 +6,12 @@
 
 #include <dt-bindings/zmk/matrix_transform.h>
 
+#include <layouts/common/60percent/ansi.dtsi>
+
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix-transform = &default_transform;
+        zmk,physical-layout = &layout_60_ansi;
     };
 
     kscan0: kscan {
@@ -58,3 +60,6 @@ RC(6,5)    RC(6,6)   RC(6,7)                     RC(7,0)                    RC(7
     };
 };
 
+&layout_60_ansi {
+    transform = <&default_transform>;
+};

--- a/app/dts/layouts/common/60percent/60percent.dtsi
+++ b/app/dts/layouts/common/60percent/60percent.dtsi
@@ -1,0 +1,72 @@
+#include <layouts/common/60percent/ansi.dtsi>
+#include <layouts/common/60percent/iso.dtsi>
+#include <layouts/common/60percent/all1u.dtsi>
+#include <layouts/common/60percent/hhkb.dtsi>
+
+&layout_60_ansi {
+    status = "disabled";
+};
+
+&layout_60_iso {
+    status = "disabled";
+};
+
+&layout_60_all1u {
+    status = "disabled";
+};
+
+&layout_60_hhkb {
+    status = "disabled";
+};
+
+/ {
+    layouts_common_60_percent_position_map: layouts_common_60_percent_position_map {
+        compatible = "zmk,physical-layout-position-map";
+
+        complete;
+
+        layout_60_all1u {
+            physical-layout = <&layout_60_all1u>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14>
+                , <15 16 17 18 19 20 21 22 23 24 25 26 27 28>
+                , <29 30 31 32 33 34 35 36 37 38 39 40 41>
+                , <42 43 44 45 46 47 48 49 50 51 52 53 54 55 56>
+                , <57 58 59 60 61 62 64 63 65>
+                ;
+        };
+
+        layout_60_ansi {
+            physical-layout = <&layout_60_ansi>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 61>
+                , <14 15 16 17 18 19 20 21 22 23 24 25 26 27>
+                , <28 29 30 31 32 33 34 35 36 37 38 39 40>
+                , <41 62 42 43 44 45 46 47 48 49 50 51 52 63 64>
+                , <53 54 55 56 57 58 60 59 65>
+                ;
+        };
+
+        layout_60_hhkb {
+            physical-layout = <&layout_60_hhkb>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 60>
+                , <14 15 16 17 18 19 20 21 22 23 24 25 26 27>
+                , <28 29 30 31 32 33 34 35 36 37 38 39 40>
+                , <41 61 42 43 44 45 46 47 48 49 50 51 52 62 63>
+                , <53 54 55 56 57 58 59 64 65>
+                ;
+        };
+
+        layout_60_iso {
+            physical-layout = <&layout_60_iso>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 62>
+                , <14 15 16 17 18 19 20 21 22 23 24 25 26 63>
+                , <27 28 29 30 31 32 33 34 35 36 37 38 40>
+                , <41 42 43 44 45 46 47 48 49 50 51 52 53 64 65>
+                , <54 55 56 57 58 59 61 60 39>
+                ;
+        };
+    };
+};

--- a/app/dts/layouts/common/60percent/all1u.dtsi
+++ b/app/dts/layouts/common/60percent/all1u.dtsi
@@ -1,0 +1,77 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_60_all1u: layout_60_all1u {
+        compatible = "zmk,physical-layout";
+        display-name = "60% All 1U";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 100 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1400    0       0     0     0>
+            , <&key_physical_attrs 150 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  150  100       0     0     0>
+            , <&key_physical_attrs 100 100  250  100       0     0     0>
+            , <&key_physical_attrs 100 100  350  100       0     0     0>
+            , <&key_physical_attrs 100 100  450  100       0     0     0>
+            , <&key_physical_attrs 100 100  550  100       0     0     0>
+            , <&key_physical_attrs 100 100  650  100       0     0     0>
+            , <&key_physical_attrs 100 100  750  100       0     0     0>
+            , <&key_physical_attrs 100 100  850  100       0     0     0>
+            , <&key_physical_attrs 100 100  950  100       0     0     0>
+            , <&key_physical_attrs 100 100 1050  100       0     0     0>
+            , <&key_physical_attrs 100 100 1150  100       0     0     0>
+            , <&key_physical_attrs 100 100 1250  100       0     0     0>
+            , <&key_physical_attrs 150 100 1350  100       0     0     0>
+            , <&key_physical_attrs 175 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  175  200       0     0     0>
+            , <&key_physical_attrs 100 100  275  200       0     0     0>
+            , <&key_physical_attrs 100 100  375  200       0     0     0>
+            , <&key_physical_attrs 100 100  475  200       0     0     0>
+            , <&key_physical_attrs 100 100  575  200       0     0     0>
+            , <&key_physical_attrs 100 100  675  200       0     0     0>
+            , <&key_physical_attrs 100 100  775  200       0     0     0>
+            , <&key_physical_attrs 100 100  875  200       0     0     0>
+            , <&key_physical_attrs 100 100  975  200       0     0     0>
+            , <&key_physical_attrs 100 100 1075  200       0     0     0>
+            , <&key_physical_attrs 100 100 1175  200       0     0     0>
+            , <&key_physical_attrs 225 100 1275  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 100 100  400  300       0     0     0>
+            , <&key_physical_attrs 100 100  500  300       0     0     0>
+            , <&key_physical_attrs 100 100  600  300       0     0     0>
+            , <&key_physical_attrs 100 100  700  300       0     0     0>
+            , <&key_physical_attrs 100 100  800  300       0     0     0>
+            , <&key_physical_attrs 100 100  900  300       0     0     0>
+            , <&key_physical_attrs 100 100 1000  300       0     0     0>
+            , <&key_physical_attrs 100 100 1100  300       0     0     0>
+            , <&key_physical_attrs 100 100 1200  300       0     0     0>
+            , <&key_physical_attrs 100 100 1300  300       0     0     0>
+            , <&key_physical_attrs 100 100 1400  300       0     0     0>
+            , <&key_physical_attrs 125 100    0  400       0     0     0>
+            , <&key_physical_attrs 125 100  125  400       0     0     0>
+            , <&key_physical_attrs 125 100  250  400       0     0     0>
+            , <&key_physical_attrs 625 100  375  400       0     0     0>
+            , <&key_physical_attrs 100 100 1000  400       0     0     0>
+            , <&key_physical_attrs 100 100 1100  400       0     0     0>
+            , <&key_physical_attrs 100 100 1200  400       0     0     0>
+            , <&key_physical_attrs 100 100 1300  400       0     0     0>
+            , <&key_physical_attrs 100 100 1400  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/60percent/ansi.dtsi
+++ b/app/dts/layouts/common/60percent/ansi.dtsi
@@ -1,0 +1,72 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_60_ansi: layout_60_ansi {
+        compatible = "zmk,physical-layout";
+        display-name = "60% ANSI";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 200 100 1300    0       0     0     0>
+            , <&key_physical_attrs 150 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  150  100       0     0     0>
+            , <&key_physical_attrs 100 100  250  100       0     0     0>
+            , <&key_physical_attrs 100 100  350  100       0     0     0>
+            , <&key_physical_attrs 100 100  450  100       0     0     0>
+            , <&key_physical_attrs 100 100  550  100       0     0     0>
+            , <&key_physical_attrs 100 100  650  100       0     0     0>
+            , <&key_physical_attrs 100 100  750  100       0     0     0>
+            , <&key_physical_attrs 100 100  850  100       0     0     0>
+            , <&key_physical_attrs 100 100  950  100       0     0     0>
+            , <&key_physical_attrs 100 100 1050  100       0     0     0>
+            , <&key_physical_attrs 100 100 1150  100       0     0     0>
+            , <&key_physical_attrs 100 100 1250  100       0     0     0>
+            , <&key_physical_attrs 150 100 1350  100       0     0     0>
+            , <&key_physical_attrs 175 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  175  200       0     0     0>
+            , <&key_physical_attrs 100 100  275  200       0     0     0>
+            , <&key_physical_attrs 100 100  375  200       0     0     0>
+            , <&key_physical_attrs 100 100  475  200       0     0     0>
+            , <&key_physical_attrs 100 100  575  200       0     0     0>
+            , <&key_physical_attrs 100 100  675  200       0     0     0>
+            , <&key_physical_attrs 100 100  775  200       0     0     0>
+            , <&key_physical_attrs 100 100  875  200       0     0     0>
+            , <&key_physical_attrs 100 100  975  200       0     0     0>
+            , <&key_physical_attrs 100 100 1075  200       0     0     0>
+            , <&key_physical_attrs 100 100 1175  200       0     0     0>
+            , <&key_physical_attrs 225 100 1275  200       0     0     0>
+            , <&key_physical_attrs 225 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  225  300       0     0     0>
+            , <&key_physical_attrs 100 100  325  300       0     0     0>
+            , <&key_physical_attrs 100 100  425  300       0     0     0>
+            , <&key_physical_attrs 100 100  525  300       0     0     0>
+            , <&key_physical_attrs 100 100  625  300       0     0     0>
+            , <&key_physical_attrs 100 100  725  300       0     0     0>
+            , <&key_physical_attrs 100 100  825  300       0     0     0>
+            , <&key_physical_attrs 100 100  925  300       0     0     0>
+            , <&key_physical_attrs 100 100 1025  300       0     0     0>
+            , <&key_physical_attrs 100 100 1125  300       0     0     0>
+            , <&key_physical_attrs 275 100 1225  300       0     0     0>
+            , <&key_physical_attrs 125 100    0  400       0     0     0>
+            , <&key_physical_attrs 125 100  125  400       0     0     0>
+            , <&key_physical_attrs 125 100  250  400       0     0     0>
+            , <&key_physical_attrs 625 100  375  400       0     0     0>
+            , <&key_physical_attrs 125 100 1000  400       0     0     0>
+            , <&key_physical_attrs 125 100 1125  400       0     0     0>
+            , <&key_physical_attrs 125 100 1250  400       0     0     0>
+            , <&key_physical_attrs 125 100 1375  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/60percent/hhkb.dtsi
+++ b/app/dts/layouts/common/60percent/hhkb.dtsi
@@ -1,0 +1,71 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_60_hhkb: layout_60_hhkb {
+        compatible = "zmk,physical-layout";
+        display-name = "60% HHKB/Tsangan layout";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 200 100 1300    0       0     0     0>
+            , <&key_physical_attrs 150 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  150  100       0     0     0>
+            , <&key_physical_attrs 100 100  250  100       0     0     0>
+            , <&key_physical_attrs 100 100  350  100       0     0     0>
+            , <&key_physical_attrs 100 100  450  100       0     0     0>
+            , <&key_physical_attrs 100 100  550  100       0     0     0>
+            , <&key_physical_attrs 100 100  650  100       0     0     0>
+            , <&key_physical_attrs 100 100  750  100       0     0     0>
+            , <&key_physical_attrs 100 100  850  100       0     0     0>
+            , <&key_physical_attrs 100 100  950  100       0     0     0>
+            , <&key_physical_attrs 100 100 1050  100       0     0     0>
+            , <&key_physical_attrs 100 100 1150  100       0     0     0>
+            , <&key_physical_attrs 100 100 1250  100       0     0     0>
+            , <&key_physical_attrs 150 100 1350  100       0     0     0>
+            , <&key_physical_attrs 175 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  175  200       0     0     0>
+            , <&key_physical_attrs 100 100  275  200       0     0     0>
+            , <&key_physical_attrs 100 100  375  200       0     0     0>
+            , <&key_physical_attrs 100 100  475  200       0     0     0>
+            , <&key_physical_attrs 100 100  575  200       0     0     0>
+            , <&key_physical_attrs 100 100  675  200       0     0     0>
+            , <&key_physical_attrs 100 100  775  200       0     0     0>
+            , <&key_physical_attrs 100 100  875  200       0     0     0>
+            , <&key_physical_attrs 100 100  975  200       0     0     0>
+            , <&key_physical_attrs 100 100 1075  200       0     0     0>
+            , <&key_physical_attrs 100 100 1175  200       0     0     0>
+            , <&key_physical_attrs 225 100 1275  200       0     0     0>
+            , <&key_physical_attrs 225 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  225  300       0     0     0>
+            , <&key_physical_attrs 100 100  325  300       0     0     0>
+            , <&key_physical_attrs 100 100  425  300       0     0     0>
+            , <&key_physical_attrs 100 100  525  300       0     0     0>
+            , <&key_physical_attrs 100 100  625  300       0     0     0>
+            , <&key_physical_attrs 100 100  725  300       0     0     0>
+            , <&key_physical_attrs 100 100  825  300       0     0     0>
+            , <&key_physical_attrs 100 100  925  300       0     0     0>
+            , <&key_physical_attrs 100 100 1025  300       0     0     0>
+            , <&key_physical_attrs 100 100 1125  300       0     0     0>
+            , <&key_physical_attrs 275 100 1225  300       0     0     0>
+            , <&key_physical_attrs 150 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  150  400       0     0     0>
+            , <&key_physical_attrs 150 100  250  400       0     0     0>
+            , <&key_physical_attrs 700 100  400  400       0     0     0>
+            , <&key_physical_attrs 150 100 1100  400       0     0     0>
+            , <&key_physical_attrs 100 100 1250  400       0     0     0>
+            , <&key_physical_attrs 150 100 1350  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/60percent/iso.dtsi
+++ b/app/dts/layouts/common/60percent/iso.dtsi
@@ -1,0 +1,73 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_60_iso: layout_60_iso {
+        compatible = "zmk,physical-layout";
+        display-name = "60% ISO";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 200 100 1300    0       0     0     0>
+            , <&key_physical_attrs 150 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  150  100       0     0     0>
+            , <&key_physical_attrs 100 100  250  100       0     0     0>
+            , <&key_physical_attrs 100 100  350  100       0     0     0>
+            , <&key_physical_attrs 100 100  450  100       0     0     0>
+            , <&key_physical_attrs 100 100  550  100       0     0     0>
+            , <&key_physical_attrs 100 100  650  100       0     0     0>
+            , <&key_physical_attrs 100 100  750  100       0     0     0>
+            , <&key_physical_attrs 100 100  850  100       0     0     0>
+            , <&key_physical_attrs 100 100  950  100       0     0     0>
+            , <&key_physical_attrs 100 100 1050  100       0     0     0>
+            , <&key_physical_attrs 100 100 1150  100       0     0     0>
+            , <&key_physical_attrs 100 100 1250  100       0     0     0>
+            , <&key_physical_attrs 175 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  175  200       0     0     0>
+            , <&key_physical_attrs 100 100  275  200       0     0     0>
+            , <&key_physical_attrs 100 100  375  200       0     0     0>
+            , <&key_physical_attrs 100 100  475  200       0     0     0>
+            , <&key_physical_attrs 100 100  575  200       0     0     0>
+            , <&key_physical_attrs 100 100  675  200       0     0     0>
+            , <&key_physical_attrs 100 100  775  200       0     0     0>
+            , <&key_physical_attrs 100 100  875  200       0     0     0>
+            , <&key_physical_attrs 100 100  975  200       0     0     0>
+            , <&key_physical_attrs 100 100 1075  200       0     0     0>
+            , <&key_physical_attrs 100 100 1175  200       0     0     0>
+            , <&key_physical_attrs 100 100 1275  200       0     0     0>
+            , <&key_physical_attrs 125 200 1375  100       0     0     0>
+            , <&key_physical_attrs 125 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  125  300       0     0     0>
+            , <&key_physical_attrs 100 100  225  300       0     0     0>
+            , <&key_physical_attrs 100 100  325  300       0     0     0>
+            , <&key_physical_attrs 100 100  425  300       0     0     0>
+            , <&key_physical_attrs 100 100  525  300       0     0     0>
+            , <&key_physical_attrs 100 100  625  300       0     0     0>
+            , <&key_physical_attrs 100 100  725  300       0     0     0>
+            , <&key_physical_attrs 100 100  825  300       0     0     0>
+            , <&key_physical_attrs 100 100  925  300       0     0     0>
+            , <&key_physical_attrs 100 100 1025  300       0     0     0>
+            , <&key_physical_attrs 100 100 1125  300       0     0     0>
+            , <&key_physical_attrs 275 100 1225  300       0     0     0>
+            , <&key_physical_attrs 125 100    0  400       0     0     0>
+            , <&key_physical_attrs 125 100  125  400       0     0     0>
+            , <&key_physical_attrs 125 100  250  400       0     0     0>
+            , <&key_physical_attrs 625 100  375  400       0     0     0>
+            , <&key_physical_attrs 125 100 1000  400       0     0     0>
+            , <&key_physical_attrs 125 100 1125  400       0     0     0>
+            , <&key_physical_attrs 125 100 1250  400       0     0     0>
+            , <&key_physical_attrs 125 100 1375  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/65percent/65percent.dtsi
+++ b/app/dts/layouts/common/65percent/65percent.dtsi
@@ -1,0 +1,72 @@
+#include <layouts/common/65percent/ansi.dtsi>
+#include <layouts/common/65percent/iso.dtsi>
+#include <layouts/common/65percent/all1u.dtsi>
+#include <layouts/common/65percent/hhkb.dtsi>
+
+&layout_65_ansi {
+    status = "disabled";
+};
+
+&layout_65_iso {
+    status = "disabled";
+};
+
+&layout_65_all1u {
+    status = "disabled";
+};
+
+&layout_65_hhkb {
+    status = "disabled";
+};
+
+/ {
+    layouts_common_65_percent_position_map: layouts_common_65_percent_position_map {
+        compatible = "zmk,physical-layout-position-map";
+
+        complete;
+
+        layout_65_all1u {
+            physical-layout = <&layout_65_all1u>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15>
+                , <16 17 18 19 20 21 22 23 24 25 26 27 28 29 30>
+                , <31 32 33 34 35 36 37 38 39 40 41 42 43 44>
+                , <45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60>
+                , <61 62 63 64 65 66 67 68 69 70>
+                ;
+        };
+
+        layout_65_ansi {
+            physical-layout = <&layout_65_ansi>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 68 14>
+                , <15 16 17 18 19 20 21 22 23 24 25 26 27 28 29>
+                , <30 31 32 33 34 35 36 37 38 39 40 41 42 43>
+                , <44 69 45 46 47 48 49 50 51 52 53 54 55 70 56 57>
+                , <58 59 60 61 62 63 64 65 66 67>
+                ;
+        };
+
+        layout_65_hhkb {
+            physical-layout = <&layout_65_hhkb>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 65 14>
+                , <15 16 17 18 19 20 21 22 23 24 25 26 27 28 29>
+                , <30 31 32 33 34 35 36 37 38 39 40 41 42 43>
+                , <44 66 45 46 47 48 49 50 51 52 53 54 55 67 68 56>
+                , <57 58 59 60 61 62 63 69 70 64>
+                ;
+        };
+
+        layout_65_iso {
+            physical-layout = <&layout_65_iso>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 69 14>
+                , <15 16 17 18 19 20 21 22 23 24 25 26 27 70 28>
+                , <29 30 31 32 33 34 35 36 37 38 39 40 42 43>
+                , <44 45 46 47 48 49 50 51 52 53 54 55 56 41 57 58>
+                , <59 60 61 62 63 64 65 66 67 68>
+                ;
+        };
+    };
+};

--- a/app/dts/layouts/common/65percent/all1u.dtsi
+++ b/app/dts/layouts/common/65percent/all1u.dtsi
@@ -1,0 +1,85 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_65_all1u: layout_65_all1u {
+        compatible = "zmk,physical-layout";
+        display-name = "65% All 1U";
+
+        kscan = <&kscan0>;
+        transform = <&matrix_transform_65_all1u>;
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 100 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1400    0       0     0     0>
+            , <&key_physical_attrs 100 100 1500    0       0     0     0>
+            , <&key_physical_attrs 150 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  150  100       0     0     0>
+            , <&key_physical_attrs 100 100  250  100       0     0     0>
+            , <&key_physical_attrs 100 100  350  100       0     0     0>
+            , <&key_physical_attrs 100 100  450  100       0     0     0>
+            , <&key_physical_attrs 100 100  550  100       0     0     0>
+            , <&key_physical_attrs 100 100  650  100       0     0     0>
+            , <&key_physical_attrs 100 100  750  100       0     0     0>
+            , <&key_physical_attrs 100 100  850  100       0     0     0>
+            , <&key_physical_attrs 100 100  950  100       0     0     0>
+            , <&key_physical_attrs 100 100 1050  100       0     0     0>
+            , <&key_physical_attrs 100 100 1150  100       0     0     0>
+            , <&key_physical_attrs 100 100 1250  100       0     0     0>
+            , <&key_physical_attrs 150 100 1350  100       0     0     0>
+            , <&key_physical_attrs 100 100 1500  100       0     0     0>
+            , <&key_physical_attrs 175 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  175  200       0     0     0>
+            , <&key_physical_attrs 100 100  275  200       0     0     0>
+            , <&key_physical_attrs 100 100  375  200       0     0     0>
+            , <&key_physical_attrs 100 100  475  200       0     0     0>
+            , <&key_physical_attrs 100 100  575  200       0     0     0>
+            , <&key_physical_attrs 100 100  675  200       0     0     0>
+            , <&key_physical_attrs 100 100  775  200       0     0     0>
+            , <&key_physical_attrs 100 100  875  200       0     0     0>
+            , <&key_physical_attrs 100 100  975  200       0     0     0>
+            , <&key_physical_attrs 100 100 1075  200       0     0     0>
+            , <&key_physical_attrs 100 100 1175  200       0     0     0>
+            , <&key_physical_attrs 225 100 1275  200       0     0     0>
+            , <&key_physical_attrs 100 100 1500  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 100 100  400  300       0     0     0>
+            , <&key_physical_attrs 100 100  500  300       0     0     0>
+            , <&key_physical_attrs 100 100  600  300       0     0     0>
+            , <&key_physical_attrs 100 100  700  300       0     0     0>
+            , <&key_physical_attrs 100 100  800  300       0     0     0>
+            , <&key_physical_attrs 100 100  900  300       0     0     0>
+            , <&key_physical_attrs 100 100 1000  300       0     0     0>
+            , <&key_physical_attrs 100 100 1100  300       0     0     0>
+            , <&key_physical_attrs 100 100 1200  300       0     0     0>
+            , <&key_physical_attrs 100 100 1300  300       0     0     0>
+            , <&key_physical_attrs 100 100 1400  300       0     0     0>
+            , <&key_physical_attrs 100 100 1500  300       0     0     0>
+            , <&key_physical_attrs 125 100    0  400       0     0     0>
+            , <&key_physical_attrs 125 100  125  400       0     0     0>
+            , <&key_physical_attrs 125 100  250  400       0     0     0>
+            , <&key_physical_attrs 625 100  375  400       0     0     0>
+            , <&key_physical_attrs 100 100 1000  400       0     0     0>
+            , <&key_physical_attrs 100 100 1100  400       0     0     0>
+            , <&key_physical_attrs 100 100 1200  400       0     0     0>
+            , <&key_physical_attrs 100 100 1300  400       0     0     0>
+            , <&key_physical_attrs 100 100 1400  400       0     0     0>
+            , <&key_physical_attrs 100 100 1500  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/65percent/ansi.dtsi
+++ b/app/dts/layouts/common/65percent/ansi.dtsi
@@ -1,0 +1,79 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_65_ansi: layout_65_ansi {
+        compatible = "zmk,physical-layout";
+        display-name = "65% ANSI";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 200 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1500    0       0     0     0>
+            , <&key_physical_attrs 150 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  150  100       0     0     0>
+            , <&key_physical_attrs 100 100  250  100       0     0     0>
+            , <&key_physical_attrs 100 100  350  100       0     0     0>
+            , <&key_physical_attrs 100 100  450  100       0     0     0>
+            , <&key_physical_attrs 100 100  550  100       0     0     0>
+            , <&key_physical_attrs 100 100  650  100       0     0     0>
+            , <&key_physical_attrs 100 100  750  100       0     0     0>
+            , <&key_physical_attrs 100 100  850  100       0     0     0>
+            , <&key_physical_attrs 100 100  950  100       0     0     0>
+            , <&key_physical_attrs 100 100 1050  100       0     0     0>
+            , <&key_physical_attrs 100 100 1150  100       0     0     0>
+            , <&key_physical_attrs 100 100 1250  100       0     0     0>
+            , <&key_physical_attrs 150 100 1350  100       0     0     0>
+            , <&key_physical_attrs 100 100 1500  100       0     0     0>
+            , <&key_physical_attrs 175 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  175  200       0     0     0>
+            , <&key_physical_attrs 100 100  275  200       0     0     0>
+            , <&key_physical_attrs 100 100  375  200       0     0     0>
+            , <&key_physical_attrs 100 100  475  200       0     0     0>
+            , <&key_physical_attrs 100 100  575  200       0     0     0>
+            , <&key_physical_attrs 100 100  675  200       0     0     0>
+            , <&key_physical_attrs 100 100  775  200       0     0     0>
+            , <&key_physical_attrs 100 100  875  200       0     0     0>
+            , <&key_physical_attrs 100 100  975  200       0     0     0>
+            , <&key_physical_attrs 100 100 1075  200       0     0     0>
+            , <&key_physical_attrs 100 100 1175  200       0     0     0>
+            , <&key_physical_attrs 225 100 1275  200       0     0     0>
+            , <&key_physical_attrs 100 100 1500  200       0     0     0>
+            , <&key_physical_attrs 225 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  225  300       0     0     0>
+            , <&key_physical_attrs 100 100  325  300       0     0     0>
+            , <&key_physical_attrs 100 100  425  300       0     0     0>
+            , <&key_physical_attrs 100 100  525  300       0     0     0>
+            , <&key_physical_attrs 100 100  625  300       0     0     0>
+            , <&key_physical_attrs 100 100  725  300       0     0     0>
+            , <&key_physical_attrs 100 100  825  300       0     0     0>
+            , <&key_physical_attrs 100 100  925  300       0     0     0>
+            , <&key_physical_attrs 100 100 1025  300       0     0     0>
+            , <&key_physical_attrs 100 100 1125  300       0     0     0>
+            , <&key_physical_attrs 175 100 1225  300       0     0     0>
+            , <&key_physical_attrs 100 100 1400  300       0     0     0>
+            , <&key_physical_attrs 100 100 1500  300       0     0     0>
+            , <&key_physical_attrs 125 100    0  400       0     0     0>
+            , <&key_physical_attrs 125 100  125  400       0     0     0>
+            , <&key_physical_attrs 125 100  250  400       0     0     0>
+            , <&key_physical_attrs 625 100  375  400       0     0     0>
+            , <&key_physical_attrs 100 100 1000  400       0     0     0>
+            , <&key_physical_attrs 100 100 1100  400       0     0     0>
+            , <&key_physical_attrs 100 100 1200  400       0     0     0>
+            , <&key_physical_attrs 100 100 1300  400       0     0     0>
+            , <&key_physical_attrs 100 100 1400  400       0     0     0>
+            , <&key_physical_attrs 100 100 1500  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/65percent/hhkb.dtsi
+++ b/app/dts/layouts/common/65percent/hhkb.dtsi
@@ -1,0 +1,76 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_65_hhkb: layout_65_hhkb {
+        compatible = "zmk,physical-layout";
+        display-name = "65% HHKB/Tsangan";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 200 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1500    0       0     0     0>
+            , <&key_physical_attrs 150 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  150  100       0     0     0>
+            , <&key_physical_attrs 100 100  250  100       0     0     0>
+            , <&key_physical_attrs 100 100  350  100       0     0     0>
+            , <&key_physical_attrs 100 100  450  100       0     0     0>
+            , <&key_physical_attrs 100 100  550  100       0     0     0>
+            , <&key_physical_attrs 100 100  650  100       0     0     0>
+            , <&key_physical_attrs 100 100  750  100       0     0     0>
+            , <&key_physical_attrs 100 100  850  100       0     0     0>
+            , <&key_physical_attrs 100 100  950  100       0     0     0>
+            , <&key_physical_attrs 100 100 1050  100       0     0     0>
+            , <&key_physical_attrs 100 100 1150  100       0     0     0>
+            , <&key_physical_attrs 100 100 1250  100       0     0     0>
+            , <&key_physical_attrs 150 100 1350  100       0     0     0>
+            , <&key_physical_attrs 100 100 1500  100       0     0     0>
+            , <&key_physical_attrs 175 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  175  200       0     0     0>
+            , <&key_physical_attrs 100 100  275  200       0     0     0>
+            , <&key_physical_attrs 100 100  375  200       0     0     0>
+            , <&key_physical_attrs 100 100  475  200       0     0     0>
+            , <&key_physical_attrs 100 100  575  200       0     0     0>
+            , <&key_physical_attrs 100 100  675  200       0     0     0>
+            , <&key_physical_attrs 100 100  775  200       0     0     0>
+            , <&key_physical_attrs 100 100  875  200       0     0     0>
+            , <&key_physical_attrs 100 100  975  200       0     0     0>
+            , <&key_physical_attrs 100 100 1075  200       0     0     0>
+            , <&key_physical_attrs 100 100 1175  200       0     0     0>
+            , <&key_physical_attrs 225 100 1275  200       0     0     0>
+            , <&key_physical_attrs 100 100 1500  200       0     0     0>
+            , <&key_physical_attrs 225 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  225  300       0     0     0>
+            , <&key_physical_attrs 100 100  325  300       0     0     0>
+            , <&key_physical_attrs 100 100  425  300       0     0     0>
+            , <&key_physical_attrs 100 100  525  300       0     0     0>
+            , <&key_physical_attrs 100 100  625  300       0     0     0>
+            , <&key_physical_attrs 100 100  725  300       0     0     0>
+            , <&key_physical_attrs 100 100  825  300       0     0     0>
+            , <&key_physical_attrs 100 100  925  300       0     0     0>
+            , <&key_physical_attrs 100 100 1025  300       0     0     0>
+            , <&key_physical_attrs 100 100 1125  300       0     0     0>
+            , <&key_physical_attrs 275 100 1225  300       0     0     0>
+            , <&key_physical_attrs 100 100 1500  300       0     0     0>
+            , <&key_physical_attrs 150 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  150  400       0     0     0>
+            , <&key_physical_attrs 150 100  250  400       0     0     0>
+            , <&key_physical_attrs 700 100  400  400       0     0     0>
+            , <&key_physical_attrs 150 100 1100  400       0     0     0>
+            , <&key_physical_attrs 100 100 1250  400       0     0     0>
+            , <&key_physical_attrs 150 100 1350  400       0     0     0>
+            , <&key_physical_attrs 100 100 1500  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/65percent/iso.dtsi
+++ b/app/dts/layouts/common/65percent/iso.dtsi
@@ -1,0 +1,80 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_65_iso: layout_65_iso {
+        compatible = "zmk,physical-layout";
+        display-name = "65% ISO";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 200 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1500    0       0     0     0>
+            , <&key_physical_attrs 150 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  150  100       0     0     0>
+            , <&key_physical_attrs 100 100  250  100       0     0     0>
+            , <&key_physical_attrs 100 100  350  100       0     0     0>
+            , <&key_physical_attrs 100 100  450  100       0     0     0>
+            , <&key_physical_attrs 100 100  550  100       0     0     0>
+            , <&key_physical_attrs 100 100  650  100       0     0     0>
+            , <&key_physical_attrs 100 100  750  100       0     0     0>
+            , <&key_physical_attrs 100 100  850  100       0     0     0>
+            , <&key_physical_attrs 100 100  950  100       0     0     0>
+            , <&key_physical_attrs 100 100 1050  100       0     0     0>
+            , <&key_physical_attrs 100 100 1150  100       0     0     0>
+            , <&key_physical_attrs 100 100 1250  100       0     0     0>
+            , <&key_physical_attrs 100 100 1500  100       0     0     0>
+            , <&key_physical_attrs 175 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  175  200       0     0     0>
+            , <&key_physical_attrs 100 100  275  200       0     0     0>
+            , <&key_physical_attrs 100 100  375  200       0     0     0>
+            , <&key_physical_attrs 100 100  475  200       0     0     0>
+            , <&key_physical_attrs 100 100  575  200       0     0     0>
+            , <&key_physical_attrs 100 100  675  200       0     0     0>
+            , <&key_physical_attrs 100 100  775  200       0     0     0>
+            , <&key_physical_attrs 100 100  875  200       0     0     0>
+            , <&key_physical_attrs 100 100  975  200       0     0     0>
+            , <&key_physical_attrs 100 100 1075  200       0     0     0>
+            , <&key_physical_attrs 100 100 1175  200       0     0     0>
+            , <&key_physical_attrs 100 100 1275  200       0     0     0>
+            , <&key_physical_attrs 125 200 1375  100       0     0     0>
+            , <&key_physical_attrs 100 100 1500  200       0     0     0>
+            , <&key_physical_attrs 125 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  125  300       0     0     0>
+            , <&key_physical_attrs 100 100  225  300       0     0     0>
+            , <&key_physical_attrs 100 100  325  300       0     0     0>
+            , <&key_physical_attrs 100 100  425  300       0     0     0>
+            , <&key_physical_attrs 100 100  525  300       0     0     0>
+            , <&key_physical_attrs 100 100  625  300       0     0     0>
+            , <&key_physical_attrs 100 100  725  300       0     0     0>
+            , <&key_physical_attrs 100 100  825  300       0     0     0>
+            , <&key_physical_attrs 100 100  925  300       0     0     0>
+            , <&key_physical_attrs 100 100 1025  300       0     0     0>
+            , <&key_physical_attrs 100 100 1125  300       0     0     0>
+            , <&key_physical_attrs 175 100 1225  300       0     0     0>
+            , <&key_physical_attrs 100 100 1400  300       0     0     0>
+            , <&key_physical_attrs 100 100 1500  300       0     0     0>
+            , <&key_physical_attrs 125 100    0  400       0     0     0>
+            , <&key_physical_attrs 125 100  125  400       0     0     0>
+            , <&key_physical_attrs 125 100  250  400       0     0     0>
+            , <&key_physical_attrs 625 100  375  400       0     0     0>
+            , <&key_physical_attrs 100 100 1000  400       0     0     0>
+            , <&key_physical_attrs 100 100 1100  400       0     0     0>
+            , <&key_physical_attrs 100 100 1200  400       0     0     0>
+            , <&key_physical_attrs 100 100 1300  400       0     0     0>
+            , <&key_physical_attrs 100 100 1400  400       0     0     0>
+            , <&key_physical_attrs 100 100 1500  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/75percent/75percent.dtsi
+++ b/app/dts/layouts/common/75percent/75percent.dtsi
@@ -1,0 +1,59 @@
+#include <layouts/common/75percent/ansi.dtsi>
+#include <layouts/common/75percent/iso.dtsi>
+#include <layouts/common/75percent/all1u.dtsi>
+
+&layout_75_ansi {
+    status = "disabled";
+};
+
+&layout_75_iso {
+    status = "disabled";
+};
+
+&layout_75_all1u {
+    status = "disabled";
+};
+
+/ {
+    layouts_common_75_percent_position_map: layouts_common_75_percent_position_map {
+        compatible = "zmk,physical-layout-position-map";
+
+        complete;
+
+        layout_75_all1u {
+            physical-layout = <&layout_75_all1u>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15>
+                , <16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31>
+                , <32 33 34 35 36 37 38 39 40 41 42 43 44 45 46>
+                , <47 48 49 50 51 52 53 54 55 56 57 58 59 60>
+                , <61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76>
+                , <77 78 79 80 81 82 83 84 85 86>
+                ;
+        };
+
+        layout_75_ansi {
+            physical-layout = <&layout_75_ansi>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15>
+                , <16 17 18 19 20 21 22 23 24 25 26 27 28 29 84 30>
+                , <31 32 33 34 35 36 37 38 39 40 41 42 43 44 45>
+                , <46 47 48 49 50 51 52 53 54 55 56 57 58 59>
+                , <60 85 61 62 63 64 65 66 67 68 69 70 71 86 72 73>
+                , <74 75 76 77 78 79 80 81 82 83>
+                ;
+        };
+
+        layout_75_iso {
+            physical-layout = <&layout_75_iso>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15>
+                , <16 17 18 19 20 21 22 23 24 25 26 27 28 29 85 30>
+                , <31 32 33 34 35 36 37 38 39 40 41 42 43 86 44>
+                , <45 46 47 48 49 50 51 52 53 54 55 56 58 59>
+                , <60 61 62 63 64 65 66 67 68 69 70 71 72 57 73 74>
+                , <75 76 77 78 79 80 81 82 83 84>
+                ;
+        };
+    };
+};

--- a/app/dts/layouts/common/75percent/all1u.dtsi
+++ b/app/dts/layouts/common/75percent/all1u.dtsi
@@ -1,0 +1,98 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_75_all1u: layout_75_all1u {
+        compatible = "zmk,physical-layout";
+        display-name = "75% All 1U";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 100 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1400    0       0     0     0>
+            , <&key_physical_attrs 100 100 1500    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  100       0     0     0>
+            , <&key_physical_attrs 100 100  500  100       0     0     0>
+            , <&key_physical_attrs 100 100  600  100       0     0     0>
+            , <&key_physical_attrs 100 100  700  100       0     0     0>
+            , <&key_physical_attrs 100 100  800  100       0     0     0>
+            , <&key_physical_attrs 100 100  900  100       0     0     0>
+            , <&key_physical_attrs 100 100 1000  100       0     0     0>
+            , <&key_physical_attrs 100 100 1100  100       0     0     0>
+            , <&key_physical_attrs 100 100 1200  100       0     0     0>
+            , <&key_physical_attrs 100 100 1300  100       0     0     0>
+            , <&key_physical_attrs 100 100 1400  100       0     0     0>
+            , <&key_physical_attrs 100 100 1500  100       0     0     0>
+            , <&key_physical_attrs 150 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  150  200       0     0     0>
+            , <&key_physical_attrs 100 100  250  200       0     0     0>
+            , <&key_physical_attrs 100 100  350  200       0     0     0>
+            , <&key_physical_attrs 100 100  450  200       0     0     0>
+            , <&key_physical_attrs 100 100  550  200       0     0     0>
+            , <&key_physical_attrs 100 100  650  200       0     0     0>
+            , <&key_physical_attrs 100 100  750  200       0     0     0>
+            , <&key_physical_attrs 100 100  850  200       0     0     0>
+            , <&key_physical_attrs 100 100  950  200       0     0     0>
+            , <&key_physical_attrs 100 100 1050  200       0     0     0>
+            , <&key_physical_attrs 100 100 1150  200       0     0     0>
+            , <&key_physical_attrs 100 100 1250  200       0     0     0>
+            , <&key_physical_attrs 150 100 1350  200       0     0     0>
+            , <&key_physical_attrs 100 100 1500  200       0     0     0>
+            , <&key_physical_attrs 175 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  175  300       0     0     0>
+            , <&key_physical_attrs 100 100  275  300       0     0     0>
+            , <&key_physical_attrs 100 100  375  300       0     0     0>
+            , <&key_physical_attrs 100 100  475  300       0     0     0>
+            , <&key_physical_attrs 100 100  575  300       0     0     0>
+            , <&key_physical_attrs 100 100  675  300       0     0     0>
+            , <&key_physical_attrs 100 100  775  300       0     0     0>
+            , <&key_physical_attrs 100 100  875  300       0     0     0>
+            , <&key_physical_attrs 100 100  975  300       0     0     0>
+            , <&key_physical_attrs 100 100 1075  300       0     0     0>
+            , <&key_physical_attrs 100 100 1175  300       0     0     0>
+            , <&key_physical_attrs 225 100 1275  300       0     0     0>
+            , <&key_physical_attrs 100 100 1500  300       0     0     0>
+            , <&key_physical_attrs 100 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  100  400       0     0     0>
+            , <&key_physical_attrs 100 100  200  400       0     0     0>
+            , <&key_physical_attrs 100 100  300  400       0     0     0>
+            , <&key_physical_attrs 100 100  400  400       0     0     0>
+            , <&key_physical_attrs 100 100  500  400       0     0     0>
+            , <&key_physical_attrs 100 100  600  400       0     0     0>
+            , <&key_physical_attrs 100 100  700  400       0     0     0>
+            , <&key_physical_attrs 100 100  800  400       0     0     0>
+            , <&key_physical_attrs 100 100  900  400       0     0     0>
+            , <&key_physical_attrs 100 100 1000  400       0     0     0>
+            , <&key_physical_attrs 100 100 1100  400       0     0     0>
+            , <&key_physical_attrs 100 100 1200  400       0     0     0>
+            , <&key_physical_attrs 100 100 1300  400       0     0     0>
+            , <&key_physical_attrs 100 100 1400  400       0     0     0>
+            , <&key_physical_attrs 100 100 1500  400       0     0     0>
+            , <&key_physical_attrs 125 100    0  500       0     0     0>
+            , <&key_physical_attrs 125 100  125  500       0     0     0>
+            , <&key_physical_attrs 125 100  250  500       0     0     0>
+            , <&key_physical_attrs 625 100  375  500       0     0     0>
+            , <&key_physical_attrs 100 100 1000  500       0     0     0>
+            , <&key_physical_attrs 100 100 1100  500       0     0     0>
+            , <&key_physical_attrs 100 100 1200  500       0     0     0>
+            , <&key_physical_attrs 100 100 1300  500       0     0     0>
+            , <&key_physical_attrs 100 100 1400  500       0     0     0>
+            , <&key_physical_attrs 100 100 1500  500       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/75percent/ansi.dtsi
+++ b/app/dts/layouts/common/75percent/ansi.dtsi
@@ -1,0 +1,95 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_75_ansi: layout_75_ansi {
+        compatible = "zmk,physical-layout";
+        display-name = "75% ANSI";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 100 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1400    0       0     0     0>
+            , <&key_physical_attrs 100 100 1500    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  100       0     0     0>
+            , <&key_physical_attrs 100 100  500  100       0     0     0>
+            , <&key_physical_attrs 100 100  600  100       0     0     0>
+            , <&key_physical_attrs 100 100  700  100       0     0     0>
+            , <&key_physical_attrs 100 100  800  100       0     0     0>
+            , <&key_physical_attrs 100 100  900  100       0     0     0>
+            , <&key_physical_attrs 100 100 1000  100       0     0     0>
+            , <&key_physical_attrs 100 100 1100  100       0     0     0>
+            , <&key_physical_attrs 100 100 1200  100       0     0     0>
+            , <&key_physical_attrs 200 100 1300  100       0     0     0>
+            , <&key_physical_attrs 100 100 1500  100       0     0     0>
+            , <&key_physical_attrs 150 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  150  200       0     0     0>
+            , <&key_physical_attrs 100 100  250  200       0     0     0>
+            , <&key_physical_attrs 100 100  350  200       0     0     0>
+            , <&key_physical_attrs 100 100  450  200       0     0     0>
+            , <&key_physical_attrs 100 100  550  200       0     0     0>
+            , <&key_physical_attrs 100 100  650  200       0     0     0>
+            , <&key_physical_attrs 100 100  750  200       0     0     0>
+            , <&key_physical_attrs 100 100  850  200       0     0     0>
+            , <&key_physical_attrs 100 100  950  200       0     0     0>
+            , <&key_physical_attrs 100 100 1050  200       0     0     0>
+            , <&key_physical_attrs 100 100 1150  200       0     0     0>
+            , <&key_physical_attrs 100 100 1250  200       0     0     0>
+            , <&key_physical_attrs 150 100 1350  200       0     0     0>
+            , <&key_physical_attrs 100 100 1500  200       0     0     0>
+            , <&key_physical_attrs 175 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  175  300       0     0     0>
+            , <&key_physical_attrs 100 100  275  300       0     0     0>
+            , <&key_physical_attrs 100 100  375  300       0     0     0>
+            , <&key_physical_attrs 100 100  475  300       0     0     0>
+            , <&key_physical_attrs 100 100  575  300       0     0     0>
+            , <&key_physical_attrs 100 100  675  300       0     0     0>
+            , <&key_physical_attrs 100 100  775  300       0     0     0>
+            , <&key_physical_attrs 100 100  875  300       0     0     0>
+            , <&key_physical_attrs 100 100  975  300       0     0     0>
+            , <&key_physical_attrs 100 100 1075  300       0     0     0>
+            , <&key_physical_attrs 100 100 1175  300       0     0     0>
+            , <&key_physical_attrs 225 100 1275  300       0     0     0>
+            , <&key_physical_attrs 100 100 1500  300       0     0     0>
+            , <&key_physical_attrs 225 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  225  400       0     0     0>
+            , <&key_physical_attrs 100 100  325  400       0     0     0>
+            , <&key_physical_attrs 100 100  425  400       0     0     0>
+            , <&key_physical_attrs 100 100  525  400       0     0     0>
+            , <&key_physical_attrs 100 100  625  400       0     0     0>
+            , <&key_physical_attrs 100 100  725  400       0     0     0>
+            , <&key_physical_attrs 100 100  825  400       0     0     0>
+            , <&key_physical_attrs 100 100  925  400       0     0     0>
+            , <&key_physical_attrs 100 100 1025  400       0     0     0>
+            , <&key_physical_attrs 100 100 1125  400       0     0     0>
+            , <&key_physical_attrs 175 100 1225  400       0     0     0>
+            , <&key_physical_attrs 100 100 1400  400       0     0     0>
+            , <&key_physical_attrs 100 100 1500  400       0     0     0>
+            , <&key_physical_attrs 125 100    0  500       0     0     0>
+            , <&key_physical_attrs 125 100  125  500       0     0     0>
+            , <&key_physical_attrs 125 100  250  500       0     0     0>
+            , <&key_physical_attrs 625 100  375  500       0     0     0>
+            , <&key_physical_attrs 100 100 1000  500       0     0     0>
+            , <&key_physical_attrs 100 100 1100  500       0     0     0>
+            , <&key_physical_attrs 100 100 1200  500       0     0     0>
+            , <&key_physical_attrs 100 100 1300  500       0     0     0>
+            , <&key_physical_attrs 100 100 1400  500       0     0     0>
+            , <&key_physical_attrs 100 100 1500  500       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/75percent/iso.dtsi
+++ b/app/dts/layouts/common/75percent/iso.dtsi
@@ -1,0 +1,96 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_75_iso: layout_75_iso {
+        compatible = "zmk,physical-layout";
+        display-name = "75% ISO";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 100 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1400    0       0     0     0>
+            , <&key_physical_attrs 100 100 1500    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  100       0     0     0>
+            , <&key_physical_attrs 100 100  500  100       0     0     0>
+            , <&key_physical_attrs 100 100  600  100       0     0     0>
+            , <&key_physical_attrs 100 100  700  100       0     0     0>
+            , <&key_physical_attrs 100 100  800  100       0     0     0>
+            , <&key_physical_attrs 100 100  900  100       0     0     0>
+            , <&key_physical_attrs 100 100 1000  100       0     0     0>
+            , <&key_physical_attrs 100 100 1100  100       0     0     0>
+            , <&key_physical_attrs 100 100 1200  100       0     0     0>
+            , <&key_physical_attrs 200 100 1300  100       0     0     0>
+            , <&key_physical_attrs 100 100 1500  100       0     0     0>
+            , <&key_physical_attrs 150 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  150  200       0     0     0>
+            , <&key_physical_attrs 100 100  250  200       0     0     0>
+            , <&key_physical_attrs 100 100  350  200       0     0     0>
+            , <&key_physical_attrs 100 100  450  200       0     0     0>
+            , <&key_physical_attrs 100 100  550  200       0     0     0>
+            , <&key_physical_attrs 100 100  650  200       0     0     0>
+            , <&key_physical_attrs 100 100  750  200       0     0     0>
+            , <&key_physical_attrs 100 100  850  200       0     0     0>
+            , <&key_physical_attrs 100 100  950  200       0     0     0>
+            , <&key_physical_attrs 100 100 1050  200       0     0     0>
+            , <&key_physical_attrs 100 100 1150  200       0     0     0>
+            , <&key_physical_attrs 100 100 1250  200       0     0     0>
+            , <&key_physical_attrs 100 100 1500  200       0     0     0>
+            , <&key_physical_attrs 175 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  175  300       0     0     0>
+            , <&key_physical_attrs 100 100  275  300       0     0     0>
+            , <&key_physical_attrs 100 100  375  300       0     0     0>
+            , <&key_physical_attrs 100 100  475  300       0     0     0>
+            , <&key_physical_attrs 100 100  575  300       0     0     0>
+            , <&key_physical_attrs 100 100  675  300       0     0     0>
+            , <&key_physical_attrs 100 100  775  300       0     0     0>
+            , <&key_physical_attrs 100 100  875  300       0     0     0>
+            , <&key_physical_attrs 100 100  975  300       0     0     0>
+            , <&key_physical_attrs 100 100 1075  300       0     0     0>
+            , <&key_physical_attrs 100 100 1175  300       0     0     0>
+            , <&key_physical_attrs 100 100 1275  300       0     0     0>
+            , <&key_physical_attrs 125 200 1375  200       0     0     0>
+            , <&key_physical_attrs 100 100 1500  300       0     0     0>
+            , <&key_physical_attrs 125 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  125  400       0     0     0>
+            , <&key_physical_attrs 100 100  225  400       0     0     0>
+            , <&key_physical_attrs 100 100  325  400       0     0     0>
+            , <&key_physical_attrs 100 100  425  400       0     0     0>
+            , <&key_physical_attrs 100 100  525  400       0     0     0>
+            , <&key_physical_attrs 100 100  625  400       0     0     0>
+            , <&key_physical_attrs 100 100  725  400       0     0     0>
+            , <&key_physical_attrs 100 100  825  400       0     0     0>
+            , <&key_physical_attrs 100 100  925  400       0     0     0>
+            , <&key_physical_attrs 100 100 1025  400       0     0     0>
+            , <&key_physical_attrs 100 100 1125  400       0     0     0>
+            , <&key_physical_attrs 175 100 1225  400       0     0     0>
+            , <&key_physical_attrs 100 100 1400  400       0     0     0>
+            , <&key_physical_attrs 100 100 1500  400       0     0     0>
+            , <&key_physical_attrs 125 100    0  500       0     0     0>
+            , <&key_physical_attrs 125 100  125  500       0     0     0>
+            , <&key_physical_attrs 125 100  250  500       0     0     0>
+            , <&key_physical_attrs 625 100  375  500       0     0     0>
+            , <&key_physical_attrs 100 100 1000  500       0     0     0>
+            , <&key_physical_attrs 100 100 1100  500       0     0     0>
+            , <&key_physical_attrs 100 100 1200  500       0     0     0>
+            , <&key_physical_attrs 100 100 1300  500       0     0     0>
+            , <&key_physical_attrs 100 100 1400  500       0     0     0>
+            , <&key_physical_attrs 100 100 1500  500       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/ortho_4x12/1x2u.dtsi
+++ b/app/dts/layouts/common/ortho_4x12/1x2u.dtsi
@@ -1,0 +1,58 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_ortho_4x12_1x2u: layout_ortho_4x12_1x2u {
+        compatible = "zmk,physical-layout";
+        display-name = "40% 1x2U Space";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  100       0     0     0>
+            , <&key_physical_attrs 100 100  500  100       0     0     0>
+            , <&key_physical_attrs 100 100  600  100       0     0     0>
+            , <&key_physical_attrs 100 100  700  100       0     0     0>
+            , <&key_physical_attrs 100 100  800  100       0     0     0>
+            , <&key_physical_attrs 100 100  900  100       0     0     0>
+            , <&key_physical_attrs 100 100 1000  100       0     0     0>
+            , <&key_physical_attrs 100 100 1100  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100  400  200       0     0     0>
+            , <&key_physical_attrs 100 100  500  200       0     0     0>
+            , <&key_physical_attrs 100 100  600  200       0     0     0>
+            , <&key_physical_attrs 100 100  700  200       0     0     0>
+            , <&key_physical_attrs 100 100  800  200       0     0     0>
+            , <&key_physical_attrs 100 100  900  200       0     0     0>
+            , <&key_physical_attrs 100 100 1000  200       0     0     0>
+            , <&key_physical_attrs 100 100 1100  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 100 100  400  300       0     0     0>
+            , <&key_physical_attrs 200 100  500  300       0     0     0>
+            , <&key_physical_attrs 100 100  700  300       0     0     0>
+            , <&key_physical_attrs 100 100  800  300       0     0     0>
+            , <&key_physical_attrs 100 100  900  300       0     0     0>
+            , <&key_physical_attrs 100 100 1000  300       0     0     0>
+            , <&key_physical_attrs 100 100 1100  300       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/ortho_4x12/2x2u.dtsi
+++ b/app/dts/layouts/common/ortho_4x12/2x2u.dtsi
@@ -1,0 +1,57 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_ortho_4x12_2x2u: layout_ortho_4x12_2x2u {
+        compatible = "zmk,physical-layout";
+        display-name = "40% 2x2U Space";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  100       0     0     0>
+            , <&key_physical_attrs 100 100  500  100       0     0     0>
+            , <&key_physical_attrs 100 100  600  100       0     0     0>
+            , <&key_physical_attrs 100 100  700  100       0     0     0>
+            , <&key_physical_attrs 100 100  800  100       0     0     0>
+            , <&key_physical_attrs 100 100  900  100       0     0     0>
+            , <&key_physical_attrs 100 100 1000  100       0     0     0>
+            , <&key_physical_attrs 100 100 1100  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100  400  200       0     0     0>
+            , <&key_physical_attrs 100 100  500  200       0     0     0>
+            , <&key_physical_attrs 100 100  600  200       0     0     0>
+            , <&key_physical_attrs 100 100  700  200       0     0     0>
+            , <&key_physical_attrs 100 100  800  200       0     0     0>
+            , <&key_physical_attrs 100 100  900  200       0     0     0>
+            , <&key_physical_attrs 100 100 1000  200       0     0     0>
+            , <&key_physical_attrs 100 100 1100  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 200 100  400  300       0     0     0>
+            , <&key_physical_attrs 200 100  600  300       0     0     0>
+            , <&key_physical_attrs 100 100  800  300       0     0     0>
+            , <&key_physical_attrs 100 100  900  300       0     0     0>
+            , <&key_physical_attrs 100 100 1000  300       0     0     0>
+            , <&key_physical_attrs 100 100 1100  300       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/ortho_4x12/all1u.dtsi
+++ b/app/dts/layouts/common/ortho_4x12/all1u.dtsi
@@ -1,0 +1,59 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_ortho_4x12_all1u: layout_ortho_4x12_all1u {
+        compatible = "zmk,physical-layout";
+        display-name = "40% All 1U/Grid";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  100       0     0     0>
+            , <&key_physical_attrs 100 100  500  100       0     0     0>
+            , <&key_physical_attrs 100 100  600  100       0     0     0>
+            , <&key_physical_attrs 100 100  700  100       0     0     0>
+            , <&key_physical_attrs 100 100  800  100       0     0     0>
+            , <&key_physical_attrs 100 100  900  100       0     0     0>
+            , <&key_physical_attrs 100 100 1000  100       0     0     0>
+            , <&key_physical_attrs 100 100 1100  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100  400  200       0     0     0>
+            , <&key_physical_attrs 100 100  500  200       0     0     0>
+            , <&key_physical_attrs 100 100  600  200       0     0     0>
+            , <&key_physical_attrs 100 100  700  200       0     0     0>
+            , <&key_physical_attrs 100 100  800  200       0     0     0>
+            , <&key_physical_attrs 100 100  900  200       0     0     0>
+            , <&key_physical_attrs 100 100 1000  200       0     0     0>
+            , <&key_physical_attrs 100 100 1100  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 100 100  400  300       0     0     0>
+            , <&key_physical_attrs 100 100  500  300       0     0     0>
+            , <&key_physical_attrs 100 100  600  300       0     0     0>
+            , <&key_physical_attrs 100 100  700  300       0     0     0>
+            , <&key_physical_attrs 100 100  800  300       0     0     0>
+            , <&key_physical_attrs 100 100  900  300       0     0     0>
+            , <&key_physical_attrs 100 100 1000  300       0     0     0>
+            , <&key_physical_attrs 100 100 1100  300       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/ortho_4x12/ortho_4x12.dtsi
+++ b/app/dts/layouts/common/ortho_4x12/ortho_4x12.dtsi
@@ -1,0 +1,53 @@
+#include <layouts/common/ortho_4x12/1x2u.dtsi>
+#include <layouts/common/ortho_4x12/2x2u.dtsi>
+#include <layouts/common/ortho_4x12/all1u.dtsi>
+
+&layout_ortho_4x12_all1u {
+    status = "disabled";
+};
+
+&layout_ortho_4x12_1x2u {
+    status = "disabled";
+};
+
+&layout_ortho_4x12_2x2u {
+    status = "disabled";
+};
+
+/ {
+    layouts_common_ortho_4x12_position_map: layouts_common_ortho_4x12_position_map {
+        compatible = "zmk,physical-layout-position-map";
+
+        complete;
+
+        layout_ortho_4x12_all1u {
+            physical-layout = <&layout_ortho_4x12_all1u>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11>
+                , <12 13 14 15 16 17 18 19 20 21 22 23>
+                , <24 25 26 27 28 29 30 31 32 33 34 35>
+                , <36 37 38 39 40 41 42 43 44 45 46 47>
+                ;
+        };
+
+        layout_ortho_4x12_2x2u {
+            physical-layout = <&layout_ortho_4x12_2x2u>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11>
+                , <12 13 14 15 16 17 18 19 20 21 22 23>
+                , <24 25 26 27 28 29 30 31 32 33 34 35>
+                , <36 37 38 39 40 46 47 41 42 43 44 45>
+                ;
+        };
+
+        layout_ortho_4x12_1x2u {
+            physical-layout = <&layout_ortho_4x12_1x2u>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11>
+                , <12 13 14 15 16 17 18 19 20 21 22 23>
+                , <24 25 26 27 28 29 30 31 32 33 34 35>
+                , <36 37 38 39 40 41 47 42 43 44 45 46>
+                ;
+        };
+    };
+};

--- a/app/dts/layouts/common/ortho_5x12/1x2u.dtsi
+++ b/app/dts/layouts/common/ortho_5x12/1x2u.dtsi
@@ -1,0 +1,70 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_ortho_5x12_1x2u: layout_ortho_5x12_1x2u {
+        compatible = "zmk,physical-layout";
+        display-name = "50% 1x2U Space";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  100       0     0     0>
+            , <&key_physical_attrs 100 100  500  100       0     0     0>
+            , <&key_physical_attrs 100 100  600  100       0     0     0>
+            , <&key_physical_attrs 100 100  700  100       0     0     0>
+            , <&key_physical_attrs 100 100  800  100       0     0     0>
+            , <&key_physical_attrs 100 100  900  100       0     0     0>
+            , <&key_physical_attrs 100 100 1000  100       0     0     0>
+            , <&key_physical_attrs 100 100 1100  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100  400  200       0     0     0>
+            , <&key_physical_attrs 100 100  500  200       0     0     0>
+            , <&key_physical_attrs 100 100  600  200       0     0     0>
+            , <&key_physical_attrs 100 100  700  200       0     0     0>
+            , <&key_physical_attrs 100 100  800  200       0     0     0>
+            , <&key_physical_attrs 100 100  900  200       0     0     0>
+            , <&key_physical_attrs 100 100 1000  200       0     0     0>
+            , <&key_physical_attrs 100 100 1100  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 100 100  400  300       0     0     0>
+            , <&key_physical_attrs 100 100  500  300       0     0     0>
+            , <&key_physical_attrs 100 100  600  300       0     0     0>
+            , <&key_physical_attrs 100 100  700  300       0     0     0>
+            , <&key_physical_attrs 100 100  800  300       0     0     0>
+            , <&key_physical_attrs 100 100  900  300       0     0     0>
+            , <&key_physical_attrs 100 100 1000  300       0     0     0>
+            , <&key_physical_attrs 100 100 1100  300       0     0     0>
+            , <&key_physical_attrs 100 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  100  400       0     0     0>
+            , <&key_physical_attrs 100 100  200  400       0     0     0>
+            , <&key_physical_attrs 100 100  300  400       0     0     0>
+            , <&key_physical_attrs 100 100  400  400       0     0     0>
+            , <&key_physical_attrs 200 100  500  400       0     0     0>
+            , <&key_physical_attrs 100 100  700  400       0     0     0>
+            , <&key_physical_attrs 100 100  800  400       0     0     0>
+            , <&key_physical_attrs 100 100  900  400       0     0     0>
+            , <&key_physical_attrs 100 100 1000  400       0     0     0>
+            , <&key_physical_attrs 100 100 1100  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/ortho_5x12/2x2u.dtsi
+++ b/app/dts/layouts/common/ortho_5x12/2x2u.dtsi
@@ -1,0 +1,69 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_ortho_5x12_2x2u: layout_ortho_5x12_2x2u {
+        compatible = "zmk,physical-layout";
+        display-name = "50% 2x2U Space";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  100       0     0     0>
+            , <&key_physical_attrs 100 100  500  100       0     0     0>
+            , <&key_physical_attrs 100 100  600  100       0     0     0>
+            , <&key_physical_attrs 100 100  700  100       0     0     0>
+            , <&key_physical_attrs 100 100  800  100       0     0     0>
+            , <&key_physical_attrs 100 100  900  100       0     0     0>
+            , <&key_physical_attrs 100 100 1000  100       0     0     0>
+            , <&key_physical_attrs 100 100 1100  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100  400  200       0     0     0>
+            , <&key_physical_attrs 100 100  500  200       0     0     0>
+            , <&key_physical_attrs 100 100  600  200       0     0     0>
+            , <&key_physical_attrs 100 100  700  200       0     0     0>
+            , <&key_physical_attrs 100 100  800  200       0     0     0>
+            , <&key_physical_attrs 100 100  900  200       0     0     0>
+            , <&key_physical_attrs 100 100 1000  200       0     0     0>
+            , <&key_physical_attrs 100 100 1100  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 100 100  400  300       0     0     0>
+            , <&key_physical_attrs 100 100  500  300       0     0     0>
+            , <&key_physical_attrs 100 100  600  300       0     0     0>
+            , <&key_physical_attrs 100 100  700  300       0     0     0>
+            , <&key_physical_attrs 100 100  800  300       0     0     0>
+            , <&key_physical_attrs 100 100  900  300       0     0     0>
+            , <&key_physical_attrs 100 100 1000  300       0     0     0>
+            , <&key_physical_attrs 100 100 1100  300       0     0     0>
+            , <&key_physical_attrs 100 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  100  400       0     0     0>
+            , <&key_physical_attrs 100 100  200  400       0     0     0>
+            , <&key_physical_attrs 100 100  300  400       0     0     0>
+            , <&key_physical_attrs 200 100  400  400       0     0     0>
+            , <&key_physical_attrs 200 100  600  400       0     0     0>
+            , <&key_physical_attrs 100 100  800  400       0     0     0>
+            , <&key_physical_attrs 100 100  900  400       0     0     0>
+            , <&key_physical_attrs 100 100 1000  400       0     0     0>
+            , <&key_physical_attrs 100 100 1100  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/ortho_5x12/all1u.dtsi
+++ b/app/dts/layouts/common/ortho_5x12/all1u.dtsi
@@ -1,0 +1,71 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_ortho_5x12_all1u: layout_ortho_5x12_all1u {
+        compatible = "zmk,physical-layout";
+        display-name = "50% All 1U/Grid";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  600    0       0     0     0>
+            , <&key_physical_attrs 100 100  700    0       0     0     0>
+            , <&key_physical_attrs 100 100  800    0       0     0     0>
+            , <&key_physical_attrs 100 100  900    0       0     0     0>
+            , <&key_physical_attrs 100 100 1000    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  100       0     0     0>
+            , <&key_physical_attrs 100 100  500  100       0     0     0>
+            , <&key_physical_attrs 100 100  600  100       0     0     0>
+            , <&key_physical_attrs 100 100  700  100       0     0     0>
+            , <&key_physical_attrs 100 100  800  100       0     0     0>
+            , <&key_physical_attrs 100 100  900  100       0     0     0>
+            , <&key_physical_attrs 100 100 1000  100       0     0     0>
+            , <&key_physical_attrs 100 100 1100  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100  400  200       0     0     0>
+            , <&key_physical_attrs 100 100  500  200       0     0     0>
+            , <&key_physical_attrs 100 100  600  200       0     0     0>
+            , <&key_physical_attrs 100 100  700  200       0     0     0>
+            , <&key_physical_attrs 100 100  800  200       0     0     0>
+            , <&key_physical_attrs 100 100  900  200       0     0     0>
+            , <&key_physical_attrs 100 100 1000  200       0     0     0>
+            , <&key_physical_attrs 100 100 1100  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 100 100  400  300       0     0     0>
+            , <&key_physical_attrs 100 100  500  300       0     0     0>
+            , <&key_physical_attrs 100 100  600  300       0     0     0>
+            , <&key_physical_attrs 100 100  700  300       0     0     0>
+            , <&key_physical_attrs 100 100  800  300       0     0     0>
+            , <&key_physical_attrs 100 100  900  300       0     0     0>
+            , <&key_physical_attrs 100 100 1000  300       0     0     0>
+            , <&key_physical_attrs 100 100 1100  300       0     0     0>
+            , <&key_physical_attrs 100 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  100  400       0     0     0>
+            , <&key_physical_attrs 100 100  200  400       0     0     0>
+            , <&key_physical_attrs 100 100  300  400       0     0     0>
+            , <&key_physical_attrs 100 100  400  400       0     0     0>
+            , <&key_physical_attrs 100 100  500  400       0     0     0>
+            , <&key_physical_attrs 100 100  600  400       0     0     0>
+            , <&key_physical_attrs 100 100  700  400       0     0     0>
+            , <&key_physical_attrs 100 100  800  400       0     0     0>
+            , <&key_physical_attrs 100 100  900  400       0     0     0>
+            , <&key_physical_attrs 100 100 1000  400       0     0     0>
+            , <&key_physical_attrs 100 100 1100  400       0     0     0>
+            ;
+    };
+};

--- a/app/dts/layouts/common/ortho_5x12/ortho_5x12.dtsi
+++ b/app/dts/layouts/common/ortho_5x12/ortho_5x12.dtsi
@@ -1,0 +1,56 @@
+#include <layouts/common/ortho_5x12/1x2u.dtsi>
+#include <layouts/common/ortho_5x12/2x2u.dtsi>
+#include <layouts/common/ortho_5x12/all1u.dtsi>
+
+&layout_ortho_5x12_all1u {
+    status = "disabled";
+};
+
+&layout_ortho_5x12_1x2u {
+    status = "disabled";
+};
+
+&layout_ortho_5x12_2x2u {
+    status = "disabled";
+};
+
+/ {
+    layouts_common_ortho_5x12_position_map: layouts_common_ortho_5x12_position_map {
+        compatible = "zmk,physical-layout-position-map";
+
+        complete;
+
+        layout_ortho_5x12_all1u {
+            physical-layout = <&layout_ortho_5x12_all1u>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11>
+                , <12 13 14 15 16 17 18 19 20 21 22 23>
+                , <24 25 26 27 28 29 30 31 32 33 34 35>
+                , <36 37 38 39 40 41 42 43 44 45 46 47>
+                , <48 49 50 51 52 53 54 55 56 57 58 59>
+                ;
+        };
+
+        layout_ortho_5x12_2x2u {
+            physical-layout = <&layout_ortho_5x12_2x2u>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11>
+                , <12 13 14 15 16 17 18 19 20 21 22 23>
+                , <24 25 26 27 28 29 30 31 32 33 34 35>
+                , <36 37 38 39 40 41 42 43 44 45 46 47>
+                , <48 49 50 51 52 58 59 53 54 55 56 57>
+                ;
+        };
+
+        layout_ortho_5x12_1x2u {
+            physical-layout = <&layout_ortho_5x12_1x2u>;
+            positions
+                = < 0  1  2  3  4  5  6  7  8  9 10 11>
+                , <12 13 14 15 16 17 18 19 20 21 22 23>
+                , <24 25 26 27 28 29 30 31 32 33 34 35>
+                , <36 37 38 39 40 41 42 43 44 45 46 47>
+                , <48 49 50 51 52 53 59 54 55 56 57 58>
+                ;
+        };
+    };
+};

--- a/app/dts/layouts/common/tkl/ansi.dtsi
+++ b/app/dts/layouts/common/tkl/ansi.dtsi
@@ -1,0 +1,98 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_tkl_ansi: layout_tkl_ansi {
+        compatible = "zmk,physical-layout";
+        display-name = "TKL 87 Key ANSI";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400    0       0     0     0>
+            , <&key_physical_attrs 100 100  500    0       0     0     0>
+            , <&key_physical_attrs 100 100  650    0       0     0     0>
+            , <&key_physical_attrs 100 100  750    0       0     0     0>
+            , <&key_physical_attrs 100 100  850    0       0     0     0>
+            , <&key_physical_attrs 100 100  950    0       0     0     0>
+            , <&key_physical_attrs 100 100 1100    0       0     0     0>
+            , <&key_physical_attrs 100 100 1200    0       0     0     0>
+            , <&key_physical_attrs 100 100 1300    0       0     0     0>
+            , <&key_physical_attrs 100 100 1400    0       0     0     0>
+            , <&key_physical_attrs 100 100 1525    0       0     0     0>
+            , <&key_physical_attrs 100 100 1625    0       0     0     0>
+            , <&key_physical_attrs 100 100 1725    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  150       0     0     0>
+            , <&key_physical_attrs 100 100  100  150       0     0     0>
+            , <&key_physical_attrs 100 100  200  150       0     0     0>
+            , <&key_physical_attrs 100 100  300  150       0     0     0>
+            , <&key_physical_attrs 100 100  400  150       0     0     0>
+            , <&key_physical_attrs 100 100  500  150       0     0     0>
+            , <&key_physical_attrs 100 100  600  150       0     0     0>
+            , <&key_physical_attrs 100 100  700  150       0     0     0>
+            , <&key_physical_attrs 100 100  800  150       0     0     0>
+            , <&key_physical_attrs 100 100  900  150       0     0     0>
+            , <&key_physical_attrs 100 100 1000  150       0     0     0>
+            , <&key_physical_attrs 100 100 1100  150       0     0     0>
+            , <&key_physical_attrs 100 100 1200  150       0     0     0>
+            , <&key_physical_attrs 200 100 1300  150       0     0     0>
+            , <&key_physical_attrs 100 100 1525  150       0     0     0>
+            , <&key_physical_attrs 100 100 1625  150       0     0     0>
+            , <&key_physical_attrs 100 100 1725  150       0     0     0>
+            , <&key_physical_attrs 150 100    0  250       0     0     0>
+            , <&key_physical_attrs 100 100  150  250       0     0     0>
+            , <&key_physical_attrs 100 100  250  250       0     0     0>
+            , <&key_physical_attrs 100 100  350  250       0     0     0>
+            , <&key_physical_attrs 100 100  450  250       0     0     0>
+            , <&key_physical_attrs 100 100  550  250       0     0     0>
+            , <&key_physical_attrs 100 100  650  250       0     0     0>
+            , <&key_physical_attrs 100 100  750  250       0     0     0>
+            , <&key_physical_attrs 100 100  850  250       0     0     0>
+            , <&key_physical_attrs 100 100  950  250       0     0     0>
+            , <&key_physical_attrs 100 100 1050  250       0     0     0>
+            , <&key_physical_attrs 100 100 1150  250       0     0     0>
+            , <&key_physical_attrs 100 100 1250  250       0     0     0>
+            , <&key_physical_attrs 150 100 1350  250       0     0     0>
+            , <&key_physical_attrs 100 100 1525  250       0     0     0>
+            , <&key_physical_attrs 100 100 1625  250       0     0     0>
+            , <&key_physical_attrs 100 100 1725  250       0     0     0>
+            , <&key_physical_attrs 175 100    0  350       0     0     0>
+            , <&key_physical_attrs 100 100  175  350       0     0     0>
+            , <&key_physical_attrs 100 100  275  350       0     0     0>
+            , <&key_physical_attrs 100 100  375  350       0     0     0>
+            , <&key_physical_attrs 100 100  475  350       0     0     0>
+            , <&key_physical_attrs 100 100  575  350       0     0     0>
+            , <&key_physical_attrs 100 100  675  350       0     0     0>
+            , <&key_physical_attrs 100 100  775  350       0     0     0>
+            , <&key_physical_attrs 100 100  875  350       0     0     0>
+            , <&key_physical_attrs 100 100  975  350       0     0     0>
+            , <&key_physical_attrs 100 100 1075  350       0     0     0>
+            , <&key_physical_attrs 100 100 1175  350       0     0     0>
+            , <&key_physical_attrs 225 100 1275  350       0     0     0>
+            , <&key_physical_attrs 225 100    0  450       0     0     0>
+            , <&key_physical_attrs 100 100  225  450       0     0     0>
+            , <&key_physical_attrs 100 100  325  450       0     0     0>
+            , <&key_physical_attrs 100 100  425  450       0     0     0>
+            , <&key_physical_attrs 100 100  525  450       0     0     0>
+            , <&key_physical_attrs 100 100  625  450       0     0     0>
+            , <&key_physical_attrs 100 100  725  450       0     0     0>
+            , <&key_physical_attrs 100 100  825  450       0     0     0>
+            , <&key_physical_attrs 100 100  925  450       0     0     0>
+            , <&key_physical_attrs 100 100 1025  450       0     0     0>
+            , <&key_physical_attrs 100 100 1125  450       0     0     0>
+            , <&key_physical_attrs 275 100 1225  450       0     0     0>
+            , <&key_physical_attrs 100 100 1625  450       0     0     0>
+            , <&key_physical_attrs 125 100    0  550       0     0     0>
+            , <&key_physical_attrs 125 100  125  550       0     0     0>
+            , <&key_physical_attrs 125 100  250  550       0     0     0>
+            , <&key_physical_attrs 625 100  375  550       0     0     0>
+            , <&key_physical_attrs 125 100 1000  550       0     0     0>
+            , <&key_physical_attrs 125 100 1125  550       0     0     0>
+            , <&key_physical_attrs 125 100 1250  550       0     0     0>
+            , <&key_physical_attrs 125 100 1375  550       0     0     0>
+            , <&key_physical_attrs 100 100 1525  550       0     0     0>
+            , <&key_physical_attrs 100 100 1625  550       0     0     0>
+            , <&key_physical_attrs 100 100 1725  550       0     0     0>
+            ;
+    };
+};


### PR DESCRIPTION
This PR adds physical layout definitions for all the common physical layouts for 40% ortho through tkl unibody keyboards as well as implementing them on the relevant boards.

All boards have been confirmed to build, but I don't have many of these boards to test on personally. I can test on all the boards I do have access to