### PR TITLE
feat: shields: add tester_nrf52840dk shield

### DIFF
--- a/app/boards/shields/tester_nrf52840dk/Kconfig.defconfig
+++ b/app/boards/shields/tester_nrf52840dk/Kconfig.defconfig
@@ -1,0 +1,12 @@
+if SHIELD_TESTER_NRF52840DK
+
+config ZMK_KEYBOARD_NAME
+    default "ZMK Tester"
+
+config ZMK_BLE
+    def_bool n
+
+config SETTINGS
+    def_bool n
+
+endif

--- a/app/boards/shields/tester_nrf52840dk/Kconfig.shield
+++ b/app/boards/shields/tester_nrf52840dk/Kconfig.shield
@@ -1,0 +1,2 @@
+config SHIELD_TESTER_NRF52840DK
+    def_bool $(shields_list_contains,tester_nrf52840dk)

--- a/app/boards/shields/tester_nrf52840dk/tester_nrf52840dk.keymap
+++ b/app/boards/shields/tester_nrf52840dk/tester_nrf52840dk.keymap
@@ -1,0 +1,33 @@
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+
+#define PIN_MACRO(name, pin) \
+/ { \
+    macros { \
+        name: name { \
+            compatible = "zmk,behavior-macro"; \
+            wait-ms = <5>; \
+            tap-ms = <5>; \
+            #binding-cells = <0>; \
+            bindings = <&kp P &kp I &kp N &kp SPACE>, pin, <&kp ENTER>; \
+        }; \
+    }; \
+};
+
+PIN_MACRO(pin0, <&kp N0>)
+PIN_MACRO(pin1, <&kp N1>)
+PIN_MACRO(pin2, <&kp N2>)
+PIN_MACRO(pin3, <&kp N3>)
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <&pin0
+                        &pin1
+                        &pin2
+                        &pin3>;
+        };
+    };
+};

--- a/app/boards/shields/tester_nrf52840dk/tester_nrf52840dk.overlay
+++ b/app/boards/shields/tester_nrf52840dk/tester_nrf52840dk.overlay
@@ -1,0 +1,27 @@
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan0;
+        zmk,matrix-transform = &transform0;
+    };
+
+    kscan0: kscan {
+        compatible = "zmk,kscan-gpio-direct";
+        wakeup-source;
+        debounce-press-ms = <10>;
+        debounce-release-ms = <10>;
+        input-gpios
+            = <&gpio0 11 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+            , <&gpio0 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+            , <&gpio0 24 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>
+            , <&gpio0 25 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+    };
+
+    transform0: keymap_transform {
+        compatible = "zmk,matrix-transform";
+        columns = <4>;
+        rows = <1>;
+        map = <RC(0,0)  RC(0,1)  RC(0,2)  RC(0,3)>;
+    };
+};

--- a/app/boards/shields/tester_nrf52840dk/tester_nrf52840dk.zmk.yml
+++ b/app/boards/shields/tester_nrf52840dk/tester_nrf52840dk.zmk.yml
@@ -1,0 +1,6 @@
+file_format: "1"
+id: tester_nrf52840dk
+name: TesternRF52840DK
+type: shield
+url: https://zmk.dev/docs/troubleshooting/hardware-issues
+requires: [nrf52840dk_nrf52840]


### PR DESCRIPTION
Adds similar shield as seen with XIAO, ProMicro to
the nRF52840-DK.

Signed-off-by: Helmut Lord <kellyhlord@gmail.com>

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
