### PR TITLE
feat(shields): Enable wired split for ergodash, prep for other wired split in-tree keyboards

### DIFF
--- a/app/boards/blackpill_f401cc.overlay
+++ b/app/boards/blackpill_f401cc.overlay
@@ -48,3 +48,5 @@
 blackpill_i2c: &i2c1 {};
 blackpill_spi: &spi1 {};
 blackpill_serial: &usart1 {};
+
+&blackpill_serial { status = "disabled"; };

--- a/app/boards/blackpill_f401ce.overlay
+++ b/app/boards/blackpill_f401ce.overlay
@@ -49,3 +49,5 @@
 blackpill_i2c: &i2c1 {};
 blackpill_spi: &spi1 {};
 blackpill_serial: &usart1 {};
+
+&blackpill_serial { status = "disabled"; };

--- a/app/boards/blackpill_f411ce.overlay
+++ b/app/boards/blackpill_f411ce.overlay
@@ -49,3 +49,5 @@
 blackpill_i2c: &i2c1 {};
 blackpill_spi: &spi1 {};
 blackpill_serial: &usart1 {};
+
+&blackpill_serial { status = "disabled"; };

--- a/app/boards/shields/ergodash/ergodash.dtsi
+++ b/app/boards/shields/ergodash/ergodash.dtsi
@@ -57,5 +57,14 @@ RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4)         RC(4,5) RC(4,6) RC(4,13) RC(4,12
             , <&pro_micro 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             ;
     };
+
+    wired_split {
+        compatible = "zmk,wired-split";
+        device = <&pro_micro_serial>;
+    };
+};
+
+&pro_micro_serial {
+    status = "okay";
 };
 

--- a/app/boards/shields/nice_view_adapter/boards/bluemicro840_v1.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/bluemicro840_v1.overlay
@@ -33,3 +33,7 @@ nice_view_spi: &spi0 {
 &pro_micro_i2c {
     status = "disabled";
 };
+
+&pro_micro_serial {
+    status = "disabled";
+};

--- a/app/boards/shields/nice_view_adapter/boards/mikoto.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/mikoto.overlay
@@ -33,3 +33,7 @@ nice_view_spi: &spi0 {
 &pro_micro_i2c {
     status = "disabled";
 };
+
+&pro_micro_serial {
+    status = "disabled";
+};

--- a/app/boards/shields/nice_view_adapter/boards/nice_nano.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nice_nano.overlay
@@ -33,3 +33,7 @@ nice_view_spi: &spi0 {
 &pro_micro_i2c {
     status = "disabled";
 };
+
+&pro_micro_serial {
+    status = "disabled";
+};

--- a/app/boards/shields/nice_view_adapter/boards/nice_nano_v2.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nice_nano_v2.overlay
@@ -33,3 +33,7 @@ nice_view_spi: &spi0 {
 &pro_micro_i2c {
     status = "disabled";
 };
+
+&pro_micro_serial {
+    status = "disabled";
+};

--- a/app/boards/shields/nice_view_adapter/boards/nrfmicro_11.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nrfmicro_11.overlay
@@ -33,3 +33,7 @@ nice_view_spi: &spi0 {
 &pro_micro_i2c {
     status = "disabled";
 };
+
+&pro_micro_serial {
+    status = "disabled";
+};

--- a/app/boards/shields/nice_view_adapter/boards/nrfmicro_11_flipped.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nrfmicro_11_flipped.overlay
@@ -33,3 +33,7 @@ nice_view_spi: &spi0 {
 &pro_micro_i2c {
     status = "disabled";
 };
+
+&pro_micro_serial {
+    status = "disabled";
+};

--- a/app/boards/shields/nice_view_adapter/boards/nrfmicro_13.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/nrfmicro_13.overlay
@@ -33,3 +33,7 @@ nice_view_spi: &spi0 {
 &pro_micro_i2c {
     status = "disabled";
 };
+
+&pro_micro_serial {
+    status = "disabled";
+};

--- a/app/boards/shields/nice_view_adapter/boards/puchi_ble_v1.overlay
+++ b/app/boards/shields/nice_view_adapter/boards/puchi_ble_v1.overlay
@@ -33,3 +33,7 @@ nice_view_spi: &spi0 {
 &pro_micro_i2c {
     status = "disabled";
 };
+
+&pro_micro_serial {
+    status = "disabled";
+};

--- a/docs/docs/development/hardware-integration/new-shield.mdx
+++ b/docs/docs/development/hardware-integration/new-shield.mdx
@@ -530,9 +530,19 @@ If testing the experimental [wired split](../../features/split-keyboards.md) sup
 };
 ```
 
-See the [wired split](../../config/split.md#wired-split) configuration for more details.
+Your shield should also ensure that the UART device used in `zmk,wired-split` is enabled, as we disable the predefined UART devices by default.
 
-For wireless split keyboards, this step should be skipped, especially since the UART pins on your controller might already be in use for other functionality.
+```dts
+&pro_micro_serial {
+    status = "okay";
+};
+```
+
+Note that enabling the UART device will prevent its pins from being used for any other purpose. For split shields to be used by both BLE-capable and BLE-incapable boards, you should setup the wired split. If a BLE-capable board is selected, the split interconnect will default to BLE, otherwise it will fall back to the wired split transport.
+If you have an optional hardware add-on that makes use of the UART pins when used wirelessly, define said add-on in a separate shield and have that shield disable the UART device.
+The in-tree `nice_view_adapter` is an example of such a shield, disabling the UART device so that one of the pins can be used for SPI instead.
+
+See the [wired split](../../config/split.md#wired-split) configuration for more details.
 
 </TabItem>
 </SplitTabs>


### PR DESCRIPTION
Currently, we disable the UART devices attached to pins of our in-tree boards. This is because when a UART device is enabled, the UART device will capture the pins it is assigned to, rendering them unusable for other purposes such as keymap scanning. UART is enabled by both ZMK Studio and USB logging, so we do not wish to have this enabled by default.

This PR demonstrates one approach for us to enable these UART devices for usage with shields that allow for wired split: We enable the correct UART device in the shield, alongside selecting it for usage with wired split. We assume that a shield which allows UART wired interconnect will not also simultaneously attempt to use said pins for some alternative purpose. If an add-on such as the nice!view with its adapter and bodge do wish to use said pins for an alternative purpose, then we see it as the add-on shield's responsibility to ensure that the UART device is disabled.

Ergodash is the in-tree keyboard used as an example, and credits to #3037 for beginning the topic.