### PR TITLE
feat(core): Make physical layout key rotation optional

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -497,6 +497,10 @@ endif # ZMK_BLE || ZMK_SPLIT_BLE
 
 endmenu # Initialization Priorities
 
+config ZMK_PHYSICAL_LAYOUT_KEY_ROTATION
+    bool "Support rotation of keys in physical layouts"
+    default y
+
 menuconfig ZMK_KSCAN
     bool "ZMK KScan Integration"
     default y

--- a/app/include/zmk/physical_layouts.h
+++ b/app/include/zmk/physical_layouts.h
@@ -21,9 +21,11 @@ struct zmk_key_physical_attrs {
     int16_t height;
     int16_t x;
     int16_t y;
+#if IS_ENABLED(CONFIG_ZMK_PHYSICAL_LAYOUT_KEY_ROTATION)
     int16_t rx;
     int16_t ry;
     int16_t r;
+#endif
 };
 
 struct zmk_physical_layout {

--- a/app/src/physical_layouts.c
+++ b/app/src/physical_layouts.c
@@ -46,9 +46,11 @@ BUILD_ASSERT(
         .height = (int16_t)(int32_t)DT_INST_PHA_BY_IDX(n, keys, i, height),                        \
         .x = (int16_t)(int32_t)DT_INST_PHA_BY_IDX(n, keys, i, x),                                  \
         .y = (int16_t)(int32_t)DT_INST_PHA_BY_IDX(n, keys, i, y),                                  \
-        .rx = (int16_t)(int32_t)DT_INST_PHA_BY_IDX(n, keys, i, rx),                                \
-        .ry = (int16_t)(int32_t)DT_INST_PHA_BY_IDX(n, keys, i, ry),                                \
-        .r = (int16_t)(int32_t)DT_INST_PHA_BY_IDX(n, keys, i, r),                                  \
+        COND_CODE_1(IS_ENABLED(CONFIG_ZMK_PHYSICAL_LAYOUT_KEY_ROTATION),                           \
+                    (.rx = (int16_t)(int32_t)DT_INST_PHA_BY_IDX(n, keys, i, rx),                   \
+                     .ry = (int16_t)(int32_t)DT_INST_PHA_BY_IDX(n, keys, i, ry),                   \
+                     .r = (int16_t)(int32_t)DT_INST_PHA_BY_IDX(n, keys, i, r), ),                  \
+                    ())                                                                            \
     }
 
 #define ZMK_LAYOUT_INST(n)                                                                         \

--- a/app/src/studio/keymap_subsystem.c
+++ b/app/src/studio/keymap_subsystem.c
@@ -278,9 +278,11 @@ static bool encode_layout_keys(pb_ostream_t *stream, const pb_field_t *field, vo
             .height = layout_kp->height,
             .x = layout_kp->x,
             .y = layout_kp->y,
+#if IS_ENABLED(CONFIG_ZMK_PHYSICAL_LAYOUT_KEY_ROTATION)
             .r = layout_kp->r,
             .rx = layout_kp->rx,
             .ry = layout_kp->ry,
+#endif
         };
 
         if (!pb_encode_submessage(stream, &zmk_keymap_KeyPhysicalAttrs_msg, &layout_kp_msg)) {

--- a/docs/docs/config/layout.md
+++ b/docs/docs/config/layout.md
@@ -203,6 +203,12 @@ Each element of the `keys` array has the shape `<&key_physical_attrs w h x y r r
 
 The `key_physical_attrs` node is defined in [`dts/physical_layouts.dtsi`](https://github.com/zmkfirmware/zmk/blob/main/app/dts/physical_layouts.dtsi) and is mandatory.
 
+## Kconfig
+
+| Config                                    | Type | Description                                                   | Default |
+| ----------------------------------------- | ---- | ------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_PHYSICAL_LAYOUT_KEY_ROTATION` | bool | Whether to store/support key rotation information internally. | y       |
+
 ## Physical Layout Position Map
 
 Defines a mapping between [physical layouts](#physical-layout), allowing key mappings to be preserved in the same locations as previously when using [ZMK Studio](../features/studio.md). Read through the [page on physical layouts](../development/hardware-integration/physical-layouts.md) for more information.


### PR DESCRIPTION
To be able to save on flash space, for layouts on space constrained devices that don't require rotation, make key rotation props optional behind a new Kconfig flag.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
