### PR TITLE
Add fire-hold-as-tap option to behavior-hold-tap

### DIFF
--- a/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
@@ -43,6 +43,8 @@ properties:
     type: boolean
   retro-tap:
     type: boolean
+  fire-hold-as-tap:
+    type: boolean
   hold-trigger-key-positions:
     type: array
     required: false

--- a/docs/docs/keymaps/behaviors/hold-tap.mdx
+++ b/docs/docs/keymaps/behaviors/hold-tap.mdx
@@ -460,3 +460,18 @@ For example, if you press `&mt LEFT_SHIFT A` and then release it without pressin
     retro-tap;
 };
 ```
+
+### `fire-hold-as-tap`
+
+If `fire-hold-as-tap` is enabled, the hold behavior will send both press and release immediately when the hold condition is met, instead of waiting for key release.  
+This prevents operating system key repeat behavior for hold actions that are intended to be momentary, such as triggering shortcut key combinations.
+
+For example, if you press and hold `&mt KC_PGUP KC_PGDN` with `fire-hold-as-tap` enabled, it will send a single `KC_PGUP` event when the hold condition triggers, and will not repeat or send additional events on key release.
+
+```dts
+&mt {
+    fire-hold-as-tap;
+};
+```
+
+**Note:** This option has no effect on the tap behavior. It only changes the way the hold action is sent.


### PR DESCRIPTION
# Add `fire-hold-as-tap` option to `behavior-hold-tap`

This introduces a new optional setting for `behavior-hold-tap` called `fire-hold-as-tap`.

When enabled, the hold behavior will send both a press and immediate release immediately when the hold condition is met, instead of sending a press on hold and a release on key-up.
This prevents operating system key repeat behavior for hold actions that are intended to be momentary. 

This is especially useful for sending keyboard shortcuts on hold, when key repeats would be undesirable or harmful.

The option is fully backwards compatible and defaults to off.

##  Feature Added

- New boolean property: `fire-hold-as-tap` for `behavior_hold_tap`
- Allows safe assignment of normal keys or simple behaviors to the hold side of hold-tap bindings
- Eliminates OS key repeats by sending both press + release immediately on hold condition

## Testing Performed

Tested locally on:
- Wireless Corne using config repo with modified ZMK fork
- Multiple hold-tap keys with `fire-hold-as-tap` set true and false
- Long key holds confirmed: no OS-level repeat triggered
- Tap behavior unaffected

## Example Usage

```dts
ht: hold_tap {
    compatible = "zmk,behavior-hold-tap";
    #binding-cells = <2>;
    bindings = <&kp>, <&kp>;
    tapping-term-ms = <300>;
    quick-tap-ms = <150>;
    flavor = "tap-preferred";
    fire-hold-as-tap;
};
```

## Additional Notes

This was implemented as an additional internal state (`STATUS_HOLD_TAP_SENT`) to avoid sending redundant key releases and keep the existing state machine clean.

If maintainers prefer, this could be split into a separate behavior (`&tap-on-hold`), but integrating it as an optional extension of `hold-tap` seems to align better with the extensibility approach of the current design.
