### PR TITLE
fix(drivers): Proper static/const for data/config

### DIFF
--- a/app/module/drivers/display/il0323.c
+++ b/app/module/drivers/display/il0323.c
@@ -371,14 +371,14 @@ static int il0323_init(const struct device *dev) {
     return il0323_controller_init(dev);
 }
 
-static struct il0323_cfg il0323_config = {
+static const struct il0323_cfg il0323_config = {
     .spi = SPI_DT_SPEC_INST_GET(0, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0),
     .reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios),
     .busy = GPIO_DT_SPEC_INST_GET(0, busy_gpios),
     .dc = GPIO_DT_SPEC_INST_GET(0, dc_gpios),
 };
 
-static struct display_driver_api il0323_driver_api = {
+static const struct display_driver_api il0323_driver_api = {
     .blanking_on = il0323_blanking_on,
     .blanking_off = il0323_blanking_off,
     .write = il0323_write,

--- a/app/module/drivers/gpio/gpio_595.c
+++ b/app/module/drivers/gpio/gpio_595.c
@@ -202,7 +202,7 @@ static int reg_595_init(const struct device *dev) {
     GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(inst, ngpios))
 
 #define REG_595_INIT(n)                                                                            \
-    static struct reg_595_config reg_595_##n##_config = {                                          \
+    static const struct reg_595_config reg_595_##n##_config = {                                    \
         .common =                                                                                  \
             {                                                                                      \
                 .port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(n),                               \

--- a/app/module/drivers/gpio/gpio_max7318.c
+++ b/app/module/drivers/gpio/gpio_max7318.c
@@ -322,7 +322,7 @@ static int max7318_init(const struct device *dev) {
     GPIO_PORT_PIN_MASK_FROM_NGPIOS(DT_INST_PROP(inst, ngpios))
 
 #define MAX7318_INIT(inst)                                                                         \
-    static struct max7318_config max7318_##inst##_config = {                                       \
+    static const struct max7318_config max7318_##inst##_config = {                                 \
         .common = {.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(inst)},                        \
         .i2c_bus = I2C_DT_SPEC_INST_GET(inst)};                                                    \
                                                                                                    \

--- a/app/module/drivers/input/input_mock.c
+++ b/app/module/drivers/input/input_mock.c
@@ -68,13 +68,10 @@ int input_mock_init(const struct device *dev) {
     return 0;
 }
 
-#define GET_EVENT(n, inst)                                                                         \
-    {}
-
 #define INPUT_MOCK_INST(n)                                                                         \
-    struct input_mock_data input_mock_data_##n = {};                                               \
-    const uint32_t mock_data_##n[] = DT_INST_PROP(n, events);                                      \
-    const struct input_mock_config input_mock_cfg_##n = {                                          \
+    static struct input_mock_data input_mock_data_##n = {};                                        \
+    static const uint32_t mock_data_##n[] = DT_INST_PROP(n, events);                               \
+    static const struct input_mock_config input_mock_cfg_##n = {                                   \
         .events = mock_data_##n,                                                                   \
         .events_len = DT_INST_PROP_LEN(n, events),                                                 \
         .startup_delay = DT_INST_PROP(n, event_startup_delay),                                     \

--- a/app/module/drivers/kscan/kscan_gpio_charlieplex.c
+++ b/app/module/drivers/kscan/kscan_gpio_charlieplex.c
@@ -445,7 +445,7 @@ static const struct kscan_driver_api kscan_charlieplex_api = {
         .charlieplex_state = kscan_charlieplex_state_##n,                                          \
     };                                                                                             \
                                                                                                    \
-    static struct kscan_charlieplex_config kscan_charlieplex_config_##n = {                        \
+    static const struct kscan_charlieplex_config kscan_charlieplex_config_##n = {                  \
         .cells = KSCAN_GPIO_LIST(kscan_charlieplex_cells_##n),                                     \
         .debounce_config =                                                                         \
             {                                                                                      \

--- a/app/module/drivers/kscan/kscan_gpio_direct.c
+++ b/app/module/drivers/kscan/kscan_gpio_direct.c
@@ -397,7 +397,7 @@ static const struct kscan_driver_api kscan_direct_api = {
         .pin_state = kscan_direct_state_##n,                                                       \
         COND_INTERRUPTS((.irqs = kscan_direct_irqs_##n, ))};                                       \
                                                                                                    \
-    static struct kscan_direct_config kscan_direct_config_##n = {                                  \
+    static const struct kscan_direct_config kscan_direct_config_##n = {                            \
         .debounce_config =                                                                         \
             {                                                                                      \
                 .debounce_press_ms = INST_DEBOUNCE_PRESS_MS(n),                                    \

--- a/app/module/drivers/kscan/kscan_gpio_matrix.c
+++ b/app/module/drivers/kscan/kscan_gpio_matrix.c
@@ -515,7 +515,7 @@ static const struct kscan_driver_api kscan_matrix_api = {
         .matrix_state = kscan_matrix_state_##n,                                                    \
         COND_INTERRUPTS((.irqs = kscan_matrix_irqs_##n, ))};                                       \
                                                                                                    \
-    static struct kscan_matrix_config kscan_matrix_config_##n = {                                  \
+    static const struct kscan_matrix_config kscan_matrix_config_##n = {                            \
         .rows = ARRAY_SIZE(kscan_matrix_rows_##n),                                                 \
         .cols = ARRAY_SIZE(kscan_matrix_cols_##n),                                                 \
         .outputs =                                                                                 \

--- a/app/module/drivers/sensor/ec11/ec11.c
+++ b/app/module/drivers/sensor/ec11/ec11.c
@@ -148,8 +148,8 @@ int ec11_init(const struct device *dev) {
 }
 
 #define EC11_INST(n)                                                                               \
-    struct ec11_data ec11_data_##n;                                                                \
-    const struct ec11_config ec11_cfg_##n = {                                                      \
+    static struct ec11_data ec11_data_##n;                                                         \
+    static const struct ec11_config ec11_cfg_##n = {                                               \
         .a = GPIO_DT_SPEC_INST_GET(n, a_gpios),                                                    \
         .b = GPIO_DT_SPEC_INST_GET(n, b_gpios),                                                    \
         .resolution = DT_INST_PROP_OR(n, resolution, 1),                                           \

--- a/app/module/drivers/sensor/max17048/max17048.c
+++ b/app/module/drivers/sensor/max17048/max17048.c
@@ -205,8 +205,8 @@ static const struct sensor_driver_api max17048_api_table = {.sample_fetch = max1
                                                             .channel_get = max17048_channel_get};
 
 #define MAX17048_INIT(inst)                                                                        \
-    static struct max17048_config max17048_##inst##_config = {.i2c_bus =                           \
-                                                                  I2C_DT_SPEC_INST_GET(inst)};     \
+    static const struct max17048_config max17048_##inst##_config = {                               \
+        .i2c_bus = I2C_DT_SPEC_INST_GET(inst)};                                                    \
                                                                                                    \
     static struct max17048_drv_data max17048_##inst##_drvdata = {                                  \
         .raw_state_of_charge = 0,                                                                  \


### PR DESCRIPTION
Save a tiny bit of RAM by properly marking our device config struct instances const consistently, and also add missing static modifiers to properly isolate config/data for drivers.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
