### PR TITLE
chore: Config dependabot for grouped npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,25 +9,6 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      production-major:
-        applies-to: "version-updates"
-        dependency-type: "production"
-        exclude-patterns:
-          - "@docusaurus/*"
-          - "tree-sitter-devicetree"
-          - "web-tree-sitter"
-        update-types:
-          - "major"
-      production-minor-patch:
-        applies-to: "version-updates"
-        dependency-type: "production"
-        exclude-patterns:
-          - "@docusaurus/*"
-          - "tree-sitter-devicetree"
-          - "web-tree-sitter"
-        update-types:
-          - "minor"
-          - "patch"
       docusaurus-major:
         applies-to: "version-updates"
         dependency-type: "production"
@@ -49,6 +30,25 @@ updates:
         patterns:
           - "tree-sitter-devicetree"
           - "web-tree-sitter"
+      prod-other-major:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        exclude-patterns:
+          - "@docusaurus/*"
+          - "tree-sitter-devicetree"
+          - "web-tree-sitter"
+        update-types:
+          - "major"
+      prod-other-minor-patch:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        exclude-patterns:
+          - "@docusaurus/*"
+          - "tree-sitter-devicetree"
+          - "web-tree-sitter"
+        update-types:
+          - "minor"
+          - "patch"
       development:
         applies-to: "version-updates"
         dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,47 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      production-version-major:
+      production-major:
         applies-to: "version-updates"
         dependency-type: "production"
+        exclude-patterns:
+          - "@docusaurus/*"
+          - "tree-sitter-devicetree"
+          - "web-tree-sitter"
         update-types:
           - "major"
-      production-version-minor-patch:
+      production-minor-patch:
         applies-to: "version-updates"
         dependency-type: "production"
+        exclude-patterns:
+          - "@docusaurus/*"
+          - "tree-sitter-devicetree"
+          - "web-tree-sitter"
         update-types:
           - "minor"
           - "patch"
-      development-version:
+      docusaurus-major:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        patterns:
+          - "@docusaurus/*"
+        update-types:
+          - "major"
+      docusaurus-minor-patch:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        patterns:
+          - "@docusaurus/*"
+        update-types:
+          - "minor"
+          - "patch"
+      tree-sitter:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        patterns:
+          - "tree-sitter-devicetree"
+          - "web-tree-sitter"
+      development:
         applies-to: "version-updates"
         dependency-type: "development"
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,21 @@ updates:
     directory: "/docs"
     schedule:
       interval: "daily"
+    groups:
+      production-version-major:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        update-types:
+          - "major"
+      production-version-minor-patch:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-version:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Attempt to organize dependabot so that:
- we don't have individual "version" (as opposed to "security") updates
- PRs are grouped into separate production and dev groups
- for production, two groups for major vs. minor+patch
- for dev, only minor+patch
- security updates aren't touched, so there will be individual PRs as is

The resulting PRs can be seen at https://github.com/caksoylar/zmk/pulls
Config reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

Open question/points for discussion:
- should we also have a separate major updates group for dev deps? or alternatively, remove minor+patch constraint?
- should security updates be constrained to minor+patch?
- any need to create other groups for specific dependencies (e.g. `docusaurus*`)?
- should we touch the GH actions ecosystem entry? I am not sure if it has prod/dev but we can create groups (with semver constraints)