### PR TITLE
fix(battery) : Fix for the conflict between the battery_voltage_divider and AIN0, and modification to allow changing the oversampling value

### DIFF
--- a/app/module/drivers/sensor/battery/battery_voltage_divider.c
+++ b/app/module/drivers/sensor/battery/battery_voltage_divider.c
@@ -110,6 +110,7 @@ static const struct sensor_driver_api bvd_api = {
 static int bvd_init(const struct device *dev) {
     struct bvd_data *drv_data = dev->data;
     const struct bvd_config *drv_cfg = dev->config;
+    uint32_t ch_mask = 0;
 
     if (drv_data->adc == NULL) {
         LOG_ERR("ADC failed to retrieve ADC driver");
@@ -130,8 +131,9 @@ static int bvd_init(const struct device *dev) {
     }
 #endif // DT_INST_NODE_HAS_PROP(0, power_gpios)
 
+    ch_mask |= BIT(drv_cfg->io_channel.channel);
     drv_data->as = (struct adc_sequence){
-        .channels = BIT(0),
+        .channels = ch_mask,
         .buffer = &drv_data->value.adc_raw,
         .buffer_size = sizeof(drv_data->value.adc_raw),
         .oversampling = 4,
@@ -143,6 +145,7 @@ static int bvd_init(const struct device *dev) {
         .gain = ADC_GAIN_1_6,
         .reference = ADC_REF_INTERNAL,
         .acquisition_time = ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 40),
+        .channel_id = drv_cfg->io_channel.channel,
         .input_positive = SAADC_CH_PSELP_PSELP_AnalogInput0 + drv_cfg->io_channel.channel,
     };
 

--- a/app/module/drivers/sensor/battery/battery_voltage_divider.c
+++ b/app/module/drivers/sensor/battery/battery_voltage_divider.c
@@ -26,6 +26,7 @@ struct bvd_config {
     struct gpio_dt_spec power;
     uint32_t output_ohm;
     uint32_t full_ohm;
+    uint8_t oversampling;
 };
 
 struct bvd_data {
@@ -136,7 +137,7 @@ static int bvd_init(const struct device *dev) {
         .channels = ch_mask,
         .buffer = &drv_data->value.adc_raw,
         .buffer_size = sizeof(drv_data->value.adc_raw),
-        .oversampling = 4,
+        .oversampling = drv_cfg->oversampling,
         .calibrate = true,
     };
 
@@ -172,6 +173,7 @@ static const struct bvd_config bvd_cfg = {
 #endif
     .output_ohm = DT_INST_PROP(0, output_ohms),
     .full_ohm = DT_INST_PROP(0, full_ohms),
+    .oversampling = DT_INST_PROP_OR(0, oversampling, 4),
 };
 
 DEVICE_DT_INST_DEFINE(0, &bvd_init, NULL, &bvd_data, &bvd_cfg, POST_KERNEL,

--- a/app/module/dts/bindings/sensor/zmk,battery-voltage-divider.yaml
+++ b/app/module/dts/bindings/sensor/zmk,battery-voltage-divider.yaml
@@ -6,3 +6,9 @@ description: Battery SoC monitoring using voltage divider
 compatible: "zmk,battery-voltage-divider"
 
 include: voltage-divider.yaml
+
+properties:
+  oversampling:
+      type: int
+      required: false
+      description: Oversampling value for ADC


### PR DESCRIPTION
**Description:**

Fixed an issue where improper ADC channel configuration caused a conflict between battery_voltage_divider and AIN0 and modified the oversampling value to be configurable via the device tree.
This pull request addresses these issues and improves the battery_voltage_divider .


**Specific issues resolved:**

- Resolved the conflict occurring when AIN0 was used as an analog input while battery_voltage_divider was assigned to a different ADC channel. (Specifically, battery level was not displayed, and console logs indicated that AIN0 values were overwriting the expected behavior.)
- Enabled setting the oversampling value to 0, resolving the issue where analog reading would stop after a certain period. More details [here](https://github.com/badjeff/zmk-analog-input-driver?tab=readme-ov-file#troubleshooting).


**Testing details:**

Tests were conducted using a board based on nRFMicro(V1.4) (AIN2 used for battery voltage monitoring) and an analog stick (Input:AIN0, AIN1), along with a keyboard featuring standard kscan. Confirmed that the conflict was resolved and that the issue causing analog reading to stop when oversampling was set to 0 was fixed.
The ZMK Config used for testing can be found [here](https://github.com/yoshikik1991/zmk-config-ergokeys_alice75/commit/d2d896f88f63fa4d30639e28084725f59c19fd01)


## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
