### PR TITLE
feat(shields): Add physical layout for Lotus58

### DIFF
--- a/app/boards/shields/lotus58/lotus58-layouts.dtsi
+++ b/app/boards/shields/lotus58/lotus58-layouts.dtsi
@@ -1,0 +1,71 @@
+#include <physical_layouts.dtsi>
+
+/ {
+    physical_layout0: physical_layout_0 {
+        compatible = "zmk,physical-layout";
+        display-name = "Default";
+
+        keys  //                     w   h    x    y     rot    rx    ry
+            = <&key_physical_attrs 100 100    0   50       0     0     0>
+            , <&key_physical_attrs 100 100  100   37       0     0     0>
+            , <&key_physical_attrs 100 100  200   12       0     0     0>
+            , <&key_physical_attrs 100 100  300    0       0     0     0>
+            , <&key_physical_attrs 100 100  400   12       0     0     0>
+            , <&key_physical_attrs 100 100  500   25       0     0     0>
+            , <&key_physical_attrs 100 100 1050   25       0     0     0>
+            , <&key_physical_attrs 100 100 1150   12       0     0     0>
+            , <&key_physical_attrs 100 100 1250    0       0     0     0>
+            , <&key_physical_attrs 100 100 1350   12       0     0     0>
+            , <&key_physical_attrs 100 100 1450   37       0     0     0>
+            , <&key_physical_attrs 100 100 1550   50       0     0     0>
+            , <&key_physical_attrs 100 100    0  150       0     0     0>
+            , <&key_physical_attrs 100 100  100  137       0     0     0>
+            , <&key_physical_attrs 100 100  200  112       0     0     0>
+            , <&key_physical_attrs 100 100  300  100       0     0     0>
+            , <&key_physical_attrs 100 100  400  112       0     0     0>
+            , <&key_physical_attrs 100 100  500  125       0     0     0>
+            , <&key_physical_attrs 100 100 1050  125       0     0     0>
+            , <&key_physical_attrs 100 100 1150  112       0     0     0>
+            , <&key_physical_attrs 100 100 1250  100       0     0     0>
+            , <&key_physical_attrs 100 100 1350  112       0     0     0>
+            , <&key_physical_attrs 100 100 1450  137       0     0     0>
+            , <&key_physical_attrs 100 100 1550  150       0     0     0>
+            , <&key_physical_attrs 100 100    0  250       0     0     0>
+            , <&key_physical_attrs 100 100  100  237       0     0     0>
+            , <&key_physical_attrs 100 100  200  212       0     0     0>
+            , <&key_physical_attrs 100 100  300  200       0     0     0>
+            , <&key_physical_attrs 100 100  400  212       0     0     0>
+            , <&key_physical_attrs 100 100  500  225       0     0     0>
+            , <&key_physical_attrs 100 100  625   75       0     0     0>
+            , <&key_physical_attrs 100 100  925   75       0     0     0>
+            , <&key_physical_attrs 100 100 1050  225       0     0     0>
+            , <&key_physical_attrs 100 100 1150  212       0     0     0>
+            , <&key_physical_attrs 100 100 1250  200       0     0     0>
+            , <&key_physical_attrs 100 100 1350  212       0     0     0>
+            , <&key_physical_attrs 100 100 1450  237       0     0     0>
+            , <&key_physical_attrs 100 100 1550  250       0     0     0>
+            , <&key_physical_attrs 100 100    0  350       0     0     0>
+            , <&key_physical_attrs 100 100  100  337       0     0     0>
+            , <&key_physical_attrs 100 100  200  312       0     0     0>
+            , <&key_physical_attrs 100 100  300  300       0     0     0>
+            , <&key_physical_attrs 100 100  400  312       0     0     0>
+            , <&key_physical_attrs 100 100  500  325       0     0     0>
+            , <&key_physical_attrs 100 100  625  275       0     0     0>
+            , <&key_physical_attrs 100 100  925  275       0     0     0>
+            , <&key_physical_attrs 100 100 1050  325       0     0     0>
+            , <&key_physical_attrs 100 100 1150  312       0     0     0>
+            , <&key_physical_attrs 100 100 1250  300       0     0     0>
+            , <&key_physical_attrs 100 100 1350  312       0     0     0>
+            , <&key_physical_attrs 100 100 1450  337       0     0     0>
+            , <&key_physical_attrs 100 100 1550  350       0     0     0>
+            , <&key_physical_attrs 100 100  250  412       0     0     0>
+            , <&key_physical_attrs 100 100  350  415       0     0     0>
+            , <&key_physical_attrs 100 100  450  425       0     0     0>
+            , <&key_physical_attrs 100 150  575  400    3000   625   475>
+            , <&key_physical_attrs 100 150  975  400 (-3000)  1025   475>
+            , <&key_physical_attrs 100 100 1100  425       0     0     0>
+            , <&key_physical_attrs 100 100 1200  415       0     0     0>
+            , <&key_physical_attrs 100 100 1300  415       0     0     0>
+            ;
+    };
+};

--- a/app/boards/shields/lotus58/lotus58.dtsi
+++ b/app/boards/shields/lotus58/lotus58.dtsi
@@ -6,17 +6,19 @@
 
 #include <dt-bindings/zmk/matrix_transform.h>
 
+#include "lotus58-layouts.dtsi"
+
 / {
     chosen {
         zephyr,display = &oled;
         zmk,kscan = &kscan0;
-        zmk,matrix-transform = &default_transform;
+        zmk,physical-layout = &physical_layout0;
     };
 
     default_transform: keymap_transform_0 {
         compatible = "zmk,matrix-transform";
         columns = <16>;
-        rows = <4>;
+        rows = <5>;
 // | SW6  | SW5  | SW4  | SW3  | SW2  | SW1  |                 | SW1  | SW2  | SW3  | SW4  | SW5  | SW6  |
 // | SW12 | SW11 | SW10 | SW9  | SW8  | SW7  |                 | SW7  | SW8  | SW9  | SW10 | SW11 | SW12 |
 // | SW18 | SW17 | SW16 | SW15 | SW14 | SW13 | SW30 |   | SW30 | SW13 | SW14 | SW15 | SW16 | SW17 | SW18 |
@@ -66,6 +68,10 @@ RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(4,5)  RC(4,6)  RC(3,6) RC(3,7
         sensors = <&left_encoder &right_encoder>;
         triggers-per-rotation = <20>;
     };
+};
+
+&physical_layout0 {
+    transform = <&default_transform>;
 };
 
 &pro_micro_i2c {

--- a/app/boards/shields/lotus58/lotus58.zmk.yml
+++ b/app/boards/shields/lotus58/lotus58.zmk.yml
@@ -9,6 +9,7 @@ features:
   - keys
   - display
   - encoder
+  - studio
 siblings:
   - lotus58_left
   - lotus58_right


### PR DESCRIPTION
Added physical layout and studio support for Lotus58.

I've tested changes on my board with this [firmware](https://github.com/ralex2304/lotus58-zmk-config/actions/runs/12624124266) and studio in chrome.

Layout is based on existing zmk layout for Lily58.