### PR TITLE
Docs: Сorrecting a wrong file name in new-shield.mdx

### DIFF
--- a/docs/docs/development/hardware-integration/new-shield.mdx
+++ b/docs/docs/development/hardware-integration/new-shield.mdx
@@ -218,7 +218,7 @@ Split keyboards can have multiple `.conf` files, one for each part. For example:
 
 - `my_keyboard.conf` - Configuration elements affect both halves
 - `my_keyboard_left.conf` - Configuration elements only affect left half
-- `my_keyboard_left.conf` - Configuration elements only affect right half
+- `my_keyboard_right.conf` - Configuration elements only affect right half
 
 In most case you'll only need to use the .conf file that affects both halves of a split board.
 


### PR DESCRIPTION
I happened to notice that in the documentation about creating a new keyboard shield, ``my_keyboard_left.conf``` is repeated twice. I decided to fix this small but minor issue.