### PR TITLE
fix(behaviors): Proper comma separated device list

### DIFF
--- a/app/src/behaviors/behavior_caps_word.c
+++ b/app/src/behaviors/behavior_caps_word.c
@@ -84,7 +84,8 @@ static int caps_word_keycode_state_changed_listener(const zmk_event_t *eh);
 ZMK_LISTENER(behavior_caps_word, caps_word_keycode_state_changed_listener);
 ZMK_SUBSCRIPTION(behavior_caps_word, zmk_keycode_state_changed);
 
-static const struct device *devs[] = {DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET)};
+#define GET_DEV(inst) DEVICE_DT_INST_GET(inst),
+static const struct device *devs[] = {DT_INST_FOREACH_STATUS_OKAY(GET_DEV)};
 
 static bool caps_word_is_caps_includelist(const struct behavior_caps_word_config *config,
                                           uint16_t usage_page, uint8_t usage_id,

--- a/app/src/behaviors/behavior_key_repeat.c
+++ b/app/src/behaviors/behavior_key_repeat.c
@@ -77,7 +77,8 @@ static int key_repeat_keycode_state_changed_listener(const zmk_event_t *eh);
 ZMK_LISTENER(behavior_key_repeat, key_repeat_keycode_state_changed_listener);
 ZMK_SUBSCRIPTION(behavior_key_repeat, zmk_keycode_state_changed);
 
-static const struct device *devs[] = {DT_INST_FOREACH_STATUS_OKAY(DEVICE_DT_INST_GET)};
+#define GET_DEV(inst) DEVICE_DT_INST_GET(inst),
+static const struct device *devs[] = {DT_INST_FOREACH_STATUS_OKAY(GET_DEV)};
 
 static int key_repeat_keycode_state_changed_listener(const zmk_event_t *eh) {
     struct zmk_keycode_state_changed *ev = as_zmk_keycode_state_changed(eh);


### PR DESCRIPTION
Properly generate the comma separated list of devs in caps word/ key repeat.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
