### PR TITLE
Optimize build workflow

### DIFF
--- a/.github/workflows/ble-test.yml
+++ b/.github/workflows/ble-test.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Enable babblesim group filter
         run: west config manifest.group-filter -- +babblesim
       - name: Update modules (west update)
-        run: west update
+        run: west update --fetch-opt=--filter=tree:0
       - name: Export Zephyr CMake package (west zephyr-export)
         run: west zephyr-export
       - name: Build BabbleSim components

--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -34,13 +34,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install yaml2json
-        run: python3 -m pip install remarshal
-
       - name: Fetch Build Matrix
         run: |
-          echo "build_matrix=$(yaml2json '${{ inputs.build_matrix_path }}' | jq -c .)" >> $GITHUB_ENV
-          yaml2json "${{ inputs.build_matrix_path }}" | jq
+          echo "build_matrix=$(yq -oj -I0 '${{ inputs.build_matrix_path }}')" >> $GITHUB_ENV
+          yq -oj "${{ inputs.build_matrix_path }}"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: West Update
         working-directory: ${{ env.base_dir }}
-        run: west update
+        run: west update --fetch-opt=--filter=tree:0
 
       - name: West Zephyr export
         working-directory: ${{ env.base_dir }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Initialize workspace (west init)
         run: west init -l app
       - name: Update modules (west update)
-        run: west update
+        run: west update --fetch-opt=--filter=tree:0
       - name: Export Zephyr CMake package (west zephyr-export)
         run: west zephyr-export
       - name: Use Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Initialize workspace (west init)
         run: west init -l app
       - name: Update modules (west update)
-        run: west update
+        run: west update --fetch-opt=--filter=tree:0
       - name: Export Zephyr CMake package (west zephyr-export)
         run: west zephyr-export
       - name: Test ${{ matrix.test }}


### PR DESCRIPTION
This PR contains two performance tweaks for the GHA build workflow:

1. Use [treeless clones](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/) when pulling in dependencies. This reduces the download size from 1.7 GB to 610 MB. 
2. Replace `yaml2json | jq` with `yq`. This saves the installation step shaving off a few more seconds.

The following table summarizes the performance impact for building a `reviung41` with the stock config on ZMK `v0.1`.

|     | cold cache | warm cache | cache size |
| --- | --- | --- | --- |
|upstream    | 5m 28s | 2m 02s | 1.7 GB |
|treeless PR | 3m 51s | 1m 45s | 610 MB |

(See https://github.com/urob/zmk-build-benchmarks/actions for the benchmarks.)

## Note

The dependency change is most impactful on cold caches. As Github caches expire after 7 days this should be a nice speed up for many `build-user-config` workflow runs.

For the upstream repo the gains are more limited since the cache should rarely be cold. On the other hand, there isn't really a downside since none of the workflows interacts with trees that aren't reachable from `HEAD`. For now I also applied the tweak to the ZMK `build` and `test` workflows but happy to revert that.

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
