### PR TITLE
fix(behaviors): correctly handle sensor rotation remainder

### DIFF
--- a/app/src/behaviors/behavior_sensor_rotate_common.c
+++ b/app/src/behaviors/behavior_sensor_rotate_common.c
@@ -34,7 +34,7 @@ int zmk_behavior_sensor_rotate_common_accept_data(
         remainder.val1 += value.val1;
         remainder.val2 += value.val2;
 
-        if (remainder.val2 >= 1000000 || remainder.val2 <= 1000000) {
+        if (abs(remainder.val2) >= 1000000) {
             remainder.val1 += remainder.val2 / 1000000;
             remainder.val2 %= 1000000;
         }


### PR DESCRIPTION
The original condition was always true, this commit fixes the condition to correctly handle the remainder for sensor rotation behaviors by using abs().

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
