### PR TITLE
docs: Add a few well known interconnects to the Hardware Metadata File page

### DIFF
--- a/docs/docs/development/hardware-integration/hardware-metadata-files.md
+++ b/docs/docs/development/hardware-integration/hardware-metadata-files.md
@@ -75,7 +75,7 @@ url: https://github.com/foostan/crkbd/
 
 ### Interconnect Requires/Exposes
 
-For boards and shields, one of the key pieces of high level information is compatibility between the two items. In particular, a board usually exposes one ore more "interconnects", the physical location/type of connections available, and their assigned possible uses (e.g. GPIO, power, ground, i2c, etc). Similarly, a shield is usually designed around one (or sometimes more) "interconnects" that allow it to connect to one of those boards.
+For boards and shields, one of the key pieces of high level information is compatibility between the two items. In particular, a board usually exposes one ore more "interconnects", the physical location/type of connections available, and their assigned possible uses (e.g. GPIO, power, ground, i2c, etc). Similarly, a shield is usually designed around one (or sometimes more) "interconnects" that allow it to connect to one of those boards. Common "interconnects" available in ZMK include (but are not limited to) `arduino_uno`, `blackpill`, `pro_micro`, and `seeed_xiao`. The names of "interconnects" may be found in the `app/boards/interconnects/` directory of ZMK source.
 
 In ZMK, we encode both of those scenarios with the `exposes` and `requires` properties, respectively. For example, for a Corne shield that requires a Pro Micro compatible controller to function, and simultaneously exposes a four pin header to be used by standard i2c OLED modules, the metadata file contains:
 


### PR DESCRIPTION
Fixes #2562 

Added two sentences to list the same set of interconnects that have pinouts shown in the New Keyboard Shield guide and point readers at the interconnects directory in source for more.