### PR TITLE
docs: Fix wakeup-source property location for composite kscan

### DIFF
--- a/docs/docs/config/kscan.md
+++ b/docs/docs/config/kscan.md
@@ -216,19 +216,21 @@ Applies to : `compatible = "zmk,kscan-composite"`
 
 Definition file: [zmk/app/dts/bindings/zmk,kscan-composite.yaml](https://github.com/zmkfirmware/zmk/blob/main/app/dts/bindings/zmk,kscan-composite.yaml)
 
-| Property  | Type | Description                                   | Default |
-| --------- | ---- | --------------------------------------------- | ------- |
-| `rows`    | int  | The number of rows in the composite matrix    |         |
-| `columns` | int  | The number of columns in the composite matrix |         |
+| Property        | Type | Description                                           | Default |
+| --------------- | ---- | ----------------------------------------------------- | ------- |
+| `rows`          | int  | The number of rows in the composite matrix            |         |
+| `columns`       | int  | The number of columns in the composite matrix         |         |
+| `wakeup-source` | bool | Mark this kscan instance as able to wake the keyboard | n       |
 
 The `zmk,kscan-composite` node should have one child node per keyboard scan driver that should be composited. Each child node can have the following properties:
 
-| Property        | Type    | Description                                                                    | Default |
-| --------------- | ------- | ------------------------------------------------------------------------------ | ------- |
-| `kscan`         | phandle | Label of the kscan driver to include                                           |         |
-| `row-offset`    | int     | Shifts row 0 of the included driver to a new row in the composite matrix       | 0       |
-| `col-offset`    | int     | Shifts column 0 of the included driver to a new column in the composite matrix | 0       |
-| `wakeup-source` | bool    | Mark this kscan instance as able to wake the keyboard                          | n       |
+| Property     | Type    | Description                                                                    | Default |
+| ------------ | ------- | ------------------------------------------------------------------------------ | ------- |
+| `kscan`      | phandle | Label of the kscan driver to include                                           |         |
+| `row-offset` | int     | Shifts row 0 of the included driver to a new row in the composite matrix       | 0       |
+| `col-offset` | int     | Shifts column 0 of the included driver to a new column in the composite matrix | 0       |
+
+If you want one of the composited kscans to be able to wake up the keyboard, make sure to set the `wakeup-source` property in its own definition, in addition to setting it for the composite kscan node itself as listed above.
 
 ### Example Configuration
 


### PR DESCRIPTION
Move the property from child nodes table to the node itself to fix docs bug. Also clarify that the property needs to be set both for child kscan(s) and the composite itself.

Originally came up in [Discord](https://discord.com/channels/719497620560543766/719909884769992755/1346746447122530304).