### PR TITLE
docs: fix path typo in module-creation.md

### DIFF
--- a/docs/docs/development/module-creation.md
+++ b/docs/docs/development/module-creation.md
@@ -108,7 +108,7 @@ The repository comes with a number of files and folders already positioned for y
 
 |                  | `keyboard` | `component` | `behavior` | `driver` | `feature` | `vfx` |
 | ---------------- | ---------- | ----------- | ---------- | -------- | --------- | ----- |
-| `board/`         | ✅         | ✅          | ❌         | ❌       | ❌        | ✅    |
+| `boards/`        | ✅         | ✅          | ❌         | ❌       | ❌        | ✅    |
 | `dts/`           | ❌         | ❌          | ✅         | ✅       | ✅        | ❌    |
 | `CMakeLists.txt` | ❌         | ❌          | ✅         | ✅       | ✅        | ✅    |
 | `Kconfig`        | ❌         | ❌          | ✅         | ✅       | ✅        | ✅    |
@@ -120,7 +120,7 @@ The below table reminds of the purpose of each of these files and folders, if yo
 
 | File or Folder   | Description                                                                           |
 | ---------------- | ------------------------------------------------------------------------------------- |
-| `board/`         | Folder containing definitions for boards, shields and interconnects                   |
+| `boards/`        | Folder containing definitions for boards, shields and interconnects                   |
 | `dts/`           | Folder containing devicetree bindings and includes with devicetree nodes (.dtsi)      |
 | `CMakeLists.txt` | CMake configuration to specify source files to build                                  |
 | `Kconfig`        | Kconfig file for the module                                                           |


### PR DESCRIPTION
The folder for boards and shields is `boards`, not `board`.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
