### PR TITLE
fix: Fix kscan prop existence test in physical layouts

### DIFF
--- a/app/src/physical_layouts.c
+++ b/app/src/physical_layouts.c
@@ -62,7 +62,7 @@ BUILD_ASSERT(
         .matrix_transform = ZMK_MATRIX_TRANSFORM_T_FOR_NODE(DT_INST_PHANDLE(n, transform)),        \
         .keys = _CONCAT(_zmk_physical_layout_keys_, n),                                            \
         .keys_len = DT_INST_PROP_LEN_OR(n, keys, 0),                                               \
-        .kscan = DEVICE_DT_GET(COND_CODE_1(DT_INST_PROP_LEN(n, kscan),                             \
+        .kscan = DEVICE_DT_GET(COND_CODE_1(DT_INST_NODE_HAS_PROP(n, kscan),                        \
                                            (DT_INST_PHANDLE(n, kscan)), (DT_CHOSEN(zmk_kscan))))};
 
 DT_INST_FOREACH_STATUS_OKAY(ZMK_LAYOUT_INST)


### PR DESCRIPTION
Currently building with a chosen physical layout which has a kscan, but no chosen "shared" kscan fails. See example [build](https://github.com/rmuraglia/zmk-config/actions/runs/11695134268) and corresponding failing [overlay](https://github.com/rmuraglia/zmk-config/blob/7fabcb6e0e9413c782edf002593730bde92b9a40/boards/shields/menura/menura.dtsi).

I am guessing this is because `DT_INST_PROP_LEN` doesn't work for phandle type properties, and we can use `DT_INST_NODE_HAS_PROP` instead. (I haven't spent too much time looking into this, happy to change if there is a better check.)