### PR TITLE
refactor(ble): add functions to check if profile is open/connected by address

### DIFF
--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -33,6 +33,9 @@ bt_addr_le_t *zmk_ble_profile_address(uint8_t index);
 bt_addr_le_t *zmk_ble_active_profile_addr(void);
 struct bt_conn *zmk_ble_active_profile_conn(void);
 
+bool zmk_ble_profile_is_connected(const bt_addr_le_t *addr);
+bool zmk_ble_profile_is_open(const bt_addr_le_t *addr);
+
 bool zmk_ble_active_profile_is_open(void);
 bool zmk_ble_active_profile_is_connected(void);
 char *zmk_ble_active_profile_name(void);

--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -33,8 +33,8 @@ bt_addr_le_t *zmk_ble_profile_address(uint8_t index);
 bt_addr_le_t *zmk_ble_active_profile_addr(void);
 struct bt_conn *zmk_ble_active_profile_conn(void);
 
-bool zmk_ble_profile_is_connected(const bt_addr_le_t *addr);
-bool zmk_ble_profile_is_open(const bt_addr_le_t *addr);
+bool zmk_ble_profile_is_connected(uint8_t index);
+bool zmk_ble_profile_is_open(uint8_t index);
 
 bool zmk_ble_active_profile_is_open(void);
 bool zmk_ble_active_profile_is_connected(void);

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -98,6 +98,9 @@ K_WORK_DEFINE(raise_profile_changed_event_work, raise_profile_changed_event_call
 bool zmk_ble_active_profile_is_open(void) { return zmk_ble_profile_is_open(active_profile); }
 
 bool zmk_ble_profile_is_open(uint8_t index) {
+    if (index >= ZMK_BLE_PROFILE_COUNT) {
+        return false;
+    }
     return !bt_addr_le_cmp(&profiles[index].peer, BT_ADDR_LE_ANY);
 }
 
@@ -121,6 +124,9 @@ bool zmk_ble_active_profile_is_connected(void) {
 }
 
 bool zmk_ble_profile_is_connected(uint8_t index) {
+    if (index >= ZMK_BLE_PROFILE_COUNT) {
+        return false;
+    }
     struct bt_conn *conn;
     struct bt_conn_info info;
     bt_addr_le_t *addr = &profiles[index].peer;

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -95,12 +95,10 @@ static void raise_profile_changed_event_callback(struct k_work *work) {
 
 K_WORK_DEFINE(raise_profile_changed_event_work, raise_profile_changed_event_callback);
 
-bool zmk_ble_active_profile_is_open(void) {
-    return zmk_ble_profile_is_open(zmk_ble_active_profile_addr());
-}
+bool zmk_ble_active_profile_is_open(void) { return zmk_ble_profile_is_open(active_profile); }
 
-bool zmk_ble_profile_is_open(const bt_addr_le_t *addr) {
-    return !bt_addr_le_cmp(addr, BT_ADDR_LE_ANY);
+bool zmk_ble_profile_is_open(uint8_t index) {
+    return !bt_addr_le_cmp(&profiles[index].peer, BT_ADDR_LE_ANY);
 }
 
 void set_profile_address(uint8_t index, const bt_addr_le_t *addr) {
@@ -119,12 +117,13 @@ void set_profile_address(uint8_t index, const bt_addr_le_t *addr) {
 }
 
 bool zmk_ble_active_profile_is_connected(void) {
-    return zmk_ble_profile_is_connected(zmk_ble_active_profile_addr());
+    return zmk_ble_profile_is_connected(active_profile);
 }
 
-bool zmk_ble_profile_is_connected(const bt_addr_le_t *addr) {
+bool zmk_ble_profile_is_connected(uint8_t index) {
     struct bt_conn *conn;
     struct bt_conn_info info;
+    bt_addr_le_t *addr = &profiles[index].peer;
     if (!bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
         return false;
     } else if ((conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr)) == NULL) {

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -96,7 +96,11 @@ static void raise_profile_changed_event_callback(struct k_work *work) {
 K_WORK_DEFINE(raise_profile_changed_event_work, raise_profile_changed_event_callback);
 
 bool zmk_ble_active_profile_is_open(void) {
-    return !bt_addr_le_cmp(&profiles[active_profile].peer, BT_ADDR_LE_ANY);
+    return zmk_ble_profile_is_open(zmk_ble_active_profile_addr());
+}
+
+bool zmk_ble_profile_is_open(const bt_addr_le_t *addr) {
+    return !bt_addr_le_cmp(addr, BT_ADDR_LE_ANY);
 }
 
 void set_profile_address(uint8_t index, const bt_addr_le_t *addr) {
@@ -115,9 +119,12 @@ void set_profile_address(uint8_t index, const bt_addr_le_t *addr) {
 }
 
 bool zmk_ble_active_profile_is_connected(void) {
+    return zmk_ble_profile_is_connected(zmk_ble_active_profile_addr());
+}
+
+bool zmk_ble_profile_is_connected(const bt_addr_le_t *addr) {
     struct bt_conn *conn;
     struct bt_conn_info info;
-    bt_addr_le_t *addr = zmk_ble_active_profile_addr();
     if (!bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
         return false;
     } else if ((conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr)) == NULL) {


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

This PR implements `zmk_ble_active_profile_is_open()` and `zmk_ble_active_profile_is_connected()` in terms of newly introduced `zmk_ble_profile_is_open(addr)` and `zmk_ble_profile_is_connected(addr)`


## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
