### PR TITLE
fix(split): Use managed queue for input report to avoid deadlock

### DIFF
--- a/app/src/split/bluetooth/Kconfig
+++ b/app/src/split/bluetooth/Kconfig
@@ -102,6 +102,17 @@ config BT_GAP_AUTO_UPDATE_CONN_PARAMS
 
 endif # !ZMK_SPLIT_ROLE_CENTRAL
 
+if ZMK_INPUT_SPLIT
+
+config ZMK_INPUT_SPLIT_MSG_QUEUE_SIZE
+    int "Max number of input split messages to queue for sending over BLE"
+    default 32
+    help
+      Sets the maximum number of input split events that can be queued for BLE notifications.
+      Increasing this reduces drops during high-rate input bursts at the cost of additional RAM.
+
+endif # ZMK_INPUT_SPLIT
+
 endmenu
 
 endif # ZMK_SPLIT_BLE

--- a/docs/docs/config/split.md
+++ b/docs/docs/config/split.md
@@ -35,6 +35,14 @@ Following bluetooth [split keyboard](../features/split-keyboards.md) settings ar
 | `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_PRIORITY`              | int  | Priority of the BLE split peripheral notify thread                         | 5                                          |
 | `CONFIG_ZMK_SPLIT_BLE_PERIPHERAL_POSITION_QUEUE_SIZE`   | int  | Max number of key state events to queue to send to the central             | 10                                         |
 
+#### Input Split
+
+The following setting only applies when using BLE split together with [input split devices](pointing.md#input-split), such as for pointing devices attached to split peripherals:
+
+| Config                                  | Type | Description                                                     | Default |
+| --------------------------------------- | ---- | --------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_INPUT_SPLIT_MSG_QUEUE_SIZE` | int  | Max number of input split events to queue for BLE notifications | 32      |
+
 ### Wired Splits
 
 Hardware UARTs have a few different modes/approaches to sending and receiving data, with different levels of complexity and performance. Not all hardware nor drivers support all modes, so ZMK has code to support different interaction modes with the UART as needed. The default mode should be properly selected based on the platform's report support, but you can choose to override the mode if needed.


### PR DESCRIPTION
I found that sometimes peripheral stops working when I use a trackball while holding down a key. When I put a trackball on central, this is not occurred.
As a result of my debug, the issue seems to come from deadlock on system work queue, so we should also use our managed work queue for peripheral's input report.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
