### PR TITLE
feat(core): Support for 64 layers

### DIFF
--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -30,7 +30,7 @@ typedef uint8_t zmk_keymap_layer_id_t;
  */
 typedef uint8_t zmk_keymap_layer_index_t;
 
-typedef uint32_t zmk_keymap_layers_state_t;
+typedef uint64_t zmk_keymap_layers_state_t;
 
 zmk_keymap_layer_id_t zmk_keymap_layer_index_to_id(zmk_keymap_layer_index_t layer_index);
 

--- a/app/src/conditional_layer.c
+++ b/app/src/conditional_layer.c
@@ -82,8 +82,8 @@ static int layer_state_changed_listener(const zmk_event_t *ev) {
 
     while (conditional_layer_updates_needed) {
         int8_t max_then_layer = -1;
-        uint32_t then_layers = 0;
-        uint32_t then_layer_state = 0;
+        uint64_t then_layers = 0;
+        uint64_t then_layer_state = 0;
 
         conditional_layer_updates_needed = false;
 

--- a/app/src/pointing/input_listener.c
+++ b/app/src/pointing/input_listener.c
@@ -56,7 +56,7 @@ struct input_listener_config_entry {
 };
 
 struct input_listener_layer_override {
-    uint32_t layer_mask;
+    uint64_t layer_mask;
     bool process_next;
     struct input_listener_config_entry config;
 };
@@ -210,7 +210,7 @@ static int filter_with_input_config(const struct input_listener_config *cfg,
     for (size_t oi = 0; oi < cfg->layer_overrides_len; oi++) {
         const struct input_listener_layer_override *override = &cfg->layer_overrides[oi];
         struct input_listener_processor_data *override_data = &data->layer_override_data[oi];
-        uint32_t mask = override->layer_mask;
+        uint64_t mask = override->layer_mask;
         uint8_t layer = 0;
         while (mask != 0) {
             if (mask & BIT(0) && zmk_keymap_layer_active(layer)) {


### PR DESCRIPTION
Ability to use for more than 32 layers by switching variable type from uint32_t to uint64_t.

- Add macro: WRITE_BIT64
- Update layer code to use BIT64 and WRITE_BIT64
- Tested and working on a Corne Mini with 55 layers

I am a first time contributor and I am unsure if this has any deeper implications than I realize, so I'm submitting it as a draft PR. Perhaps it will be useful if anyone else makes a layout with an absurd number of layers and wonders why it is not working.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
