### PR TITLE
fix(studio): Properly return complete keymap from RPC

### DIFF
--- a/app/src/studio/keymap_subsystem.c
+++ b/app/src/studio/keymap_subsystem.c
@@ -97,23 +97,28 @@ static bool encode_keymap_layers(pb_ostream_t *stream, const pb_field_t *field, 
     return true;
 }
 
+static void populate_keymap_extra_props(zmk_keymap_Keymap *keymap) {
+    keymap->max_layer_name_length = CONFIG_ZMK_KEYMAP_LAYER_NAME_MAX_LEN;
+
+    keymap->available_layers = 0;
+
+    for (zmk_keymap_layer_index_t index = 0; index < ZMK_KEYMAP_LAYERS_LEN; index++) {
+        zmk_keymap_layer_id_t id = zmk_keymap_layer_index_to_id(index);
+
+        if (id == UINT8_MAX) {
+            keymap->available_layers = ZMK_KEYMAP_LAYERS_LEN - index;
+            break;
+        }
+    }
+}
+
 zmk_studio_Response get_keymap(const zmk_studio_Request *req) {
     LOG_DBG("");
     zmk_keymap_Keymap resp = zmk_keymap_Keymap_init_zero;
 
     resp.layers.funcs.encode = encode_keymap_layers;
 
-    resp.max_layer_name_length = CONFIG_ZMK_KEYMAP_LAYER_NAME_MAX_LEN;
-    resp.available_layers = 0;
-
-    for (zmk_keymap_layer_index_t index = 0; index < ZMK_KEYMAP_LAYERS_LEN; index++) {
-        zmk_keymap_layer_id_t id = zmk_keymap_layer_index_to_id(index);
-
-        if (id == UINT8_MAX) {
-            resp.available_layers = ZMK_KEYMAP_LAYERS_LEN - index;
-            break;
-        }
-    }
+    populate_keymap_extra_props(&resp);
 
     return KEYMAP_RESPONSE(get_keymap, resp);
 }
@@ -332,6 +337,7 @@ zmk_studio_Response set_active_physical_layout(const zmk_studio_Request *req) {
         zmk_keymap_SetActivePhysicalLayoutResponse_init_zero;
     resp.which_result = zmk_keymap_SetActivePhysicalLayoutResponse_ok_tag;
     resp.result.ok.layers.funcs.encode = encode_keymap_layers;
+    populate_keymap_extra_props(&resp.result.ok);
 
     if (old == index) {
         return KEYMAP_RESPONSE(set_active_physical_layout, resp);


### PR DESCRIPTION
Ensure the set active physical layout RPC returns the full keymap details including the available layers.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
