### PR TITLE
feat(core): Allow idle and deep sleep timeouts to be set at runtime

### DIFF
--- a/app/include/zmk/activity.h
+++ b/app/include/zmk/activity.h
@@ -9,3 +9,11 @@
 enum zmk_activity_state { ZMK_ACTIVITY_ACTIVE, ZMK_ACTIVITY_IDLE, ZMK_ACTIVITY_SLEEP };
 
 enum zmk_activity_state zmk_activity_get_state(void);
+
+uint32_t zmk_activity_get_idle_timeout(void);
+void zmk_activity_set_idle_timeout(uint32_t timeout);
+
+#if IS_ENABLED(CONFIG_ZMK_SLEEP)
+uint32_t zmk_activity_get_sleep_timeout(void);
+void zmk_activity_set_sleep_timeout(uint32_t timeout);
+#endif


### PR DESCRIPTION
This adds functions to set the idle and deep sleep timeouts, the new timeouts are persisted in settings across reboots of the board

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
