### PR TITLE
fix(display): Make stock battery widget depend on the right symbol

### DIFF
--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -10,7 +10,7 @@ config ZMK_WIDGET_LAYER_STATUS
 
 config ZMK_WIDGET_BATTERY_STATUS
     bool "Widget for battery charge information, using small icons"
-    depends on BT
+    depends on ZMK_BATTERY_REPORTING
     select LV_USE_LABEL
 
 if ZMK_WIDGET_BATTERY_STATUS


### PR DESCRIPTION
Currently, if `CONFIG_BT` is turned on but `CONFIG_ZMK_BATTERY_REPORTING` is turned off (which happens e.g. on `ARCH_POSIX` due to https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig#L155), builds with stock display widgets fails because of a linker error:

```
/usr/bin/ld.bfd: app/libapp.a(battery_status.c.obj): in function `battery_status_get_state':
/home/.../zmk/app/src/display/widgets/battery_status.c:66:(.text.battery_status_get_state+0x2): undefined reference to `as_zmk_battery_state_changed'
/usr/bin/ld.bfd: /home/.../zmk/app/src/display/widgets/battery_status.c:69:(.text.battery_status_get_state+0x24): undefined reference to `zmk_battery_state_of_charge'
/usr/bin/ld.bfd: app/libapp.a(battery_status.c.obj):/home/.../zmk/app/src/display/widgets/battery_status.c:79:(.event_subscription+0x10): undefined reference to `zmk_event_zmk_battery_state_changed'
```

This is because the event depends on `CONFIG_ZMK_BATTERY_REPORTING`. This fixes the `depends on` symbol of the widget so it depends on the correct symbol.