### PR TITLE
fix(split): Properly return from command handler

### DIFF
--- a/app/src/split/peripheral.c
+++ b/app/src/split/peripheral.c
@@ -55,13 +55,14 @@ int zmk_split_transport_peripheral_command_handler(
         if (err) {
             LOG_ERR("Failed to invoke behavior %s: %d", binding.behavior_dev, err);
         }
+        return err;
     }
     case ZMK_SPLIT_TRANSPORT_CENTRAL_CMD_TYPE_SET_PHYSICAL_LAYOUT: {
-        zmk_physical_layouts_select(cmd.data.set_physical_layout.layout_idx);
+        return zmk_physical_layouts_select(cmd.data.set_physical_layout.layout_idx);
     }
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_PERIPHERAL_HID_INDICATORS)
     case ZMK_SPLIT_TRANSPORT_CENTRAL_CMD_TYPE_SET_HID_INDICATORS: {
-        raise_zmk_hid_indicators_changed((struct zmk_hid_indicators_changed){
+        return raise_zmk_hid_indicators_changed((struct zmk_hid_indicators_changed){
             .indicators = cmd.data.set_hid_indicators.indicators});
     }
 #endif


### PR DESCRIPTION
#3103 introduced a small bug where spurious HID indicator events with garbage data would be raised on the peripheral when behaviours are invoked as the switch statement didn't return in each case and continued to chain down. This properly returns from each case to stop this happening

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
