### PR TITLE
docs: touchups on the soft off information for improved clarity.

### DIFF
--- a/docs/docs/development/hardware-integration/includes/_gpio-key-matrix.md
+++ b/docs/docs/development/hardware-integration/includes/_gpio-key-matrix.md
@@ -11,4 +11,4 @@ Here is an example for a keyboard with a GPIO pin that reads from the matrix:
 };
 ```
 
-Matrix inputs are triggered by pulling the specified pin high, typically by pressing some combination of switches which connects the matrix input to a matrix output.
+MCU inputs are triggered by pulling the specified pin high, typically by pressing some combination of switches which connects the MCU input to an MCU output.

--- a/docs/docs/development/hardware-integration/includes/_gpio-key-wakeup.md
+++ b/docs/docs/development/hardware-integration/includes/_gpio-key-wakeup.md
@@ -12,3 +12,4 @@ Here is an example for a keyboard with a GPIO pin reused from a matrix kscan:
 ```
 
 The GPIO settings should match those in the kscan, so the above would be set to `(GPIO_ACTIVE_LOW | GPIO_PULL_UP)` for a direct kscan.
+The specified pin should be the MCU input pin of the switch used for waking from soft off (for a `col2row` matrix, the MCU input pins are the row pins).

--- a/docs/docs/development/hardware-integration/includes/_soft-off-behavior.md
+++ b/docs/docs/development/hardware-integration/includes/_soft-off-behavior.md
@@ -8,6 +8,7 @@ Behind the scenes, a hardware dedicated GPIO pin utilizes the [soft off behavior
         hw_soft_off: hw_soft_off {
             compatible = "zmk,behavior-soft-off";
             #binding-cells = <0>;
+            split-peripheral-off-on-press; // Turn peripheral off immediately for reliability
             hold-time-ms = <2000>; // Only turn off if the key is held for 2 seconds or longer.
         };
     };

--- a/docs/docs/development/hardware-integration/includes/_soft-off-waker.md
+++ b/docs/docs/development/hardware-integration/includes/_soft-off-waker.md
@@ -14,3 +14,4 @@ We need to add another device which will be enabled only when the keyboard is go
 ```
 
 The properties for the `gpio-key-wakeup-trigger` node can be found in the [appropriate configuration section](../../../config/power.md#gpio-key-wakeup-trigger).
+In particular, note the `extra-gpios` property containing the MCU output pins of any keys used to wake the keyboard (for a `col2row` matrix, these are your columns).

--- a/docs/docs/keymaps/behaviors/soft-off.md
+++ b/docs/docs/keymaps/behaviors/soft-off.md
@@ -38,3 +38,13 @@ By default, the keyboard will be turned off as soon as the key bound to the beha
     };
 };
 ```
+
+The peripheral half of a [split keyboard](../../features/split-keyboards.md) will always enter the soft off state immediately when triggering the behavior, regardless of the `hold-time-ms` setting. This is to ensure reliability, as otherwise the central may enter the soft off state before notifying the peripheral that it should also do so.
+
+If you wish to change this setting, and thus accept the potential for reliability issues, you may remove the `split-peripheral-off-on-press` flag from the behavior:
+
+```dts
+&soft_off {
+    /delete-property/ split-peripheral-off-on-press;
+};
+```


### PR DESCRIPTION
Minor improvements to the soft off setup docs to improve some clarity things. Also documented the split peripheral off on press property with information on its purpose.

Makes #2299 redundant.