### PR TITLE
fix(core): int to pointer cast in bas proxy

### DIFF
--- a/app/src/split/bluetooth/central_bas_proxy.c
+++ b/app/src/split/bluetooth/central_bas_proxy.c
@@ -30,7 +30,7 @@ static void blvl_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value
 
 static ssize_t read_blvl(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf,
                          uint16_t len, uint16_t offset) {
-    const uint8_t source = (uint8_t)(uint32_t)attr->user_data;
+    const uint8_t source = *(uint8_t *)attr->user_data;
     uint8_t level = 0;
     int rc = zmk_split_central_get_peripheral_battery_level(source, &level);
 
@@ -60,7 +60,7 @@ static const struct bt_gatt_cpf aux_level_cpf = {
 
 #define PERIPH_BATT_LEVEL_ATTRS(i, _)                                                              \
     BT_GATT_CHARACTERISTIC(BT_UUID_BAS_BATTERY_LEVEL, BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,     \
-                           BT_GATT_PERM_READ, read_blvl, NULL, i),                                 \
+                           BT_GATT_PERM_READ, read_blvl, NULL, ((uint8_t[]){i})),                  \
         BT_GATT_CCC(blvl_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),                 \
         BT_GATT_CPF(&aux_level_cpf), BT_GATT_CUD(PERIPH_CUD(i), BT_GATT_PERM_READ),
 


### PR DESCRIPTION
Fixes #3095 

Direct int to pointer cast causing build to fail in some build environments. With `docker.io/zmkfirmware/zmk-dev-arm:3.5` it's a warning instead.

Before: <https://github.com/Genteure/zmk-config-issue3095/actions/runs/19007070311/job/54282593007#step:11:117>
After: <https://github.com/Genteure/zmk-config-issue3095/actions/runs/19007544474/job/54283724669#step:11:111>

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
