### PR TITLE
feat(sleep): Option to enter deep sleep after ble connection severed

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -449,6 +449,19 @@ config ZMK_IDLE_SLEEP_TIMEOUT
 #ZMK_SLEEP
 endif
 
+config ZMK_SLEEP_ON_BLE_DISCONNECT
+    bool "Enable deep sleep on BLE disconnection"
+    depends on ZMK_SLEEP 
+
+if ZMK_SLEEP_ON_BLE_DISCONNECT
+
+config ZMK_SLEEP_DISCONNECT_TIMER
+    int "Milliseconds of disconnection before entering deep sleep"
+    default 600000
+
+# ZMK_SLEEP_ON_BLE_DISCONNECT
+endif
+
 config ZMK_EXT_POWER
     bool "Enable support to control external power output"
     default y

--- a/app/include/zmk/split/bluetooth/peripheral.h
+++ b/app/include/zmk/split/bluetooth/peripheral.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#define IS_SPLIT_PERIPHERAL                                                                        \
+    (IS_ENABLED(CONFIG_ZMK_SPLIT) && !IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL))
+
 bool zmk_split_bt_peripheral_is_connected(void);
 
 bool zmk_split_bt_peripheral_is_bonded(void);

--- a/app/src/behaviors/behavior_soft_off.c
+++ b/app/src/behaviors/behavior_soft_off.c
@@ -12,6 +12,7 @@
 
 #include <zmk/pm.h>
 #include <zmk/behavior.h>
+#include <zmk/split/bluetooth/peripheral.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
@@ -24,8 +25,6 @@ struct behavior_soft_off_data {
     uint32_t press_start;
 };
 
-#define IS_SPLIT_PERIPHERAL                                                                        \
-    (IS_ENABLED(CONFIG_ZMK_SPLIT) && !IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL))
 
 static int behavior_soft_off_init(const struct device *dev) { return 0; };
 


### PR DESCRIPTION
Introduce a new Kconfig flag to enable enter SLEEP mode on device if BT connection severed from main active profile, added with some logic changes to enable this modality. This addresses issue #2198 

``` Central
[00:01:34.235,137] <dbg> zmk: disconnected: Disconnected from <BT_ADDR> (public) (reason 0x13)
[00:01:34.235,168] <dbg> zmk: disconnected: Active profile disconnected
[00:01:34.235,351] <dbg> zmk: split_central_disconnected: Disconnected: <BT_ADDR> (public) (reason 19)
[00:01:34.235,382] <dbg> zmk: update_advertising: advertising from 0 to 2
[00:01:34.236,022] <dbg> zmk: zmk_usb_get_conn_state: state: 3
[00:01:34.236,022] <dbg> zmk: get_selected_transport: Only USB is ready.
[00:01:34.248,809] <inf> bas: BAS Notifications enabled
[00:01:34.250,091] <dbg> zmk: connected: Connected thread: 0x20005aa8
[00:01:34.250,305] <dbg> zmk: connected: Connected 0C:53:B7:7A:18:00 (public)
[00:01:34.250,335] <dbg> zmk: update_advertising: advertising from 0 to 2
[00:01:34.251,068] <dbg> zmk: split_central_connected: SKIPPING FOR ROLE 1
[00:01:34.434,783] <dbg> zmk: security_changed: Security changed: <BT_ADDR> (public) level 4
[00:01:35.092,773] <dbg> zmk: le_param_updated: <BT_ADDR> (public): interval 12 latency 0 timeout 72
[00:01:39.214,050] <dbg> zmk: vddh_sample_fetch: ADC raw 3023 ~ 4425 mV => 100%
[00:01:39.265,045] <dbg> zmk: le_param_updated:<BT_ADDR> (public): interval 12 latency 0 timeout 72
```
🔝 main device logs

``` Peripheral
[00:01:39.835,266] <dbg> zmk: zmk_physical_layouts_kscan_process_msgq: Row: 3, col: 0, position: 39, pressed: true
[00:01:39.835,266] <dbg> zmk: split_listener:
[00:01:39.889,129] <dbg> zmk: kscan_matrix_read: Sending event at 3,0 state off
[00:01:39.889,251] <dbg> zmk: zmk_physical_layouts_kscan_process_msgq: Row: 3, col: 0, position: 39, pressed: false
[00:01:39.889,282] <dbg> zmk: split_listener:
[00:01:59.285,888] <dbg> zmk: split_svc_pos_state_ccc: value 0
[00:01:59.286,041] <dbg> zmk: disconnected: Disconnected from <BT_ADDR> (random) (reason 0x08)
[00:01:59.286,102] <dbg> zmk: set_status_symbol: connected? false
[00:02:00.567,077] <dbg> zmk: set_status_symbol: connected? false
```
🔝 peripheral logs

Currently the feature testing done as such:
1. Set to Kconfig flags in my config
	- `CONFIG_ZMK_SLEEP_ON_BLE_DISCONNECT=y`
	- `CONFIG_ZMK_SLEEP_DISCONNECT_TIMER=10000`
2. Built using the following west commands:
	- `west build -p -d build/right -b nice_nano_v2 -S zmk-usb-logging -- -DSHIELD=corne_right`
	- `west build -p -d build/left -b nice_nano_v2 -S zmk-usb-logging -- -DSHIELD=corne_left`

3. Connected to the central split and tested by disconnecting Bluetooth to the active device the split keyboard is connected to, logs attached above.
4. Connected to the peripheral split and tested it by disconnecting Bluetooth to the active device which led to the main device entering sleep, and subsequently after losing connection to the active device, the peripheral device automatically entered sleep.

Haven't done testing on non-split keyboard as I do not have access to such systems.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
