### PR TITLE
refactor(behaviors): Remove unneeded init funcs.

### DIFF
--- a/app/src/behaviors/behavior_backlight.c
+++ b/app/src/behaviors/behavior_backlight.c
@@ -94,8 +94,6 @@ static const struct behavior_parameter_metadata metadata = {
 
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 
-static int behavior_backlight_init(const struct device *dev) { return 0; }
-
 static int
 on_keymap_binding_convert_central_state_dependent_params(struct zmk_behavior_binding *binding,
                                                          struct zmk_behavior_binding_event event) {
@@ -170,7 +168,7 @@ static const struct behavior_driver_api behavior_backlight_driver_api = {
 #endif
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, behavior_backlight_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_backlight_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_backlight_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_bt.c
+++ b/app/src/behaviors/behavior_bt.c
@@ -112,8 +112,6 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
     return -ENOTSUP;
 }
 
-static int behavior_bt_init(const struct device *dev) { return 0; };
-
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     return ZMK_BEHAVIOR_OPAQUE;
@@ -127,7 +125,7 @@ static const struct behavior_driver_api behavior_bt_driver_api = {
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, behavior_bt_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_bt_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_bt_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_ext_power.c
+++ b/app/src/behaviors/behavior_ext_power.c
@@ -64,8 +64,6 @@ static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
     return ZMK_BEHAVIOR_OPAQUE;
 }
 
-static int behavior_ext_power_init(const struct device *dev) { return 0; };
-
 static const struct behavior_driver_api behavior_ext_power_driver_api = {
     .binding_convert_central_state_dependent_params =
         on_keymap_binding_convert_central_state_dependent_params,
@@ -74,7 +72,7 @@ static const struct behavior_driver_api behavior_ext_power_driver_api = {
     .locality = BEHAVIOR_LOCALITY_GLOBAL,
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, behavior_ext_power_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_ext_power_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_ext_power_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_key_press.c
+++ b/app/src/behaviors/behavior_key_press.c
@@ -37,8 +37,6 @@ static const struct behavior_parameter_metadata metadata = {
 
 #endif
 
-static int behavior_key_press_init(const struct device *dev) { return 0; };
-
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
@@ -60,7 +58,7 @@ static const struct behavior_driver_api behavior_key_press_driver_api = {
 };
 
 #define KP_INST(n)                                                                                 \
-    BEHAVIOR_DT_INST_DEFINE(n, behavior_key_press_init, NULL, NULL, NULL, POST_KERNEL,             \
+    BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,                                \
                             CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_key_press_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)

--- a/app/src/behaviors/behavior_key_repeat.c
+++ b/app/src/behaviors/behavior_key_repeat.c
@@ -77,7 +77,7 @@ static int key_repeat_keycode_state_changed_listener(const zmk_event_t *eh);
 ZMK_LISTENER(behavior_key_repeat, key_repeat_keycode_state_changed_listener);
 ZMK_SUBSCRIPTION(behavior_key_repeat, zmk_keycode_state_changed);
 
-static const struct device *devs[DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT)];
+static const struct device *devs[] = {DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET)};
 
 static int key_repeat_keycode_state_changed_listener(const zmk_event_t *eh) {
     struct zmk_keycode_state_changed *ev = as_zmk_keycode_state_changed(eh);
@@ -85,11 +85,8 @@ static int key_repeat_keycode_state_changed_listener(const zmk_event_t *eh) {
         return ZMK_EV_EVENT_BUBBLE;
     }
 
-    for (int i = 0; i < DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT); i++) {
+    for (int i = 0; i < ARRAY_SIZE(devs); i++) {
         const struct device *dev = devs[i];
-        if (dev == NULL) {
-            continue;
-        }
 
         struct behavior_key_repeat_data *data = dev->data;
         const struct behavior_key_repeat_config *config = dev->config;
@@ -106,20 +103,13 @@ static int key_repeat_keycode_state_changed_listener(const zmk_event_t *eh) {
     return ZMK_EV_EVENT_BUBBLE;
 }
 
-static int behavior_key_repeat_init(const struct device *dev) {
-    const struct behavior_key_repeat_config *config = dev->config;
-    devs[config->index] = dev;
-    return 0;
-}
-
 #define KR_INST(n)                                                                                 \
     static struct behavior_key_repeat_data behavior_key_repeat_data_##n = {};                      \
     static struct behavior_key_repeat_config behavior_key_repeat_config_##n = {                    \
-        .index = n,                                                                                \
         .usage_pages = DT_INST_PROP(n, usage_pages),                                               \
         .usage_pages_count = DT_INST_PROP_LEN(n, usage_pages),                                     \
     };                                                                                             \
-    BEHAVIOR_DT_INST_DEFINE(n, behavior_key_repeat_init, NULL, &behavior_key_repeat_data_##n,      \
+    BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, &behavior_key_repeat_data_##n,                          \
                             &behavior_key_repeat_config_##n, POST_KERNEL,                          \
                             CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_key_repeat_driver_api);
 

--- a/app/src/behaviors/behavior_key_toggle.c
+++ b/app/src/behaviors/behavior_key_toggle.c
@@ -27,8 +27,6 @@ struct behavior_key_toggle_config {
     enum toggle_mode toggle_mode;
 };
 
-static int behavior_key_toggle_init(const struct device *dev) { return 0; }
-
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
@@ -87,8 +85,7 @@ static const struct behavior_driver_api behavior_key_toggle_driver_api = {
     static const struct behavior_key_toggle_config behavior_key_toggle_config_##n = {              \
         .toggle_mode = DT_ENUM_IDX(DT_DRV_INST(n), toggle_mode),                                   \
     };                                                                                             \
-    BEHAVIOR_DT_INST_DEFINE(n, behavior_key_toggle_init, NULL, NULL,                               \
-                            &behavior_key_toggle_config_##n, POST_KERNEL,                          \
+    BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, &behavior_key_toggle_config_##n, POST_KERNEL,     \
                             CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_key_toggle_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KT_INST)

--- a/app/src/behaviors/behavior_mod_morph.c
+++ b/app/src/behaviors/behavior_mod_morph.c
@@ -80,8 +80,6 @@ static const struct behavior_driver_api behavior_mod_morph_driver_api = {
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 };
 
-static int behavior_mod_morph_init(const struct device *dev) { return 0; }
-
 #define _TRANSFORM_ENTRY(idx, node)                                                                \
     {                                                                                              \
         .behavior_dev = DEVICE_DT_NAME(DT_INST_PHANDLE_BY_IDX(node, bindings, idx)),               \
@@ -100,7 +98,7 @@ static int behavior_mod_morph_init(const struct device *dev) { return 0; }
                                    (DT_INST_PROP(n, mods) & ~DT_INST_PROP(n, keep_mods))),         \
     };                                                                                             \
     static struct behavior_mod_morph_data behavior_mod_morph_data_##n = {};                        \
-    BEHAVIOR_DT_INST_DEFINE(n, behavior_mod_morph_init, NULL, &behavior_mod_morph_data_##n,        \
+    BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, &behavior_mod_morph_data_##n,                           \
                             &behavior_mod_morph_config_##n, POST_KERNEL,                           \
                             CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mod_morph_driver_api);
 

--- a/app/src/behaviors/behavior_momentary_layer.c
+++ b/app/src/behaviors/behavior_momentary_layer.c
@@ -36,11 +36,6 @@ static const struct behavior_parameter_metadata metadata = {
 
 #endif
 
-struct behavior_mo_config {};
-struct behavior_mo_data {};
-
-static int behavior_mo_init(const struct device *dev) { return 0; };
-
 static int mo_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d layer %d", event.position, binding->param1);
@@ -61,9 +56,5 @@ static const struct behavior_driver_api behavior_mo_driver_api = {
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 };
 
-static const struct behavior_mo_config behavior_mo_config = {};
-
-static struct behavior_mo_data behavior_mo_data;
-
-BEHAVIOR_DT_INST_DEFINE(0, behavior_mo_init, NULL, &behavior_mo_data, &behavior_mo_config,
-                        POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mo_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_mo_driver_api);

--- a/app/src/behaviors/behavior_mouse_key_press.c
+++ b/app/src/behaviors/behavior_mouse_key_press.c
@@ -19,8 +19,6 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
-static int behavior_mouse_key_press_init(const struct device *dev) { return 0; };
-
 static void process_key_state(const struct device *dev, int32_t val, bool pressed) {
     for (int i = 0; i < ZMK_HID_MOUSE_NUM_BUTTONS; i++) {
         if (val & BIT(i)) {
@@ -52,7 +50,7 @@ static const struct behavior_driver_api behavior_mouse_key_press_driver_api = {
     .binding_pressed = on_keymap_binding_pressed, .binding_released = on_keymap_binding_released};
 
 #define MKP_INST(n)                                                                                \
-    BEHAVIOR_DT_INST_DEFINE(n, behavior_mouse_key_press_init, NULL, NULL, NULL, POST_KERNEL,       \
+    BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, NULL, POST_KERNEL,                                \
                             CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                                   \
                             &behavior_mouse_key_press_driver_api);
 

--- a/app/src/behaviors/behavior_none.c
+++ b/app/src/behaviors/behavior_none.c
@@ -16,8 +16,6 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
-static int behavior_none_init(const struct device *dev) { return 0; };
-
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     return ZMK_BEHAVIOR_OPAQUE;
@@ -36,7 +34,7 @@ static const struct behavior_driver_api behavior_none_driver_api = {
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, behavior_none_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_none_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_none_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_outputs.c
+++ b/app/src/behaviors/behavior_outputs.c
@@ -72,8 +72,6 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
     return -ENOTSUP;
 }
 
-static int behavior_out_init(const struct device *dev) { return 0; }
-
 static const struct behavior_driver_api behavior_outputs_driver_api = {
     .binding_pressed = on_keymap_binding_pressed,
 #if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
@@ -81,7 +79,7 @@ static const struct behavior_driver_api behavior_outputs_driver_api = {
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, behavior_out_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_outputs_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_outputs_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_reset.c
+++ b/app/src/behaviors/behavior_reset.c
@@ -21,8 +21,6 @@ struct behavior_reset_config {
     int type;
 };
 
-static int behavior_reset_init(const struct device *dev) { return 0; };
-
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
@@ -46,9 +44,8 @@ static const struct behavior_driver_api behavior_reset_driver_api = {
 #define RST_INST(n)                                                                                \
     static const struct behavior_reset_config behavior_reset_config_##n = {                        \
         .type = DT_INST_PROP(n, type)};                                                            \
-    BEHAVIOR_DT_INST_DEFINE(n, behavior_reset_init, NULL, NULL, &behavior_reset_config_##n,        \
-                            POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                      \
-                            &behavior_reset_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, &behavior_reset_config_##n, POST_KERNEL,          \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_reset_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(RST_INST)
 

--- a/app/src/behaviors/behavior_rgb_underglow.c
+++ b/app/src/behaviors/behavior_rgb_underglow.c
@@ -131,8 +131,6 @@ static const struct behavior_parameter_metadata metadata = {
 
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 
-static int behavior_rgb_underglow_init(const struct device *dev) { return 0; }
-
 static int
 on_keymap_binding_convert_central_state_dependent_params(struct zmk_behavior_binding *binding,
                                                          struct zmk_behavior_binding_event event) {
@@ -265,7 +263,7 @@ static const struct behavior_driver_api behavior_rgb_underglow_driver_api = {
 #endif
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, behavior_rgb_underglow_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_rgb_underglow_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_rgb_underglow_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_sensor_rotate.c
+++ b/app/src/behaviors/behavior_sensor_rotate.c
@@ -16,8 +16,6 @@ static const struct behavior_driver_api behavior_sensor_rotate_driver_api = {
     .sensor_binding_accept_data = zmk_behavior_sensor_rotate_common_accept_data,
     .sensor_binding_process = zmk_behavior_sensor_rotate_common_process};
 
-static int behavior_sensor_rotate_init(const struct device *dev) { return 0; };
-
 #define _TRANSFORM_ENTRY(idx, node)                                                                \
     {                                                                                              \
         .behavior_dev = DEVICE_DT_NAME(DT_INST_PHANDLE_BY_IDX(node, bindings, idx)),               \
@@ -35,9 +33,8 @@ static int behavior_sensor_rotate_init(const struct device *dev) { return 0; };
         .override_params = false,                                                                  \
     };                                                                                             \
     static struct behavior_sensor_rotate_data behavior_sensor_rotate_data_##n = {};                \
-    BEHAVIOR_DT_INST_DEFINE(n, behavior_sensor_rotate_init, NULL,                                  \
-                            &behavior_sensor_rotate_data_##n, &behavior_sensor_rotate_config_##n,  \
-                            POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                      \
-                            &behavior_sensor_rotate_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(                                                                       \
+        n, NULL, NULL, &behavior_sensor_rotate_data_##n, &behavior_sensor_rotate_config_##n,       \
+        POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_sensor_rotate_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SENSOR_ROTATE_INST)

--- a/app/src/behaviors/behavior_sensor_rotate_var.c
+++ b/app/src/behaviors/behavior_sensor_rotate_var.c
@@ -16,8 +16,6 @@ static const struct behavior_driver_api behavior_sensor_rotate_var_driver_api = 
     .sensor_binding_accept_data = zmk_behavior_sensor_rotate_common_accept_data,
     .sensor_binding_process = zmk_behavior_sensor_rotate_common_process};
 
-static int behavior_sensor_rotate_var_init(const struct device *dev) { return 0; };
-
 #define SENSOR_ROTATE_VAR_INST(n)                                                                  \
     static struct behavior_sensor_rotate_config behavior_sensor_rotate_var_config_##n = {          \
         .cw_binding = {.behavior_dev = DEVICE_DT_NAME(DT_INST_PHANDLE_BY_IDX(n, bindings, 0))},    \
@@ -26,9 +24,9 @@ static int behavior_sensor_rotate_var_init(const struct device *dev) { return 0;
         .override_params = true,                                                                   \
     };                                                                                             \
     static struct behavior_sensor_rotate_data behavior_sensor_rotate_var_data_##n = {};            \
-    BEHAVIOR_DT_INST_DEFINE(                                                                       \
-        n, behavior_sensor_rotate_var_init, NULL, &behavior_sensor_rotate_var_data_##n,            \
-        &behavior_sensor_rotate_var_config_##n, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,  \
-        &behavior_sensor_rotate_var_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, &behavior_sensor_rotate_var_data_##n,                   \
+                            &behavior_sensor_rotate_var_config_##n, POST_KERNEL,                   \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                                   \
+                            &behavior_sensor_rotate_var_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SENSOR_ROTATE_VAR_INST)

--- a/app/src/behaviors/behavior_soft_off.c
+++ b/app/src/behaviors/behavior_soft_off.c
@@ -27,8 +27,6 @@ struct behavior_soft_off_data {
 #define IS_SPLIT_PERIPHERAL                                                                        \
     (IS_ENABLED(CONFIG_ZMK_SPLIT) && !IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL))
 
-static int behavior_soft_off_init(const struct device *dev) { return 0; };
-
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
@@ -86,8 +84,7 @@ static const struct behavior_driver_api behavior_soft_off_driver_api = {
             DT_INST_PROP_OR(n, split_peripheral_off_on_press, false),                              \
     };                                                                                             \
     static struct behavior_soft_off_data bso_data_##n = {};                                        \
-    BEHAVIOR_DT_INST_DEFINE(n, behavior_soft_off_init, NULL, &bso_data_##n, &bso_config_##n,       \
-                            POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                      \
-                            &behavior_soft_off_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, &bso_data_##n, &bso_config_##n, POST_KERNEL,            \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_soft_off_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(BSO_INST)

--- a/app/src/behaviors/behavior_studio_unlock.c
+++ b/app/src/behaviors/behavior_studio_unlock.c
@@ -17,8 +17,6 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
-static int behavior_studio_unlock_init(const struct device *dev) { return 0; };
-
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     zmk_studio_core_unlock();
@@ -39,7 +37,7 @@ static const struct behavior_driver_api behavior_studio_unlock_driver_api = {
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, behavior_studio_unlock_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_studio_unlock_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_studio_unlock_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_to_layer.c
+++ b/app/src/behaviors/behavior_to_layer.c
@@ -17,8 +17,6 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
-static int behavior_to_init(const struct device *dev) { return 0; };
-
 static int to_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d layer %d", event.position, binding->param1);
@@ -61,7 +59,7 @@ static const struct behavior_driver_api behavior_to_driver_api = {
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, behavior_to_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_to_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_to_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/app/src/behaviors/behavior_toggle_layer.c
+++ b/app/src/behaviors/behavior_toggle_layer.c
@@ -27,8 +27,6 @@ struct behavior_tog_config {
     enum toggle_mode toggle_mode;
 };
 
-static int behavior_tog_init(const struct device *dev) { return 0; };
-
 static int tog_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d layer %d", event.position, binding->param1);
@@ -85,9 +83,8 @@ static const struct behavior_driver_api behavior_tog_driver_api = {
     static const struct behavior_tog_config behavior_tog_config_##n = {                            \
         .toggle_mode = DT_ENUM_IDX(DT_DRV_INST(n), toggle_mode),                                   \
     };                                                                                             \
-    BEHAVIOR_DT_INST_DEFINE(n, behavior_tog_init, NULL, NULL, &behavior_tog_config_##n,            \
-                            POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,                      \
-                            &behavior_tog_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, NULL, NULL, NULL, &behavior_tog_config_##n, POST_KERNEL,            \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_tog_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KT_INST)
 

--- a/app/src/behaviors/behavior_transparent.c
+++ b/app/src/behaviors/behavior_transparent.c
@@ -16,8 +16,6 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
 
-static int behavior_transparent_init(const struct device *dev) { return 0; };
-
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     return ZMK_BEHAVIOR_TRANSPARENT;
@@ -36,7 +34,7 @@ static const struct behavior_driver_api behavior_transparent_driver_api = {
 #endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
 };
 
-BEHAVIOR_DT_INST_DEFINE(0, behavior_transparent_init, NULL, NULL, NULL, POST_KERNEL,
-                        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_transparent_driver_api);
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_transparent_driver_api);
 
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */

--- a/docs/docs/development/new-behavior.mdx
+++ b/docs/docs/development/new-behavior.mdx
@@ -165,7 +165,7 @@ struct behavior_<behavior_name>_config {
     bool example_config_param3;
 };
 
-// Initialization Function
+// Initialization Function (Optional)
 static int <behavior_name>_init(const struct device *dev) {
     return 0;
 };
@@ -177,7 +177,7 @@ static const struct behavior_driver_api <behavior_name>_driver_api = {
 
 BEHAVIOR_DT_INST_DEFINE(0,                                                    // Instance Number (Equal to 0 for behaviors that don't require multiple instances,
                                                                               //                  Equal to n for behaviors that do make use of multiple instances)
-                        <behavior_name>_init, NULL,                           // Initialization Function, Power Management Device Pointer
+                        <behavior_name>_init, NULL,                           // Initialization Function, Power Management Device Pointer (Both Optional)
                         &<behavior_name>_data, &<behavior_name>_config,       // Behavior Data Pointer, Behavior Configuration Pointer (Both Optional)
                         POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,     // Initialization Level, Device Priority
                         &<behavior_name>_driver_api);                         // API Structure
@@ -283,7 +283,7 @@ Note that in the hold-tap example, the instance number, `0`, has been replaced b
 
 Behaviors also require the following parameters of `BEHAVIOR_DT_INST_DEFINE` to be changed:
 
-##### Initialization function
+##### Initialization function (optional)
 
 Comes in the form `static int <behavior_name>_init(const struct device *dev)`. Initialization functions preconfigure any data, like resetting timers and position for hold-taps and tap-dances. All initialization functions `return 0;` once complete.
 


### PR DESCRIPTION
Initialization functions are optional for Zephyr drivers, so remove all our superfluous empty init functions.

Good call out from @Nick-Munnich on #2842 

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
