### PR TITLE
fix(core): Generate correct keymap layer names for all builds

### DIFF
--- a/app/include/zmk/keymap.h
+++ b/app/include/zmk/keymap.h
@@ -7,13 +7,20 @@
 #pragma once
 
 #include <zmk/events/position_state_changed.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/devicetree.h>
+
+#define ZMK_KEYMAP_LAYERS_FOREACH(_fn)                                                             \
+    COND_CODE_1(IS_ENABLED(CONFIG_ZMK_STUDIO), (DT_FOREACH_CHILD(DT_INST(0, zmk_keymap), _fn)),    \
+                (DT_FOREACH_CHILD_STATUS_OKAY(DT_INST(0, zmk_keymap), _fn)))
+
+#define ZMK_KEYMAP_LAYERS_FOREACH_SEP(_fn, _sep)                                                   \
+    COND_CODE_1(IS_ENABLED(CONFIG_ZMK_STUDIO),                                                     \
+                (DT_FOREACH_CHILD_SEP(DT_INST(0, zmk_keymap), _fn, _sep)),                         \
+                (DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_INST(0, zmk_keymap), _fn, _sep)))
 
 #define ZMK_LAYER_CHILD_LEN_PLUS_ONE(node) 1 +
-#define ZMK_KEYMAP_LAYERS_LEN                                                                      \
-    (COND_CODE_1(                                                                                  \
-        IS_ENABLED(CONFIG_ZMK_STUDIO),                                                             \
-        (DT_FOREACH_CHILD(DT_INST(0, zmk_keymap), ZMK_LAYER_CHILD_LEN_PLUS_ONE)),                  \
-        (DT_FOREACH_CHILD_STATUS_OKAY(DT_INST(0, zmk_keymap), ZMK_LAYER_CHILD_LEN_PLUS_ONE))) 0)
+#define ZMK_KEYMAP_LAYERS_LEN (ZMK_KEYMAP_LAYERS_FOREACH(ZMK_LAYER_CHILD_LEN_PLUS_ONE) 0)
 
 /**
  * @brief A layer ID is a stable identifier to refer to a layer, regardless of ordering.

--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -74,12 +74,7 @@ static uint8_t keymap_layer_orders[ZMK_KEYMAP_LAYERS_LEN];
 
 #define KEYMAP_VAR(_name, _opts, no_init)                                                          \
     static _opts struct zmk_behavior_binding _name[ZMK_KEYMAP_LAYERS_LEN][ZMK_KEYMAP_LEN] = {      \
-        COND_CODE_0(                                                                               \
-            no_init,                                                                               \
-            (COND_CODE_1(IS_ENABLED(CONFIG_ZMK_STUDIO),                                            \
-                         (DT_INST_FOREACH_CHILD_SEP(0, TRANSFORMED_LAYER, (, ))),                  \
-                         (DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(0, TRANSFORMED_LAYER, (, ))))),    \
-            (0))};
+        COND_CODE_0(no_init, (ZMK_KEYMAP_LAYERS_FOREACH_SEP(TRANSFORMED_LAYER, (, ))), (0))};
 
 KEYMAP_VAR(zmk_keymap, COND_CODE_1(IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE), (), (const)),
            IS_ENABLED(CONFIG_ZMK_STUDIO))
@@ -89,14 +84,14 @@ KEYMAP_VAR(zmk_keymap, COND_CODE_1(IS_ENABLED(CONFIG_ZMK_KEYMAP_SETTINGS_STORAGE
 KEYMAP_VAR(zmk_stock_keymap, const, 0)
 
 static char zmk_keymap_layer_names[ZMK_KEYMAP_LAYERS_LEN][CONFIG_ZMK_KEYMAP_LAYER_NAME_MAX_LEN] = {
-    DT_INST_FOREACH_CHILD_SEP(0, LAYER_NAME, (, ))};
+    ZMK_KEYMAP_LAYERS_FOREACH_SEP(LAYER_NAME, (, ))};
 
 static uint32_t changed_layer_names = 0;
 
 #else
 
 static const char *zmk_keymap_layer_names[ZMK_KEYMAP_LAYERS_LEN] = {
-    DT_INST_FOREACH_CHILD_SEP(0, LAYER_NAME, (, ))};
+    ZMK_KEYMAP_LAYERS_FOREACH_SEP(LAYER_NAME, (, ))};
 
 #endif
 


### PR DESCRIPTION
Properly account for studio and non-studio builds for the generation of the layer names stored within the keymap system.

Fixes #3045

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
