### PR TITLE
chore(docs): Fix prettier warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
         types_or: [c++, c]
         args:
           - -i
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: 787fb9f542b140ba0b2aced38e6a3e68021647a3
     hooks:
       - id: prettier
         exclude: |
@@ -22,9 +22,6 @@ repos:
               CHANGELOG.md|
               .release-please-manifest.json
           )$
-        # Workaround for https://github.com/pre-commit/mirrors-prettier/issues/29
-        additional_dependencies:
-          - prettier@2.8.7
   - repo: https://github.com/jorisroovers/gitlint
     rev: v0.19.1
     hooks:

--- a/docs/docs/development/hardware-integration/dongle.mdx
+++ b/docs/docs/development/hardware-integration/dongle.mdx
@@ -310,4 +310,5 @@ To use your dongled keyboard with [ZMK Studio](../../features/studio.md), apply 
 If you ever want to "undongle" your keyboard, simply remove these CMake arguments and flash the resulting firmware (after a `settings_reset`).
 
 [^1]: If you have a custom dongle that uses an onboard MCU, then you will need to take a slightly different approach that isn't currently documented.
+
 [^2]: If you are building locally, you can append these flags to the end of the [build command](../local-toolchain/build-flash.mdx#cmake-arguments).

--- a/docs/src/components/hardware-list.tsx
+++ b/docs/src/components/hardware-list.tsx
@@ -20,10 +20,9 @@ function itemIds(item: HardwareMetadata) {
   if (item.type == "board" || item.type == "shield") {
     const nodes = (item.siblings ?? [item.id])
       .map((id) => <code key={id}>{id}</code>)
-      .reduce<ElementOrString[]>(
-        (prev, curr, index) => [...prev, index > 0 ? ", " : "", curr],
-        []
-      );
+      .reduce<
+        ElementOrString[]
+      >((prev, curr, index) => [...prev, index > 0 ? ", " : "", curr], []);
     return <span key={item.id}>{nodes}</span>;
   } else {
     return <code key={item.id}>{item.id}</code>;

--- a/docs/src/components/interconnect-tabs.tsx
+++ b/docs/src/components/interconnect-tabs.tsx
@@ -10,8 +10,12 @@ interface InterconnectTabsProps {
 }
 
 function mapInterconnect(interconnect: Interconnect, gpio: boolean) {
-  const content = require(`@site/src/data/interconnects/${interconnect.id}/design_guideline.md`);
-  const imageUrl = require(`@site/docs/assets/interconnects/${interconnect.id}/pinout.png`);
+  const content = require(
+    `@site/src/data/interconnects/${interconnect.id}/design_guideline.md`
+  );
+  const imageUrl = require(
+    `@site/docs/assets/interconnects/${interconnect.id}/pinout.png`
+  );
   return (
     <TabItem value={interconnect.id} key={interconnect.id}>
       <img src={imageUrl.default} />

--- a/docs/src/css/power-estimate.css
+++ b/docs/src/css/power-estimate.css
@@ -15,7 +15,8 @@
 .powerEstimateBar {
   height: 64px;
   width: 100%;
-  box-shadow: rgba(0, 0, 0, 0.03) 0px 10px 20px 0px,
+  box-shadow:
+    rgba(0, 0, 0, 0.03) 0px 10px 20px 0px,
     rgba(0, 0, 0, 0.1) 0px 1px 4px 0px;
   border-radius: 64px;
   display: flex;

--- a/docs/src/css/power-profiler.css
+++ b/docs/src/css/power-profiler.css
@@ -9,7 +9,8 @@
   padding: 10px 20px;
   background: var(--ifm-background-surface-color);
   border-radius: 4px;
-  box-shadow: rgba(0, 0, 0, 0.03) 0px 10px 20px 0px,
+  box-shadow:
+    rgba(0, 0, 0, 0.03) 0px 10px 20px 0px,
     rgba(0, 0, 0, 0.1) 0px 1px 4px 0px;
 }
 
@@ -40,7 +41,8 @@ span[data-tooltip]::before {
   background: var(--ifm-background-surface-color);
   opacity: 0;
   visibility: hidden;
-  box-shadow: rgba(0, 0, 0, 0.03) 0px 10px 20px 0px,
+  box-shadow:
+    rgba(0, 0, 0, 0.03) 0px 10px 20px 0px,
     rgba(0, 0, 0, 0.1) 0px 1px 4px 0px;
   transition: opacity 0.2s ease;
   transform: translate(-50%, -100%);
@@ -180,7 +182,8 @@ select > option {
   padding: 20px 20px;
   background: var(--ifm-background-surface-color);
   border-radius: 4px;
-  box-shadow: rgba(0, 0, 0, 0.03) 0px 10px 20px 0px,
+  box-shadow:
+    rgba(0, 0, 0, 0.03) 0px 10px 20px 0px,
     rgba(0, 0, 0, 0.1) 0px 1px 4px 0px;
   width: 500px;
 }

--- a/docs/src/keymap-upgrade/textedit.ts
+++ b/docs/src/keymap-upgrade/textedit.ts
@@ -1,7 +1,10 @@
 import type { SyntaxNode } from "web-tree-sitter";
 
 export class Range {
-  constructor(public startIndex: number, public endIndex: number) {}
+  constructor(
+    public startIndex: number,
+    public endIndex: number
+  ) {}
 }
 
 export class TextEdit extends Range {


### PR DESCRIPTION
Clean up lingering prettier warnings. These are causing failures in our zmk-docker worflows, which check that prettier runs properly. See https://github.com/zmkfirmware/zmk-docker/actions/runs/15376917506/job/43263738558?pr=168