### PR TITLE
feat(display): Add ability to set display on/off pin.

### DIFF
--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -62,3 +62,12 @@ See the Devicetree bindings for your display. Here are the bindings for common d
 - [SSD1306 (spi)](https://docs.zephyrproject.org/3.5.0/build/dts/api/bindings/display/solomon,ssd1306fb-spi.html)
 
 A full list of drivers provided by Zephyr can be found in [Zephyr's Devicetree bindings index](https://docs.zephyrproject.org/3.5.0/build/dts/api/bindings.html).
+
+### Chosen nodes
+
+Applies to: [`/chosen` node](https://docs.zephyrproject.org/3.5.0/build/dts/intro-syntax-structure.html#aliases-and-chosen-nodes)
+
+| Property          | Type | Description                                                                                              |
+| ----------------- | ---- | -------------------------------------------------------------------------------------------------------- |
+| `zephyr,display`  | path | The display device to use.                                                                               |
+| `zmk,display-led` | path | The LED device to use for on/off blanking, if the hardware requires it. Can be a PWM or GPIO LED device. |


### PR DESCRIPTION
Zephyr is still working on the plan upstream for generically controlling display "backlight" pins with GPIO/PWM, so in the meantime, add our own chosen property `zmk,display-led` that is set to an LED device child to allow blanking/unblanking of devices that use a dedicated backlight control pin.

Basically looks like this in the devicetree:

```
/ {
    chosen {
        zephyr,display = &vik_st7789v;
        zmk,display-led = &disp_led;
    };

    leds {
        compatible = "gpio-leds";

        disp_led: disp_led {
            gpios = <&vik_conn 3 GPIO_ACTIVE_HIGH>;
            label = "Display LED";
        };
    };
};
```

And then you need to enable the `CONFIG_LED=y` Kconfig flag to build that driver subsystem in.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
