### PR TITLE
Disable high voltage DC-DC by default

### DIFF
--- a/app/boards/arm/mikoto/Kconfig
+++ b/app/boards/arm/mikoto/Kconfig
@@ -7,7 +7,7 @@ config BOARD_ENABLE_DCDC
 config BOARD_ENABLE_DCDC_HV
     bool "High voltage DCDC converter"
     select SOC_DCDC_NRF52X_HV
-    default y
+    default n
     depends on (BOARD_MIKOTO)
 
 choice BOARD_MIKOTO_CHARGER_CURRENT

--- a/app/boards/arm/nice_nano/Kconfig
+++ b/app/boards/arm/nice_nano/Kconfig
@@ -9,5 +9,5 @@ config BOARD_ENABLE_DCDC
 config BOARD_ENABLE_DCDC_HV
     bool "High voltage DCDC converter"
     select SOC_DCDC_NRF52X_HV
-    default y
+    default n
     depends on (BOARD_NICE_NANO_V2)


### PR DESCRIPTION
Given a typical setup of a battery at ~4 V and a nice!nano v2 running at 3.3 V, I measured a small increase in power usage (using a Nordic PPK2) when SOC_DCDC_NRF52X_HV was enabled. This changes the nice_nano_v2 and mikoto boards so this option is disabled by default.

Fixes #2990