### PR TITLE
feat(boards): Add numpad layouts

### DIFF
--- a/app/dts/layouts/common/numpad/17_key.dtsi
+++ b/app/dts/layouts/common/numpad/17_key.dtsi
@@ -1,0 +1,43 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_17_key: layout_numpad_17_key {
+        compatible = "zmk,physical-layout";
+        display-name = "17 Key Numpad";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 200  300  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 200  300  300       0     0     0>
+            , <&key_physical_attrs 200 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  200  400       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_17_key {
+        physical-layout = <&layout_numpad_17_key>;
+        positions
+            = <17 18 19 20>
+            , < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 21>
+            , <11 12 13 14>
+            , <15 22 16 23>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/18_key.dtsi
+++ b/app/dts/layouts/common/numpad/18_key.dtsi
@@ -1,0 +1,44 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_18_key: layout_numpad_18_key {
+        compatible = "zmk,physical-layout";
+        display-name = "18 Key Numpad";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 200  300  300       0     0     0>
+            , <&key_physical_attrs 200 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  200  400       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_18_key {
+        physical-layout = <&layout_numpad_18_key>;
+        positions
+            = <18 19 20 21>
+            , < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 11>
+            , <12 13 14 15>
+            , <16 22 17 23>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/18_key_00.dtsi
+++ b/app/dts/layouts/common/numpad/18_key_00.dtsi
@@ -1,0 +1,44 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_18_key_00: layout_numpad_18_key_00 {
+        compatible = "zmk,physical-layout";
+        display-name = "18 Key Numpad (00)";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 200  300  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 200  300  300       0     0     0>
+            , <&key_physical_attrs 100 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  100  400       0     0     0>
+            , <&key_physical_attrs 100 100  200  400       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_18_key_00 {
+        physical-layout = <&layout_numpad_18_key_00>;
+        positions
+            = <18 19 20 21>
+            , < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 22>
+            , <11 12 13 14>
+            , <15 16 17 23>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/19_key_00.dtsi
+++ b/app/dts/layouts/common/numpad/19_key_00.dtsi
@@ -1,0 +1,45 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_19_key_00: layout_numpad_19_key_00 {
+        compatible = "zmk,physical-layout";
+        display-name = "19 Key Numpad (00)";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 200  300  300       0     0     0>
+            , <&key_physical_attrs 100 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  100  400       0     0     0>
+            , <&key_physical_attrs 100 100  200  400       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_19_key_00 {
+        physical-layout = <&layout_numpad_19_key_00>;
+        positions
+            = <19 20 21 22>
+            , < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 11>
+            , <12 13 14 15>
+            , <16 17 18 23>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/20_key.dtsi
+++ b/app/dts/layouts/common/numpad/20_key.dtsi
@@ -1,0 +1,46 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_20_key: layout_numpad_20_key {
+        compatible = "zmk,physical-layout";
+        display-name = "20 Key Numpad";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  100       0     0     0>
+            , <&key_physical_attrs 100 100  100  100       0     0     0>
+            , <&key_physical_attrs 100 100  200  100       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100    0  200       0     0     0>
+            , <&key_physical_attrs 100 100  100  200       0     0     0>
+            , <&key_physical_attrs 100 100  200  200       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100    0  300       0     0     0>
+            , <&key_physical_attrs 100 100  100  300       0     0     0>
+            , <&key_physical_attrs 100 100  200  300       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 100 100    0  400       0     0     0>
+            , <&key_physical_attrs 100 100  100  400       0     0     0>
+            , <&key_physical_attrs 100 100  200  400       0     0     0>
+            , <&key_physical_attrs 100 100  300  400       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_20_key {
+        physical-layout = <&layout_numpad_20_key>;
+        positions
+            = <20 21 22 23>
+            , < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 11>
+            , <12 13 14 15>
+            , <16 17 18 19>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/21_key.dtsi
+++ b/app/dts/layouts/common/numpad/21_key.dtsi
@@ -1,0 +1,47 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_21_key: layout_numpad_21_key {
+        compatible = "zmk,physical-layout";
+        display-name = "21 Key Numpad";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  125       0     0     0>
+            , <&key_physical_attrs 100 100  100  125       0     0     0>
+            , <&key_physical_attrs 100 100  200  125       0     0     0>
+            , <&key_physical_attrs 100 100  300  125       0     0     0>
+            , <&key_physical_attrs 100 100    0  225       0     0     0>
+            , <&key_physical_attrs 100 100  100  225       0     0     0>
+            , <&key_physical_attrs 100 100  200  225       0     0     0>
+            , <&key_physical_attrs 100 200  300  225       0     0     0>
+            , <&key_physical_attrs 100 100    0  325       0     0     0>
+            , <&key_physical_attrs 100 100  100  325       0     0     0>
+            , <&key_physical_attrs 100 100  200  325       0     0     0>
+            , <&key_physical_attrs 100 100    0  425       0     0     0>
+            , <&key_physical_attrs 100 100  100  425       0     0     0>
+            , <&key_physical_attrs 100 100  200  425       0     0     0>
+            , <&key_physical_attrs 100 200  300  425       0     0     0>
+            , <&key_physical_attrs 200 100    0  525       0     0     0>
+            , <&key_physical_attrs 100 100  200  525       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_21_key {
+        physical-layout = <&layout_numpad_21_key>;
+        positions
+            = < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 11>
+            , <12 13 14 21>
+            , <15 16 17 18>
+            , <19 22 20 23>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/22_key.dtsi
+++ b/app/dts/layouts/common/numpad/22_key.dtsi
@@ -1,0 +1,48 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_22_key: layout_numpad_22_key {
+        compatible = "zmk,physical-layout";
+        display-name = "22 Key Numpad";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  125       0     0     0>
+            , <&key_physical_attrs 100 100  100  125       0     0     0>
+            , <&key_physical_attrs 100 100  200  125       0     0     0>
+            , <&key_physical_attrs 100 100  300  125       0     0     0>
+            , <&key_physical_attrs 100 100    0  225       0     0     0>
+            , <&key_physical_attrs 100 100  100  225       0     0     0>
+            , <&key_physical_attrs 100 100  200  225       0     0     0>
+            , <&key_physical_attrs 100 100  300  225       0     0     0>
+            , <&key_physical_attrs 100 100    0  325       0     0     0>
+            , <&key_physical_attrs 100 100  100  325       0     0     0>
+            , <&key_physical_attrs 100 100  200  325       0     0     0>
+            , <&key_physical_attrs 100 100  300  325       0     0     0>
+            , <&key_physical_attrs 100 100    0  425       0     0     0>
+            , <&key_physical_attrs 100 100  100  425       0     0     0>
+            , <&key_physical_attrs 100 100  200  425       0     0     0>
+            , <&key_physical_attrs 100 200  300  425       0     0     0>
+            , <&key_physical_attrs 200 100    0  525       0     0     0>
+            , <&key_physical_attrs 100 100  200  525       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_22_key {
+        physical-layout = <&layout_numpad_22_key>;
+        positions
+            = < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 11>
+            , <12 13 14 15>
+            , <16 17 18 19>
+            , <20 22 21 23>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/22_key_00.dtsi
+++ b/app/dts/layouts/common/numpad/22_key_00.dtsi
@@ -1,0 +1,48 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_22_key_00: layout_numpad_22_key_00 {
+        compatible = "zmk,physical-layout";
+        display-name = "22 Key Numpad (00)";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  125       0     0     0>
+            , <&key_physical_attrs 100 100  100  125       0     0     0>
+            , <&key_physical_attrs 100 100  200  125       0     0     0>
+            , <&key_physical_attrs 100 100  300  125       0     0     0>
+            , <&key_physical_attrs 100 100    0  225       0     0     0>
+            , <&key_physical_attrs 100 100  100  225       0     0     0>
+            , <&key_physical_attrs 100 100  200  225       0     0     0>
+            , <&key_physical_attrs 100 200  300  225       0     0     0>
+            , <&key_physical_attrs 100 100    0  325       0     0     0>
+            , <&key_physical_attrs 100 100  100  325       0     0     0>
+            , <&key_physical_attrs 100 100  200  325       0     0     0>
+            , <&key_physical_attrs 100 100    0  425       0     0     0>
+            , <&key_physical_attrs 100 100  100  425       0     0     0>
+            , <&key_physical_attrs 100 100  200  425       0     0     0>
+            , <&key_physical_attrs 100 200  300  425       0     0     0>
+            , <&key_physical_attrs 100 100    0  525       0     0     0>
+            , <&key_physical_attrs 100 100  100  525       0     0     0>
+            , <&key_physical_attrs 100 100  200  525       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_22_key_00 {
+        physical-layout = <&layout_numpad_22_key_00>;
+        positions
+            = < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 11>
+            , <12 13 14 22>
+            , <15 16 17 18>
+            , <19 20 21 23>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/23_key_00.dtsi
+++ b/app/dts/layouts/common/numpad/23_key_00.dtsi
@@ -1,0 +1,49 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_23_key_00: layout_numpad_23_key_00 {
+        compatible = "zmk,physical-layout";
+        display-name = "23 Key Numpad (00)";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  125       0     0     0>
+            , <&key_physical_attrs 100 100  100  125       0     0     0>
+            , <&key_physical_attrs 100 100  200  125       0     0     0>
+            , <&key_physical_attrs 100 100  300  125       0     0     0>
+            , <&key_physical_attrs 100 100    0  225       0     0     0>
+            , <&key_physical_attrs 100 100  100  225       0     0     0>
+            , <&key_physical_attrs 100 100  200  225       0     0     0>
+            , <&key_physical_attrs 100 100  300  225       0     0     0>
+            , <&key_physical_attrs 100 100    0  325       0     0     0>
+            , <&key_physical_attrs 100 100  100  325       0     0     0>
+            , <&key_physical_attrs 100 100  200  325       0     0     0>
+            , <&key_physical_attrs 100 100  300  325       0     0     0>
+            , <&key_physical_attrs 100 100    0  425       0     0     0>
+            , <&key_physical_attrs 100 100  100  425       0     0     0>
+            , <&key_physical_attrs 100 100  200  425       0     0     0>
+            , <&key_physical_attrs 100 200  300  425       0     0     0>
+            , <&key_physical_attrs 100 100    0  525       0     0     0>
+            , <&key_physical_attrs 100 100  100  525       0     0     0>
+            , <&key_physical_attrs 100 100  200  525       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_23_key_00 {
+        physical-layout = <&layout_numpad_23_key_00>;
+        positions
+            = < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 11>
+            , <12 13 14 15>
+            , <16 17 18 19>
+            , <20 21 22 23>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/24_key.dtsi
+++ b/app/dts/layouts/common/numpad/24_key.dtsi
@@ -1,0 +1,50 @@
+#include <layouts/common/numpad/position_map.dtsi>
+#include <physical_layouts.dtsi>
+
+/ {
+    layout_numpad_24_key: layout_numpad_24_key {
+        compatible = "zmk,physical-layout";
+        display-name = "24 Key Numpad";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0    0       0     0     0>
+            , <&key_physical_attrs 100 100  100    0       0     0     0>
+            , <&key_physical_attrs 100 100  200    0       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100    0  125       0     0     0>
+            , <&key_physical_attrs 100 100  100  125       0     0     0>
+            , <&key_physical_attrs 100 100  200  125       0     0     0>
+            , <&key_physical_attrs 100 100  300  125       0     0     0>
+            , <&key_physical_attrs 100 100    0  225       0     0     0>
+            , <&key_physical_attrs 100 100  100  225       0     0     0>
+            , <&key_physical_attrs 100 100  200  225       0     0     0>
+            , <&key_physical_attrs 100 100  300  225       0     0     0>
+            , <&key_physical_attrs 100 100    0  325       0     0     0>
+            , <&key_physical_attrs 100 100  100  325       0     0     0>
+            , <&key_physical_attrs 100 100  200  325       0     0     0>
+            , <&key_physical_attrs 100 100  300  325       0     0     0>
+            , <&key_physical_attrs 100 100    0  425       0     0     0>
+            , <&key_physical_attrs 100 100  100  425       0     0     0>
+            , <&key_physical_attrs 100 100  200  425       0     0     0>
+            , <&key_physical_attrs 100 100  300  425       0     0     0>
+            , <&key_physical_attrs 100 100    0  525       0     0     0>
+            , <&key_physical_attrs 100 100  100  525       0     0     0>
+            , <&key_physical_attrs 100 100  200  525       0     0     0>
+            , <&key_physical_attrs 100 100  300  525       0     0     0>
+            ;
+    };
+};
+
+&layouts_common_numpad_position_map {
+    layout_numpad_24_key {
+        physical-layout = <&layout_numpad_24_key>;
+        positions
+            = < 0  1  2  3>
+            , < 4  5  6  7>
+            , < 8  9 10 11>
+            , <12 13 14 15>
+            , <16 17 18 19>
+            , <20 21 22 23>
+            ;
+    };
+};

--- a/app/dts/layouts/common/numpad/position_map.dtsi
+++ b/app/dts/layouts/common/numpad/position_map.dtsi
@@ -1,0 +1,7 @@
+/ {
+    layouts_common_numpad_position_map: layouts_common_numpad_position_map {
+        compatible = "zmk,physical-layout-position-map";
+
+        complete;
+    };
+};


### PR DESCRIPTION
Added physical layouts for the following variants of numpads:

- With and without extra top row
- 2U plus key or 1U plus and backspace keys
- 2U 0 key or 1U 0 and 00 keys
- Full 1U grid/macropad layout

Other layouts exist, such as "southpaw" horizontally mirrored layouts, and layouts with a fifth column, but those seem to be much less common. There are a lot of layouts here already, so we can add the less common ones later if anyone asks for them.