### PR TITLE
fix(split): Enable wired split by default if DTS is set

### DIFF
--- a/app/src/split/Kconfig
+++ b/app/src/split/Kconfig
@@ -18,7 +18,7 @@ config ZMK_SPLIT_BLE
 
 config ZMK_SPLIT_WIRED
     bool "Wired Split"
-    default y if !ZMK_SPLIT_BLE
+    default y
     depends on DT_HAS_ZMK_WIRED_SPLIT_ENABLED
     select SERIAL
     select RING_BUFFER

--- a/docs/docs/config/split.md
+++ b/docs/docs/config/split.md
@@ -51,7 +51,7 @@ Following wired [split keyboard](../features/split-keyboards.md) settings are de
 
 | Config                                       | Type | Description                                                       | Default                                                       |
 | -------------------------------------------- | ---- | ----------------------------------------------------------------- | ------------------------------------------------------------- |
-| `CONFIG_ZMK_SPLIT_WIRED`                     | bool | Use wired connection to communicate between split keyboard halves | y (if no BLE split and devicetree is set appropriately)       |
+| `CONFIG_ZMK_SPLIT_WIRED`                     | bool | Use wired connection to communicate between split keyboard halves | y (if devicetree is set appropriately)                        |
 | `CONFIG_ZMK_SPLIT_WIRED_UART_MODE_ASYNC`     | bool | Async (DMA) mode                                                  | y if the driver supports it (excluding nRF52 with known bugs) |
 | `CONFIG_ZMK_SPLIT_WIRED_UART_MODE_INTERRUPT` | bool | Interrupt mode                                                    | y if the hardware supports it                                 |
 | `CONFIG_ZMK_SPLIT_WIRED_UART_MODE_POLLING`   | bool | Polling mode                                                      | y if neither other mode is supported                          |


### PR DESCRIPTION
Remove the previous condition on ZMK_SPLIT_WIRED that only enabled it if !ZMK_BLE. We'll defer to the `depends on` to ensure the DTS exists to use wired split to make that decision on enabling the feature.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
