### PR TITLE
fix: Kconfig refactor now works correctly with external modules

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -687,13 +687,22 @@ module = ZMK
 module-str = zmk
 source "subsys/logging/Kconfig.template.log_config"
 
+# This loads ZMK's internal board and shield Kconfigs
 rsource "boards/Kconfig"
 rsource "boards/shields/*/Kconfig.defconfig"
 rsource "boards/shields/*/Kconfig.shield"
 
+# This loads custom shields defconfigs (from BOARD_ROOT)
+# Duplicated from Kconfig.zephyr
+osource "$(KCONFIG_BINARY_DIR)/Kconfig.shield.defconfig"
+
+source "$(BOARD_DIR)/Kconfig.defconfig"
+
+# This loads board and shield Kconfigs found under zmk-config/config/
 osource "$(ZMK_CONFIG)/boards/shields/*/Kconfig.defconfig"
 osource "$(ZMK_CONFIG)/boards/shields/*/Kconfig.shield"
 
+# This loads ZMK's sensible defaults
 rsource "Kconfig.defaults"
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
The refactor of 2537 didn't account for external module boards and shields. This fixes it by pulling in the relevant Kconfig bits from `kconfig.zephyr` a bit earlier. Results in some duplication of defaults, but acceptable duplication I'd say.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
