### PR TITLE
fix: Fix build with Studio and USB but not UART

### DIFF
--- a/app/src/studio/Kconfig
+++ b/app/src/studio/Kconfig
@@ -51,11 +51,13 @@ if ZMK_STUDIO_RPC
 
 menu "Transports"
 
+DT_CHOSEN_ZMK_STUDIO_RPC_UART := zmk,studio-rpc-uart
+
 config ZMK_STUDIO_TRANSPORT_UART
     bool "Serial"
     select SERIAL
     select RING_BUFFER
-    default y if ZMK_USB || ARCH_POSIX
+    default y if $(dt_chosen_enabled,$(DT_CHOSEN_ZMK_STUDIO_RPC_UART))
 
 config ZMK_STUDIO_TRANSPORT_UART_RX_STACK_SIZE
     int "RX Stack Size"


### PR DESCRIPTION
Changed CONFIG_ZMK_STUDIO_TRANSPORT_UART to automatically enable itself whenever a zmk,studio-rpc-uart chosen node is specified. The previous behavior of enabling if CONFIG_ZMK_USB was enabled broke builds when CONFIG_ZMK_STUDIO was enabled but the chosen node wasn't specified.