### PR TITLE
fix: Optimize layout changes by doing runtime mapping

### DIFF
--- a/app/include/zmk/physical_layouts.h
+++ b/app/include/zmk/physical_layouts.h
@@ -49,3 +49,12 @@ int zmk_physical_layouts_revert_selected(void);
 
 int zmk_physical_layouts_get_position_map(uint8_t source, uint8_t dest, size_t map_size,
                                           uint32_t map[map_size]);
+
+/**
+ * @brief Get a pointer to a position map array for mapping a key position in the selected
+ *        physical layout to the stock/chosen physical layout
+ *
+ * @retval a negative errno value in the case of errors
+ * @retval a positive length of the position map array that map is updated to point to.
+ */
+int zmk_physical_layouts_get_selected_to_stock_position_map(uint32_t const **map);


### PR DESCRIPTION
* To avoid tons of migration, extra flash writes, etc, we keep the keymaps and settings using a key position index that's tied to the stock layout, and at runtime mapping key positions as needed.
