### PR TITLE
fix(studio): Update position map querying

### DIFF
--- a/app/src/physical_layouts.c
+++ b/app/src/physical_layouts.c
@@ -81,7 +81,8 @@ DT_FOREACH_CHILD_SEP(DT_INST(0, POS_MAP_COMPAT), ZMK_POS_MAP_LEN_CHECK, (;));
 #define ZMK_POS_MAP_ENTRY(node_id)                                                                 \
     {                                                                                              \
         .layout = COND_CODE_1(                                                                     \
-            DT_HAS_COMPAT_STATUS_OKAY(DT_PHANDLE(node_id, physical_layout)),                       \
+            UTIL_AND(DT_NODE_HAS_COMPAT(DT_PHANDLE(node_id, physical_layout), DT_DRV_COMPAT),      \
+                     DT_NODE_HAS_STATUS(DT_PHANDLE(node_id, physical_layout), okay)),              \
             (&_CONCAT(_zmk_physical_layout_, DT_PHANDLE(node_id, physical_layout))), (NULL)),      \
         .positions = DT_PROP(node_id, positions),                                                  \
     }


### PR DESCRIPTION
`DT_HAS_COMPAT_STATUS_OKAY` expects a compatible, what we actually want to do is check if the physical layout node in a position map is compatible with zmk_physical_layout and in ok status.

For that, we'd use `DT_NODE_HAS_COMPAT_STATUS` but `COND_CODE_1` only supports functions with one or two args, so we have to use UTIL_AND to accomplish the same behavior.