### PR TITLE
fix(behaviors): Correct macro release state for parametrized macros

### DIFF
--- a/app/src/behaviors/behavior_macro.c
+++ b/app/src/behaviors/behavior_macro.c
@@ -129,7 +129,9 @@ static int behavior_macro_init(const struct device *dev) {
             LOG_DBG("Release will resume at %d", state->release_state.start_index);
             break;
         } else {
-            // Ignore regular invokable bindings
+            // Mostly ignore regular invokable bindings, except they will consume macro parameters
+            state->release_state.param1_source = PARAM_SOURCE_BINDING;
+            state->release_state.param2_source = PARAM_SOURCE_BINDING;
         }
     }
 

--- a/app/tests/macros/param-then-no-param/events.patterns
+++ b/app/tests/macros/param-then-no-param/events.patterns
@@ -1,0 +1,2 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p

--- a/app/tests/macros/param-then-no-param/keycode_events.snapshot
+++ b/app/tests/macros/param-then-no-param/keycode_events.snapshot
@@ -1,0 +1,8 @@
+kp_pressed: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x04 implicit_mods 0x00 explicit_mods 0x00
+mo_pressed: position 0 layer 1
+kp_pressed: usage_page 0x07 keycode 0x1C implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x1C implicit_mods 0x00 explicit_mods 0x00
+mo_released: position 0 layer 1
+kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00

--- a/app/tests/macros/param-then-no-param/native_posix_64.keymap
+++ b/app/tests/macros/param-then-no-param/native_posix_64.keymap
@@ -1,0 +1,47 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    macros {
+        kp_l1: kp_l1 {
+            compatible = "zmk,behavior-macro-one-param";
+            #binding-cells = <1>;
+            wait-ms = <5>;
+            tap-ms = <5>;
+            bindings
+            = <&macro_param_1to1>
+            , <&macro_tap &kp MACRO_PLACEHOLDER>
+            , <&macro_press &mo 1>
+            , <&macro_pause_for_release>
+            , <&macro_release &mo 1>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+            &kp_l1 A &kp B
+            &kp C    &none>;
+        };
+
+        other_layer {
+            bindings = <
+            &kp X    &kp Y
+            &kp Z    &none>;
+        };
+    };
+};
+
+&kscan {
+    events = <
+        ZMK_MOCK_PRESS(0,0,20)   // press macro (taps A)
+        ZMK_MOCK_PRESS(0,1,20)   // press Y
+        ZMK_MOCK_RELEASE(0,1,20) // release Y
+        ZMK_MOCK_RELEASE(0,0,20) // release macro
+        ZMK_MOCK_PRESS(1,0,10)   // press C
+        ZMK_MOCK_RELEASE(1,0,10) // release C
+    >;
+};


### PR DESCRIPTION
This PR adds a test for a macro bug where parameter passing isn't working correctly after `&macro_pause_for_release`, and proposes a fix.

The root cause seems to be that when pre-computing release state in `behavior_macro_init`, the parameter passing logic of the on-press portion is only partially taken into account. That is, control bindings like `&macro_param_1to1` are properly consumed (through the `handle_control_binding` calls) but whether the parameters are then used by a non-control behavior isn't considered: the release state precomputation does not replicate the resetting of `param*_source` variables that happens within `replace_params` during the on-press portion of the bindings. So the fix is to do this reset whenever a non-control behavior is encountered, emulating the `replace_params` call inside `queue_macro`.

As an example, in the added test, `&kp MACRO_PLACEHOLDER` consumes the previous `&macro_param_1to1` directive, both before `&macro_pause_for_release`. But `&mo 1` that comes after the release still uses the first parameter because the release state precomputation didn't apply the `param*_source` resetting logic.

Fixes #2921.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
