### PR TITLE
chore: Add some basic encoder tests

### DIFF
--- a/app/tests/encoders/behavior_keymap.dtsi
+++ b/app/tests/encoders/behavior_keymap.dtsi
@@ -1,0 +1,44 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &tog 2 &kp X
+                &tog 1 &none
+            >;
+            sensor-bindings = <&inc_dec_kp A B>;
+        };
+        skip_layer {
+            bindings = <
+                &trans &kp Y
+                &none &none
+            >;
+            sensor-bindings = <&inc_dec_kp N M>;
+        };
+        alt_layer {
+            bindings = <
+                &trans &kp Z
+                &none &none
+            >;
+            sensor-bindings = <&inc_dec_kp C D>;
+        };
+    };
+
+    mock_encoder: mock_encoder {
+        compatible = "zmk,sensor-encoder-mock";
+        status = "okay";
+        event-startup-delay = <200>;
+        event-period = <200>;
+    };
+
+    sensors: sensors {
+        compatible = "zmk,keymap-sensors";
+        sensors = <&mock_encoder>;
+        triggers-per-rotation = <20>;
+    };
+};

--- a/app/tests/encoders/layers-1/events.patterns
+++ b/app/tests/encoders/layers-1/events.patterns
@@ -1,0 +1,2 @@
+s/.*hid_listener_keycode_//p
+s/.*layer_changed/layer_changed/p

--- a/app/tests/encoders/layers-1/keycode_events.snapshot
+++ b/app/tests/encoders/layers-1/keycode_events.snapshot
@@ -1,0 +1,3 @@
+layer_changed: layer 2 state 1
+pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/encoders/layers-1/native_posix_64.keymap
+++ b/app/tests/encoders/layers-1/native_posix_64.keymap
@@ -1,0 +1,11 @@
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = < ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_PRESS(1,1,8000)
+    >;
+};
+
+&mock_encoder {
+    events = <18>;
+};

--- a/app/tests/encoders/layers-2/events.patterns
+++ b/app/tests/encoders/layers-2/events.patterns
@@ -1,0 +1,2 @@
+s/.*hid_listener_keycode_//p
+s/.*layer_changed/layer_changed/p

--- a/app/tests/encoders/layers-2/keycode_events.snapshot
+++ b/app/tests/encoders/layers-2/keycode_events.snapshot
@@ -1,0 +1,4 @@
+layer_changed: layer 1 state 1
+layer_changed: layer 2 state 1
+pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/encoders/layers-2/native_posix_64.keymap
+++ b/app/tests/encoders/layers-2/native_posix_64.keymap
@@ -1,0 +1,11 @@
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = < ZMK_MOCK_PRESS(1,0,10) ZMK_MOCK_PRESS(0,0,10)
+    ZMK_MOCK_PRESS(1,1,8000)
+    >;
+};
+
+&mock_encoder {
+    events = <18>;
+};

--- a/app/tests/encoders/rotate/events.patterns
+++ b/app/tests/encoders/rotate/events.patterns
@@ -1,0 +1,1 @@
+s/.*hid_listener_keycode_//p

--- a/app/tests/encoders/rotate/keycode_events.snapshot
+++ b/app/tests/encoders/rotate/keycode_events.snapshot
@@ -1,0 +1,4 @@
+pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+pressed: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
+released: usage_page 0x07 keycode 0x05 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/encoders/rotate/native_posix_64.keymap
+++ b/app/tests/encoders/rotate/native_posix_64.keymap
@@ -1,0 +1,10 @@
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = < ZMK_MOCK_PRESS(1,1,1000)
+    >;
+};
+
+&mock_encoder {
+    events = <18 (-18)>;
+};


### PR DESCRIPTION
Adds some very basic encoder tests for rotating, and basic layers. Mock Kscans don't seem to interact nicely, slightly on the hacky side. However, better to have hacky rudimentary tests than no tests.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
