### PR TITLE
fix: Fix inconsistent column offset property

### DIFF
--- a/app/boards/arm/ferris/ferris_rev02.dts
+++ b/app/boards/arm/ferris/ferris_rev02.dts
@@ -54,7 +54,7 @@
 
         right {
             kscan = <&kscan_right>;
-            column-offset = <5>;
+            col-offset = <5>;
         };
     };
 

--- a/app/boards/shields/snap/snap_right.overlay
+++ b/app/boards/shields/snap/snap_right.overlay
@@ -23,7 +23,7 @@ kscan_direct: kscan_direct {
         direct {
             kscan = <&kscan_direct>;
             row-offset = <1>;
-            column-offset = <8>;
+            col-offset = <8>;
     };
 };
 

--- a/app/dts/bindings/zmk,kscan-composite.yaml
+++ b/app/dts/bindings/zmk,kscan-composite.yaml
@@ -26,6 +26,11 @@ child-binding:
     row-offset:
       type: int
       default: 0
+    col-offset:
+      type: int
+      default: 0
+
     column-offset:
       type: int
       default: 0
+      deprecated: true

--- a/app/module/drivers/kscan/kscan_composite.c
+++ b/app/module/drivers/kscan/kscan_composite.c
@@ -25,7 +25,7 @@ struct kscan_composite_child_config {
 #define CHILD_CONFIG(inst)                                                                         \
     {.child = DEVICE_DT_GET(DT_PHANDLE(inst, kscan)),                                              \
      .row_offset = DT_PROP(inst, row_offset),                                                      \
-     .column_offset = DT_PROP(inst, column_offset)},
+     .column_offset = DT_PROP_OR(inst, col_offset, DT_PROP(inst, column_offset))},
 
 struct kscan_composite_config {
     const struct kscan_composite_child_config *children;

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -223,11 +223,11 @@ Definition file: [zmk/app/dts/bindings/zmk,kscan-composite.yaml](https://github.
 
 The `zmk,kscan-composite` node should have one child node per keyboard scan driver that should be composited. Each child node can have the following properties:
 
-| Property        | Type    | Description                                                                    | Default |
-| --------------- | ------- | ------------------------------------------------------------------------------ | ------- |
-| `kscan`         | phandle | Label of the kscan driver to include                                           |         |
-| `row-offset`    | int     | Shifts row 0 of the included driver to a new row in the composite matrix       | 0       |
-| `column-offset` | int     | Shifts column 0 of the included driver to a new column in the composite matrix | 0       |
+| Property     | Type    | Description                                                                    | Default |
+| ------------ | ------- | ------------------------------------------------------------------------------ | ------- |
+| `kscan`      | phandle | Label of the kscan driver to include                                           |         |
+| `row-offset` | int     | Shifts row 0 of the included driver to a new row in the composite matrix       | 0       |
+| `col-offset` | int     | Shifts column 0 of the included driver to a new column in the composite matrix | 0       |
 
 ### Example Configuration
 


### PR DESCRIPTION
Renamed the composite kscan's column-offset property to col-offset for consistency with other properties such as matrix transform's col-offset and matrix kscan's col-gpios.

column-offset remains supported but is deprecated.