### PR TITLE
fix: Disable display feature for settings_reset

### DIFF
--- a/app/boards/shields/settings_reset/settings_reset.conf
+++ b/app/boards/shields/settings_reset/settings_reset.conf
@@ -2,3 +2,5 @@ CONFIG_SETTINGS=y
 CONFIG_ZMK_SETTINGS_RESET_ON_START=y
 # Disable BLE so splits don't try to re-pair until normal firmware is flashed.
 CONFIG_ZMK_BLE=n
+# Disable displays so status screens that rely on BLE do not fail the build.
+CONFIG_ZMK_DISPLAY=n


### PR DESCRIPTION
Without this tweak, a build like `west build -b corneish_zen_v2_left -- -DSHIELD=settings_reset` fails because the status screens are enabled and they expect certain APIs related to e.g. BT profiles that don't get built. This can be an issue with any onboard controller keyboard that enables a display with status screen by default, like ones that live in modules. While good practice would be to `#if defined` guard the appropriate widgets, there is also no reason to have display enabled with settings reset.