### PR TITLE
feat(shields): Allow disabling WPM widget in nice!view shield

### DIFF
--- a/app/boards/shields/nice_view/Kconfig.defconfig
+++ b/app/boards/shields/nice_view/Kconfig.defconfig
@@ -52,4 +52,8 @@ endif # !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
 config ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN
     select LV_FONT_MONTSERRAT_26
 
+config NICE_VIEW_WPM_WIDGET
+    bool "Enable/Disable WPM widget"
+    default y if NICE_VIEW_WIDGET_STATUS
+
 endif # SHIELD_NICE_VIEW

--- a/app/boards/shields/nice_view/widgets/status.c
+++ b/app/boards/shields/nice_view/widgets/status.c
@@ -51,8 +51,10 @@ static void draw_top(lv_obj_t *widget, lv_color_t cbuf[], const struct status_st
 
     lv_draw_label_dsc_t label_dsc;
     init_label_dsc(&label_dsc, LVGL_FOREGROUND, &lv_font_montserrat_16, LV_TEXT_ALIGN_RIGHT);
+#if IS_ENABLED(CONFIG_NICE_VIEW_WPM_WIDGET)
     lv_draw_label_dsc_t label_dsc_wpm;
     init_label_dsc(&label_dsc_wpm, LVGL_FOREGROUND, &lv_font_unscii_8, LV_TEXT_ALIGN_RIGHT);
+#endif  
     lv_draw_rect_dsc_t rect_black_dsc;
     init_rect_dsc(&rect_black_dsc, LVGL_BACKGROUND);
     lv_draw_rect_dsc_t rect_white_dsc;
@@ -89,6 +91,7 @@ static void draw_top(lv_obj_t *widget, lv_color_t cbuf[], const struct status_st
     lv_canvas_draw_text(canvas, 0, 0, CANVAS_SIZE, &label_dsc, output_text);
 
     // Draw WPM
+#if IS_ENABLED(CONFIG_NICE_VIEW_WPM_WIDGET)
     lv_canvas_draw_rect(canvas, 0, 21, 68, 42, &rect_white_dsc);
     lv_canvas_draw_rect(canvas, 1, 22, 66, 40, &rect_black_dsc);
 
@@ -119,6 +122,8 @@ static void draw_top(lv_obj_t *widget, lv_color_t cbuf[], const struct status_st
         points[i].y = 60 - (state->wpm[i] - min) * 36 / range;
     }
     lv_canvas_draw_line(canvas, points, 10, &line_dsc);
+
+#endif
 
     // Rotate canvas
     rotate_canvas(canvas, cbuf);
@@ -325,9 +330,11 @@ struct wpm_status_state wpm_status_get_state(const zmk_event_t *eh) {
     return (struct wpm_status_state){.wpm = zmk_wpm_get_state()};
 };
 
+#if IS_ENABLED(CONFIG_NICE_VIEW_WPM_WIDGET)
 ZMK_DISPLAY_WIDGET_LISTENER(widget_wpm_status, struct wpm_status_state, wpm_status_update_cb,
                             wpm_status_get_state)
 ZMK_SUBSCRIPTION(widget_wpm_status, zmk_wpm_state_changed);
+#endif
 
 int zmk_widget_status_init(struct zmk_widget_status *widget, lv_obj_t *parent) {
     widget->obj = lv_obj_create(parent);
@@ -336,7 +343,11 @@ int zmk_widget_status_init(struct zmk_widget_status *widget, lv_obj_t *parent) {
     lv_obj_align(top, LV_ALIGN_TOP_RIGHT, 0, 0);
     lv_canvas_set_buffer(top, widget->cbuf, CANVAS_SIZE, CANVAS_SIZE, LV_IMG_CF_TRUE_COLOR);
     lv_obj_t *middle = lv_canvas_create(widget->obj);
+#if IS_ENABLED(CONFIG_NICE_VIEW_WPM_WIDGET)
     lv_obj_align(middle, LV_ALIGN_TOP_LEFT, 24, 0);
+#else
+    lv_obj_align(middle, LV_ALIGN_TOP_LEFT, 40, 0);
+#endif   
     lv_canvas_set_buffer(middle, widget->cbuf2, CANVAS_SIZE, CANVAS_SIZE, LV_IMG_CF_TRUE_COLOR);
     lv_obj_t *bottom = lv_canvas_create(widget->obj);
     lv_obj_align(bottom, LV_ALIGN_TOP_LEFT, -44, 0);
@@ -346,7 +357,9 @@ int zmk_widget_status_init(struct zmk_widget_status *widget, lv_obj_t *parent) {
     widget_battery_status_init();
     widget_output_status_init();
     widget_layer_status_init();
+#if IS_ENABLED(CONFIG_NICE_VIEW_WPM_WIDGET)
     widget_wpm_status_init();
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Added a new flag: "NICE_VIEW_WPM_WIDGET" in order to enable/disable the wpm widget. The default value is "y". 

When the "NICE_VIEW_WPM_WIDGET" is "n", it centers vertically the profiles widget.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
