### PR TITLE
feat(display): Add config for display update period

### DIFF
--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -13,6 +13,10 @@ config ZMK_DISPLAY_BLANK_ON_IDLE
     bool "Blank display on idle"
     default y if SSD1306
 
+config ZMK_DISPLAY_TICK_PERIOD_MS
+    int "Period (in ms) between display task execution"
+    default 10
+
 if LV_USE_THEME_MONO
 
 config ZMK_DISPLAY_INVERT

--- a/app/src/display/main.c
+++ b/app/src/display/main.c
@@ -39,8 +39,6 @@ __attribute__((weak)) lv_obj_t *zmk_display_status_screen() { return NULL; }
 
 void display_tick_cb(struct k_work *work) { lv_task_handler(); }
 
-#define TICK_MS 10
-
 K_WORK_DEFINE(display_tick_work, display_tick_cb);
 
 #if IS_ENABLED(CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED)
@@ -69,7 +67,8 @@ void unblank_display_cb(struct k_work *work) {
 #endif
     display_blanking_off(display);
 #if !IS_ENABLED(CONFIG_ARCH_POSIX)
-    k_timer_start(&display_timer, K_MSEC(TICK_MS), K_MSEC(TICK_MS));
+    k_timer_start(&display_timer, K_MSEC(CONFIG_ZMK_DISPLAY_TICK_PERIOD_MS),
+                  K_MSEC(CONFIG_ZMK_DISPLAY_TICK_PERIOD_MS));
 #endif // !IS_ENABLED(CONFIG_ARCH_POSIX)
 }
 

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -14,15 +14,17 @@ Definition files:
 - [zmk/app/src/display/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/Kconfig)
 - [zmk/app/src/display/widgets/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/widgets/Kconfig)
 
-| Config                                             | Type | Description                                                    | Default |
-| -------------------------------------------------- | ---- | -------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_DISPLAY`                               | bool | Enable support for displays                                    | n       |
-| `CONFIG_ZMK_DISPLAY_INVERT`                        | bool | Invert display colors from black-on-white to white-on-black    | n       |
-| `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool | Enable a widget to show the highest, active layer              | y       |
-| `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool | Enable a widget to show battery charge information             | y       |
-| `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool | If battery widget is enabled, show percentage instead of icons | n       |
-| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool | Enable a widget to show the current output (USB/BLE)           | y       |
-| `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool | Enable a widget to show words per minute                       | n       |
+| Config                                             | Type | Description                                                    | Default      |
+| -------------------------------------------------- | ---- | -------------------------------------------------------------- | ------------ |
+| `CONFIG_ZMK_DISPLAY`                               | bool | Enable support for displays                                    | n            |
+| `CONFIG_ZMK_DISPLAY_BLANK_ON_IDLE`                 | bool | Blank display on idle                                          | y if SSD1306 |
+| `CONFIG_ZMK_DISPLAY_TICK_PERIOD_MS`                | int  | Period (in ms) between display task execution                  | 10           |
+| `CONFIG_ZMK_DISPLAY_INVERT`                        | bool | Invert display colors from black-on-white to white-on-black    | n            |
+| `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool | Enable a widget to show the highest, active layer              | y            |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool | Enable a widget to show battery charge information             | y            |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool | If battery widget is enabled, show percentage instead of icons | n            |
+| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool | Enable a widget to show the current output (USB/BLE)           | y            |
+| `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool | Enable a widget to show words per minute                       | n            |
 
 Note that `CONFIG_ZMK_DISPLAY_INVERT` setting might not work as expected with custom status screens that utilize images.
 


### PR DESCRIPTION
Add `CONFIG_ZMK_DISPLAY_TICK_PERIOD_MS` Kconfig to allow tweaking the period between display updates.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
