### PR TITLE
Adding length check to layer_label in nice_view status widget, to enable numeric layer display. (fixes #2540)

### DIFF
--- a/app/boards/shields/nice_view/widgets/status.c
+++ b/app/boards/shields/nice_view/widgets/status.c
@@ -179,7 +179,7 @@ static void draw_bottom(lv_obj_t *widget, lv_color_t cbuf[], const struct status
     lv_canvas_draw_rect(canvas, 0, 0, CANVAS_SIZE, CANVAS_SIZE, &rect_black_dsc);
 
     // Draw layer
-    if (state->layer_label == NULL) {
+    if (state->layer_label == NULL || strlen(state->layer_label) == 0) {
         char text[10] = {};
 
         sprintf(text, "LAYER %i", state->layer_index);


### PR DESCRIPTION
Fixes https://github.com/zmkfirmware/zmk/issues/2540

When display names are not present, the `layer_label` field may appear as an empty (zero-length) string rather than `NULL`; in either case, the status widget should show "LAYER N" where N is the 0-indexed layer number.
