### PR TITLE
fix(hid): Fix scroll value truncation

### DIFF
--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -377,9 +377,9 @@ int zmk_hid_mouse_button_release(zmk_mouse_button_t button);
 int zmk_hid_mouse_buttons_press(zmk_mouse_button_flags_t buttons);
 int zmk_hid_mouse_buttons_release(zmk_mouse_button_flags_t buttons);
 void zmk_hid_mouse_movement_set(int16_t x, int16_t y);
-void zmk_hid_mouse_scroll_set(int8_t x, int8_t y);
+void zmk_hid_mouse_scroll_set(int16_t x, int16_t y);
 void zmk_hid_mouse_movement_update(int16_t x, int16_t y);
-void zmk_hid_mouse_scroll_update(int8_t x, int8_t y);
+void zmk_hid_mouse_scroll_update(int16_t x, int16_t y);
 void zmk_hid_mouse_clear(void);
 
 #endif // IS_ENABLED(CONFIG_ZMK_POINTING)

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -445,7 +445,7 @@ void zmk_hid_mouse_movement_update(int16_t hwheel, int16_t wheel) {
     LOG_DBG("Mouse movement updated to %d/%d", mouse_report.body.d_x, mouse_report.body.d_y);
 }
 
-void zmk_hid_mouse_scroll_set(int8_t hwheel, int8_t wheel) {
+void zmk_hid_mouse_scroll_set(int16_t hwheel, int16_t wheel) {
     mouse_report.body.d_scroll_x = hwheel;
     mouse_report.body.d_scroll_y = wheel;
 
@@ -453,7 +453,7 @@ void zmk_hid_mouse_scroll_set(int8_t hwheel, int8_t wheel) {
             mouse_report.body.d_scroll_y);
 }
 
-void zmk_hid_mouse_scroll_update(int8_t hwheel, int8_t wheel) {
+void zmk_hid_mouse_scroll_update(int16_t hwheel, int16_t wheel) {
     mouse_report.body.d_scroll_x += hwheel;
     mouse_report.body.d_scroll_y += wheel;
 


### PR DESCRIPTION
Fix 8 bit truncation of 16 bit scroll values when passed into functions `zmk_hid_mouse_scroll_set` and `zmk_hid_mouse_scroll_update`.

Fixes: #2864

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
