### PR TITLE
fix(ci): Set days before issue stale to 1000

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,7 @@ jobs:
             This PR was closed because it had no activity for over 10 months.
             Feel free to give a status update or re-open when it has been
             rebased and is ready for review (again).
+          days-before-issue-stale: 1000 # ~3 years
           days-before-issue-close: -1
           ascending: true # Process older PRs first
           operations-per-run: 30 # Default value, listed here again to make it explicit


### PR DESCRIPTION
The stale action is currently marking a lot of issues stale. While these markers could be useful, it is being far overaggressive in marking issues with stale.

Considering the development speed of ZMK, I feel 1000 days before an issue is marked as stale is fair. Being marked as stale for issues has the effect of drawing maintainer eyes. However, it also has the side effect of slowing down the responsiveness of the stale action. 

We could also bump the operations-per-run value if necessary, but I'd like to try this first.