### PR TITLE
Fix: allow kscan-composite to wake up device.

### DIFF
--- a/app/dts/bindings/zmk,kscan-composite.yaml
+++ b/app/dts/bindings/zmk,kscan-composite.yaml
@@ -3,6 +3,8 @@ description: |
 
 compatible: "zmk,kscan-composite"
 
+include: kscan.yaml
+
 properties:
   label:
     type: string

--- a/app/module/drivers/kscan/kscan_composite.c
+++ b/app/module/drivers/kscan/kscan_composite.c
@@ -70,8 +70,10 @@ static int kscan_composite_disable_callback(const struct device *dev) {
         const struct kscan_composite_child_config *child_cfg = &cfg->children[i];
 
 #if IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || IS_ENABLED(CONFIG_PM_DEVICE)
-        if (pm_device_wakeup_is_enabled(dev) && pm_device_wakeup_is_enabled(child_cfg->child)) {
-            continue;
+        if (pm_device_wakeup_is_capable(child_cfg->child) &&
+            pm_device_wakeup_is_enabled(child_cfg->child) &&
+            !pm_device_wakeup_enable(child_cfg->child, false)) {
+            LOG_ERR("Failed to disable wakeup for %s", child_cfg->child->name);
         }
 #endif // IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || IS_ENABLED(CONFIG_PM_DEVICE)
 

--- a/app/module/drivers/kscan/kscan_composite.c
+++ b/app/module/drivers/kscan/kscan_composite.c
@@ -44,6 +44,13 @@ static int kscan_composite_enable_callback(const struct device *dev) {
     for (int i = 0; i < cfg->children_len; i++) {
         const struct kscan_composite_child_config *child_cfg = &cfg->children[i];
 
+#if IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || IS_ENABLED(CONFIG_PM_DEVICE)
+        if (pm_device_wakeup_is_enabled(dev) && pm_device_wakeup_is_capable(child_cfg->child) &&
+            !pm_device_wakeup_enable(child_cfg->child, true)) {
+            LOG_ERR("Failed to enable wakeup for %s", child_cfg->child->name);
+        }
+#endif // IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || IS_ENABLED(CONFIG_PM_DEVICE)
+
 #if IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)
         if (!pm_device_runtime_is_enabled(dev) && pm_device_runtime_is_enabled(child_cfg->child)) {
             pm_device_runtime_get(child_cfg->child);
@@ -61,6 +68,12 @@ static int kscan_composite_disable_callback(const struct device *dev) {
     const struct kscan_composite_config *cfg = dev->config;
     for (int i = 0; i < cfg->children_len; i++) {
         const struct kscan_composite_child_config *child_cfg = &cfg->children[i];
+
+#if IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || IS_ENABLED(CONFIG_PM_DEVICE)
+        if (pm_device_wakeup_is_enabled(dev) && pm_device_wakeup_is_enabled(child_cfg->child)) {
+            continue;
+        }
+#endif // IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || IS_ENABLED(CONFIG_PM_DEVICE)
 
         kscan_disable_callback(child_cfg->child);
 

--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -223,11 +223,12 @@ Definition file: [zmk/app/dts/bindings/zmk,kscan-composite.yaml](https://github.
 
 The `zmk,kscan-composite` node should have one child node per keyboard scan driver that should be composited. Each child node can have the following properties:
 
-| Property     | Type    | Description                                                                    | Default |
-| ------------ | ------- | ------------------------------------------------------------------------------ | ------- |
-| `kscan`      | phandle | Label of the kscan driver to include                                           |         |
-| `row-offset` | int     | Shifts row 0 of the included driver to a new row in the composite matrix       | 0       |
-| `col-offset` | int     | Shifts column 0 of the included driver to a new column in the composite matrix | 0       |
+| Property        | Type    | Description                                                                    | Default |
+| --------------- | ------- | ------------------------------------------------------------------------------ | ------- |
+| `kscan`         | phandle | Label of the kscan driver to include                                           |         |
+| `row-offset`    | int     | Shifts row 0 of the included driver to a new row in the composite matrix       | 0       |
+| `col-offset`    | int     | Shifts column 0 of the included driver to a new column in the composite matrix | 0       |
+| `wakeup-source` | bool    | Mark this kscan instance as able to wake the keyboard                          | n       |
 
 ### Example Configuration
 


### PR DESCRIPTION
The kscan-composite driver does not respect the wakeup capabilities of its child kscans.
This branch fixes that by checking for their capabilities and whether the composite kscan is a wakeup source, before disabling them.

Relates to https://github.com/zmkfirmware/zmk/issues/2654 and https://github.com/zmkfirmware/zmk/pull/2673

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
