### PR TITLE
docs: Fix typos in local-toolchain/setup

### DIFF
--- a/docs/docs/development/local-toolchain/setup/container.mdx
+++ b/docs/docs/development/local-toolchain/setup/container.mdx
@@ -106,7 +106,7 @@ first make them available by creating volumes.
 </Tabs>
 
 Once this is done, you can refer to the `zmk-config` with
-`/workspace/zmk-config` and `/workspace/zmk-modules` to the modules instead of
+`/workspaces/zmk-config` and `/workspaces/zmk-modules` to the modules instead of
 using their full path like it is shown in the
 [build commands](../build-flash.mdx), since these are the locations they were
 mounted to in the container.


### PR DESCRIPTION
Just noticed there's a typo in the docs. I believe it should be `/workspaces/*`, not `/workspace/*`.