### PR TITLE
fix: Allow setting `wakeup-source` on composite.

### DIFF
--- a/app/dts/bindings/zmk,kscan-composite.yaml
+++ b/app/dts/bindings/zmk,kscan-composite.yaml
@@ -3,6 +3,8 @@ description: |
 
 compatible: "zmk,kscan-composite"
 
+include: kscan.yaml
+
 properties:
   label:
     type: string

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -216,10 +216,11 @@ Applies to : `compatible = "zmk,kscan-composite"`
 
 Definition file: [zmk/app/dts/bindings/zmk,kscan-composite.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk,kscan-composite.yaml)
 
-| Property  | Type | Description                                   | Default |
-| --------- | ---- | --------------------------------------------- | ------- |
-| `rows`    | int  | The number of rows in the composite matrix    |         |
-| `columns` | int  | The number of columns in the composite matrix |         |
+| Property        | Type | Description                                                                                                                   | Default |
+| --------------- | ---- | ----------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `rows`          | int  | The number of rows in the composite matrix                                                                                    |         |
+| `columns`       | int  | The number of columns in the composite matrix                                                                                 |         |
+| `wakeup-source` | bool | Mark this kscan instance as able to wake the keyboard. Required to keep the child kscan devices from being suspended as well. |
 
 The `zmk,kscan-composite` node should have one child node per keyboard scan driver that should be composited. Each child node can have the following properties:
 


### PR DESCRIPTION
Include the base `kscan.yaml` to allow settings `wakeup-source` on composite kscan devices.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
