### PR TITLE
docs: Typo in CMake Arguments example code blocks

### DIFF
--- a/docs/docs/development/local-toolchain/build-flash.mdx
+++ b/docs/docs/development/local-toolchain/build-flash.mdx
@@ -99,14 +99,14 @@ command. These are invoked whenever a new build system is generated. To add
 permanent arguments, set the `build.cmake-args` configuration option.
 
 ```sh
-west config build.cmake-args -- -DSHIELD=kyra_left
+west config build.cmake-args -- -DSHIELD=kyria_left
 ```
 
 Multiple arguments are added by assigning a string to the configuration option:
 
 ```sh
 west config build.cmake-args \
-  -- "-DSHIELD=kyra_left -DZMK_CONFIG=/absolute/path/to/zmk-config"
+  -- "-DSHIELD=kyria_left -DZMK_CONFIG=/absolute/path/to/zmk-config"
 ```
 
 ### Pristine Building


### PR DESCRIPTION
Fixes a typo in the code blocks [CMake Arguments section of Building and Flashing](https://zmk.dev/docs/development/local-toolchain/build-flash#cmake-arguments): replaces mention of `kyra` with `kyria`.
