### PR TITLE
fix typo for pip requirements extras file

### DIFF
--- a/docs/docs/development/local-toolchain/setup/native.mdx
+++ b/docs/docs/development/local-toolchain/setup/native.mdx
@@ -206,7 +206,7 @@ pip install -r zephyr/scripts/requirements-base.txt
 If you are going to build firmware with [ZMK Studio](../../../features/studio.md), also install `requirements-extra.txt` dependencies:
 
 ```sh
-pip install -r zephyr/scripts/requirements-extra.txt
+pip install -r zephyr/scripts/requirements-extras.txt
 ```
 
 </TabItem>


### PR DESCRIPTION
When trying to setup the a environment, trying to pip install the extra requirements did not work as the file was slightly misnamed.