### PR TITLE
Suggest using cu for USB log viewing on macOS

### DIFF
--- a/docs/docs/development/usb-logging.mdx
+++ b/docs/docs/development/usb-logging.mdx
@@ -86,7 +86,7 @@ You can connect to the device with [tio](https://tio.github.io/) (can be install
 sudo tio /dev/tty.usbmodem14401
 ```
 
-Alternatively, `cu` should be preinstalled:
+Alternatively, `cu` should be preinstalled (see `man cu` for usage instructions):
 
 ```sh
 sudo cu -l /dev/tty.usbmodem14401


### PR DESCRIPTION
It may not be as friendly, but `cu` should be available while `tio` can be hard to install.

See e.g. https://jasonmurray.org/posts/2020/serialconsolemacos/

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
