### PR TITLE
feat(ci): Add stale GitHub Action to automatically close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: "Mark and close stale PRs in the repo"
+on:
+  schedule:
+    - cron: "00 14 * * *" # runs daily at 14:00 https://crontab.guru/#00_14_*_*_*
+
+jobs:
+  stale:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/stale@v9.1.0
+        with:
+          days-before-pr-stale: 300 # ~10 months
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not
+            had activity in 10 months. It will be closed in 14 days if no
+            further activity occurs. Feel free to give a status update or
+            re-open when it has been rebased and is ready for review (again).
+            Thanks!
+          days-before-pr-close: 14
+          close-pr-message: >
+            This PR was closed because it had no activity for over 10 months.
+            Feel free to give a status update or re-open when it has been
+            rebased and is ready for review (again).
+          days-before-issue-close: -1
+          ascending: true # Process older PRs first
+          operations-per-run: 30 # Default value, listed here again to make it explicit


### PR DESCRIPTION
Add a GitHub Action to automatically close stale PRs. This can be adapted to close stale issues too, but I think we should focus on PRs first and then make a followup to close issues once PRs have gotten more under control.

The action was adapted from [netlify/build](https://github.com/netlify/build/blob/main/.github/workflows/stalebot.yml) (MIT licensed) where it is functioning as expected, but for [issues](https://github.com/netlify/build/issues/5299). Documentation on the action can be found [here](https://github.com/actions/stale).