### PR TITLE
feat(power): Allow runtime toggling of deep sleep functionality

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources_ifdef(CONFIG_USB_DEVICE_STACK app PRIVATE src/events/usb_conn_sta
 target_sources(app PRIVATE src/behaviors/behavior_reset.c)
 target_sources_ifdef(CONFIG_ZMK_EXT_POWER app PRIVATE src/behaviors/behavior_ext_power.c)
 target_sources_ifdef(CONFIG_ZMK_BEHAVIOR_SOFT_OFF app PRIVATE src/behaviors/behavior_soft_off.c)
+target_sources_ifdef(CONFIG_ZMK_SLEEP app PRIVATE src/behaviors/behavior_set_sleep.c)
 add_subdirectory_ifdef(CONFIG_ZMK_POINTING src/pointing/)
 if ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
   target_sources(app PRIVATE src/hid.c)

--- a/app/dts/behaviors.dtsi
+++ b/app/dts/behaviors.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 The ZMK Contributors
+ * Copyright (c) 2025 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */
@@ -28,3 +28,4 @@
 #include <behaviors/soft_off.dtsi>
 #include <behaviors/studio_unlock.dtsi>
 #include <behaviors/mouse_keys.dtsi>
+#include <behaviors/set_sleep.dtsi>

--- a/app/dts/behaviors/set_sleep.dtsi
+++ b/app/dts/behaviors/set_sleep.dtsi
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/zmk/behaviors.h>
+
+/ {
+    behaviors {
+#if ZMK_BEHAVIOR_OMIT(SLEEP)
+        /omit-if-no-ref/
+#endif
+        sleep: sleep {
+            compatible = "zmk,behavior-set-sleep";
+            #binding-cells = <1>;
+            display-name = "Sleep";
+        };
+    };
+};

--- a/app/dts/bindings/behaviors/zmk,behavior-set-sleep.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-set-sleep.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Set sleep behavior
+
+compatible: "zmk,behavior-set-sleep"
+
+include: one_param.yaml

--- a/app/include/dt-bindings/zmk/set_sleep.h
+++ b/app/include/dt-bindings/zmk/set_sleep.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#define SLEEP_ON 0
+#define SLEEP_OFF 1
+#define SLEEP_TOGG 2

--- a/app/include/zmk/activity.h
+++ b/app/include/zmk/activity.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The ZMK Contributors
+ * Copyright (c) 2025 The ZMK Contributors
  *
  * SPDX-License-Identifier: MIT
  */
@@ -9,3 +9,9 @@
 enum zmk_activity_state { ZMK_ACTIVITY_ACTIVE, ZMK_ACTIVITY_IDLE, ZMK_ACTIVITY_SLEEP };
 
 enum zmk_activity_state zmk_activity_get_state(void);
+
+#if IS_ENABLED(CONFIG_ZMK_SLEEP)
+void zmk_enable_sleep(void);
+void zmk_disable_sleep(void);
+void zmk_toggle_sleep(void);
+#endif

--- a/app/src/behaviors/behavior_set_sleep.c
+++ b/app/src/behaviors/behavior_set_sleep.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#define DT_DRV_COMPAT zmk_behavior_set_sleep
+
+#include <zephyr/device.h>
+#include <drivers/behavior.h>
+#include <zephyr/logging/log.h>
+
+#include <dt-bindings/zmk/set_sleep.h>
+
+#include <zmk/behavior.h>
+#include <zmk/activity.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+
+static const struct behavior_parameter_value_metadata std_values[] = {
+    {
+        .value = SLEEP_TOGG,
+        .display_name = "Toggle Sleep State",
+        .type = BEHAVIOR_PARAMETER_VALUE_TYPE_VALUE,
+    },
+    {
+        .value = SLEEP_ON,
+        .display_name = "Enable Sleep",
+        .type = BEHAVIOR_PARAMETER_VALUE_TYPE_VALUE,
+    },
+    {
+        .value = SLEEP_OFF,
+        .display_name = "Disable Sleep",
+        .type = BEHAVIOR_PARAMETER_VALUE_TYPE_VALUE,
+    },
+};
+
+static const struct behavior_parameter_metadata_set std_set = {
+    .param1_values = std_values,
+    .param1_values_len = ARRAY_SIZE(std_values),
+};
+
+static const struct behavior_parameter_metadata metadata = {
+    .sets_len = 1,
+    .sets = &std_set,
+};
+
+#endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+
+static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
+    switch (binding->param1) {
+    case SLEEP_TOGG:
+        zmk_toggle_sleep();
+        return 0;
+    case SLEEP_ON:
+        zmk_enable_sleep();
+        return 0;
+    case SLEEP_OFF:
+        zmk_disable_sleep();
+        return 0;
+    default:
+        LOG_ERR("Unknown output command: %d", binding->param1);
+    }
+
+    return -ENOTSUP;
+}
+
+static const struct behavior_driver_api behavior_set_sleep_driver_api = {
+    .binding_pressed = on_keymap_binding_pressed,
+    .locality = BEHAVIOR_LOCALITY_GLOBAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .parameter_metadata = &metadata,
+#endif // IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+};
+
+BEHAVIOR_DT_INST_DEFINE(0, NULL, NULL, NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_set_sleep_driver_api);
+
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT) */


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

Opening this as a draft just to get eyes on it.

There's nothing really preventing runtime toggling of deep sleep functionality - and it allows users more configurability without making them recompile / reflash.

I struggled getting automated tests to work - for some reason, my `CONFIG_ZMK_SLEEP=y` was not getting picked up when the test suite built - I left a note in discord about it.

I have tested the change on real hardware (including on a split keyboard, to make sure both halves act properly). From my testing, it seems to work.

Once I get some feedback, I can add docs.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
