### PR TITLE
docs: Fix broken anchors in dongle page

### DIFF
--- a/docs/docs/development/hardware-integration/dongle.mdx
+++ b/docs/docs/development/hardware-integration/dongle.mdx
@@ -15,7 +15,7 @@ Benefits:
 
 Disadvantages:
 
-- An extra [board](../../faq.md#what-is-a-board) is needed (any BLE-capable board that ZMK supports will work).
+- An extra [board](index.mdx#what-is-a-board) is needed (any BLE-capable board that ZMK supports will work).
 - The keyboard becomes unusable without the dongle.
 
 Depending on how the dongle is used, there are some additional [latency considerations](../../features/split-keyboards.md#latency-considerations) to keep in mind.
@@ -300,7 +300,7 @@ include:
 You can then flash the firmware to your device as detailed in our [user setup](../../user-setup.mdx#installing-the-firmware) and [split keyboard](../../features/split-keyboards.md#building-and-flashing-firmware) pages.
 
 :::warning
-Before flashing your new firmware, you need to flash `settings_reset` [firmware](../../troubleshooting/connection-issues.mdx#acquiring-a-reset-uf2) on all devices to ensure they can pair to each other.
+Before flashing your new firmware, you need to flash `settings_reset` [firmware](../../troubleshooting/connection-issues.mdx#building-a-reset-firmware) on all devices to ensure they can pair to each other.
 :::
 
 To use your dongled keyboard with [ZMK Studio](../../features/studio.md), apply the instructions for [building with Studio](../../features/studio.md#building) to the dongle.


### PR DESCRIPTION
Noticed these while working on #2704, I guess we overlooked it before the final merge.