### PR TITLE
docs: Document requirements-extra.txt and endpoint selection for Studio

### DIFF
--- a/docs/.prettierignore
+++ b/docs/.prettierignore
@@ -4,3 +4,4 @@ build
 *.mustache
 hardware-metadata.json
 src/hardware-metadata.d.ts
+docs/development/local-toolchain/setup/native.mdx

--- a/docs/.prettierignore
+++ b/docs/.prettierignore
@@ -4,4 +4,3 @@ build
 *.mustache
 hardware-metadata.json
 src/hardware-metadata.d.ts
-docs/development/local-toolchain/setup/native.mdx

--- a/docs/docs/development/local-toolchain/setup/native.mdx
+++ b/docs/docs/development/local-toolchain/setup/native.mdx
@@ -203,6 +203,12 @@ west zephyr-export
 pip install -r zephyr/scripts/requirements-base.txt
 ```
 
+If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+
+```sh
+pip install -r zephyr/scripts/requirements-extra.txt
+```
+
 </TabItem>
 <TabItem value="glob">
 <Tabs groupId="operating-systems" queryString defaultValue="ubuntu">
@@ -295,6 +301,12 @@ west zephyr-export
 pip3 install --user -r zephyr/scripts/requirements-base.txt
 ```
 
+If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+
+```sh
+pip3 install -r zephyr/scripts/requirements-extra.txt
+```
+
   </TabItem>
 
   <TabItem value="win" label="Windows">
@@ -305,6 +317,12 @@ pip3 install --user -r zephyr/scripts/requirements-base.txt
 pip install -r zephyr/scripts/requirements-base.txt
 ```
 
+If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+
+```sh
+pip install -r zephyr/scripts/requirements-extra.txt
+```
+
   </TabItem>
 
   <TabItem value="mac" label="Mac OS">
@@ -312,6 +330,12 @@ pip install -r zephyr/scripts/requirements-base.txt
 
 ```sh
 pip3 install -r zephyr/scripts/requirements-base.txt
+```
+
+If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+
+```sh
+pip3 install -r zephyr/scripts/requirements-extra.txt
 ```
 
   </TabItem>

--- a/docs/docs/development/local-toolchain/setup/native.mdx
+++ b/docs/docs/development/local-toolchain/setup/native.mdx
@@ -109,61 +109,61 @@ These steps are very similar to Zephyr's [Get Zephyr and install Python dependen
 
 1. Use `apt` to install Python `venv` package:
 
-   ```sh
-   sudo apt install python3-venv
-   ```
+```sh
+sudo apt install python3-venv
+```
 
 2. Create a new virtual environment and activate it:
 
-   ```sh
-   python3 -m venv .venv
-   source .venv/bin/activate
-   ```
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+```
 
   </TabItem>
 
   <TabItem value="win" label="Windows">
 1. Create a new virtual environment:
 
-   ```sh
-   python -m venv .venv
-   ```
+```sh
+python -m venv .venv
+```
 
 2. Activate the virtual environment:
 
-   <WinTermTabs>
-     <TabItem value="cmd">
+  <WinTermTabs>
+    <TabItem value="cmd">
 
-   ```sh
-   .venv\Scripts\activate.bat
-   ```
+```sh
+.venv\Scripts\activate.bat
+```
 
-     </TabItem>
+    </TabItem>
 
-     <TabItem value="ps">
+    <TabItem value="ps">
 
-   ```powershell
-   .venv\Scripts\Activate.ps1
-   ```
+```powershell
+.venv\Scripts\Activate.ps1
+```
 
-     </TabItem>
+    </TabItem>
 
-   </WinTermTabs>
+  </WinTermTabs>
   </TabItem>
 
   <TabItem value="mac" label="Mac OS">
 
 1. Create a new virtual environment:
 
-   ```sh
-   python3 -m venv .venv
-   ```
+```sh
+python3 -m venv .venv
+```
 
 2. Activate the virtual environment:
 
-   ```sh
-   source .venv/bin/activate
-   ```
+```sh
+source .venv/bin/activate
+```
 
   </TabItem>
 </Tabs>
@@ -174,40 +174,40 @@ Once activated your shell will be prefixed with `(.venv)`. The virtual environme
 Remember to activate the virtual environment every time you start working.
 :::
 
-4. Install `west`:
+4. Install west:
 
-   ```sh
-   pip install west
-   ```
+```sh
+pip install west
+```
 
 5. Initialize the application and update to fetch modules, including Zephyr:
 
-   ```sh
-   west init -l app/
-   west update
-   ```
+```sh
+west init -l app/
+west update
+```
 
-   :::tip
-   This step pulls down quite a bit of tooling, be patient!
-   :::
+:::tip
+This step pulls down quite a bit of tooling, be patient!
+:::
 
 6. Export a [Zephyr CMake package](https://docs.zephyrproject.org/3.5.0/build/zephyr_cmake_package.html#cmake-pkg). This allows CMake to automatically load boilerplate code required for building Zephyr applications.
 
-   ```sh
-   west zephyr-export
-   ```
+```sh
+west zephyr-export
+```
 
 7. Install the additional dependencies found in Zephyr's `requirements-base.txt`:
 
-   ```sh
-   pip install -r zephyr/scripts/requirements-base.txt
-   ```
+```sh
+pip install -r zephyr/scripts/requirements-base.txt
+```
 
-   If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
 
-   ```sh
-   pip install -r zephyr/scripts/requirements-extra.txt
-   ```
+```sh
+pip install -r zephyr/scripts/requirements-extra.txt
+```
 
 </TabItem>
 <TabItem value="glob">
@@ -215,52 +215,52 @@ Remember to activate the virtual environment every time you start working.
   <TabItem value="ubuntu" label="Ubuntu">
 1. Install `west`:
 
-   ```sh
-   pip3 install --user -U west
-   ```
+```sh
+pip3 install --user -U west
+```
 
-   :::note
-   You need `~/.local/bin` to be on your `PATH` environment variable; verify that it is by running
+:::note
+You need `~/.local/bin` to be on your `PATH` environment variable; verify that it is by running
 
-   ```sh
-   west --version
-   ```
+```sh
+west --version
+```
 
-   If this prints an error rather than a `west` version number, then add `~/.local/bin` to your `PATH`:
+If this prints an error rather than a `west` version number, then add `~/.local/bin` to your `PATH`:
 
-   ```sh
-   echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
-   source ~/.bashrc
-   ```
+```sh
+echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
 
-   :::
+:::
 
   </TabItem>
 
   <TabItem value="win" label="Windows">
 1. Install `west`:
 
-   ```sh
-   pip install -U west
-   ```
+```sh
+pip install -U west
+```
 
-   :::note
-   You need the Python scripts directory to be on your PATH environment variable; verify that it is by running
+:::note
+You need the Python scripts directory to be on your PATH environment variable; verify that it is by running
 
-   ```sh
-   west --version
-   ```
+```sh
+west --version
+```
 
-   If this prints an error rather than a `west` version number, then add said directory to your `PATH` with PowerShell:
+If this prints an error rather than a `west` version number, then add said directory to your `PATH` with PowerShell:
 
-   ```powershell
-   $Scripts = python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
-   $Path = [Environment]::GetEnvironmentVariable('PATH', 'User')
-   [Environment]::SetEnvironmentVariable('PATH', "$Path;$Scripts", 'User')
-   $env:PATH += ";$Scripts"
-   ```
+```powershell
+$Scripts = python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
+$Path = [Environment]::GetEnvironmentVariable('PATH', 'User')
+[Environment]::SetEnvironmentVariable('PATH', "$Path;$Scripts", 'User')
+$env:PATH += ";$Scripts"
+```
 
-   :::
+:::
 
   </TabItem>
 
@@ -268,44 +268,44 @@ Remember to activate the virtual environment every time you start working.
 
 1. Install `west`:
 
-   ```sh
-   pip3 install -U west
-   ```
+```sh
+pip3 install -U west
+```
 
   </TabItem>
 </Tabs>
 
 2. Initialize the application and update to fetch modules, including Zephyr:
 
-   ```sh
-   west init -l app/
-   west update
-   ```
+```sh
+west init -l app/
+west update
+```
 
-   :::tip
-   This step pulls down quite a bit of tooling, be patient!
-   :::
+:::tip
+This step pulls down quite a bit of tooling, be patient!
+:::
 
 3. Export a [Zephyr CMake package](https://docs.zephyrproject.org/3.5.0/build/zephyr_cmake_package.html#cmake-pkg). This allows CMake to automatically load boilerplate code required for building Zephyr applications.
 
-   ```sh
-   west zephyr-export
-   ```
+```sh
+west zephyr-export
+```
 
 <Tabs groupId="operating-systems" queryString defaultValue="ubuntu" className="secrettabs">
   <TabItem value="ubuntu" label="Ubuntu">
 
 4. Install the additional dependencies found in Zephyr's `requirements-base.txt`:
 
-   ```sh
-   pip3 install --user -r zephyr/scripts/requirements-base.txt
-   ```
+```sh
+pip3 install --user -r zephyr/scripts/requirements-base.txt
+```
 
-   If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
 
-   ```sh
-   pip3 install -r zephyr/scripts/requirements-extra.txt
-   ```
+```sh
+pip3 install -r zephyr/scripts/requirements-extra.txt
+```
 
   </TabItem>
 
@@ -313,30 +313,30 @@ Remember to activate the virtual environment every time you start working.
 
 4. Install the additional dependencies found in Zephyr's `requirements-base.txt`:
 
-   ```sh
-   pip install -r zephyr/scripts/requirements-base.txt
-   ```
+```sh
+pip install -r zephyr/scripts/requirements-base.txt
+```
 
-   If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
 
-   ```sh
-   pip install -r zephyr/scripts/requirements-extra.txt
-   ```
+```sh
+pip install -r zephyr/scripts/requirements-extra.txt
+```
 
   </TabItem>
 
   <TabItem value="mac" label="Mac OS">
 4. Install the additional dependencies found in Zephyr's `requirements-base.txt`.
 
-   ```sh
-   pip3 install -r zephyr/scripts/requirements-base.txt
-   ```
+```sh
+pip3 install -r zephyr/scripts/requirements-base.txt
+```
 
-   If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
 
-   ```sh
-   pip3 install -r zephyr/scripts/requirements-extra.txt
-   ```
+```sh
+pip3 install -r zephyr/scripts/requirements-extra.txt
+```
 
   </TabItem>
 </Tabs>

--- a/docs/docs/development/local-toolchain/setup/native.mdx
+++ b/docs/docs/development/local-toolchain/setup/native.mdx
@@ -109,61 +109,61 @@ These steps are very similar to Zephyr's [Get Zephyr and install Python dependen
 
 1. Use `apt` to install Python `venv` package:
 
-```sh
-sudo apt install python3-venv
-```
+   ```sh
+   sudo apt install python3-venv
+   ```
 
 2. Create a new virtual environment and activate it:
 
-```sh
-python3 -m venv .venv
-source .venv/bin/activate
-```
+   ```sh
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
 
   </TabItem>
 
   <TabItem value="win" label="Windows">
 1. Create a new virtual environment:
 
-```sh
-python -m venv .venv
-```
+   ```sh
+   python -m venv .venv
+   ```
 
 2. Activate the virtual environment:
 
-  <WinTermTabs>
-    <TabItem value="cmd">
+   <WinTermTabs>
+     <TabItem value="cmd">
 
-```sh
-.venv\Scripts\activate.bat
-```
+   ```sh
+   .venv\Scripts\activate.bat
+   ```
 
-    </TabItem>
+     </TabItem>
 
-    <TabItem value="ps">
+     <TabItem value="ps">
 
-```powershell
-.venv\Scripts\Activate.ps1
-```
+   ```powershell
+   .venv\Scripts\Activate.ps1
+   ```
 
-    </TabItem>
+     </TabItem>
 
-  </WinTermTabs>
+   </WinTermTabs>
   </TabItem>
 
   <TabItem value="mac" label="Mac OS">
 
 1. Create a new virtual environment:
 
-```sh
-python3 -m venv .venv
-```
+   ```sh
+   python3 -m venv .venv
+   ```
 
 2. Activate the virtual environment:
 
-```sh
-source .venv/bin/activate
-```
+   ```sh
+   source .venv/bin/activate
+   ```
 
   </TabItem>
 </Tabs>
@@ -174,40 +174,40 @@ Once activated your shell will be prefixed with `(.venv)`. The virtual environme
 Remember to activate the virtual environment every time you start working.
 :::
 
-4. Install west:
+4. Install `west`:
 
-```sh
-pip install west
-```
+   ```sh
+   pip install west
+   ```
 
 5. Initialize the application and update to fetch modules, including Zephyr:
 
-```sh
-west init -l app/
-west update
-```
+   ```sh
+   west init -l app/
+   west update
+   ```
 
-:::tip
-This step pulls down quite a bit of tooling, be patient!
-:::
+   :::tip
+   This step pulls down quite a bit of tooling, be patient!
+   :::
 
 6. Export a [Zephyr CMake package](https://docs.zephyrproject.org/3.5.0/build/zephyr_cmake_package.html#cmake-pkg). This allows CMake to automatically load boilerplate code required for building Zephyr applications.
 
-```sh
-west zephyr-export
-```
+   ```sh
+   west zephyr-export
+   ```
 
 7. Install the additional dependencies found in Zephyr's `requirements-base.txt`:
 
-```sh
-pip install -r zephyr/scripts/requirements-base.txt
-```
+   ```sh
+   pip install -r zephyr/scripts/requirements-base.txt
+   ```
 
-If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+   If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
 
-```sh
-pip install -r zephyr/scripts/requirements-extra.txt
-```
+   ```sh
+   pip install -r zephyr/scripts/requirements-extra.txt
+   ```
 
 </TabItem>
 <TabItem value="glob">
@@ -215,52 +215,52 @@ pip install -r zephyr/scripts/requirements-extra.txt
   <TabItem value="ubuntu" label="Ubuntu">
 1. Install `west`:
 
-```sh
-pip3 install --user -U west
-```
+   ```sh
+   pip3 install --user -U west
+   ```
 
-:::note
-You need `~/.local/bin` to be on your `PATH` environment variable; verify that it is by running
+   :::note
+   You need `~/.local/bin` to be on your `PATH` environment variable; verify that it is by running
 
-```sh
-west --version
-```
+   ```sh
+   west --version
+   ```
 
-If this prints an error rather than a `west` version number, then add `~/.local/bin` to your `PATH`:
+   If this prints an error rather than a `west` version number, then add `~/.local/bin` to your `PATH`:
 
-```sh
-echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
-source ~/.bashrc
-```
+   ```sh
+   echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
+   source ~/.bashrc
+   ```
 
-:::
+   :::
 
   </TabItem>
 
   <TabItem value="win" label="Windows">
 1. Install `west`:
 
-```sh
-pip install -U west
-```
+   ```sh
+   pip install -U west
+   ```
 
-:::note
-You need the Python scripts directory to be on your PATH environment variable; verify that it is by running
+   :::note
+   You need the Python scripts directory to be on your PATH environment variable; verify that it is by running
 
-```sh
-west --version
-```
+   ```sh
+   west --version
+   ```
 
-If this prints an error rather than a `west` version number, then add said directory to your `PATH` with PowerShell:
+   If this prints an error rather than a `west` version number, then add said directory to your `PATH` with PowerShell:
 
-```powershell
-$Scripts = python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
-$Path = [Environment]::GetEnvironmentVariable('PATH', 'User')
-[Environment]::SetEnvironmentVariable('PATH', "$Path;$Scripts", 'User')
-$env:PATH += ";$Scripts"
-```
+   ```powershell
+   $Scripts = python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
+   $Path = [Environment]::GetEnvironmentVariable('PATH', 'User')
+   [Environment]::SetEnvironmentVariable('PATH', "$Path;$Scripts", 'User')
+   $env:PATH += ";$Scripts"
+   ```
 
-:::
+   :::
 
   </TabItem>
 
@@ -268,44 +268,44 @@ $env:PATH += ";$Scripts"
 
 1. Install `west`:
 
-```sh
-pip3 install -U west
-```
+   ```sh
+   pip3 install -U west
+   ```
 
   </TabItem>
 </Tabs>
 
 2. Initialize the application and update to fetch modules, including Zephyr:
 
-```sh
-west init -l app/
-west update
-```
+   ```sh
+   west init -l app/
+   west update
+   ```
 
-:::tip
-This step pulls down quite a bit of tooling, be patient!
-:::
+   :::tip
+   This step pulls down quite a bit of tooling, be patient!
+   :::
 
 3. Export a [Zephyr CMake package](https://docs.zephyrproject.org/3.5.0/build/zephyr_cmake_package.html#cmake-pkg). This allows CMake to automatically load boilerplate code required for building Zephyr applications.
 
-```sh
-west zephyr-export
-```
+   ```sh
+   west zephyr-export
+   ```
 
 <Tabs groupId="operating-systems" queryString defaultValue="ubuntu" className="secrettabs">
   <TabItem value="ubuntu" label="Ubuntu">
 
 4. Install the additional dependencies found in Zephyr's `requirements-base.txt`:
 
-```sh
-pip3 install --user -r zephyr/scripts/requirements-base.txt
-```
+   ```sh
+   pip3 install --user -r zephyr/scripts/requirements-base.txt
+   ```
 
-If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+   If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
 
-```sh
-pip3 install -r zephyr/scripts/requirements-extra.txt
-```
+   ```sh
+   pip3 install -r zephyr/scripts/requirements-extra.txt
+   ```
 
   </TabItem>
 
@@ -313,30 +313,30 @@ pip3 install -r zephyr/scripts/requirements-extra.txt
 
 4. Install the additional dependencies found in Zephyr's `requirements-base.txt`:
 
-```sh
-pip install -r zephyr/scripts/requirements-base.txt
-```
+   ```sh
+   pip install -r zephyr/scripts/requirements-base.txt
+   ```
 
-If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+   If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
 
-```sh
-pip install -r zephyr/scripts/requirements-extra.txt
-```
+   ```sh
+   pip install -r zephyr/scripts/requirements-extra.txt
+   ```
 
   </TabItem>
 
   <TabItem value="mac" label="Mac OS">
 4. Install the additional dependencies found in Zephyr's `requirements-base.txt`.
 
-```sh
-pip3 install -r zephyr/scripts/requirements-base.txt
-```
+   ```sh
+   pip3 install -r zephyr/scripts/requirements-base.txt
+   ```
 
-If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
+   If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
 
-```sh
-pip3 install -r zephyr/scripts/requirements-extra.txt
-```
+   ```sh
+   pip3 install -r zephyr/scripts/requirements-extra.txt
+   ```
 
   </TabItem>
 </Tabs>

--- a/docs/docs/features/studio.md
+++ b/docs/docs/features/studio.md
@@ -64,6 +64,13 @@ To use ZMK Studio over USB, you need permission to access the USB serial port. T
 
 :::
 
+:::note
+
+If you are connected to the computer over both USB and BLE endpoints, you should set the keyboard output to the same endpoint that you connect to ZMK Studio using.
+For example, if you are connecting to ZMK Studio over USB, ensure that USB output is selected by invoking the `&out OUT_USB` [behavior](../keymaps/behaviors/outputs.md).
+
+:::
+
 ## Building
 
 Building for ZMK Studio involves two main additional items.


### PR DESCRIPTION
- Fixes #2951. I assume this is required for other OS as well and not just Windows, but if anyone confirms it isn't then we can remove. It currently seems fine to me to recommend installing nevertheless.
- Fixes #2645.
- ~~Reformats the native toolchain setup file so that paragraphs and othes elements within a list item are properly indented.~~ Reverted, can't figure out how to get the pre-commit workflow to ignore the file as well.

Before:
<img width="975" height="455" alt="image" src="https://github.com/user-attachments/assets/69e4e0a6-f999-4dbc-85d0-db87519cc916" />

After:
<img width="978" height="464" alt="image" src="https://github.com/user-attachments/assets/4cec74c0-96b5-4d05-b5a6-758fe371cfeb" />

~~This required disabling prettier on the file, since it wanted to clobber all the indents and I don't think there is a way to add a range ignore in mdx files. I can drop the commit, but I don't think it's worth for me to spend more time trying to make prettier happy.~~