### PR TITLE
docs: Add release version to the docs, with links and warning banner

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,6 +1,32 @@
+const { execSync } = require("child_process");
 const path = require("path");
 const theme = require("./src/theme/prism/themes/github");
 const darkTheme = require("./src/theme/prism/themes/github-dark-dimmed");
+const { releaseVersions } = require("./zmk-release-versions.json");
+
+const gitBranch =
+  process.env.BRANCH ||
+  execSync("git branch --show-current", { encoding: "utf-8" }).trim();
+const isDevelopmentVersion =
+  gitBranch === "main" || !/^v\d+\.\d+-branch$/.test(gitBranch);
+const versionNavbarItems = [
+  {
+    label: "Pre-Release",
+    description: "Current active development branch (main)",
+    href: "https://zmk.dev/docs/",
+  },
+  ...releaseVersions.map((r) => ({
+    label: "v" + r,
+    description: "Stable release v" + r,
+    href: `https://v${r.replaceAll(".", "-")}-branch.zmk.dev/docs/`,
+  })),
+];
+
+const versionDropDownLabel = isDevelopmentVersion
+  ? versionNavbarItems[0].label
+  : versionNavbarItems.find((item) => {
+      return item.label === gitBranch.replace("-branch", "");
+    });
 
 module.exports = {
   title: "ZMK Firmware",
@@ -11,6 +37,10 @@ module.exports = {
   trailingSlash: "false",
   organizationName: "zmkfirmware", // Usually your GitHub org/user name.
   projectName: "zmk", // Usually your repo name.
+  customFields: {
+    isDevelopmentVersion,
+    releaseVersions,
+  },
   plugins: [
     "@docusaurus/theme-mermaid",
     path.resolve(__dirname, "src/docusaurus-tree-sitter-plugin"),
@@ -51,16 +81,29 @@ module.exports = {
           label: "Docs",
           position: "left",
         },
-        { to: "blog", label: "Blog", position: "left" },
+        isDevelopmentVersion
+          ? { to: "blog", label: "Blog", position: "left" }
+          : { href: "https://zmk.dev/blog", label: "Blog", position: "left" },
         {
-          to: "power-profiler",
-          label: "Power Profiler",
+          type: "dropdown",
+          label: "Tools",
           position: "left",
+          items: [
+            {
+              to: "power-profiler",
+              label: "Power Profiler",
+            },
+            {
+              to: "keymap-upgrader",
+              label: "Keymap Upgrader",
+            },
+          ],
         },
         {
-          to: "keymap-upgrader",
-          label: "Keymap Upgrader",
-          position: "left",
+          type: "dropdown",
+          label: versionDropDownLabel,
+          position: "right",
+          items: versionNavbarItems,
         },
         {
           href: "https://zmk.studio/",
@@ -69,7 +112,8 @@ module.exports = {
         },
         {
           href: "https://github.com/zmkfirmware/zmk",
-          label: "GitHub",
+          "aria-label": "ZMK GitHub Repository",
+          className: "header-github-link",
           position: "right",
         },
       ],

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -23,6 +23,21 @@
   --docusaurus-highlighted-code-line-bg: rgb(255 255 255 / 8%);
 }
 
+.header-github-link::before {
+  content: "";
+  width: 24px;
+  height: 24px;
+  display: flex;
+  background-color: var(--ifm-navbar-link-color);
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E");
+  transition: background-color var(--ifm-transition-fast)
+    var(--ifm-transition-timing-default);
+}
+
+.header-github-link:hover::before {
+  background-color: var(--ifm-navbar-link-hover-color);
+}
+
 .docusaurus-highlight-code-line {
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));

--- a/docs/src/theme/DocVersionBanner/index.tsx
+++ b/docs/src/theme/DocVersionBanner/index.tsx
@@ -1,0 +1,60 @@
+import { type ReactNode } from "react";
+import clsx from "clsx";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Link from "@docusaurus/Link";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import type { Props } from "@theme/DocVersionBanner";
+
+function ZMKReleaseLink({ version }: { version: string }): ReactNode {
+  return (
+    <Link
+      href={`https://v${version.replaceAll(".", "-")}-branch.zmk.dev/docs/`}
+    >
+      v{version}
+    </Link>
+  );
+}
+
+function DevWarningBanner({
+  className,
+  latestVersion,
+}: Props & { latestVersion: string }): ReactNode {
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        "alert alert--warning margin-bottom--md"
+      )}
+      role="alert"
+    >
+      You're viewing the documentation for the development version of ZMK. You
+      may want the latest release <ZMKReleaseLink version={latestVersion} />.
+    </div>
+  );
+}
+
+export default function DocVersionBanner({ className }: Props): ReactNode {
+  const {
+    siteConfig: { customFields },
+  } = useDocusaurusContext();
+
+  if (
+    !customFields?.releaseVersions ||
+    !Array.isArray(customFields.releaseVersions)
+  ) {
+    return null;
+  }
+
+  const releaseVersions: [string] = customFields.releaseVersions as [string];
+
+  if (customFields.isDevelopmentVersion) {
+    return (
+      <DevWarningBanner
+        className={className}
+        latestVersion={releaseVersions[0]}
+      />
+    );
+  }
+  return null;
+}

--- a/docs/zmk-release-versions.json
+++ b/docs/zmk-release-versions.json
@@ -1,0 +1,3 @@
+{
+  "releaseVersions": ["0.3"]
+}


### PR DESCRIPTION
Add versions to the sidebar of the documentation, and when viewing the deployment on zmk.dev, which tracks `main`, add a banner warning about possibly prefering the docs for a particular stable release.

If we like this strategy, I can add commits to v0.2-branch and v0.1-branch so those deploy as well, then include them in the list of release versions.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
