### PR TITLE
fix: Force Ubuntu 22.04, pending CI fixes.

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Fetch Build Keyboards
     outputs:
       build_matrix: ${{ env.build_matrix }}


### PR DESCRIPTION
Address reported build failures in the community for those affected by `ubuntu-latest` roll out to 24.04: https://github.com/actions/runner-images/issues/10636