### PR TITLE
feat(toolchain): Improved local setup

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -2,8 +2,12 @@ cmake_minimum_required(VERSION 3.13.1)
 
 set(CONFIG_APPLICATION_DEFINED_SYSCALL true)
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../zmk-config AND NOT DEFINED ZMK_CONFIG_LOCAL_MODULE)
+  set(ZMK_CONFIG_LOCAL_MODULE ${CMAKE_CURRENT_SOURCE_DIR}/../zmk-config)
+endif()
+
 set(ZEPHYR_BOARD_ALIASES "boards/aliases.cmake")
-set(ZEPHYR_EXTRA_MODULES "${ZMK_EXTRA_MODULES};${CMAKE_CURRENT_SOURCE_DIR}/module;${CMAKE_CURRENT_SOURCE_DIR}/keymap-module")
+set(EXTRA_ZEPHYR_MODULES "${ZMK_EXTRA_MODULES};${CMAKE_CURRENT_SOURCE_DIR}/module;${CMAKE_CURRENT_SOURCE_DIR}/keymap-module;${ZMK_CONFIG_LOCAL_MODULE}")
 
 # Find Zephyr. This also loads Zephyr's build system.
 find_package(Zephyr REQUIRED HINTS ../zephyr)

--- a/app/keymap-module/modules/modules.cmake
+++ b/app/keymap-module/modules/modules.cmake
@@ -41,6 +41,10 @@ elseif(DEFINED ENV{ZMK_CONFIG})
 
 elseif(user_config_app_cmake_lists)
     set(ZMK_CONFIG ${user_config_app_cmake_lists})
+
+elseif(EXISTS ${APPLICATION_SOURCE_DIR}/../zmk-config/config)
+    set(ZMK_CONFIG ${APPLICATION_SOURCE_DIR}/../zmk-config/config)
+
 endif()
 
 # Store the selected user_config in the cache
@@ -50,10 +54,12 @@ if (ZMK_CONFIG)
     set(ENV{ZMK_CONFIG} "${ZMK_CONFIG}")
     if(EXISTS ${ZMK_CONFIG}/boards)
         message(STATUS "Adding ZMK config directory as board root: ${ZMK_CONFIG}")
+        message(DEPRECATION "Using the config folder as board root is deprecated.")
         list(APPEND BOARD_ROOT ${ZMK_CONFIG})
     endif()
     if(EXISTS ${ZMK_CONFIG}/dts)
         message(STATUS "Adding ZMK config directory as DTS root: ${ZMK_CONFIG}")
+        message(DEPRECATION "Using the config folder as DTS root is deprecated.")
         list(APPEND DTS_ROOT ${ZMK_CONFIG})
     endif()
 endif()

--- a/docs/docs/development/local-toolchain/build-flash.mdx
+++ b/docs/docs/development/local-toolchain/build-flash.mdx
@@ -143,7 +143,11 @@ Build times can be significantly reduced after the initial build by omitting all
 
 ### Building With External Modules
 
-ZMK supports loading additional boards, shields, code, etc. from [external Zephyr modules](https://docs.zephyrproject.org/3.5.0/develop/modules.html), facilitating out-of-tree management and versioning independent of the ZMK repository. To build with any additional modules, use the `ZMK_EXTRA_MODULES` define added to your `west build` command.
+ZMK supports loading additional boards, shields, code, etc. from [external Zephyr modules](https://docs.zephyrproject.org/3.5.0/develop/modules.html), facilitating out-of-tree management and versioning independent of the ZMK repository.
+
+**Building with any modules specified in `zmk/zmk-config/config/west.yml` is done automatically.**
+
+To build with any additional modules beyond that, use the `ZMK_EXTRA_MODULES` define added to your `west build` command.
 
 For instance, building with the `my-vendor-keebs-module` checked out to your documents directory, you would build like:
 
@@ -157,27 +161,28 @@ When adding multiple modules, make sure they are separated by a semicolon, e.g.:
 west build -b nice_nano_v2 -- -DSHIELD=vendor_shield -DZMK_EXTRA_MODULES="C:/Users/myUser/Documents/my-vendor-keebs-module;C:/Users/myUser/Documents/my-other-keebs-module"
 ```
 
-### Building from `zmk-config` Folder
+### Building from Alternative `zmk-config` Folders
 
-Instead of building .uf2 files using the default keymap and config files, you
-can build using files from your [`zmk-config` folder](../../user-setup.mdx#github-repo)
-by adding `-DZMK_CONFIG="C:/the/absolute/path/config"` to your `west build`
+ZMK will build using files from your []`zmk/zmk-config/config` folder](../../user-setup.mdx#github-repo) automatically.
+If you have an alternative `zmk-config` that you'd like to use instead, you can point to it with the `ZMK_CONFIG` CMake argument.
+
+Add the `-DZMK_CONFIG="C:/the/absolute/path/alternative/config"` to your `west build`
 command. **Notice that this path should point to the folder labeled `config`
-within your `zmk-config` folder.**
-
-For instance, building kyria firmware from a user `myUser`'s `zmk-config` folder
-on Windows may look something like this:
+within your `zmk-config` folder.** For example:
 
 ```sh
 west build -b nice_nano -- -DSHIELD=kyria_left \
-  -DZMK_CONFIG="C:/Users/myUser/Documents/Github/zmk-config/config"
+  -DZMK_CONFIG="C:/Users/myUser/Documents/Github/zmk-config-two/config"
 ```
 
-:::warning
-If your config is also a [module](../../features/modules.mdx), then you should
-also add the root (the folder in which the `zephyr` folder is found) of your
-`zmk-config` as an [external module to build with](#building-with-external-modules).
-:::
+If this alternative config is also a [module](../../features/modules.mdx), you will need to mark it as such with the `ZMK_CONFIG_LOCAL_MODULE` flag.
+Note that this flag should point to the `zmk-config` root, _not_ the folder labeled `config`.
+
+```sh
+west build -b nice_nano -- -DSHIELD=kyria_left \
+  -DZMK_CONFIG="C:/Users/myUser/Documents/Github/zmk-config-two/config" \
+  -DZMK_CONFIG_LOCAL_MODULE="C:/Users/myUser/Documents/Github/zmk-config-two"
+```
 
 ## Flashing
 

--- a/docs/docs/development/local-toolchain/setup/native.mdx
+++ b/docs/docs/development/local-toolchain/setup/native.mdx
@@ -92,6 +92,12 @@ Then step into the repository.
 cd zmk
 ```
 
+Clone your `zmk-config` into the repository, making sure that the local name for it is `zmk-config`.
+
+```sh
+git clone git@github.com:<Your Username>/zmk-config.git zmk-config
+```
+
 ## 3. Get Zephyr and install Python dependencies
 
 :::note
@@ -179,7 +185,7 @@ pip install west
 5. Initialize the application and update to fetch modules, including Zephyr:
 
 ```sh
-west init -l app/
+west init -l local/
 west update
 ```
 
@@ -268,7 +274,7 @@ pip3 install -U west
 2. Initialize the application and update to fetch modules, including Zephyr:
 
 ```sh
-west init -l app/
+west init -l local/
 west update
 ```
 

--- a/local/config-import.yml
+++ b/local/config-import.yml
@@ -1,0 +1,6 @@
+manifest:
+  self:
+    import:
+      file: ../zmk-config/config/west.yml
+      name-blocklist: [zmk]
+      path-prefix: modules

--- a/local/west.yml
+++ b/local/west.yml
@@ -1,0 +1,5 @@
+manifest:
+  self:
+    import:
+      - config-import.yml
+      - ../app/west.yml


### PR DESCRIPTION
Proof of concept of an idea to have a nicer local setup. See https://discord.com/channels/719497620560543766/1313518832434020384/1313518835055198371 for context.

For existing users wanting to try this out:
1. Checkout the branch
2. Place your `zmk-config` as a subdirectory of `zmk`, by cloning or otherwise. You should have `zmk/zmk-config`, with that naming.
3. Edit `zmk/.west/config` to point the manifest to `zmk/local/west.yml`:
```
[manifest]
path = local
file = west.yml
```
4. Run `west update`

You should now be able to build and flash as usual, using the `zmk-config`'s `config/west.yml` to manage external modules, and with your `zmk-config` working fine for your own custom stuff, keymaps, etc. without the need to write `-DZMK_EXTRA_MODULES` etc for building.

Needs discussion, testing, and improved documentation.

TODO: Figure out a nicer interaction with our local west test and west manifest commands.