### PR TITLE
docs: Add secondary functions for the keypad number keys

### DIFF
--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -2376,7 +2376,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_1", "KP_N1"],
-    description: "1",
+    description: "1 and End",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2397,7 +2397,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_2", "KP_N2"],
-    description: "2",
+    description: "2 and ⬇ [Down Arrow]",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2418,7 +2418,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_3", "KP_N3"],
-    description: "3",
+    description: "3 and Page Down",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2439,7 +2439,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_4", "KP_N4"],
-    description: "4",
+    description: "4 and ⬅ [Left Arrow]",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2481,7 +2481,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_6", "KP_N6"],
-    description: "6",
+    description: "6 and ⮕ [Right Arrow]",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2502,7 +2502,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_7", "KP_N7"],
-    description: "7",
+    description: "7 and Home",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2523,7 +2523,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_8", "KP_N8"],
-    description: "8",
+    description: "8 and ⬆ [Up Arrow]",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2544,7 +2544,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_9", "KP_N9"],
-    description: "9",
+    description: "9 and Page Up",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2565,7 +2565,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_0", "KP_N0"],
-    description: "0",
+    description: "0 and Insert",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2586,7 +2586,7 @@ export default [
   },
   {
     names: ["KP_DOT"],
-    description: ". [Dot]",
+    description: ". [Dot] and Delete",
     context: "Keypad",
     clarify: false,
     usages: [

--- a/docs/src/data/hid.js
+++ b/docs/src/data/hid.js
@@ -2376,7 +2376,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_1", "KP_N1"],
-    description: "1 and End",
+    description: "Keypad 1 and End",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2397,7 +2397,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_2", "KP_N2"],
-    description: "2 and ⬇ [Down Arrow]",
+    description: "Keypad 2 and Down Arrow",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2418,7 +2418,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_3", "KP_N3"],
-    description: "3 and Page Down",
+    description: "Keypad 3 and Page Down",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2439,7 +2439,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_4", "KP_N4"],
-    description: "4 and ⬅ [Left Arrow]",
+    description: "Keypad 4 and Left Arrow",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2460,7 +2460,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_5", "KP_N5"],
-    description: "5",
+    description: "Keypad 5",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2481,7 +2481,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_6", "KP_N6"],
-    description: "6 and ⮕ [Right Arrow]",
+    description: "Keypad 6 and Right Arrow",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2502,7 +2502,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_7", "KP_N7"],
-    description: "7 and Home",
+    description: "Keypad 7 and Home",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2523,7 +2523,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_8", "KP_N8"],
-    description: "8 and ⬆ [Up Arrow]",
+    description: "Keypad 8 and Up Arrow",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2544,7 +2544,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_9", "KP_N9"],
-    description: "9 and Page Up",
+    description: "Keypad 9 and Page Up",
     context: "Keypad",
     clarify: false,
     usages: [
@@ -2565,7 +2565,7 @@ export default [
   },
   {
     names: ["KP_NUMBER_0", "KP_N0"],
-    description: "0 and Insert",
+    description: "Keypad 0 and Insert",
     context: "Keypad",
     clarify: false,
     usages: [


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)

## Description

This PR is simply to add the information for the alternate or secondary function of the keypad number keys used in the List of Keycodes docs page.  
With the current state of the docs, I was not aware that those keycodes will only serve as numbers when the Numlock is enabled.