### PR TITLE
fix(split): add source to battery event

### DIFF
--- a/app/src/split/central.c
+++ b/app/src/split/central.c
@@ -58,6 +58,7 @@ int zmk_split_transport_central_peripheral_event_handler(
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING)
     case ZMK_SPLIT_TRANSPORT_PERIPHERAL_EVENT_TYPE_BATTERY_EVENT: {
         struct zmk_peripheral_battery_state_changed battery_ev = {
+            .source = source,
             .state_of_charge = ev.data.battery_event.level,
         };
         peripheral_battery_levels[source] = ev.data.battery_event.level;


### PR DESCRIPTION
147c340 introduces a bug where the peripheral battery level is always reported with index 0. This should not be the case if there are more than one peripherals.