### PR TITLE
fix(behaviors): Deactivate caps_word after modified numerics

### DIFF
--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -112,9 +112,10 @@ static bool caps_word_is_alpha(uint8_t usage_id) {
     return (usage_id >= HID_USAGE_KEY_KEYBOARD_A && usage_id <= HID_USAGE_KEY_KEYBOARD_Z);
 }
 
-static bool caps_word_is_numeric(uint8_t usage_id) {
+static bool caps_word_is_numeric(uint8_t usage_id, uint8_t implicit_modifiers) {
     return (usage_id >= HID_USAGE_KEY_KEYBOARD_1_AND_EXCLAMATION &&
-            usage_id <= HID_USAGE_KEY_KEYBOARD_0_AND_RIGHT_PARENTHESIS);
+            usage_id <= HID_USAGE_KEY_KEYBOARD_0_AND_RIGHT_PARENTHESIS &&
+            (implicit_modifiers | zmk_hid_get_explicit_mods()) == 0);
 }
 
 static void caps_word_enhance_usage(const struct behavior_caps_word_config *config,
@@ -148,7 +149,7 @@ static int caps_word_keycode_state_changed_listener(const zmk_event_t *eh) {
 
         caps_word_enhance_usage(config, ev);
 
-        if (!caps_word_is_alpha(ev->keycode) && !caps_word_is_numeric(ev->keycode) &&
+        if (!caps_word_is_alpha(ev->keycode) && !caps_word_is_numeric(ev->keycode, ev->implicit_modifiers) &&
             !is_mod(ev->usage_page, ev->keycode) &&
             !caps_word_is_caps_includelist(config, ev->usage_page, ev->keycode,
                                            ev->implicit_modifiers)) {

--- a/app/tests/caps-word/deactivate-by-numeric-with-modifiers-explicit/events.patterns
+++ b/app/tests/caps-word/deactivate-by-numeric-with-modifiers-explicit/events.patterns
@@ -1,0 +1,3 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_implicit_modifiers_//p
+s/.*caps_word_enhance_usage/enhance_usage/p

--- a/app/tests/caps-word/deactivate-by-numeric-with-modifiers-explicit/keycode_events.snapshot
+++ b/app/tests/caps-word/deactivate-by-numeric-with-modifiers-explicit/keycode_events.snapshot
@@ -1,0 +1,17 @@
+enhance_usage: Enhancing usage 0x04 with modifiers: 0x02
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x02 explicit_mods 0x00
+press: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x02
+pressed: usage_page 0x07 keycode 0x26 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x26 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00

--- a/app/tests/caps-word/deactivate-by-numeric-with-modifiers-explicit/native_posix_64.keymap
+++ b/app/tests/caps-word/deactivate-by-numeric-with-modifiers-explicit/native_posix_64.keymap
@@ -1,0 +1,32 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+            &caps_word &kp A
+            &kp LSHFT  &kp N9
+            >;
+        };
+    };
+};
+
+&kscan {
+    events = <
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    ZMK_MOCK_PRESS(0,1,10)
+    ZMK_MOCK_RELEASE(0,1,10)
+    ZMK_MOCK_PRESS(1,0,10)
+    ZMK_MOCK_PRESS(1,1,10)
+    ZMK_MOCK_RELEASE(1,1,10)
+    ZMK_MOCK_RELEASE(1,0,10)
+    ZMK_MOCK_PRESS(0,1,10)
+    ZMK_MOCK_RELEASE(0,1,10)
+    >;
+};

--- a/app/tests/caps-word/deactivate-by-numeric-with-modifiers-implicit/events.patterns
+++ b/app/tests/caps-word/deactivate-by-numeric-with-modifiers-implicit/events.patterns
@@ -1,0 +1,3 @@
+s/.*hid_listener_keycode_//p
+s/.*hid_implicit_modifiers_//p
+s/.*caps_word_enhance_usage/enhance_usage/p

--- a/app/tests/caps-word/deactivate-by-numeric-with-modifiers-implicit/keycode_events.snapshot
+++ b/app/tests/caps-word/deactivate-by-numeric-with-modifiers-implicit/keycode_events.snapshot
@@ -1,0 +1,13 @@
+enhance_usage: Enhancing usage 0x04 with modifiers: 0x02
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x02 explicit_mods 0x00
+press: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0x26 implicit_mods 0x02 explicit_mods 0x00
+press: Modifiers set to 0x02
+released: usage_page 0x07 keycode 0x26 implicit_mods 0x02 explicit_mods 0x00
+release: Modifiers set to 0x00
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+press: Modifiers set to 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+release: Modifiers set to 0x00

--- a/app/tests/caps-word/deactivate-by-numeric-with-modifiers-implicit/native_posix_64.keymap
+++ b/app/tests/caps-word/deactivate-by-numeric-with-modifiers-implicit/native_posix_64.keymap
@@ -1,0 +1,30 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+            &caps_word &kp A
+            &kp LPAR
+            >;
+        };
+    };
+};
+
+&kscan {
+    events = <
+    ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_RELEASE(0,0,10)
+    ZMK_MOCK_PRESS(0,1,10)
+    ZMK_MOCK_RELEASE(0,1,10)
+    ZMK_MOCK_PRESS(1,0,10)
+    ZMK_MOCK_RELEASE(1,0,10)
+    ZMK_MOCK_PRESS(0,1,10)
+    ZMK_MOCK_RELEASE(0,1,10)
+    >;
+};


### PR DESCRIPTION
Fixes #2723.

The caps_word behavior now strictly honors `[A-Za-z0-9_]` as the default continuation characters. (Previously `!@#$%^&*()` were mistakenly also honored.)

I discovered this by trying to use caps_word for comment markers like `FIXME(mt):` and finding that the opening left parenthesis didn't deactivate caps_word.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
