### PR TITLE
fix: Fix wakeup from kscan wrapped in sideband.

### DIFF
--- a/app/src/kscan_sideband_behaviors.c
+++ b/app/src/kscan_sideband_behaviors.c
@@ -111,6 +111,9 @@ static int ksbb_enable(const struct device *dev) {
         pm_device_runtime_get(config->kscan);
     }
 #elif IS_ENABLED(CONFIG_PM_DEVICE)
+    if (pm_device_wakeup_is_capable(config->kscan)) {
+        pm_device_wakeup_enable(config->kscan, true);
+    }
     pm_device_action_run(config->kscan, PM_DEVICE_ACTION_RESUME);
 #endif // IS_ENABLED(CONFIG_PM_DEVICE)
 
@@ -132,6 +135,10 @@ static int ksbb_disable(const struct device *dev) {
         pm_device_runtime_put(config->kscan);
     }
 #elif IS_ENABLED(CONFIG_PM_DEVICE)
+    if (pm_device_wakeup_is_capable(config->kscan) && !pm_device_wakeup_is_enabled(dev) &&
+        pm_device_wakeup_is_enabled(config->kscan)) {
+        pm_device_wakeup_enable(config->kscan, false);
+    }
     pm_device_action_run(config->kscan, PM_DEVICE_ACTION_SUSPEND);
 #endif // IS_ENABLED(CONFIG_PM_DEVICE)
 

--- a/app/src/physical_layouts.c
+++ b/app/src/physical_layouts.c
@@ -393,10 +393,9 @@ static int zmk_physical_layouts_init(void) {
 #if IS_ENABLED(CONFIG_PM_DEVICE)
     for (int l = 0; l < ARRAY_SIZE(layouts); l++) {
         const struct zmk_physical_layout *pl = layouts[l];
-        if (pl->kscan) {
-            if (pm_device_wakeup_is_capable(pl->kscan)) {
-                pm_device_wakeup_enable(pl->kscan, true);
-            }
+        if (pl->kscan && pm_device_wakeup_is_capable(pl->kscan) &&
+            !pm_device_wakeup_enable(pl->kscan, true)) {
+            LOG_WRN("Failed to wakeup enable %s", pl->kscan->name);
         }
     }
 #endif // IS_ENABLED(CONFIG_PM_DEVICE)


### PR DESCRIPTION
* If using a sideband kscan device to wrap a native kscan device, ensure the inner kscan device is also wakeup enabled to it can be waken from a deep sleep state by key press.

