### PR TITLE
fix(build.yaml): pin tj-actions/changed-files action due to compromise

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -430,7 +430,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: tj-actions/changed-files@v45
+      - uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # pin to v45.0.8 due to https://github.com/tj-actions/changed-files/issues/2463 https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
         id: changed-files
         with:
           json: true


### PR DESCRIPTION
Ideally it's be swapped out for an alternative but for now this is to mitigate running known compromised code.

Or, y'all can locally clone the Action's repo from the hash that's been pinned and push it as a mirror to the zmkfirmware org to be more safe for now?

Additionally, automerge and PR creation of updates for this action should be disabled for now to prevent accidental updates to the latest hash.

https://github.com/tj-actions/changed-files/issues/2463
https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

(Forked, edited and PRed from GitHub Mobile app to make it quick so none of the below have been done, hope y'all don't mind for a simple change)

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
