### PR TITLE
fix(behaviors): Make multiple sticky keys work on same key position

### DIFF
--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -44,7 +44,6 @@ struct active_sticky_key {
     uint8_t source;
 #endif
     uint32_t param1;
-    uint32_t param2;
     const struct behavior_sticky_key_config *config;
     // timer data.
     bool timer_started;
@@ -59,7 +58,7 @@ struct active_sticky_key {
 struct active_sticky_key active_sticky_keys[ZMK_BHV_STICKY_KEY_MAX_HELD] = {};
 
 static struct active_sticky_key *store_sticky_key(struct zmk_behavior_binding_event *event,
-                                                  uint32_t param1, uint32_t param2,
+                                                  uint32_t param1,
                                                   const struct behavior_sticky_key_config *config) {
     for (int i = 0; i < ZMK_BHV_STICKY_KEY_MAX_HELD; i++) {
         struct active_sticky_key *const sticky_key = &active_sticky_keys[i];
@@ -72,7 +71,6 @@ static struct active_sticky_key *store_sticky_key(struct zmk_behavior_binding_ev
         sticky_key->source = event->source;
 #endif
         sticky_key->param1 = param1;
-        sticky_key->param2 = param2;
         sticky_key->config = config;
         sticky_key->release_at = 0;
         sticky_key->timer_cancelled = false;
@@ -108,7 +106,6 @@ static inline int press_sticky_key_behavior(struct active_sticky_key *sticky_key
     struct zmk_behavior_binding binding = {
         .behavior_dev = sticky_key->config->behavior.behavior_dev,
         .param1 = sticky_key->param1,
-        .param2 = sticky_key->param2,
     };
     struct zmk_behavior_binding_event event = {
         .position = sticky_key->position,
@@ -125,7 +122,6 @@ static inline int release_sticky_key_behavior(struct active_sticky_key *sticky_k
     struct zmk_behavior_binding binding = {
         .behavior_dev = sticky_key->config->behavior.behavior_dev,
         .param1 = sticky_key->param1,
-        .param2 = sticky_key->param2,
     };
     struct zmk_behavior_binding_event event = {
         .position = sticky_key->position,
@@ -168,7 +164,7 @@ static int on_sticky_key_binding_pressed(struct zmk_behavior_binding *binding,
         stop_timer(sticky_key);
         release_sticky_key_behavior(sticky_key, event.timestamp);
     }
-    sticky_key = store_sticky_key(&event, binding->param1, binding->param2, cfg);
+    sticky_key = store_sticky_key(&event, binding->param1, cfg);
     if (sticky_key == NULL) {
         LOG_ERR("unable to store sticky key, did you press more than %d sticky_key?",
                 ZMK_BHV_STICKY_KEY_MAX_HELD);

--- a/app/src/behaviors/behavior_sticky_key.c
+++ b/app/src/behaviors/behavior_sticky_key.c
@@ -85,12 +85,18 @@ static struct active_sticky_key *store_sticky_key(struct zmk_behavior_binding_ev
 }
 
 static void clear_sticky_key(struct active_sticky_key *sticky_key) {
+    LOG_DBG("clearing sticky key at position %d, param %d", sticky_key->position,
+            sticky_key->param1);
     sticky_key->position = ZMK_BHV_STICKY_KEY_POSITION_FREE;
 }
 
-static struct active_sticky_key *find_sticky_key(uint32_t position) {
+static struct active_sticky_key *
+find_sticky_key(uint32_t position, struct zmk_behavior_binding behavior, uint32_t binding_param) {
     for (int i = 0; i < ZMK_BHV_STICKY_KEY_MAX_HELD; i++) {
-        if (active_sticky_keys[i].position == position && !active_sticky_keys[i].timer_cancelled) {
+        if (active_sticky_keys[i].position == position &&
+            active_sticky_keys[i].config->behavior.behavior_dev == behavior.behavior_dev &&
+            active_sticky_keys[i].param1 == binding_param &&
+            !active_sticky_keys[i].timer_cancelled) {
             return &active_sticky_keys[i];
         }
     }
@@ -156,8 +162,9 @@ static int on_sticky_key_binding_pressed(struct zmk_behavior_binding *binding,
     const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct behavior_sticky_key_config *cfg = dev->config;
     struct active_sticky_key *sticky_key;
-    sticky_key = find_sticky_key(event.position);
+    sticky_key = find_sticky_key(event.position, cfg->behavior, binding->param1);
     if (sticky_key != NULL) {
+        LOG_DBG("found same sticky key pressed at position %d, release it first", event.position);
         stop_timer(sticky_key);
         release_sticky_key_behavior(sticky_key, event.timestamp);
     }
@@ -178,7 +185,10 @@ static int on_sticky_key_binding_pressed(struct zmk_behavior_binding *binding,
 
 static int on_sticky_key_binding_released(struct zmk_behavior_binding *binding,
                                           struct zmk_behavior_binding_event event) {
-    struct active_sticky_key *sticky_key = find_sticky_key(event.position);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    const struct behavior_sticky_key_config *cfg = dev->config;
+    struct active_sticky_key *sticky_key =
+        find_sticky_key(event.position, cfg->behavior, binding->param1);
     if (sticky_key == NULL) {
         LOG_ERR("ACTIVE STICKY KEY CLEARED TOO EARLY");
         return ZMK_BEHAVIOR_OPAQUE;

--- a/app/tests/sticky-keys/12-macro/events.patterns
+++ b/app/tests/sticky-keys/12-macro/events.patterns
@@ -1,0 +1,1 @@
+s/.*hid_listener_keycode_//p

--- a/app/tests/sticky-keys/12-macro/keycode_events.snapshot
+++ b/app/tests/sticky-keys/12-macro/keycode_events.snapshot
@@ -1,0 +1,4 @@
+pressed: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/sticky-keys/12-macro/native_posix_64.keymap
+++ b/app/tests/sticky-keys/12-macro/native_posix_64.keymap
@@ -1,0 +1,36 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    behaviors {
+        ZMK_MACRO(sk_sl, wait-ms = <1>; tap-ms = <1>; bindings = <&sk LEFT_CONTROL &sl 1>;)
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &sk_sl &mo 1
+                &kp Y &kp B>;
+        };
+
+        upper_layer {
+            bindings = <
+                &kp T  &kp X
+                &kp A  &kp Z>;
+        };
+    };
+};
+
+&kscan {
+    events = <
+        /* tap sk_sl */
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+        /* tap A */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+    >;
+};

--- a/app/tests/sticky-keys/12-same-position-mods/events.patterns
+++ b/app/tests/sticky-keys/12-same-position-mods/events.patterns
@@ -1,0 +1,1 @@
+s/.*hid_listener_keycode_//p

--- a/app/tests/sticky-keys/12-same-position-mods/keycode_events.snapshot
+++ b/app/tests/sticky-keys/12-same-position-mods/keycode_events.snapshot
@@ -1,0 +1,6 @@
+pressed: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/sticky-keys/12-same-position-mods/native_posix_64.keymap
+++ b/app/tests/sticky-keys/12-same-position-mods/native_posix_64.keymap
@@ -1,0 +1,39 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &sk LEFT_CONTROL &mo 1
+                &kp A &kp B>;
+        };
+
+        lower_layer {
+            bindings = <
+                &sk LEFT_SHIFT  &kp X
+                &kp Y  &kp Z>;
+        };
+    };
+};
+
+&kscan {
+    events = <
+        /* tap sk LEFT_CONTROL */
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+        /* switch to lower layer */
+        ZMK_MOCK_PRESS(0,1,10)
+        /* tap sk LEFT_SHIFT */
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+        /* deactivate lower layer */
+        ZMK_MOCK_RELEASE(0,1,10)
+        /* tap A */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+    >;
+};

--- a/app/tests/sticky-keys/12-same-position-sk-sl/events.patterns
+++ b/app/tests/sticky-keys/12-same-position-sk-sl/events.patterns
@@ -1,0 +1,1 @@
+s/.*hid_listener_keycode_//p

--- a/app/tests/sticky-keys/12-same-position-sk-sl/keycode_events.snapshot
+++ b/app/tests/sticky-keys/12-same-position-sk-sl/keycode_events.snapshot
@@ -1,0 +1,4 @@
+pressed: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0xE0 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/sticky-keys/12-same-position-sk-sl/native_posix_64.keymap
+++ b/app/tests/sticky-keys/12-same-position-sk-sl/native_posix_64.keymap
@@ -1,0 +1,45 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &sk LEFT_CONTROL &mo 1
+                &kp A &kp B>;
+        };
+
+        lower_layer {
+            bindings = <
+                &sl 2  &kp X
+                &kp Y  &kp Z>;
+        };
+
+        upper_layer {
+            bindings = <
+                &kp T  &kp X
+                &kp A  &kp Z>;
+        };
+    };
+};
+
+&kscan {
+    events = <
+        /* tap sk LEFT_CONTROL */
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+        /* switch to lower layer */
+        ZMK_MOCK_PRESS(0,1,10)
+        /* tap sl upper_layer */
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+        /* tap A */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        /* deactivate lower layer */
+        ZMK_MOCK_RELEASE(0,1,10)
+    >;
+};


### PR DESCRIPTION
Sticky keys have logic implemented so that if you press the same sticky key a second time, it releases the first press before activating a sticky key press again. However, multiple sticky keys are only disambiguated by key position, which means that you currently cannot have active multiple sticky keys that are triggered from the same key position. This scenario occurs under a couple conditions:

- You activate a sticky key (e.g. `&sk LCTRL`), then activate a different sticky key e.g. (`&sk LSHIFT`) on a different layer but at the same key position
- You activate multiple sticky keys on a macro invocation (e.g. with `bindings = <&sk LSHIFT>, <&sl 1>;`)

Using only the key position is usually enough to disambiguate multiple active instances of a behavior; for instance for hold-taps, you cannot press the same key position again while one hold-tap is active at that position. However this doesn't apply to sticky keys since they stay active after you release the key that activates them.

In order to support above scenarios, add three tests covering them and modify the implementation to use behavior binding (e.g. `&kp` vs. `&mo`) and parameter (e.g. `LCTRL` vs. `LSHIFT`) in addition to key position to disambiguate between active sticky keys.

Also remove the redundant `param2` storage in sticky keys since they only accept one binding cell, can drop this refactor commit if it is unnecessary.

Fixes #508 and #1421.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
