### PR TITLE
docs: Fix hold-trigger-on-release description

### DIFF
--- a/docs/docs/keymaps/behaviors/hold-tap.mdx
+++ b/docs/docs/keymaps/behaviors/hold-tap.mdx
@@ -415,7 +415,7 @@ the hold-tap. For home-row mods, this is not always ideal, because it prevents c
   </details>
 #### `hold-trigger-on-release`
 
-If set, instead of the keys listed in `hold-trigger-key-positions` producing a tap when _pressed_ before `tapping-term-ms` expires, they instead produce a tap when _released_ before `tapping-term-ms` expires.
+If set, instead of the keys **not** listed in `hold-trigger-key-positions` producing a tap when _pressed_ before `tapping-term-ms` expires, they instead produce a tap when _released_ before `tapping-term-ms` expires.
 
 ```dts
 &mt {


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

From https://zmk.dev/docs/keymaps/behaviors/hold-tap#hold-trigger-on-release:

> If set, instead of the keys listed in `hold-trigger-key-positions` producing a tap when _pressed_ before `tapping-term-ms` expires, they instead produce a tap when _released_ before `tapping-term-ms` expires.

Positional hold-tap only affects keys **not** listed in `hold-trigger-key-positions`, therefore `hold-trigger-on-release` also applies only to keys that are **not** listed.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
