### PR TITLE
refactor(keymap): Reduce flash usage for studio builds

### DIFF
--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -10,7 +10,10 @@
 
 #define ZMK_LAYER_CHILD_LEN_PLUS_ONE(node) 1 +
 #define ZMK_KEYMAP_LAYERS_LEN                                                                      \
-    (DT_FOREACH_CHILD(DT_INST(0, zmk_keymap), ZMK_LAYER_CHILD_LEN_PLUS_ONE) 0)
+    (COND_CODE_1(                                                                                  \
+        IS_ENABLED(CONFIG_ZMK_STUDIO),                                                             \
+        (DT_FOREACH_CHILD(DT_INST(0, zmk_keymap), ZMK_LAYER_CHILD_LEN_PLUS_ONE)),                  \
+        (DT_FOREACH_CHILD_STATUS_OKAY(DT_INST(0, zmk_keymap), ZMK_LAYER_CHILD_LEN_PLUS_ONE))) 0)
 
 /**
  * @brief A layer ID is a stable identifier to refer to a layer, regardless of ordering.

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -72,17 +72,21 @@ static uint8_t keymap_layer_orders[ZMK_KEYMAP_LAYERS_LEN];
 
 #endif // IS_ENABLED(CONFIG_ZMK_KEYMAP_LAYER_REORDERING)
 
-#define KEYMAP_VAR(_name, _opts)                                                                   \
+#define KEYMAP_VAR(_name, _opts, no_init)                                                          \
     static _opts struct zmk_behavior_binding _name[ZMK_KEYMAP_LAYERS_LEN][ZMK_KEYMAP_LEN] = {      \
-        COND_CODE_1(IS_ENABLED(CONFIG_ZMK_STUDIO),                                                 \
-                    (DT_INST_FOREACH_CHILD_SEP(0, TRANSFORMED_LAYER, (, ))),                       \
-                    (DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(0, TRANSFORMED_LAYER, (, ))))};
+        COND_CODE_0(                                                                               \
+            no_init,                                                                               \
+            (COND_CODE_1(IS_ENABLED(CONFIG_ZMK_STUDIO),                                            \
+                         (DT_INST_FOREACH_CHILD_SEP(0, TRANSFORMED_LAYER, (, ))),                  \
+                         (DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(0, TRANSFORMED_LAYER, (, ))))),    \
+            (0))};
 
-KEYMAP_VAR(zmk_keymap, COND_CODE_1(IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE), (), (const)))
+KEYMAP_VAR(zmk_keymap, COND_CODE_1(IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE), (), (const)),
+           IS_ENABLED(CONFIG_ZMK_STUDIO))
 
 #if IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE)
 
-KEYMAP_VAR(zmk_stock_keymap, const)
+KEYMAP_VAR(zmk_stock_keymap, const, 0)
 
 static char zmk_keymap_layer_names[ZMK_KEYMAP_LAYERS_LEN][CONFIG_ZMK_KEYMAP_LAYER_NAME_MAX_LEN] = {
     DT_INST_FOREACH_CHILD_SEP(0, LAYER_NAME, (, ))};
@@ -954,6 +958,9 @@ SETTINGS_STATIC_HANDLER_DEFINE(keymap, "keymap", NULL, keymap_handle_set, keymap
 int keymap_init(void) {
 #if IS_ENABLED(CONFIG_ZMK_KEYMAP_LAYER_REORDERING)
     load_stock_keymap_layer_ordering();
+#endif
+#if IS_ENABLED(CONFIG_ZMK_STUDIO)
+    reload_from_stock_keymap();
 #endif
 
     return 0;


### PR DESCRIPTION
When building for ZMK Studio, we can use the constant stock keymap for init of the in-memory keymap, to avoid duplicate flash usage for the keymap from the devicetree.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
