### PR TITLE
Allow running tests from anywhere and support EXTRA_MODULES

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,14 @@ on:
   push:
     paths:
       - ".github/workflows/test.yml"
+      - "app/run-test.sh"
       - "app/tests/**"
       - "app/src/**"
       - "app/include/**"
   pull_request:
     paths:
       - ".github/workflows/test.yml"
+      - "app/run-test.sh"
       - "app/tests/**"
       - "app/src/**"
       - "app/include/**"

--- a/app/run-test.sh
+++ b/app/run-test.sh
@@ -3,6 +3,15 @@
 # Copyright (c) 2020 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
+##
+# Optional environment variables, paths can be absolute or relative to $(pwd):
+#  ZMK_SRC_DIR:             Path to zmk/app (default is ./)
+#  ZMK_BUILD_DIR:           Path to build directory (default is $ZMK_SRC_DIR/build)
+#  ZMK_EXTRA_MODULES:       Path to at most one module (in addition to any in west.yml)
+#  ZMK_TESTS_VERBOSE:       Be more verbose
+#  ZMK_TESTS_AUTO_ACCEPT:   Replace snapshot files with new key events
+#  J:                       Number of parallel jobs (default is 4)
+
 if [ -z "$1" ]; then
     echo "Usage: ./run-test.sh <path to testcase>"
     exit 1
@@ -10,45 +19,62 @@ fi
 
 path="$1"
 if [ $path = "all" ]; then
-    path="tests"
+    path="${ZMK_SRC_DIR-.}/tests"
 fi
+
+ZMK_BUILD_DIR=${ZMK_BUILD_DIR:-${ZMK_SRC_DIR:-.}/build}
+mkdir -p ${ZMK_BUILD_DIR}/tests
 
 testcases=$(find $path -name native_posix_64.keymap -exec dirname \{\} \;)
 num_cases=$(echo "$testcases" | wc -l)
 if [ $num_cases -gt 1 ] || [ "$testcases" != "$path" ]; then
-    echo "" > ./build/tests/pass-fail.log
-    echo "$testcases" | xargs -L 1 -P ${J:-4} ./run-test.sh
+    echo "" >${ZMK_BUILD_DIR}/tests/pass-fail.log
+    echo "$testcases" | xargs -L 1 -P ${J:-4} ${0}
     err=$?
-    sort -k2 ./build/tests/pass-fail.log
+    sort -k2 ${ZMK_BUILD_DIR}/tests/pass-fail.log
     exit $err
 fi
 
-testcase="$path"
+testcase=$(realpath $path | sed -n -e "s|.*/tests/||p")
 echo "Running $testcase:"
 
-west build -d build/$testcase -b native_posix_64 -- -DCONFIG_ASSERT=y -DZMK_CONFIG="$(pwd)/$testcase" > /dev/null 2>&1
+build_cmd="west build ${ZMK_SRC_DIR:+-s $ZMK_SRC_DIR} -d ${ZMK_BUILD_DIR}/tests/$testcase \
+    -b native_posix_64 -p -- -DCONFIG_ASSERT=y -DZMK_CONFIG="$(realpath $path)" \
+    ${ZMK_EXTRA_MODULES:+-DZMK_EXTRA_MODULES="$(realpath ${ZMK_EXTRA_MODULES})"}"
+
+if [ -z ${ZMK_TESTS_VERBOSE} ]; then
+    $build_cmd >/dev/null 2>&1
+else
+    echo "ZMK_SRC_DIR:   ${ZMK_SRC_DIR:-.}"
+    echo "ZMK_BUILD_DIR: $ZMK_BUILD_DIR"
+    $build_cmd
+fi
+
 if [ $? -gt 0 ]; then
-    echo "FAILED: $testcase did not build" | tee -a ./build/tests/pass-fail.log
+    echo "FAILED: $testcase did not build" | tee -a ${ZMK_BUILD_DIR}/tests/pass-fail.log
     exit 1
 fi
 
-./build/$testcase/zephyr/zmk.exe | sed -e "s/.*> //" | tee build/$testcase/keycode_events_full.log | sed -n -f $testcase/events.patterns > build/$testcase/keycode_events.log
-diff -auZ $testcase/keycode_events.snapshot build/$testcase/keycode_events.log
+${ZMK_BUILD_DIR}/tests/$testcase/zephyr/zmk.exe |
+    sed -e "s/.*> //" |
+    tee ${ZMK_BUILD_DIR}/tests/$testcase/keycode_events_full.log |
+    sed -n -f $path/events.patterns >${ZMK_BUILD_DIR}/tests/$testcase/keycode_events.log
+
+diff -auZ $path/keycode_events.snapshot ${ZMK_BUILD_DIR}/tests/$testcase/keycode_events.log
 if [ $? -gt 0 ]; then
-    if [ -f $testcase/pending ]; then
-        echo "PENDING: $testcase" | tee -a ./build/tests/pass-fail.log
+    if [ -f $path/pending ]; then
+        echo "PENDING: $testcase" | tee -a ${ZMK_BUILD_DIR}/tests/pass-fail.log
         exit 0
     fi
 
-
     if [ -n "${ZMK_TESTS_AUTO_ACCEPT}" ]; then
         echo "Auto-accepting failure for $testcase"
-        cp build/$testcase/keycode_events.log $testcase/keycode_events.snapshot
+        cp ${ZMK_BUILD_DIR}/tests/$testcase/keycode_events.log $path/keycode_events.snapshot
     else
-        echo "FAILED: $testcase" | tee -a ./build/tests/pass-fail.log
+        echo "FAILED: $testcase" | tee -a ${ZMK_BUILD_DIR}/tests/pass-fail.log
         exit 1
     fi
 fi
 
-echo "PASS: $testcase" | tee -a ./build/tests/pass-fail.log
+echo "PASS: $testcase" | tee -a ${ZMK_BUILD_DIR}/tests/pass-fail.log
 exit 0


### PR DESCRIPTION
This includes a few tweaks to `run-tests.sh`
- Properly deal with paths so the the script can be run from any working directory
- Add environment variables to set non-standard `ZMK_SRC_DIR` and `ZMK_BUILD_DIR` paths
- Add option to specify `ZMK_EXTRA_MODULES`
- Path arguments can be either absolute paths or relative to the current working directory. This applies to:
  - location of script (e.g., `app/run-tests.sh` or `/workspace/zmk/app/run-tests.sh`)
  - test path (e.g., `app/tests/gresc` or `/workspace/zmk/app/tests/gresc`, or even `gresc` if we are in `.../tests`)
  - values of `ZMK_SRC_DIR`, `ZMK_BUILD_DIR` and `ZMK_EXTRA_MODULES`

---

Being able to run tests from anywhere in the workspace is mostly a quality-of-life improvement. The real application is to test modules without having to re-invent the wheel.

For instance, suppose the working directory is the root of a workspace with the following structure:
```
.
├── build
├── some-module
│   ├── tests
│   └── ...
├── zmk
└── ...
```

Then one could run the module tests as follows:
```sh
# use absolute paths if planning to change working directory
export ZMK_SRC_DIR=zmk/app            # or $(realpath zmk/app)
export ZMK_BUILD_DIR=build            # or $(realpath build)
export ZMK_EXTRA_MODULES=some-module  # or $(realpath some-module)
./zmk/app/run-tests some-module
```

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
