### PR TITLE
fix(boards): Disable uart serial node in Xiao BLE by default

### DIFF
--- a/app/boards/seeeduino_xiao_ble.overlay
+++ b/app/boards/seeeduino_xiao_ble.overlay
@@ -19,6 +19,8 @@
     };
 };
 
+&xiao_serial { status = "disabled"; };
+
 &adc {
     status = "okay";
 };


### PR DESCRIPTION
`xiao_serial` node corresponds to `uart0`, which uses D6 and D7 pins by default on Xiaos. When logging or Studio USB snippets are used, they turn on `CONFIG_SERIAL` and this prevents those pins from being used for other things, even though both use serial over USB. 

For RP2040 this is disabled in https://github.com/zmkfirmware/zmk/blob/main/app/boards/seeeduino_xiao_rp2040.overlay#L7, for Hummingbird shield this was disabled at the shield level but was (mistakenly?) removed in https://github.com/zmkfirmware/zmk/commit/e0339a2a57c33b86e351f31b04345ee8c984b075#diff-b0c154eb8d05802c1c61671a7e9e2ca6021c2ec81127f2c57194a84d7a85cdbfL57.

Is there a reason to not disable it by default for ZMK at the board level, like this? I can't think of any. Other boards like nice!nano don't set `status = "okay";` either.

Fixes #1887.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
