### PR TITLE
docs: Make default keymap in new shield guide complete

### DIFF
--- a/docs/docs/development/hardware-integration/new-shield.mdx
+++ b/docs/docs/development/hardware-integration/new-shield.mdx
@@ -488,11 +488,12 @@ If all of your physical layouts use the same `kscan` node under the hood, you ca
 
 Each keyboard should provide a default keymap to be used when building the firmware, which can be overridden and customized by user configs.
 For "shield keyboards", this should be placed in the `boards/shields/my_keyboard/my_keyboard.keymap` file.
-The keymap is configured as an additional devicetree overlay that includes the following:
 
 Here is an example simple keymap for a 3x3 macropad, with only one layer:
 
 ```dts title="my_keyboard.keymap"
+#include <dt-bindings/zmk/keys.h>
+
 / {
     keymap {
         compatible = "zmk,keymap";


### PR DESCRIPTION
Add the missing header include to make it a complete example as it seems to be intended that way. Also clean up the extra sentence.
