### PR TITLE
fix: pip install faliure on ubuntu-latest

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Fetch Build Keyboards
     outputs:
       build_matrix: ${{ env.build_matrix }}
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install yaml2json
-        run: python3 -m pip install remarshal
+        run: pipx install remarshal
 
       - name: Fetch Build Matrix
         run: |


### PR DESCRIPTION
Related: #2507 

![image](https://github.com/user-attachments/assets/951e0caf-be0b-4d07-8ef0-23d191867ace)

Tested by creating a new repository and adding the following workflow:

```yaml
on:
  push:
  workflow_dispatch:

jobs:
  build:
    strategy:
      matrix:
        os: [ubuntu-24.04, ubuntu-22.04]
    runs-on: ${{ matrix.os }}
    steps:

      - name: Mock build.yaml file
        run: |
          cat <<EOF > build.yaml
          ---
          include:
            - board: nice_nano_v2
              shield: corne_left
              snippet: studio-rpc-usb-uart
            - board: nice_nano_v2
              shield: corne_right
          EOF

      - name: Install yaml2json
        run: pipx install remarshal

      - name: Fetch Build Matrix
        run: |
          yaml2json "build.yaml" | jq
```