### PR TITLE
feat(ble): Add function to get profile address by index

### DIFF
--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -28,6 +28,7 @@ int zmk_ble_prof_disconnect(uint8_t index);
 
 int zmk_ble_active_profile_index(void);
 int zmk_ble_profile_index(const bt_addr_le_t *addr);
+bt_addr_le_t *zmk_ble_profile_address(uint8_t index);
 
 bt_addr_le_t *zmk_ble_active_profile_addr(void);
 struct bt_conn *zmk_ble_active_profile_conn(void);

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -250,6 +250,13 @@ int zmk_ble_profile_index(const bt_addr_le_t *addr) {
     return -ENODEV;
 }
 
+bt_addr_le_t *zmk_ble_profile_address(uint8_t index) {
+    if (index >= ZMK_BLE_PROFILE_COUNT) {
+        return (bt_addr_le_t *)(BT_ADDR_LE_NONE);
+    }
+    return &profiles[index].peer;
+}
+
 #if IS_ENABLED(CONFIG_SETTINGS)
 static void ble_save_profile_work(struct k_work *work) {
     settings_save_one("ble/active_profile", &active_profile, sizeof(active_profile));


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

This PR adds a `bt_addr_le_t *zmk_ble_profile_address(uint8_t index)` function to get a profile address by index. 

This is the smallest (and hopefully most likely to be merged?) core change I could find to allow #2265 to be implemented in an module.


## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
