### PR TITLE
fix(combos): Restore prompts for two deprecated Kconfigs

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -444,13 +444,13 @@ config ZMK_COMBO_MAX_PRESSED_COMBOS
     default 4
 
 config ZMK_COMBO_MAX_COMBOS_PER_KEY
-    int
+    int "Deprecated: Max combos per key"
     default 0
     help
       Deprecated: Storage for combos is now determined automatically
 
 config ZMK_COMBO_MAX_KEYS_PER_COMBO
-    int
+    int "Deprecated: Max keys per combo"
     default 0
     help
        Deprecated: This is now auto-calculated based on `key-positions` in devicetree


### PR DESCRIPTION
Restore prompts for deprecated combo Kconfig symbols, to avoid errors for existing builds that set them explicitly.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
