### PR TITLE
fix: Fix warnings in nanopb encoding code

### DIFF
--- a/app/src/studio/behavior_subsystem.c
+++ b/app/src/studio/behavior_subsystem.c
@@ -84,7 +84,7 @@ static bool encode_value_description(pb_ostream_t *stream, const pb_field_t *fie
         zmk_behaviors_BehaviorParameterValueDescription desc =
             zmk_behaviors_BehaviorParameterValueDescription_init_zero;
         desc.name.funcs.encode = encode_value_description_name;
-        desc.name.arg = val;
+        desc.name.arg = (void *)val;
 
         switch (val->type) {
         case BEHAVIOR_PARAMETER_VALUE_TYPE_VALUE:

--- a/app/src/studio/keymap_subsystem.c
+++ b/app/src/studio/keymap_subsystem.c
@@ -301,10 +301,10 @@ static bool encode_layouts(pb_ostream_t *stream, const pb_field_t *field, void *
         zmk_keymap_PhysicalLayout layout = zmk_keymap_PhysicalLayout_init_zero;
 
         layout.name.funcs.encode = encode_layout_name;
-        layout.name.arg = l;
+        layout.name.arg = (void *)l;
 
         layout.keys.funcs.encode = encode_layout_keys;
-        layout.keys.arg = l;
+        layout.keys.arg = (void *)l;
 
         if (!pb_encode_submessage(stream, &zmk_keymap_PhysicalLayout_msg, &layout)) {
             LOG_WRN("Failed to encode layout submessage");
@@ -459,10 +459,10 @@ zmk_studio_Response restore_layer(const zmk_studio_Request *req) {
         resp.result.ok.id = restore_req->layer_id;
 
         resp.result.ok.name.funcs.encode = encode_layer_name;
-        resp.result.ok.name.arg = &restore_req->layer_id;
+        resp.result.ok.name.arg = (void *)&restore_req->layer_id;
 
         resp.result.ok.bindings.funcs.encode = encode_layer_bindings;
-        resp.result.ok.bindings.arg = &restore_req->layer_id;
+        resp.result.ok.bindings.arg = (void *)&restore_req->layer_id;
 
         raise_zmk_studio_rpc_notification((struct zmk_studio_rpc_notification){
             .notification = KEYMAP_NOTIFICATION(unsaved_changes_status_changed, true)});


### PR DESCRIPTION
The `arg` field on nanopb structs is a `void*` because it is shared between the encode and decode callbacks, even though the encode callback probably should not modify the data. We are passing const data using this non-const pointer, which causes warnings about discarding const. This commit explicitly casts to `void*` to suppress these warnings.