### PR TITLE
fix(behaviors): Macros to include behavior metadata

### DIFF
--- a/app/dts/bindings/behaviors/macro_base.yaml
+++ b/app/dts/bindings/behaviors/macro_base.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2022 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
+include: behavior-metadata.yaml
+
 properties:
   bindings:
     type: phandle-array


### PR DESCRIPTION
Ensure macros can be given metadata/studio display names by including behavior metadata in base macro bindings.
