### PR TITLE
feat(boards): Add glove80 nexus node for extension GPIO.

### DIFF
--- a/app/boards/arm/glove80/glove80_lh.dts
+++ b/app/boards/arm/glove80/glove80_lh.dts
@@ -36,6 +36,21 @@
     vbatt: vbatt {
         compatible = "zmk,battery-nrf-vddh";
     };
+
+    glove80_ext: connector {
+        compatible = "moergo,glove80-ext";
+        #gpio-cells = <2>;
+        gpio-map-mask = <0xffffffff 0xffffffc0>;
+        gpio-map-pass-thru = <0 0x3f>;
+        gpio-map
+            = <1 0 &gpio0 22 0>     /* EXT1 */
+            , <2 0 &gpio0 21 0>     /* EXT2 */
+            , <3 0 &gpio0 24 0>     /* EXT3 */
+            , <4 0 &gpio0 20 0>     /* EXT4 */
+            , <5 0 &gpio0 25 0>     /* EXT5 */
+            , <6 0 &gpio1 00 0>     /* EXT6 */
+            ;
+    };
 };
 
 &spi3 {

--- a/app/boards/arm/glove80/glove80_rh.dts
+++ b/app/boards/arm/glove80/glove80_rh.dts
@@ -37,6 +37,21 @@
     vbatt: vbatt {
         compatible = "zmk,battery-nrf-vddh";
     };
+
+    glove80_ext: connector {
+        compatible = "moergo,glove80-ext";
+        #gpio-cells = <2>;
+        gpio-map-mask = <0xffffffff 0xffffffc0>;
+        gpio-map-pass-thru = <0 0x3f>;
+        gpio-map
+            = <1 0 &gpio0 21 0>     /* EXT1 */
+            , <2 0 &gpio0 24 0>     /* EXT2 */
+            , <3 0 &gpio0 20 0>     /* EXT3 */
+            , <4 0 &gpio0 25 0>     /* EXT4 */
+            , <5 0 &gpio0 22 0>     /* EXT5 */
+            , <6 0 &gpio1 00 0>     /* EXT6 */
+            ;
+    };
 };
 
 &spi3 {

--- a/app/dts/bindings/gpio/moergo,glove80-ext.yaml
+++ b/app/dts/bindings/gpio/moergo,glove80-ext.yaml
@@ -1,0 +1,24 @@
+# Copyright (C) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: |
+  GPIO pins exposed on the Glove80 internal extension header.
+
+  See https://docs.moergo.com/glove80-user-guide/appendix-more-customizations/
+
+  Both sides of the Glove80 split keyboard expose a set of 6 extra GPIO pins
+  for customization, with different underlying nRF52 pins used on each side.
+  This nexus node allows referencing the pins generically without being tied
+  to a specific left/right side pin assignment.
+
+
+      - GND                    VEXT  -
+      - VDDH                   EXT1  1
+      2 EXT2                   EXT3  3
+      4 EXT4                   EXT5  5
+      6 SWO_EXT6               RESET -
+      - SWDCLK                 SWDIO -
+
+compatible: "moergo,glove80-ext"
+
+include: [gpio-nexus.yaml, base.yaml]

--- a/app/dts/bindings/vendor-prefixes.txt
+++ b/app/dts/bindings/vendor-prefixes.txt
@@ -1,1 +1,2 @@
 zmk	ZMK Project
+moergo	MoErgo


### PR DESCRIPTION
Added based on the docs from https://docs.moergo.com/glove80-user-guide/appendix-more-customizations/#extending-the-glove80-electronics to make it easier to address the GPIO on the glove80 in a uniform way across halves.