### PR TITLE
docs: fix missing link and example introduction

### DIFF
--- a/docs/docs/keymaps/behaviors/hold-tap.mdx
+++ b/docs/docs/keymaps/behaviors/hold-tap.mdx
@@ -185,7 +185,7 @@ Below is a brief overview of the options set.
   This interrupt flavor is primarily used to decide between hold and tap, rather than using [tapping-term-ms](#tapping-term-ms).
   This matches how modifiers are used a majority of the time (hold shift, tap a key, release shift).
 - [`require-prior-idle-ms`](#require-prior-idle-ms) is set to 125ms to resolve to taps immediately when typing at speed, which helps eliminate typing delay.
-- [Positional hold taps](#positional-hold-tap-and-hold-trigger-key-positions) with [`hold-trigger-on-release`] are used to avoid accidental hold resolutions when typing sequences of letters all with the same hand.
+- [Positional hold taps](#positional-hold-tap-and-hold-trigger-key-positions) with [`hold-trigger-on-release`](#hold-trigger-on-release) are used to avoid accidental hold resolutions when typing sequences of letters all with the same hand.
 - [`tapping-term-ms`](#tapping-term-ms) is set to a higher value of 280ms, but not unreasonably high, so that same hand modifiers can still be used with intention.
 - [`quick-tap-ms`](#quick-tap-ms) is set to 175ms, for the event where a tapped key may wish to be held down.
 


### PR DESCRIPTION
Just two little docs fixes encountered while reading it. :wink: 