### PR TITLE
feat: Add RGB underglow and backlighting events

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -88,7 +88,9 @@ if ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
 endif()
 
 target_sources_ifdef(CONFIG_ZMK_RGB_UNDERGLOW app PRIVATE src/behaviors/behavior_rgb_underglow.c)
+
 target_sources_ifdef(CONFIG_ZMK_BACKLIGHT app PRIVATE src/behaviors/behavior_backlight.c)
+target_sources_ifdef(CONFIG_ZMK_BACKLIGHT app PRIVATE src/events/backlight_state_changed.c)
 
 target_sources_ifdef(CONFIG_ZMK_BATTERY_REPORTING app PRIVATE src/events/battery_state_changed.c)
 target_sources_ifdef(CONFIG_ZMK_BATTERY_REPORTING app PRIVATE src/battery.c)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -88,6 +88,7 @@ if ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
 endif()
 
 target_sources_ifdef(CONFIG_ZMK_RGB_UNDERGLOW app PRIVATE src/behaviors/behavior_rgb_underglow.c)
+target_sources_ifdef(CONFIG_ZMK_RGB_UNDERGLOW app PRIVATE src/events/underglow_state_changed.c)
 
 target_sources_ifdef(CONFIG_ZMK_BACKLIGHT app PRIVATE src/behaviors/behavior_backlight.c)
 target_sources_ifdef(CONFIG_ZMK_BACKLIGHT app PRIVATE src/events/backlight_state_changed.c)

--- a/app/include/zmk/backlight.h
+++ b/app/include/zmk/backlight.h
@@ -6,6 +6,11 @@
 
 #pragma once
 
+struct zmk_backlight_state {
+    uint8_t brightness;
+    bool on;
+};
+
 int zmk_backlight_on(void);
 int zmk_backlight_off(void);
 int zmk_backlight_toggle(void);

--- a/app/include/zmk/events/backlight_state_changed.h
+++ b/app/include/zmk/events/backlight_state_changed.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <zephyr/kernel.h>
+#include <zmk/event_manager.h>
+#include <zmk/backlight.h>
+
+struct zmk_backlight_state_changed {
+    struct zmk_backlight_state state;
+};
+
+ZMK_EVENT_DECLARE(zmk_backlight_state_changed);

--- a/app/include/zmk/events/underglow_state_changed.h
+++ b/app/include/zmk/events/underglow_state_changed.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <zephyr/kernel.h>
+#include <zmk/event_manager.h>
+#include <zmk/rgb_underglow.h>
+
+struct zmk_underglow_state_changed {
+    struct zmk_underglow_state state;
+};
+
+ZMK_EVENT_DECLARE(zmk_underglow_state_changed);

--- a/app/include/zmk/rgb_underglow.h
+++ b/app/include/zmk/rgb_underglow.h
@@ -12,6 +12,14 @@ struct zmk_led_hsb {
     uint8_t b;
 };
 
+struct zmk_underglow_state {
+    struct zmk_led_hsb color;
+    uint8_t animation_speed;
+    uint8_t current_effect;
+    uint16_t animation_step;
+    bool on;
+};
+
 int zmk_rgb_underglow_toggle(void);
 int zmk_rgb_underglow_get_state(bool *state);
 int zmk_rgb_underglow_on(void);

--- a/app/src/backlight.c
+++ b/app/src/backlight.c
@@ -19,6 +19,7 @@
 #include <zmk/event_manager.h>
 #include <zmk/events/activity_state_changed.h>
 #include <zmk/events/usb_conn_state_changed.h>
+#include <zmk/events/backlight_state_changed.h>
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
@@ -34,13 +35,8 @@ static const struct device *const backlight_dev = DEVICE_DT_GET(DT_CHOSEN(zmk_ba
 
 #define BRT_MAX 100
 
-struct backlight_state {
-    uint8_t brightness;
-    bool on;
-};
-
-static struct backlight_state state = {.brightness = CONFIG_ZMK_BACKLIGHT_BRT_START,
-                                       .on = IS_ENABLED(CONFIG_ZMK_BACKLIGHT_ON_START)};
+static struct zmk_backlight_state state = {.brightness = CONFIG_ZMK_BACKLIGHT_BRT_START,
+                                           .on = IS_ENABLED(CONFIG_ZMK_BACKLIGHT_ON_START)};
 
 static int zmk_backlight_update(void) {
     uint8_t brt = zmk_backlight_get_brt();
@@ -53,6 +49,7 @@ static int zmk_backlight_update(void) {
             return rc;
         }
     }
+    raise_zmk_backlight_state_changed((struct zmk_backlight_state_changed){.state = state});
     return 0;
 }
 

--- a/app/src/events/backlight_state_changed.c
+++ b/app/src/events/backlight_state_changed.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/kernel.h>
+#include <zmk/events/backlight_state_changed.h>
+
+ZMK_EVENT_IMPL(zmk_backlight_state_changed);

--- a/app/src/events/underglow_state_changed.c
+++ b/app/src/events/underglow_state_changed.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/kernel.h>
+#include <zmk/events/underglow_state_changed.h>
+
+ZMK_EVENT_IMPL(zmk_underglow_state_changed);


### PR DESCRIPTION
As a preparation for a respin of #2036 RGB underglow and backlighting need their own state changed events

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
