### PR TITLE
feat(pointing): Release pressed keys on disconnect

### DIFF
--- a/app/include/zmk/pointing/input_split.h
+++ b/app/include/zmk/pointing/input_split.h
@@ -8,3 +8,4 @@
 
 int zmk_input_split_report_peripheral_event(uint8_t reg, uint8_t type, uint16_t code, int32_t value,
                                             bool sync);
+int zmk_input_split_peripheral_disconnected(uint8_t reg);

--- a/app/src/pointing/Kconfig
+++ b/app/src/pointing/Kconfig
@@ -73,6 +73,11 @@ config ZMK_INPUT_SPLIT_INIT_PRIORITY
     int "Input Split initialization priority"
     default INPUT_INIT_PRIORITY
 
+
+config ZMK_INPUT_SPLIT_MAX_TRACKED_KEYS
+    int "Input Split max tracked keys to release on peripheral disconnect"
+    default 5
+
 endif # ZMK_INPUT_SPLIT
 
 endif # ZMK_POINTING

--- a/app/src/pointing/input_split.c
+++ b/app/src/pointing/input_split.c
@@ -26,12 +26,72 @@ struct zis_entry {
 
 static const struct zis_entry proxy_inputs[] = {DT_INST_FOREACH_STATUS_OKAY(ZIS_ENTRY)};
 
+#define PLUS_ONE(n) +1
+
+static uint16_t proxy_active_keys[(0 DT_INST_FOREACH_STATUS_OKAY(PLUS_ONE))]
+                                 [CONFIG_ZMK_INPUT_SPLIT_MAX_TRACKED_KEYS];
+
+static int replace_active_key(size_t input, uint16_t find, uint16_t replace) {
+    for (size_t k = 0; k < CONFIG_ZMK_INPUT_SPLIT_MAX_TRACKED_KEYS; k++) {
+        if (proxy_active_keys[input][k] == find) {
+            proxy_active_keys[input][k] = replace;
+            return 0;
+        }
+    }
+
+    return -ENODEV;
+}
+
 int zmk_input_split_report_peripheral_event(uint8_t reg, uint8_t type, uint16_t code, int32_t value,
                                             bool sync) {
     LOG_DBG("Got peripheral event for %d!", reg);
     for (size_t i = 0; i < ARRAY_SIZE(proxy_inputs); i++) {
         if (reg == proxy_inputs[i].reg) {
+            if (type == INPUT_EV_KEY) {
+                if (value) {
+                    int ret = replace_active_key(i, 0, code);
+                    if (ret < 0) {
+                        LOG_WRN("Failed to track pressed key %d", ret);
+                    }
+                } else {
+                    int ret = replace_active_key(i, code, 0);
+                    if (ret < 0) {
+                        LOG_WRN("Failed to untrack released key %d", ret);
+                    }
+                }
+            }
             return input_report(proxy_inputs[i].dev, type, code, value, sync, K_NO_WAIT);
+        }
+    }
+
+    return -ENODEV;
+}
+
+int zmk_input_split_peripheral_disconnected(uint8_t reg) {
+    for (size_t i = 0; i < ARRAY_SIZE(proxy_inputs); i++) {
+        if (reg == proxy_inputs[i].reg) {
+            uint16_t prev = 0;
+            for (size_t k = 0; k < CONFIG_ZMK_INPUT_SPLIT_MAX_TRACKED_KEYS; k++) {
+                if (proxy_active_keys[i][k] != 0) {
+                    if (prev != 0) {
+                        int ret = input_report(proxy_inputs[i].dev, INPUT_EV_KEY, prev, 0, false,
+                                               K_NO_WAIT);
+                        if (ret < 0) {
+                            LOG_WRN("Failed to report release event on disconnect (%d)", ret);
+                        }
+                    }
+
+                    prev = proxy_active_keys[i][k];
+                    proxy_active_keys[i][k] = 0;
+                }
+            }
+
+            if (prev != 0) {
+                int ret = input_report(proxy_inputs[i].dev, INPUT_EV_KEY, prev, 0, true, K_NO_WAIT);
+                if (ret < 0) {
+                    LOG_WRN("Failed to report release event on disconnect (%d)", ret);
+                }
+            }
         }
     }
 

--- a/app/src/split/bluetooth/central.c
+++ b/app/src/split/bluetooth/central.c
@@ -121,7 +121,7 @@ void release_peripheral_input_subs(struct bt_conn *conn) {
     for (size_t i = 0; i < ARRAY_SIZE(peripheral_input_slots); i++) {
         if (peripheral_input_slots[i].conn == conn) {
             peripheral_input_slots[i].conn = NULL;
-            // memset(&peripheral_input_slots[i], 0, sizeof(struct peripheral_input_slot));
+            zmk_input_split_peripheral_disconnected(peripheral_input_slots[i].reg);
         }
     }
 }


### PR DESCRIPTION
Match the behavior for key press release on split peripheral disconnect, and track pressed input keys to release them as needed on disconnect.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
