### PR TITLE
Improve VS Code Python settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "esbenp.prettier-vscode",
+    "ms-python.black-formatter",
     "ms-python.python",
     "ms-vscode.cpptools",
     "plorefice.devicetree",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
     "*.overlay": "dts",
     "*.keymap": "dts"
   },
-  "python.formatting.provider": "black",
   "[c]": {
     "editor.formatOnSave": true
   },
@@ -13,7 +12,7 @@
   },
   "[python]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "ms-python.python"
+    "editor.defaultFormatter": "ms-python.black-formatter"
   },
   "[css][json][jsonc][html][markdown][yaml]": {
     "editor.formatOnSave": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "*.overlay": "dts",
     "*.keymap": "dts"
   },
+  "python.analysis.include": ["app/scripts", "zephyr/scripts"],
   "[c]": {
     "editor.formatOnSave": true
   },


### PR DESCRIPTION
Removed the deprecated `python.formatting.provider` setting and switched to using correct extension for formatting Python files now that different formatters have been broken out into separate extensions.

Limited Python analysis to only the directories containing Python scripts, so VS Code doesn't slow down while scanning all of Zephyr.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
