### PR TITLE
feat(pointing): Allow input processor aborting before sending to central

### DIFF
--- a/app/src/pointing/input_split.c
+++ b/app/src/pointing/input_split.c
@@ -56,8 +56,10 @@ int zmk_input_split_report_peripheral_event(uint8_t reg, uint8_t type, uint16_t 
                  "Peripheral input splits need an `input` property set");                          \
     void split_input_handler_##n(struct input_event *evt) {                                        \
         for (size_t i = 0; i < ARRAY_SIZE(processors_##n); i++) {                                  \
-            zmk_input_processor_handle_event(processors_##n[i].dev, evt, processors_##n[i].param1, \
-                                             processors_##n[i].param2, NULL);                      \
+            int ret = zmk_input_processor_handle_event(processors_##n[i].dev, evt,                 \
+                                                       processors_##n[i].param1,                   \
+                                                       processors_##n[i].param2, NULL);            \
+            if (ret == ZMK_INPUT_PROC_CONTINUE) { continue; } else { return; }                     \
         }                                                                                          \
         zmk_split_bt_report_input(DT_INST_REG_ADDR(n), evt->type, evt->code, evt->value,           \
                                   evt->sync);                                                      \


### PR DESCRIPTION
Add exit point in input processor loop on split input. That allow aborting the chain of processing before sending event to central from split peripheral.

Two ZIP modules had been designed with this change, that reduce BT loading between peripherals and central (mostly, at dongle mode)
- Rate limiter: https://github.com/badjeff/zmk-input-processor-report-rate-limit
- Compressor: https://github.com/badjeff/zmk-input-processor-xyz


<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
