### PR TITLE
fix(kscan): Remove warning when charlieplex is built without CONFIG_PM_DEVICE

### DIFF
--- a/app/module/drivers/kscan/kscan_gpio_charlieplex.c
+++ b/app/module/drivers/kscan/kscan_gpio_charlieplex.c
@@ -168,6 +168,8 @@ static int kscan_charlieplex_set_all_outputs(const struct device *dev, const int
     return 0;
 }
 
+#if IS_ENABLED(CONFIG_PM_DEVICE)
+
 static int kscan_charlieplex_disconnect_all(const struct device *dev) {
     const struct kscan_charlieplex_config *config = dev->config;
 
@@ -182,6 +184,8 @@ static int kscan_charlieplex_disconnect_all(const struct device *dev) {
 
     return 0;
 }
+
+#endif
 
 static int kscan_charlieplex_interrupt_configure(const struct device *dev,
                                                  const gpio_flags_t flags) {


### PR DESCRIPTION
`kscan_charlieplex_disconnect_all` is only used within a `CONFIG_PM_DEVICE` block, so if the firmware is built without the flag it spits out a warning.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
