### PR TITLE
fix(pm): add state check to soft off device suspension

### DIFF
--- a/app/src/pm.c
+++ b/app/src/pm.c
@@ -108,6 +108,11 @@ int zmk_pm_soft_off(void) {
     for (int i = 0; i < device_count; i++) {
         const struct device *dev = &devs[i];
 
+        if (!device_is_ready(dev) || pm_device_is_busy(dev) || pm_device_state_is_locked(dev) ||
+            pm_device_runtime_is_enabled(dev)) {
+            continue;
+        }
+
         if (pm_device_wakeup_is_enabled(dev)) {
             pm_device_wakeup_enable(dev, false);
         }


### PR DESCRIPTION
Check device state before suspension during soft-off to avoid unexpected behavior from incorrectly suspended devices, using the same existing pattern in `zmk_pm_suspend_devices`. 
Fixes high current consumption on XIAO nRF52840 upon wakeup from soft-off, likely caused by the QSPI flash being put in a weird state.

Tested on XIAO nRF52840 and XIAO nRF52840 Plus:
- Before: 4.6mA current draw after wake from soft-off (requires multiple additional resets to clear)
- After: Normal 40µA current draw after wake from soft-off.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [X] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [X] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
