### PR TITLE
fix: include a header file for RC macros

### DIFF
--- a/app/boards/shields/tester_xiao/tester_xiao.overlay
+++ b/app/boards/shields/tester_xiao/tester_xiao.overlay
@@ -1,3 +1,5 @@
+#include <dt-bindings/zmk/matrix_transform.h>
+
 / {
     chosen {
         zmk,kscan = &kscan0;


### PR DESCRIPTION
This PR is for tester_xiao.

To test the following article, I specified `seeeduino_xiao_ble` and `tester_xiao` for `west build`, but a `devicetree error` occurred. This happened on Github Actions using the new zmk-config.

https://zmk.dev/docs/troubleshooting/hardware-issues

The issue occurred because the RC macro was not defined, and I addressed it by adding `#include <dt-bindings/zmk/matrix_transform.h>` to the `.overlay` file.

I would appreciate it if you could comment if there is a more appropriate solution or if there is any additional code that needs to be included.