### PR TITLE
nice!view: battery percentage

### DIFF
--- a/app/boards/shields/nice_view/Kconfig.defconfig
+++ b/app/boards/shields/nice_view/Kconfig.defconfig
@@ -43,6 +43,9 @@ config NICE_VIEW_WIDGET_STATUS
 config NICE_VIEW_WIDGET_INVERTED
     bool "Invert custom status widget colors"
 
+config NICE_VIEW_WIDGET_BATTERY_SHOW_PERCENTAGE
+    bool "Show battery percentage in status widget"
+
 if !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
 
 config NICE_VIEW_WIDGET_STATUS

--- a/app/boards/shields/nice_view/widgets/util.c
+++ b/app/boards/shields/nice_view/widgets/util.c
@@ -28,7 +28,18 @@ void draw_battery(lv_obj_t *canvas, const struct status_state *state) {
 
     canvas_draw_rect(canvas, 0, 2, 29, 12, &rect_white_dsc);
     canvas_draw_rect(canvas, 1, 3, 27, 10, &rect_black_dsc);
+
+#if CONFIG_NICE_VIEW_WIDGET_BATTERY_SHOW_PERCENTAGE
+    lv_draw_label_dsc_t label_dsc_battery;
+    init_label_dsc(&label_dsc_battery, LVGL_FOREGROUND, &lv_font_unscii_8, LV_TEXT_ALIGN_RIGHT);
+
+    char battery_text[6] = {};
+    snprintf(battery_text, sizeof(battery_text), "%d", state->battery);
+    canvas_draw_text(canvas, 2, 4, 24, &label_dsc_battery, battery_text);
+#else
     canvas_draw_rect(canvas, 2, 4, (state->battery + 2) / 4, 8, &rect_white_dsc);
+#endif
+
     canvas_draw_rect(canvas, 30, 5, 3, 6, &rect_white_dsc);
     canvas_draw_rect(canvas, 31, 6, 1, 4, &rect_black_dsc);
 


### PR DESCRIPTION
Add text in the battery symbol to show battery percentage. Can be enabled by setting `CONFIG_NICE_VIEW_WIDGET_BATTERY_SHOW_PERCENTAGE=y`.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- ~~[ ] Additional tests are included, if changing behaviors/core code that is testable.~~
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
