### PR TITLE
docs: Update intro page

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -11,35 +11,41 @@ ZMK's goal is to provide a modern and powerful firmware that is wireless-first a
 
 Below table lists major features/capabilities currently supported in ZMK, as well as ones that are currently under development and not planned.
 
-| Legend: | ✅ Supported | 🚧 Under Development | 💡 Planned | ❌ Not Planned |
-| :------ | :----------- | :------------------- | :--------- | -------------- |
+| Legend: | ✅ Supported | 🚧 Under Development | ❌ Not Planned |
+| :------ | :----------- | :------------------- | -------------- |
 
-| Feature                                                                                                                                                | Support |
+| Hardware                                                                                        | Support |
+| ----------------------------------------------------------------------------------------------- | :-----: |
+| [Split Keyboards](features/split-keyboards.md)                                                  |   ✅    |
+| [Low Active Power Usage](/power-profiler)                                                       |   ✅    |
+| [Encoders](features/encoders.md)                                                                |   ✅    |
+| [LED-based Lighting](features/lighting.md)                                                      |   ✅    |
+| [Displays](features/displays.md)                                                                |   🚧    |
+| [Pointing Devices](features/pointing.md)                                                        |   ✅    |
+| [Low Power Sleep States](features/low-power-states.md)                                          |   ✅    |
+| [Low Power Mode (VCC Shutoff)](keymaps/behaviors/power.md)                                      |   ✅    |
+| [Battery Level Reporting](features/battery.md)                                                  |   ✅    |
+| [Support for a Wide Range of ARM Chips](https://docs.zephyrproject.org/3.5.0/boards/index.html) |   ✅    |
+| Support for AVR/8-Bit Chips                                                                     |   ❌    |
+
+| Connectivity                                                                 | Support |
+| ---------------------------------------------------------------------------- | :-----: |
+| Low-Latency BLE Support                                                      |   ✅    |
+| [Multi-Device Simultaneous BLE Connectivity](features/bluetooth.md#profiles) |   ✅    |
+| [USB Connectivity](keymaps/behaviors/outputs.md)                             |   ✅    |
+
+| Keymap Features                                                                                                                                        | Support |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------ | :-----: |
-| Low-Latency BLE Support                                                                                                                                |   ✅    |
-| [Multi-Device BLE Support](features/bluetooth.md#profiles)                                                                                             |   ✅    |
-| [USB Connectivity](keymaps/behaviors/outputs.md)                                                                                                       |   ✅    |
 | [User Configuration Repositories](user-setup.mdx)                                                                                                      |   ✅    |
 | [Keymaps and Layers](keymaps/index.mdx)                                                                                                                |   ✅    |
-| [Split Keyboard Support](features/split-keyboards.md)                                                                                                  |   ✅    |
+| [Wide Range of Keycodes Including Media and Consumer Codes](keymaps/list-of-keycodes.mdx)                                                              |   ✅    |
 | [Hold-Taps](keymaps/behaviors/hold-tap.mdx) (including [Mod-Tap](keymaps/behaviors/mod-tap.md) and [Layer-Tap](keymaps/behaviors/layers.md#layer-tap)) |   ✅    |
 | [Tap-Dances](keymaps/behaviors/tap-dance.mdx)                                                                                                          |   ✅    |
-| [Wide Range of Keycodes Including Media and Consumer Codes](keymaps/list-of-keycodes.mdx)                                                              |   ✅    |
-| [Encoders](features/encoders.md)                                                                                                                       |   ✅    |
-| [LED-based Lighting](features/lighting.md)                                                                                                             |   ✅    |
-| [Displays](features/displays.md)                                                                                                                       |   🚧    |
 | [Sticky (One Shot) Keys](keymaps/behaviors/sticky-key.md)                                                                                              |   ✅    |
 | [Combos](keymaps/combos.md)                                                                                                                            |   ✅    |
 | [Macros](keymaps/behaviors/macros.md)                                                                                                                  |   ✅    |
 | [Mouse Keys](keymaps/behaviors/mouse-emulation.md)                                                                                                     |   ✅    |
-| [Pointing Devices](features/pointing.md)                                                                                                               |   ✅    |
-| [Low Active Power Usage](/power-profiler)                                                                                                              |   ✅    |
-| [Low Power Sleep States](features/low-power-states.md)                                                                                                 |   ✅    |
-| [Low Power Mode (VCC Shutoff)](keymaps/behaviors/power.md)                                                                                             |   ✅    |
-| [Battery Reporting](features/battery.md)                                                                                                               |   ✅    |
 | [Realtime Keymap Updating](features/studio.md)                                                                                                         |   🚧    |
-| Support for AVR/8-Bit Chips                                                                                                                            |   ❌    |
-| [Support for a Wide Range of ARM Chips](https://docs.zephyrproject.org/3.5.0/boards/index.html)                                                        |   ✅    |
 
 ## Code of Conduct
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -16,14 +16,17 @@ Below table lists major features/capabilities currently supported in ZMK, as wel
 
 | Hardware                                                                                        | Support |
 | ----------------------------------------------------------------------------------------------- | :-----: |
-| [Split Keyboards](features/split-keyboards.md)                                                  |   ✅    |
+| [Wireless Split Keyboards](features/split-keyboards.md)                                         |   ✅    |
+| Wired Split Keyboards                                                                           |   🚧    |
 | [Low Active Power Usage](/power-profiler)                                                       |   ✅    |
 | [Encoders](features/encoders.md)                                                                |   ✅    |
 | [LED-based Lighting](features/lighting.md)                                                      |   ✅    |
 | [Displays](features/displays.md)                                                                |   🚧    |
 | [Pointing Devices](features/pointing.md)                                                        |   ✅    |
+| Multitouch Touchpads (PTP)                                                                      |   🚧    |
 | [Low Power Sleep States](features/low-power-states.md)                                          |   ✅    |
-| [Low Power Mode (VCC Shutoff)](keymaps/behaviors/power.md)                                      |   ✅    |
+| [Low Power Mode (VCC Shutoff) for Peripherals](keymaps/behaviors/power.md)                      |   ✅    |
+| Improved Power Handling for Multiple Peripherals                                                |   🚧    |
 | [Battery Level Reporting](features/battery.md)                                                  |   ✅    |
 | [Support for a Wide Range of ARM Chips](https://docs.zephyrproject.org/3.5.0/boards/index.html) |   ✅    |
 | Support for AVR/8-Bit Chips                                                                     |   ❌    |

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -28,17 +28,17 @@ Below table lists major features/capabilities currently supported in ZMK, as wel
 | [Support for a Wide Range of ARM Chips](https://docs.zephyrproject.org/3.5.0/boards/index.html) |   ✅    |
 | Support for AVR/8-Bit Chips                                                                     |   ❌    |
 
-| Connectivity                                                                 | Support |
-| ---------------------------------------------------------------------------- | :-----: |
-| Low-Latency BLE Support                                                      |   ✅    |
-| [Multi-Device Simultaneous BLE Connectivity](features/bluetooth.md#profiles) |   ✅    |
-| [USB Connectivity](keymaps/behaviors/outputs.md)                             |   ✅    |
+| Connectivity                                                    | Support |
+| --------------------------------------------------------------- | :-----: |
+| Low-Latency BLE Support                                         |   ✅    |
+| [Multi-Device BLE Connectivity](features/bluetooth.md#profiles) |   ✅    |
+| [USB Connectivity](keymaps/behaviors/outputs.md)                |   ✅    |
 
 | Keymap Features                                                                                                                                        | Support |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------ | :-----: |
 | [User Configuration Repositories](user-setup.mdx)                                                                                                      |   ✅    |
 | [Keymaps and Layers](keymaps/index.mdx)                                                                                                                |   ✅    |
-| [Wide Range of Keycodes Including Media and Consumer Codes](keymaps/list-of-keycodes.mdx)                                                              |   ✅    |
+| [Wide Range of Keycodes (Including Media and Consumer)](keymaps/list-of-keycodes.mdx)                                                                  |   ✅    |
 | [Hold-Taps](keymaps/behaviors/hold-tap.mdx) (including [Mod-Tap](keymaps/behaviors/mod-tap.md) and [Layer-Tap](keymaps/behaviors/layers.md#layer-tap)) |   ✅    |
 | [Tap-Dances](keymaps/behaviors/tap-dance.mdx)                                                                                                          |   ✅    |
 | [Sticky (One Shot) Keys](keymaps/behaviors/sticky-key.md)                                                                                              |   ✅    |

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -4,49 +4,44 @@ sidebar_label: Introduction
 slug: /
 ---
 
-ZMK Firmware is an open source (MIT) keyboard
-firmware built on the [Zephyr™ Project](https://zephyrproject.org/) Real Time Operating System (RTOS). ZMK's goal is to provide a modern, wireless, and powerful firmware free of licensing issues.
+ZMK Firmware is an open source (MIT) keyboard firmware built on the [Zephyr™ Project](https://zephyrproject.org/) Real Time Operating System (RTOS).
+ZMK's goal is to provide a modern and powerful firmware that is wireless-first and free of licensing issues.
 
 ## Features
 
-ZMK is currently missing some features found in other popular firmware. This table compares the features supported by ZMK, BlueMicro and QMK:
+Below table lists major features/capabilities currently supported in ZMK, as well as ones that are currently under development and not planned.
 
-| Legend: | ✅ Supported | 🚧 Under Development | 💡 Planned |
-| :------ | :----------- | :------------------- | :--------- |
+| Legend: | ✅ Supported | 🚧 Under Development | 💡 Planned | ❌ Not Planned |
+| :------ | :----------- | :------------------- | :--------- | -------------- |
 
-| **Feature**                                                                                                                                                | ZMK | BlueMicro | QMK |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | :-: | :-------: | :-: |
-| Low Latency BLE Support                                                                                                                                    | ✅  |    ✅     |     |
-| Multi-Device BLE Support                                                                                                                                   | ✅  |           |     |
-| [USB Connectivity](keymaps/behaviors/outputs.md)                                                                                                           | ✅  |    ✅     | ✅  |
-| User Configuration Repositories                                                                                                                            | ✅  |           |     |
-| Split Keyboard Support                                                                                                                                     | ✅  |    ✅     | ✅  |
-| [Keymaps and Layers](keymaps/behaviors/layers.md)                                                                                                          | ✅  |    ✅     | ✅  |
-| [Hold-Tap](keymaps/behaviors/hold-tap.mdx) (which includes [Mod-Tap](keymaps/behaviors/mod-tap.md) and [Layer-Tap](keymaps/behaviors/layers.md#layer-tap)) | ✅  |    ✅     | ✅  |
-| [Tap-Dance](keymaps/behaviors/tap-dance.mdx)                                                                                                               | ✅  |  ✅[^2]   | ✅  |
-| [Keyboard Keycodes](keymaps/list-of-keycodes.mdx#keyboard)                                                                                                 | ✅  |    ✅     | ✅  |
-| [Media](keymaps/list-of-keycodes.mdx#media-controls) & [Consumer](keymaps/list-of-keycodes.mdx#consumer-controls) Codes                                    | ✅  |    ✅     | ✅  |
-| [Encoders](features/encoders.md)                                                                                                                           | ✅  |    ✅     | ✅  |
-| [Display Support](features/displays.md)[^1]                                                                                                                | 🚧  |    🚧     | ✅  |
-| [LED-based Lighting](features/lighting.md)                                                                                                                 | ✅  |    ✅     | ✅  |
-| One Shot Keys                                                                                                                                              | ✅  |    ✅     | ✅  |
-| [Combo Keys](keymaps/combos.md)                                                                                                                            | ✅  |           | ✅  |
-| [Macros](keymaps/behaviors/macros.md)                                                                                                                      | ✅  |    ✅     | ✅  |
-| Mouse Keys                                                                                                                                                 | ✅  |    ✅     | ✅  |
-| Low Active Power Usage                                                                                                                                     | ✅  |           |     |
-| Low Power Sleep States                                                                                                                                     | ✅  |    ✅     |     |
-| [Low Power Mode (VCC Shutoff)](keymaps/behaviors/power.md)                                                                                                 | ✅  |    ✅     |     |
-| Battery Reporting                                                                                                                                          | ✅  |    ✅     |     |
-| Shell over BLE                                                                                                                                             | 💡  |           |     |
-| Realtime Keymap Updating                                                                                                                                   | 💡  |           | ✅  |
-| AVR/8 Bit                                                                                                                                                  |     |           | ✅  |
-| [Wide Range of ARM Chips Supported](https://docs.zephyrproject.org/3.5.0/boards/index.html)                                                                | ✅  |           |     |
-
-[^2]: Tap-Dances are limited to single and double-tap on BlueMicro
-[^1]: OLEDs are currently proof of concept in ZMK.
+| Feature                                                                                                                                                | Support |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------ | :-----: |
+| Low-Latency BLE Support                                                                                                                                |   ✅    |
+| [Multi-Device BLE Support](features/bluetooth.md#profiles)                                                                                             |   ✅    |
+| [USB Connectivity](keymaps/behaviors/outputs.md)                                                                                                       |   ✅    |
+| [User Configuration Repositories](user-setup.mdx)                                                                                                      |   ✅    |
+| [Keymaps and Layers](keymaps/index.mdx)                                                                                                                |   ✅    |
+| [Split Keyboard Support](features/split-keyboards.md)                                                                                                  |   ✅    |
+| [Hold-Taps](keymaps/behaviors/hold-tap.mdx) (including [Mod-Tap](keymaps/behaviors/mod-tap.md) and [Layer-Tap](keymaps/behaviors/layers.md#layer-tap)) |   ✅    |
+| [Tap-Dances](keymaps/behaviors/tap-dance.mdx)                                                                                                          |   ✅    |
+| [Wide Range of Keycodes Including Media and Consumer Codes](keymaps/list-of-keycodes.mdx)                                                              |   ✅    |
+| [Encoders](features/encoders.md)                                                                                                                       |   ✅    |
+| [LED-based Lighting](features/lighting.md)                                                                                                             |   ✅    |
+| [Displays](features/displays.md)                                                                                                                       |   🚧    |
+| [Sticky (One Shot) Keys](keymaps/behaviors/sticky-key.md)                                                                                              |   ✅    |
+| [Combos](keymaps/combos.md)                                                                                                                            |   ✅    |
+| [Macros](keymaps/behaviors/macros.md)                                                                                                                  |   ✅    |
+| [Mouse Keys](keymaps/behaviors/mouse-emulation.md)                                                                                                     |   ✅    |
+| [Pointing Devices](features/pointing.md)                                                                                                               |   ✅    |
+| [Low Active Power Usage](/power-profiler)                                                                                                              |   ✅    |
+| [Low Power Sleep States](features/low-power-states.md)                                                                                                 |   ✅    |
+| [Low Power Mode (VCC Shutoff)](keymaps/behaviors/power.md)                                                                                             |   ✅    |
+| [Battery Reporting](features/battery.md)                                                                                                               |   ✅    |
+| [Realtime Keymap Updating](features/studio.md)                                                                                                         |   🚧    |
+| Support for AVR/8-Bit Chips                                                                                                                            |   ❌    |
+| [Support for a Wide Range of ARM Chips](https://docs.zephyrproject.org/3.5.0/boards/index.html)                                                        |   ✅    |
 
 ## Code of Conduct
 
-Please note that this project is released with a
-[Contributor Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
+Please note that this project is released with a [Contributor Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
 By participating in this project you agree to abide by its terms.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -5,7 +5,8 @@ slug: /
 ---
 
 ZMK Firmware is an open source (MIT) keyboard firmware built on the [Zephyr™ Project](https://zephyrproject.org/) Real Time Operating System (RTOS).
-ZMK's goal is to provide a modern and powerful firmware that is wireless-first and free of licensing issues.
+ZMK's goal is to provide a modern and powerful firmware that is designed for power-efficiency, flexibility, and broad hardware support.
+ZMK is capable of being used for both wired and wireless input devices.
 
 ## Features
 
@@ -14,22 +15,22 @@ Below table lists major features/capabilities currently supported in ZMK, as wel
 | Legend: | ✅ Supported | 🚧 Under Development | ❌ Not Planned |
 | :------ | :----------- | :------------------- | -------------- |
 
-| Hardware                                                                                        | Support |
-| ----------------------------------------------------------------------------------------------- | :-----: |
-| [Wireless Split Keyboards](features/split-keyboards.md)                                         |   ✅    |
-| Wired Split Keyboards                                                                           |   🚧    |
-| [Low Active Power Usage](/power-profiler)                                                       |   ✅    |
-| [Encoders](features/encoders.md)                                                                |   ✅    |
-| [LED-based Lighting](features/lighting.md)                                                      |   ✅    |
-| [Displays](features/displays.md)                                                                |   🚧    |
-| [Pointing Devices](features/pointing.md)                                                        |   ✅    |
-| Multitouch Touchpads (PTP)                                                                      |   🚧    |
-| [Low Power Sleep States](features/low-power-states.md)                                          |   ✅    |
-| [Low Power Mode (VCC Shutoff) for Peripherals](keymaps/behaviors/power.md)                      |   ✅    |
-| Improved Power Handling for Multiple Peripherals                                                |   🚧    |
-| [Battery Level Reporting](features/battery.md)                                                  |   ✅    |
-| [Support for a Wide Range of ARM Chips](https://docs.zephyrproject.org/3.5.0/boards/index.html) |   ✅    |
-| Support for AVR/8-Bit Chips                                                                     |   ❌    |
+| Hardware                                                                                                      | Support |
+| ------------------------------------------------------------------------------------------------------------- | :-----: |
+| [Wireless Split Keyboards](features/split-keyboards.md)                                                       |   ✅    |
+| Wired Split Keyboards                                                                                         |   🚧    |
+| [Low Active Power Usage](/power-profiler)                                                                     |   ✅    |
+| [Encoders](features/encoders.md)                                                                              |   ✅    |
+| [LED-based Lighting](features/lighting.md)                                                                    |   ✅    |
+| [Displays](features/displays.md)                                                                              |   🚧    |
+| [Pointing Devices](features/pointing.md)                                                                      |   ✅    |
+| Multitouch Touchpads (PTP)                                                                                    |   🚧    |
+| [Low Power Sleep States](features/low-power-states.md)                                                        |   ✅    |
+| [Low Power Mode (VCC Shutoff) for Peripherals](keymaps/behaviors/power.md)                                    |   ✅    |
+| Improved Power Handling for Multiple Peripherals                                                              |   🚧    |
+| [Battery Level Reporting](features/battery.md)                                                                |   ✅    |
+| [Support for a Wide Range of 32-bit Microcontrollers](https://docs.zephyrproject.org/3.5.0/boards/index.html) |   ✅    |
+| Support for AVR/8-bit Chips                                                                                   |   ❌    |
 
 | Connectivity                                                    | Support |
 | --------------------------------------------------------------- | :-----: |
@@ -41,7 +42,8 @@ Below table lists major features/capabilities currently supported in ZMK, as wel
 | ------------------------------------------------------------------------------------------------------------------------------------------------------ | :-----: |
 | [User Configuration Repositories](user-setup.mdx)                                                                                                      |   ✅    |
 | [Keymaps and Layers](keymaps/index.mdx)                                                                                                                |   ✅    |
-| [Wide Range of Keycodes (Including Media and Consumer)](keymaps/list-of-keycodes.mdx)                                                                  |   ✅    |
+| [Wide Range of Keycodes](keymaps/list-of-keycodes.mdx)                                                                                                 |   ✅    |
+| [Flexible Behavior System](keymaps/behaviors/index.mdx)                                                                                                |   ✅    |
 | [Hold-Taps](keymaps/behaviors/hold-tap.mdx) (including [Mod-Tap](keymaps/behaviors/mod-tap.md) and [Layer-Tap](keymaps/behaviors/layers.md#layer-tap)) |   ✅    |
 | [Tap-Dances](keymaps/behaviors/tap-dance.mdx)                                                                                                          |   ✅    |
 | [Sticky (One Shot) Keys](keymaps/behaviors/sticky-key.md)                                                                                              |   ✅    |

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -4,6 +4,8 @@ sidebar_label: Introduction
 slug: /
 ---
 
+import { Columns, Column } from "@site/src/components/columns";
+
 ZMK Firmware is an open source (MIT) keyboard firmware built on the [Zephyr™ Project](https://zephyrproject.org/) Real Time Operating System (RTOS).
 ZMK's goal is to provide a modern and powerful firmware that is designed for power-efficiency, flexibility, and broad hardware support.
 ZMK is capable of being used for both wired and wireless input devices.
@@ -12,8 +14,17 @@ ZMK is capable of being used for both wired and wireless input devices.
 
 Below table lists major features/capabilities currently supported in ZMK, as well as ones that are currently under development and not planned.
 
+<Columns>
+  <Column className="full-width-table">
+
 | Legend: | ✅ Supported | 🚧 Under Development | ❌ Not Planned |
 | :------ | :----------- | :------------------- | -------------- |
+
+  </Column>
+</Columns>
+
+<Columns>
+  <Column className="full-width-table">
 
 | Hardware                                                                                                      | Support |
 | ------------------------------------------------------------------------------------------------------------- | :-----: |
@@ -31,6 +42,9 @@ Below table lists major features/capabilities currently supported in ZMK, as wel
 | [Battery Level Reporting](features/battery.md)                                                                |   ✅    |
 | [Support for a Wide Range of 32-bit Microcontrollers](https://docs.zephyrproject.org/3.5.0/boards/index.html) |   ✅    |
 | Support for AVR/8-bit Chips                                                                                   |   ❌    |
+
+  </Column>
+  <Column className="full-width-table">
 
 | Connectivity                                                    | Support |
 | --------------------------------------------------------------- | :-----: |
@@ -51,6 +65,9 @@ Below table lists major features/capabilities currently supported in ZMK, as wel
 | [Macros](keymaps/behaviors/macros.md)                                                                                                                  |   ✅    |
 | [Mouse Keys](keymaps/behaviors/mouse-emulation.md)                                                                                                     |   ✅    |
 | [Realtime Keymap Updating](features/studio.md)                                                                                                         |   🚧    |
+
+  </Column>
+</Columns>
 
 ## Code of Conduct
 

--- a/docs/src/components/columns.tsx
+++ b/docs/src/components/columns.tsx
@@ -1,0 +1,32 @@
+import React, { ReactNode, CSSProperties } from "react";
+import clsx from "clsx";
+
+interface ColumnsProps {
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+// className will allow you to pass either your custom classes or the native infima classes https://infima.dev/docs/layout/grid.
+// style will allow you to either pass your custom styles directly, which can be an alternative to the "styles.module.css" file in certain cases.
+export function Columns({ children, className, style }: ColumnsProps) {
+  return (
+    <div className="container center">
+      <div className={clsx("row", className)} style={style}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+interface ColumnProps {
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+export function Column({ children, className, style }: ColumnProps) {
+  return (
+    <div className={clsx("col", className)} style={style}>
+      {children}
+    </div>
+  );
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -50,3 +50,8 @@
 .secrettabs {
   display: none;
 }
+
+.full-width-table table {
+  width: 100%;
+  display: table;
+}


### PR DESCRIPTION
Attempt to update the intro page to docs, converting the comparison table to a feature/capabilities list. Then, split it into categories and add new items for in-progress work.

The last two are split into different commits, if you want to see intermediate states (but I'll squash them all into one before merging).
