### PR TITLE
feat: Tweaks for reduced nanopb stack usage.

### DIFF
--- a/app/west.yml
+++ b/app/west.yml
@@ -30,9 +30,9 @@ manifest:
           - edtt
           - trusted-firmware-m
     - name: nanopb
-      revision: 65cbefb4695bc7af1cb733ced99618afb3586b20
+      revision: 0a21c7ca2a98c5821d2836e41cc5c520e43fd0c0
       path: modules/lib/nanopb
-      remote: zephyrproject-rtos
+      remote: zmkfirmware
     - name: zmk-studio-messages
       revision: a79267a9661241a6603b6da3d2b3f71e8023a9d9
       path: modules/msgs/zmk-studio-messages


### PR DESCRIPTION
Worked on some tweaks to reduce our stack usage for our RPC stack, in particular with some tweaks to nanopb that bring it's stack size usage down.

See https://github.com/zmkfirmware/nanopb/commit/bf328175df765d05cbc0c19734af85378af0280c for the change to nanopb (which we now have a fork of) and the small changes to Zephyr that I'll merge into our fork when we're happy.

With this change, on USB on stm32f072, I can drop the RPC stack size to 2048 and have enough wiggle room to space (normal usage seems to go up to 1700 bytes or so).

Needs more testing, but the nanopb code changes are fairly innocuous.