### PR TITLE
feat(split): Allow wired split for Ergodash

### DIFF
--- a/app/boards/shields/ergodash/ergodash.dtsi
+++ b/app/boards/shields/ergodash/ergodash.dtsi
@@ -12,6 +12,11 @@
         zmk,matrix-transform = &default_transform;
     };
 
+    wired_split {
+        compatible = "zmk,wired-split";
+        device = <&pro_micro_serial>;
+    };
+
     default_transform: keymap_transform_0 {
         compatible = "zmk,matrix-transform";
         columns = <14>;


### PR DESCRIPTION
The Ergodash shield uses a Pro Micro compatible TRRS wired split configuration. This small change enables this with the existing Ergodash shield definition.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] ~~Additional tests are included, if changing behaviors/core code that is testable.~~
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] ~~Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).~~
