### PR TITLE
fix(events): Add NULL check for `as_##event_type`.

### DIFF
--- a/app/include/zmk/event_manager.h
+++ b/app/include/zmk/event_manager.h
@@ -57,6 +57,9 @@ struct zmk_event_subscription {
         return ZMK_EVENT_RAISE(ev);                                                                \
     };                                                                                             \
     struct event_type *as_##event_type(const zmk_event_t *eh) {                                    \
+        if (eh == NULL) {                                                                          \
+            return NULL;                                                                           \
+        }                                                                                          \
         return (eh->event == &zmk_event_##event_type) ? &((struct event_type##_event *)eh)->data   \
                                                       : NULL;                                      \
     };


### PR DESCRIPTION
See #2792 where this cause segfault.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [0] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [-]Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
