### PR TITLE
fix(docs): docs home img alt text

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -37,7 +37,7 @@ function Feature({ imageUrl, title, description }) {
     <div className={classnames("col col--4", styles.feature)}>
       {imgUrl && (
         <div className="text--center">
-          <img className={styles.featureImage} src={imgUrl} alt={title} />
+          <img className={styles.featureImage} src={imgUrl} alt="" />
         </div>
       )}
       <h3>{title}</h3>


### PR DESCRIPTION
Img alt text on the home page was shown as alt="[object Object]"
since title was a react node and not text

This PR fixes that

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).

## Screenshots

![image](https://github.com/user-attachments/assets/581a5c9f-381f-4841-b1c0-901d2871fc63)

