### PR TITLE
feat(display): Add label widget

### DIFF
--- a/app/include/zmk/display/widgets/label.h
+++ b/app/include/zmk/display/widgets/label.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <lvgl.h>
+#include <zephyr/kernel.h>
+
+struct zmk_widget_label {
+    sys_snode_t node;
+    lv_obj_t *obj;
+};
+
+int zmk_widget_label_init(struct zmk_widget_label *widget, lv_obj_t *parent);
+lv_obj_t *zmk_widget_label_obj(struct zmk_widget_label *widget);

--- a/app/src/display/status_screen.c
+++ b/app/src/display/status_screen.c
@@ -9,6 +9,7 @@
 #include <zmk/display/widgets/battery_status.h>
 #include <zmk/display/widgets/layer_status.h>
 #include <zmk/display/widgets/wpm_status.h>
+#include <zmk/display/widgets/label.h>
 #include <zmk/display/status_screen.h>
 
 #include <zephyr/logging/log.h>
@@ -32,6 +33,10 @@ static struct zmk_widget_layer_status layer_status_widget;
 
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_WPM_STATUS)
 static struct zmk_widget_wpm_status wpm_status_widget;
+#endif
+
+#if IS_ENABLED(CONFIG_ZMK_WIDGET_LABEL)
+static struct zmk_widget_label label_widget;
 #endif
 
 lv_obj_t *zmk_display_status_screen() {
@@ -64,6 +69,13 @@ lv_obj_t *zmk_display_status_screen() {
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_WPM_STATUS)
     zmk_widget_wpm_status_init(&wpm_status_widget, screen);
     lv_obj_align(zmk_widget_wpm_status_obj(&wpm_status_widget), LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+#endif
+
+#if IS_ENABLED(CONFIG_ZMK_WIDGET_LABEL)
+    zmk_widget_label_init(&label_widget, screen);
+    lv_obj_set_style_text_font(zmk_widget_label_obj(&label_widget), lv_theme_get_font_small(screen),
+                               LV_PART_MAIN);
+    lv_obj_align(zmk_widget_label_obj(&label_widget), LV_ALIGN_CENTER, 0, 0);
 #endif
     return screen;
 }

--- a/app/src/display/widgets/CMakeLists.txt
+++ b/app/src/display/widgets/CMakeLists.txt
@@ -6,3 +6,4 @@ target_sources_ifdef(CONFIG_ZMK_WIDGET_OUTPUT_STATUS app PRIVATE output_status.c
 target_sources_ifdef(CONFIG_ZMK_WIDGET_PERIPHERAL_STATUS app PRIVATE peripheral_status.c)
 target_sources_ifdef(CONFIG_ZMK_WIDGET_LAYER_STATUS app PRIVATE layer_status.c)
 target_sources_ifdef(CONFIG_ZMK_WIDGET_WPM_STATUS app PRIVATE wpm_status.c)
+target_sources_ifdef(CONFIG_ZMK_WIDGET_LABEL app PRIVATE label.c)

--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -36,4 +36,13 @@ config ZMK_WIDGET_WPM_STATUS
     select LV_USE_LABEL
     select ZMK_WPM
 
+config ZMK_WIDGET_LABEL
+    bool "Widget for displaying custom messages"
+    select LV_USE_LABEL
+
+config ZMK_WIDGET_LABEL_TEXT
+    string "Custom message to display"
+    default "ZMK"
+    depends on ZMK_WIDGET_LABEL
+
 endmenu

--- a/app/src/display/widgets/label.c
+++ b/app/src/display/widgets/label.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/kernel.h>
+
+#include <zmk/display.h>
+#include <zmk/display/widgets/label.h>
+
+int zmk_widget_label_init(struct zmk_widget_label *widget, lv_obj_t *parent) {
+    widget->obj = lv_label_create(parent);
+    lv_label_set_text(widget->obj, CONFIG_ZMK_WIDGET_LABEL_TEXT);
+
+    return 0;
+}
+
+lv_obj_t *zmk_widget_label_obj(struct zmk_widget_label *widget) { return widget->obj; }

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -14,17 +14,19 @@ Definition files:
 - [zmk/app/src/display/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/Kconfig)
 - [zmk/app/src/display/widgets/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/src/display/widgets/Kconfig)
 
-| Config                                             | Type | Description                                                    | Default      |
-| -------------------------------------------------- | ---- | -------------------------------------------------------------- | ------------ |
-| `CONFIG_ZMK_DISPLAY`                               | bool | Enable support for displays                                    | n            |
-| `CONFIG_ZMK_DISPLAY_BLANK_ON_IDLE`                 | bool | Blank display on idle                                          | y if SSD1306 |
-| `CONFIG_ZMK_DISPLAY_TICK_PERIOD_MS`                | int  | Period (in ms) between display task execution                  | 10           |
-| `CONFIG_ZMK_DISPLAY_INVERT`                        | bool | Invert display colors from black-on-white to white-on-black    | n            |
-| `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool | Enable a widget to show the highest, active layer              | y            |
-| `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool | Enable a widget to show battery charge information             | y            |
-| `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool | If battery widget is enabled, show percentage instead of icons | n            |
-| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool | Enable a widget to show the current output (USB/BLE)           | y            |
-| `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool | Enable a widget to show words per minute                       | n            |
+| Config                                             | Type   | Description                                                    | Default      |
+| -------------------------------------------------- | ------ | -------------------------------------------------------------- | ------------ |
+| `CONFIG_ZMK_DISPLAY`                               | bool   | Enable support for displays                                    | n            |
+| `CONFIG_ZMK_DISPLAY_BLANK_ON_IDLE`                 | bool   | Blank display on idle                                          | y if SSD1306 |
+| `CONFIG_ZMK_DISPLAY_TICK_PERIOD_MS`                | int    | Period (in ms) between display task execution                  | 10           |
+| `CONFIG_ZMK_DISPLAY_INVERT`                        | bool   | Invert display colors from black-on-white to white-on-black    | n            |
+| `CONFIG_ZMK_WIDGET_LAYER_STATUS`                   | bool   | Enable a widget to show the highest, active layer              | y            |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS`                 | bool   | Enable a widget to show battery charge information             | y            |
+| `CONFIG_ZMK_WIDGET_BATTERY_STATUS_SHOW_PERCENTAGE` | bool   | If battery widget is enabled, show percentage instead of icons | n            |
+| `CONFIG_ZMK_WIDGET_OUTPUT_STATUS`                  | bool   | Enable a widget to show the current output (USB/BLE)           | y            |
+| `CONFIG_ZMK_WIDGET_WPM_STATUS`                     | bool   | Enable a widget to show words per minute                       | n            |
+| `CONFIG_ZMK_WIDGET_LABEL`                          | bool   | Enable a widget to display custom messages                     | n            |
+| `CONFIG_ZMK_WIDGET_LABEL_TEXT`                     | string | Custom message to display                                      | ZMK          |
 
 Note that `CONFIG_ZMK_DISPLAY_INVERT` setting might not work as expected with custom status screens that utilize images.
 


### PR DESCRIPTION
This is a barebones label widget for displaying a  custom message in the center of display.

The widget can be enabled using CONFIG_ZMK_WIDGET_LABEL in the .conf file.
The displayed message is configured using CONFIG_ZMK_WIDGET_LABEL_TEXT(default is "ZMK").
Docs have been updated to include the new configuration options.

Demo example:
<img width="961" height="1280" alt="image" src="https://github.com/user-attachments/assets/7399e455-e152-44ab-9df6-bd1fb814f34d" />

My end goal is to create a widget capable of displaying custom icons, using lvgls' image lib.

This PR is a re-open of #2025 after everything was rebased and its ready for review again.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
