### PR TITLE
blog: clarify west upgrade command for venv vs global installation

### DIFF
--- a/docs/blog/2025-12-09-zephyr-4-1.md
+++ b/docs/blog/2025-12-09-zephyr-4-1.md
@@ -115,7 +115,7 @@ Once the container has rebuilt, VS Code will be running the 4.1 Docker image.
 The following steps will get you building ZMK locally against Zephyr 4.1:
 
 - Run the updated [toolchain installation](/docs/development/local-toolchain/setup) steps, and once completed, remove the previously installed SDK version (optional, existing SDK should still work)
-- Install the latest version of `west` by running `pip3 install --user --update west`.
+- Install the latest version of `west` by running `pip3 install --upgrade west` in a virtual environment, or add the `--user` flag if `west` is installed globally: `pip3 install --user --upgrade west`.
 - Pull the latest ZMK `main` with `git pull` for your ZMK checkout
 - Run `west update` to pull the updated Zephyr version and its dependencies
 


### PR DESCRIPTION
Fix incorrect pip flag and distinguish between venv and global west installations in Zephyr 4.1 update post

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
