### PR TITLE
Fix rgb underglow hsb not saving in settings.

### DIFF
--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -381,7 +381,7 @@ int zmk_rgb_underglow_set_hsb(struct zmk_led_hsb color) {
 
     state.color = color;
 
-    return 0;
+    return zmk_rgb_underglow_save_state();
 }
 
 struct zmk_led_hsb zmk_rgb_underglow_calc_hue(int direction) {


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

I have noticed that changing HSB for the rgb underglow subsystem would not save the new value in settings except if an effect change was involved.

This is because the save function is not called in the `zmk_rgb_underglow_set_hsb` function.
Interestingly it is called in all other set functions of the API.

Even more interestingly, https://github.com/zmkfirmware/zmk/blob/239baa487509ace108d36f0e5c627d61a3d95f53/app/src/behaviors/behavior_rgb_underglow.c#L135 in the behavior binding file, even tho each keycode could correspont to one of the other functions of the API that directly maps to their intention; they all get remapped to the `zmk_rgb_underglow_set_hsb`.

In either case, `zmk_rgb_underglow_set_hsb` should call the save function.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
