### PR TITLE
docs: Some minor improvements to the studio features page

### DIFF
--- a/docs/docs/features/studio.md
+++ b/docs/docs/features/studio.md
@@ -2,7 +2,13 @@
 title: ZMK Studio
 ---
 
-ZMK Studio provides runtime update functionality to ZMK powered devices, allowing users to change their keymap layers without flashing new firmware to their keyboards. Studio is still under active development, and is not yet ready for casual end user use.
+ZMK Studio provides runtime update functionality to ZMK powered devices, allowing users to change their keymap layers without flashing new firmware to their keyboards.
+
+:::info
+
+To use ZMK Studio, a keyboard needs to be [configured appropriately](#adding-zmk-studio-support-to-a-keyboard). ZMK has updated some, but not all, of its in-tree keyboards for use with ZMK Studio, the list of which can be found [here](/blog/2024/11/11/zmk-studio-mvp-ga). If your keyboard is supported by an external module/config, check with the maintainer to see if support has been added.
+
+:::
 
 ## Capabilities
 
@@ -153,8 +159,14 @@ The reserved layers will be ignored during regular ZMK builds but will become av
 
 ## Adding ZMK Studio Support to a Keyboard
 
-To allow ZMK Studio to be used with a keyboard, the keyboard will need to have a physical layout with the `keys` property defined. Relevant information can be found in:
+To allow ZMK Studio to be used with a keyboard, the keyboard will need to have a physical layout with the `keys` property defined. The keyboard should also **not** have a `chosen` `zmk,matrix-transform`. Relevant information can be found in:
 
 - The [dedicated page on physical layouts](../development/hardware-integration/physical-layouts.md), informing you how to define one
 - The [new shield guide](../development/hardware-integration/new-shield.mdx), informing you how to select a physical layout once defined
 - The corresponding [configuration page](../config/layout.md#physical-layout), for reference
+
+To use the `studio-rpc-usb-uart` snippet, the keyboard also needs to be configured to allow CDC-ACM console snippets (this is also used for [USB logging](../development/usb-logging.mdx)). If your keyboard is a composite keyboard, consisting of an in-tree board and a shield, then you can skip this step as the board will already be configured properly. Relevant information on that can be found [in the Zephyr documentation](https://docs.zephyrproject.org/3.5.0/snippets/cdc-acm-console/README.html).
+
+Firmware with ZMK Studio enabled require significantly more RAM. Some MCUs, such as the STM32F072 series, will require fine tuning of various settings in order to reduce the RAM consumption enough for a Studio enabled build to fit.
+
+Finally, once you have successfully built and tested firmware with ZMK Studio enabled, add the `studio` flag to your keyboard's [metadata](../development/hardware-integration/hardware-metadata-files#features).


### PR DESCRIPTION
Added some notes on additional things to check when setting up Studio for a device, namely RAM consumption and CDC-ACM snippet support.

Also added a note to the top of the features page informing users that the keyboard needs to be configured correctly for use with Studio.
