### PR TITLE
fix(combos): Properly report combos len with emply block

### DIFF
--- a/app/include/zmk/combos.h
+++ b/app/include/zmk/combos.h
@@ -8,9 +8,9 @@
 
 #include <zephyr/devicetree.h>
 
-#define ZMK_COMBOS_UTIL_ONE(n) 1
+#define ZMK_COMBOS_UTIL_ONE(n) +1
 
 #define ZMK_COMBOS_LEN                                                                             \
-    COND_CODE_1(                                                                                   \
-        DT_HAS_COMPAT_STATUS_OKAY(zmk_combos),                                                     \
-        (DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_INST(0, zmk_combos), ZMK_COMBOS_UTIL_ONE, (+))), (0))
+    COND_CODE_1(DT_HAS_COMPAT_STATUS_OKAY(zmk_combos),                                             \
+                (0 DT_FOREACH_CHILD_STATUS_OKAY(DT_INST(0, zmk_combos), ZMK_COMBOS_UTIL_ONE)),     \
+                (0))

--- a/app/tests/pointing/mouse-move/processors/behaviors_hold_tap/native_posix_64.keymap
+++ b/app/tests/pointing/mouse-move/processors/behaviors_hold_tap/native_posix_64.keymap
@@ -18,6 +18,10 @@
 };
 
 / {
+    combos {
+        compatible = "zmk,combos";
+    };
+
     keymap {
         compatible = "zmk,keymap";
         label ="Default keymap";


### PR DESCRIPTION
Handle the scenario where there is an empty combos block and return a zero combos length.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
