### PR TITLE
feat(split): add split transport changed event

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -96,6 +96,7 @@ target_sources_ifdef(CONFIG_ZMK_BATTERY_REPORTING app PRIVATE src/battery.c)
 target_sources_ifdef(CONFIG_ZMK_HID_INDICATORS app PRIVATE src/events/hid_indicators_changed.c)
 
 target_sources_ifdef(CONFIG_ZMK_SPLIT app PRIVATE src/events/split_peripheral_status_changed.c)
+target_sources_ifdef(CONFIG_ZMK_SPLIT app PRIVATE src/events/split_transport_changed.c)
 add_subdirectory_ifdef(CONFIG_ZMK_SPLIT src/split)
 
 target_sources_ifdef(CONFIG_USB_DEVICE_STACK app PRIVATE src/usb.c)

--- a/app/include/zmk/events/split_transport_changed.h
+++ b/app/include/zmk/events/split_transport_changed.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <zephyr/kernel.h>
+#include <zmk/event_manager.h>
+#include <zmk/split/transport/types.h>
+
+struct zmk_split_transport_changed {
+    uint32_t addr;
+    struct zmk_split_transport_status status;
+};
+
+ZMK_EVENT_DECLARE(zmk_split_transport_changed)

--- a/app/include/zmk/split/central.h
+++ b/app/include/zmk/split/central.h
@@ -46,3 +46,5 @@ int zmk_split_central_update_hid_indicator(zmk_hid_indicators_t indicators);
 int zmk_split_central_get_peripheral_battery_level(uint8_t source, uint8_t *level);
 
 #endif // IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING)
+
+bool zmk_split_transport_get_available(uint32_t addr);

--- a/app/include/zmk/split/central.h
+++ b/app/include/zmk/split/central.h
@@ -48,3 +48,5 @@ int zmk_split_central_get_peripheral_battery_level(uint8_t source, uint8_t *leve
 #endif // IS_ENABLED(CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING)
 
 bool zmk_split_transport_get_available(uint32_t addr);
+
+uint32_t zmk_split_get_transport_addr_at_index(uint8_t index);

--- a/app/include/zmk/split/peripheral.h
+++ b/app/include/zmk/split/peripheral.h
@@ -9,3 +9,5 @@
 #include <zmk/split/transport/types.h>
 
 int zmk_split_peripheral_report_event(const struct zmk_split_transport_peripheral_event *event);
+
+bool zmk_split_transport_get_available(uint32_t addr);

--- a/app/include/zmk/split/peripheral.h
+++ b/app/include/zmk/split/peripheral.h
@@ -11,3 +11,5 @@
 int zmk_split_peripheral_report_event(const struct zmk_split_transport_peripheral_event *event);
 
 bool zmk_split_transport_get_available(uint32_t addr);
+
+uint32_t zmk_split_get_transport_addr_at_index(uint8_t index);

--- a/app/src/events/split_transport_changed.c
+++ b/app/src/events/split_transport_changed.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2025 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/kernel.h>
+#include <zmk/events/split_transport_changed.h>
+
+ZMK_EVENT_IMPL(zmk_split_transport_changed);

--- a/app/src/split/central.c
+++ b/app/src/split/central.c
@@ -226,6 +226,16 @@ bool zmk_split_transport_get_available(uint32_t addr) {
     return 0;
 }
 
+uint32_t zmk_split_get_transport_addr_at_index(uint8_t index) {
+    struct zmk_split_transport_central *t;
+    ptrdiff_t count;
+    STRUCT_SECTION_COUNT(zmk_split_transport_central, &count);
+    if ((ptrdiff_t)index > count)
+        return 0;
+    STRUCT_SECTION_GET(zmk_split_transport_central, index, &t);
+    return (uint32_t)t;
+}
+
 static int central_init(void) {
     STRUCT_SECTION_FOREACH(zmk_split_transport_central, t) {
         if (!t->api->set_status_callback) {

--- a/app/src/split/peripheral.c
+++ b/app/src/split/peripheral.c
@@ -57,13 +57,14 @@ int zmk_split_transport_peripheral_command_handler(
         if (err) {
             LOG_ERR("Failed to invoke behavior %s: %d", binding.behavior_dev, err);
         }
+        return err;
     }
     case ZMK_SPLIT_TRANSPORT_CENTRAL_CMD_TYPE_SET_PHYSICAL_LAYOUT: {
-        zmk_physical_layouts_select(cmd.data.set_physical_layout.layout_idx);
+        return zmk_physical_layouts_select(cmd.data.set_physical_layout.layout_idx);
     }
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_PERIPHERAL_HID_INDICATORS)
     case ZMK_SPLIT_TRANSPORT_CENTRAL_CMD_TYPE_SET_HID_INDICATORS: {
-        raise_zmk_hid_indicators_changed((struct zmk_hid_indicators_changed){
+        return raise_zmk_hid_indicators_changed((struct zmk_hid_indicators_changed){
             .indicators = cmd.data.set_hid_indicators.indicators});
     }
 #endif

--- a/app/src/split/peripheral.c
+++ b/app/src/split/peripheral.c
@@ -144,6 +144,16 @@ bool zmk_split_transport_get_available(uint32_t addr) {
     return 0;
 }
 
+uint32_t zmk_split_get_transport_addr_at_index(uint8_t index) {
+    struct zmk_split_transport_peripheral *t;
+    ptrdiff_t count;
+    STRUCT_SECTION_COUNT(zmk_split_transport_peripheral, &count);
+    if ((ptrdiff_t)index > count)
+        return 0;
+    STRUCT_SECTION_GET(zmk_split_transport_peripheral, index, &t);
+    return (uint32_t)t;
+}
+
 static int peripheral_init(void) {
     STRUCT_SECTION_FOREACH(zmk_split_transport_peripheral, t) {
         if (!t->api->set_status_callback) {

--- a/app/src/split/peripheral.c
+++ b/app/src/split/peripheral.c
@@ -18,6 +18,8 @@
 #include <zmk/events/sensor_event.h>
 #include <zmk/events/battery_state_changed.h>
 
+#include <zmk/events/split_transport_changed.h>
+
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_PERIPHERAL_HID_INDICATORS)
 #include <zmk/events/hid_indicators_changed.h>
 #endif
@@ -115,6 +117,8 @@ static int select_first_available_transport(void) {
 
 static int transport_status_changed_cb(const struct zmk_split_transport_peripheral *p,
                                        struct zmk_split_transport_status status) {
+    raise_zmk_split_transport_changed(
+        (struct zmk_split_transport_changed){.addr = (uint32_t)p, .status = status});
     if (p == active_transport) {
         LOG_DBG("Peripheral at %p changed status: enabled %d, available %d, connections %d", p,
                 status.enabled, status.available, status.connections);
@@ -125,6 +129,16 @@ static int transport_status_changed_cb(const struct zmk_split_transport_peripher
         }
     } else {
         select_first_available_transport();
+    }
+
+    return 0;
+}
+
+bool zmk_split_transport_get_available(uint32_t addr) {
+    STRUCT_SECTION_FOREACH(zmk_split_transport_peripheral, t) {
+        if ((uint32_t)t == addr) {
+            return t->api->get_status().available;
+        }
     }
 
     return 0;


### PR DESCRIPTION
Opening this as a draft for now pending feedback as it's not in a very finished state, but this adds an event that gets raised when the split transport state changes, with the transport pointer as an int (serving as the address of the transport) and the transport status. Since this event isn't raised on startup a small helper function was also added to get the available state when supplied with an address

This is useful for triggering display or custom indicator changes when the transport changes from wireless to wired

This all *functions* however needing to know the pointer of the transport you're interested in is rather annoying, in testing i've had to compile the firmware, then look at the logs to see what the address of the transport i'm interested in is, then change a kconfig value to look for that pointer in my events, I have no idea how this would work without logging. perhaps this PR could add an enum into the split code with the transport type?