### PR TITLE
Add studio metadata feature

### DIFF
--- a/app/boards/arm/adv360pro/adv360pro.zmk.yml
+++ b/app/boards/arm/adv360pro/adv360pro.zmk.yml
@@ -8,6 +8,7 @@ features:
   - keys
   - underglow
   - backlight
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/arm/bt60/bt60_v1.zmk.yml
+++ b/app/boards/arm/bt60/bt60_v1.zmk.yml
@@ -6,6 +6,7 @@ arch: arm
 features:
   - keys
   - encoder
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/arm/bt60/bt60_v1_hs.zmk.yml
+++ b/app/boards/arm/bt60/bt60_v1_hs.zmk.yml
@@ -6,6 +6,7 @@ arch: arm
 features:
   - keys
   - encoder
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/arm/ckp/bt60_v2.zmk.yml
+++ b/app/boards/arm/ckp/bt60_v2.zmk.yml
@@ -8,6 +8,7 @@ features:
   - encoder
   - underglow
   - backlight
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/arm/ckp/bt65_v1.zmk.yml
+++ b/app/boards/arm/ckp/bt65_v1.zmk.yml
@@ -8,6 +8,7 @@ features:
   - encoder
   - underglow
   - backlight
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/arm/ckp/bt75_v1.zmk.yml
+++ b/app/boards/arm/ckp/bt75_v1.zmk.yml
@@ -8,6 +8,7 @@ features:
   - encoder
   - underglow
   - backlight
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/arm/corneish_zen/corneish_zen_v1.zmk.yml
+++ b/app/boards/arm/corneish_zen/corneish_zen_v1.zmk.yml
@@ -7,6 +7,7 @@ arch: arm
 features:
   - keys
   - display
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/arm/corneish_zen/corneish_zen_v2.zmk.yml
+++ b/app/boards/arm/corneish_zen/corneish_zen_v2.zmk.yml
@@ -7,6 +7,7 @@ arch: arm
 features:
   - keys
   - display
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/arm/glove80/glove80.zmk.yml
+++ b/app/boards/arm/glove80/glove80.zmk.yml
@@ -8,6 +8,7 @@ features:
   - keys
   - underglow
   - backlight
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/arm/nice60/nice60.zmk.yml
+++ b/app/boards/arm/nice60/nice60.zmk.yml
@@ -6,6 +6,7 @@ arch: arm
 features:
   - keys
   - underglow
+  - studio
 outputs:
   - usb
   - ble

--- a/app/boards/shields/boardsource5x12/boardsource5x12.zmk.yml
+++ b/app/boards/shields/boardsource5x12/boardsource5x12.zmk.yml
@@ -6,3 +6,4 @@ url: https://boardsource.xyz/store/5ecb802c86879c9a0c22db61
 requires: [pro_micro]
 features:
   - keys
+  - studio

--- a/app/boards/shields/contra/contra.zmk.yml
+++ b/app/boards/shields/contra/contra.zmk.yml
@@ -6,3 +6,4 @@ url: https://github.com/ai03-2725/Contra
 requires: [pro_micro]
 features:
   - keys
+  - studio

--- a/app/boards/shields/corne/corne.zmk.yml
+++ b/app/boards/shields/corne/corne.zmk.yml
@@ -9,6 +9,7 @@ features:
   - keys
   - display
   - underglow
+  - studio
 siblings:
   - corne_left
   - corne_right

--- a/app/boards/shields/cradio/cradio.zmk.yml
+++ b/app/boards/shields/cradio/cradio.zmk.yml
@@ -7,6 +7,7 @@ requires: [pro_micro]
 exposes: [i2c_oled]
 features:
   - keys
+  - studio
 siblings:
   - cradio_left
   - cradio_right

--- a/app/boards/shields/crbn/crbn.zmk.yml
+++ b/app/boards/shields/crbn/crbn.zmk.yml
@@ -7,3 +7,4 @@ requires: [pro_micro]
 features:
   - keys
   - encoder
+  - studio

--- a/app/boards/shields/hummingbird/hummingbird.zmk.yml
+++ b/app/boards/shields/hummingbird/hummingbird.zmk.yml
@@ -6,3 +6,4 @@ url: https://github.com/PJE66/hummingbird
 requires: [seeed_xiao]
 features:
   - keys
+  - studio

--- a/app/boards/shields/jian/jian.zmk.yml
+++ b/app/boards/shields/jian/jian.zmk.yml
@@ -6,6 +6,7 @@ url: https://github.com/KGOH/Jian-Info
 requires: [pro_micro]
 features:
   - keys
+  - studio
 siblings:
   - jian_left
   - jian_right

--- a/app/boards/shields/jiran/jiran.zmk.yml
+++ b/app/boards/shields/jiran/jiran.zmk.yml
@@ -6,6 +6,7 @@ url: https://github.com/Ladniy/jiran
 requires: [pro_micro]
 features:
   - keys
+  - studio
 siblings:
   - jiran_left
   - jiran_right

--- a/app/boards/shields/jorne/jorne.zmk.yml
+++ b/app/boards/shields/jorne/jorne.zmk.yml
@@ -9,6 +9,7 @@ features:
   - keys
   - display
   - underglow
+  - studio
 siblings:
   - jorne_left
   - jorne_right

--- a/app/boards/shields/kyria/kyria.zmk.yml
+++ b/app/boards/shields/kyria/kyria.zmk.yml
@@ -10,6 +10,7 @@ features:
   - display
   - encoder
   - underglow
+  - studio
 siblings:
   - kyria_left
   - kyria_right

--- a/app/boards/shields/kyria/kyria_rev3.zmk.yml
+++ b/app/boards/shields/kyria/kyria_rev3.zmk.yml
@@ -10,6 +10,7 @@ features:
   - display
   - encoder
   - underglow
+  - studio
 siblings:
   - kyria_rev3_left
   - kyria_rev3_right

--- a/app/boards/shields/lily58/lily58.zmk.yml
+++ b/app/boards/shields/lily58/lily58.zmk.yml
@@ -8,6 +8,7 @@ exposes: [i2c_oled]
 features:
   - keys
   - display
+  - studio
 siblings:
   - lily58_left
   - lily58_right

--- a/app/boards/shields/m60/m60.zmk.yml
+++ b/app/boards/shields/m60/m60.zmk.yml
@@ -6,3 +6,4 @@ url: https://makerdiary.com/pages/m60-mechanical-keyboard
 requires: [makerdiary_nrf52840_m2]
 features:
   - keys
+  - studio

--- a/app/boards/shields/reviung41/reviung41.zmk.yml
+++ b/app/boards/shields/reviung41/reviung41.zmk.yml
@@ -6,3 +6,4 @@ url: https://github.com/gtips/reviung/tree/master/reviung41
 requires: [pro_micro]
 features:
   - keys
+  - studio

--- a/app/boards/shields/sofle/sofle.zmk.yml
+++ b/app/boards/shields/sofle/sofle.zmk.yml
@@ -10,6 +10,7 @@ features:
   - display
   - encoder
   - underglow
+  - studio
 siblings:
   - sofle_left
   - sofle_right

--- a/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.zmk.yml
+++ b/app/boards/shields/splitkb_aurora_corne/splitkb_aurora_corne.zmk.yml
@@ -7,6 +7,7 @@ requires: [pro_micro]
 exposes: [i2c_oled]
 features:
   - keys
+  - studio
 siblings:
   - splitkb_aurora_corne_left
   - splitkb_aurora_corne_right

--- a/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58.zmk.yml
+++ b/app/boards/shields/splitkb_aurora_lily58/splitkb_aurora_lily58.zmk.yml
@@ -7,6 +7,7 @@ requires: [pro_micro]
 exposes: [i2c_oled]
 features:
   - keys
+  - studio
 siblings:
   - splitkb_aurora_lily58_left
   - splitkb_aurora_lily58_right

--- a/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.zmk.yml
+++ b/app/boards/shields/splitkb_aurora_sofle/splitkb_aurora_sofle.zmk.yml
@@ -10,6 +10,7 @@ features:
   - display
   - encoder
   - underglow
+  - studio
 siblings:
   - splitkb_aurora_sofle_left
   - splitkb_aurora_sofle_right

--- a/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.zmk.yml
+++ b/app/boards/shields/splitkb_aurora_sweep/splitkb_aurora_sweep.zmk.yml
@@ -7,6 +7,7 @@ requires: [pro_micro]
 exposes: [i2c_oled]
 features:
   - keys
+  - studio
 siblings:
   - splitkb_aurora_sweep_left
   - splitkb_aurora_sweep_right

--- a/app/boards/shields/zmk_uno/zmk_uno.zmk.yml
+++ b/app/boards/shields/zmk_uno/zmk_uno.zmk.yml
@@ -8,3 +8,4 @@ features:
   - keys
   - encoder
   - display
+  - studio

--- a/docs/docs/development/hardware-integration/hardware-metadata-files.md
+++ b/docs/docs/development/hardware-integration/hardware-metadata-files.md
@@ -95,6 +95,7 @@ Boards and shields should document the sets of hardware features found on them u
 - `encoder` - Indicates the hardware contains one or more rotary encoders.
 - `underglow` - Indicates the hardware includes underglow LEDs.
 - `backlight` - Indicates the hardware includes backlight LEDs.
+- `studio` - Indicates the keyboard is ready to use with [ZMK Studio](../../features/studio.md).
 - `pointer` (future) - Used to indicate the hardware includes one or more pointer inputs, e.g. joystick, touchpad, or trackpoint.
 
 ### Siblings

--- a/schema/hardware-metadata.schema.json
+++ b/schema/hardware-metadata.schema.json
@@ -57,7 +57,8 @@
           "encoder",
           "underglow",
           "backlight",
-          "pointer"
+          "pointer",
+          "studio"
         ]
       }
     },


### PR DESCRIPTION
Add a new `studio` option to the `features` list in our metadata files to indicate the board/shield supports ZMK Studio.