### PR TITLE
fix(pointing): Avoids mutex leak for default layer toggle event

### DIFF
--- a/app/src/pointing/input_processor_temp_layer.c
+++ b/app/src/pointing/input_processor_temp_layer.c
@@ -134,9 +134,6 @@ static int handle_layer_state_changed(const struct device *dev, const zmk_event_
     if (ret < 0) {
         return ret;
     }
-    if (data->state.toggle_layer == 0) {
-        return ZMK_EV_EVENT_BUBBLE;
-    }
     if (!zmk_keymap_layer_active(zmk_keymap_layer_index_to_id(data->state.toggle_layer))) {
         LOG_DBG("Deactivating layer that was activated by this processor");
         data->state.is_active = false;


### PR DESCRIPTION
Temp layer freezes by mutex leak if layer state change event happens for default layer.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
