### PR TITLE
refactor(Kconfig): Move BT_DEVICE_APPEARANCE to defaults

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -25,9 +25,6 @@ config USB_DEVICE_PID
 config USB_DEVICE_MANUFACTURER
     default "ZMK Project"
 
-config BT_DEVICE_APPEARANCE
-    default 961
-
 config BT_DIS_PNP_VID
     default 0x1D50
 
@@ -221,9 +218,6 @@ config BT_GATT_NOTIFY_MULTIPLE
 
 config BT_GATT_AUTO_SEC_REQ
     default (ZMK_SPLIT_BLE && !ZMK_SPLIT_ROLE_CENTRAL)
-
-config BT_DEVICE_APPEARANCE
-    default 961
 
 config BT_PERIPHERAL_PREF_MIN_INT
     default 6

--- a/app/Kconfig.defaults
+++ b/app/Kconfig.defaults
@@ -5,6 +5,10 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
     default 2048 if SOC_RP2040
     default 2048 if ZMK_BLE
 
+# Basic
+config BT_DEVICE_APPEARANCE
+    default 961
+
 # HID
 if ZMK_HID_REPORT_TYPE_HKRO
 


### PR DESCRIPTION
Move the Kconfig symbol that was used in #3115 to Kconfig.defaults, so that it can be overridden in a Kconfig.defconfig file. It makes sense to me to allow that, so that e.g. a shield config for what is mainly pointing device can set it by default. I tested and the override now works as expected.

Also note that two copies of the setting were deleted from `Kconfig`, since I am guessing it was missed in #3115 that one existed already. (cc. @efogdev)