### PR TITLE
fix(usb): Fix `-Wincompatible-pointer-types` compiler error

### DIFF
--- a/app/src/usb_hid.c
+++ b/app/src/usb_hid.c
@@ -89,7 +89,7 @@ static int get_report_cb(const struct device *dev, struct usb_setup_packet *setu
     case HID_REPORT_TYPE_INPUT:
         switch (setup->wValue & HID_GET_REPORT_ID_MASK) {
         case ZMK_HID_REPORT_ID_KEYBOARD: {
-            *data = get_keyboard_report(len);
+            *data = get_keyboard_report((size_t *)len);
             break;
         }
         case ZMK_HID_REPORT_ID_CONSUMER: {


### PR DESCRIPTION
Fix #2794, where `get_keyboard_report(len)` didn't convert `len` from `int32_t *` to `size_t *`.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
