### PR TITLE
docs: Document the default flavor of layer-tap

### DIFF
--- a/docs/docs/keymaps/behaviors/hold-tap.mdx
+++ b/docs/docs/keymaps/behaviors/hold-tap.mdx
@@ -53,7 +53,9 @@ Note that you can also [define a custom hold-tap](#custom-hold-tap-examples) and
 
 ## Layer-Tap
 
-The "layer-tap" behavior works identically to the mod-tap behavior, but instead of outputting one of two keys, it activates a specified layer as its "hold" action.
+The "layer-tap" behavior works similarly to the mod-tap behavior, but instead of outputting one of two keys, it activates a specified layer as its "hold" action.
+
+By default, layer-tap is configured with the ["tap-preferred" `flavor`](#interrupt-flavors).
 
 ### Behavior Binding
 


### PR DESCRIPTION
I assumed that `&lt` had the same default flavor as `&mt` and didn't see anything mentioned differently in the docs, but I recently learned it defaults to `tap-preferred`:
https://github.com/zmkfirmware/zmk/blob/ad6a181d7ec34fb6e31134f6bb991a9b2d0b8f78/app/dts/behaviors/layer_tap.dtsi#L17

This PR updates the documentation for `&lt` to describe that!

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
