### PR TITLE
fix(boards): Fix typo in BT75 metadata

### DIFF
--- a/app/boards/arm/ckp/bt75_v1.zmk.yml
+++ b/app/boards/arm/ckp/bt75_v1.zmk.yml
@@ -1,6 +1,6 @@
 file_format: "1"
 id: bt75_v1
-name: BT75_V1
+name: BT75 V1
 type: board
 arch: arm
 features:


### PR DESCRIPTION
Spotted this underscore that shouldn't be there when reading the studio blog post, as per the other BTxx / CKP series boards it should just have a space
