### PR TITLE
docs: Remove all references to nice_nano_v2 and seeeduino_xiao_ble

### DIFF
--- a/docs/docs/config/system.md
+++ b/docs/docs/config/system.md
@@ -144,7 +144,7 @@ Re-flashing a bootloader built without the SoftDevice will require firmware buil
 Enable snippets by adding `snippet: <snippet>` to your `build.yaml` for the appropriate board:
 
 ```yaml
-- board: nrfmicro_13_52833
+- board: nrfmicro@1.3.0/nrf52833
   snippet: nrf52833-nosd
   shield: corne_left
 ```
@@ -152,7 +152,7 @@ Enable snippets by adding `snippet: <snippet>` to your `build.yaml` for the appr
 For local builds, add `-S <snippet>` to your build command. For example:
 
 ```sh
-west build -b nrfmicro_13_52833 -S nrf52833-nosd -- -DSHIELD=corne_left
+west build -b nrfmicro@1.3.0/nrf52833 -S nrf52833-nosd -- -DSHIELD=corne_left
 ```
 
 ZMK implements the following system configuration snippets:

--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -58,13 +58,13 @@ You can build additional keyboards with GitHub actions by appending them to `bui
 
 ```yaml
 include:
-  - board: nice_nano
+  - board: nice_nano@1
     shield: corne_left
-  - board: nice_nano
+  - board: nice_nano@1
     shield: corne_right
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: lily58_left
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: lily58_right
 ```
 

--- a/docs/docs/development/hardware-integration/dongle.mdx
+++ b/docs/docs/development/hardware-integration/dongle.mdx
@@ -289,12 +289,12 @@ include:
   # Your other keyboard parts here
   # -----------------------------------------
   # Change the board appropriately, you can use any board
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: my_keyboard_dongle
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: settings_reset
   # Add these cmake-args to the peripherals you wish to use with the dongle
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: my_keyboard
     cmake-args: -DCONFIG_ZMK_SPLIT=y -DCONFIG_ZMK_SPLIT_ROLE_CENTRAL=n
 ```

--- a/docs/docs/development/hardware-integration/hardware-metadata-files.md
+++ b/docs/docs/development/hardware-integration/hardware-metadata-files.md
@@ -6,7 +6,7 @@ title: Hardware Metadata Files
 
 ZMK makes use of an additional metadata YAML file for all boards and shields to provide high level information about the hardware to be incorporated into setup scripts/utilities, website hardware list, etc.
 
-The naming convention for metadata files is `{item_id}.zmk.yml`, where the `item_id` is the board/shield identifier, including version information but excluding any optional split `_left`/`_right` suffix, e.g. `corne.zmk.yml` or `nrfmicro_11.zmk.yml`.
+The naming convention for metadata files is `{item_id}.zmk.yml`, where the `item_id` is the board/shield identifier, including version information but excluding any optional split `_left`/`_right` suffix, e.g. `corne.zmk.yml` or `nrfmicro_nrf52840.zmk.yml`.
 
 ## Example File
 

--- a/docs/docs/development/hardware-integration/lighting/underglow.md
+++ b/docs/docs/development/hardware-integration/lighting/underglow.md
@@ -11,7 +11,7 @@ See the documentation page on [pin control](../pinctrl.mdx) for detailed informa
 
 Shields written for boards which support RGB underglow should add a `boards/` folder underneath the shield folder. Inside this `boards/` folder, create a `<board>.overlay` for any of the boards the shield can be used with. Place all hardware-specific configurations in these `.overlay` files.
 
-For example: the `kyria` shield has a [`boards/nice_nano_v2.overlay`](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/kyria/boards/nice_nano_v2.overlay) and a [`boards/nrfmicro_13.overlay`](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/kyria/boards/nrfmicro_13.overlay), which configure a WS2812 LED strip for the `nice_nano_v2` and `nrfmicro_13` boards respectively.
+For example: the `kyria` shield has a [`boards/nice_nano.overlay`](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/kyria/boards/nice_nano.overlay) and a [`boards/nrfmicro_13.overlay`](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/kyria/boards/nrfmicro_13.overlay), which configure a WS2812 LED strip for the `nice_nano` and `nrfmicro_13` boards respectively.
 
 ### nRF52-Based Boards
 

--- a/docs/docs/development/hardware-integration/pinctrl.mdx
+++ b/docs/docs/development/hardware-integration/pinctrl.mdx
@@ -28,7 +28,6 @@ Pin control is always defined for a _board_, never for a shield:
   boards/shields/sofle/
   ├── boards/
   │   ├── nice_nano.overlay
-  │   ├── nice_nano_v2.overlay
   │   ├── nrfmicro_11.overlay
   │   └── nrfmicro_13.overlay
   └── <sofle shield defining files>

--- a/docs/docs/development/local-toolchain/build-flash.mdx
+++ b/docs/docs/development/local-toolchain/build-flash.mdx
@@ -114,7 +114,7 @@ west config build.cmake-args \
 When building for a new board and/or shield after having built one previously, you may need to enable the pristine build option. This option removes all existing files in the build directory before regenerating them, and can be enabled by adding either --pristine or -p to the command:
 
 ```sh
-west build -p -b nice_nano_v2 -- -DSHIELD=kyria_left
+west build -p -b nice_nano -- -DSHIELD=kyria_left
 ```
 
 ### Building For Split Keyboards
@@ -126,13 +126,13 @@ For split keyboards, you will have to build and flash each side separately the f
 By default, the `build` command outputs a single .uf2 file named `zmk.uf2` so building left and then right immediately after will overwrite your left firmware. In addition, you will need to pristine build each side to ensure the correct files are used. To avoid having to pristine build every time and separate the left and right build files, we recommend setting up separate build directories for each half. You can do this by using the `-d` parameter and first building left into `build/left`:
 
 ```sh
-west build -d build/left -b nice_nano_v2 -- -DSHIELD=kyria_left
+west build -d build/left -b nice_nano -- -DSHIELD=kyria_left
 ```
 
 and then building right into `build/right`:
 
 ```sh
-west build -d build/right -b nice_nano_v2 -- -DSHIELD=kyria_right
+west build -d build/right -b nice_nano -- -DSHIELD=kyria_right
 ```
 
 This produces `left` and `right` subfolders under the `build` directory and two separate .uf2 files. For future work on a specific half, use the `-d` parameter again to ensure you are building into the correct location.
@@ -148,13 +148,13 @@ ZMK supports loading additional boards, shields, code, etc. from [external ZMK m
 For instance, building with the `my-vendor-keebs-module` checked out to your documents directory, you would build like:
 
 ```
-west build -b nice_nano_v2 -- -DSHIELD=vendor_shield -DZMK_EXTRA_MODULES="C:/Users/myUser/Documents/my-vendor-keebs-module"
+west build -b nice_nano -- -DSHIELD=vendor_shield -DZMK_EXTRA_MODULES="C:/Users/myUser/Documents/my-vendor-keebs-module"
 ```
 
 When adding multiple modules, make sure they are separated by a semicolon, e.g.:
 
 ```
-west build -b nice_nano_v2 -- -DSHIELD=vendor_shield -DZMK_EXTRA_MODULES="C:/Users/myUser/Documents/my-vendor-keebs-module;C:/Users/myUser/Documents/my-other-keebs-module"
+west build -b nice_nano -- -DSHIELD=vendor_shield -DZMK_EXTRA_MODULES="C:/Users/myUser/Documents/my-vendor-keebs-module;C:/Users/myUser/Documents/my-other-keebs-module"
 ```
 
 ### Building from `zmk-config` Folder

--- a/docs/docs/development/usb-logging.mdx
+++ b/docs/docs/development/usb-logging.mdx
@@ -28,7 +28,7 @@ requires adding a `snippet: zmk-usb-logging` to your `build.yaml` file for any b
 ```yaml
 ---
 include:
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: corne_left
     snippet: zmk-usb-logging
 ```
@@ -36,7 +36,7 @@ include:
 When building locally, the `-S`/`--snippet` flag can be passed to `west build` to enable the snippet, e.g.
 
 ```sh
-west build -b nice_nano_v2 -S zmk-usb-logging -- -DSHIELD="corne_left"
+west build -b nice_nano -S zmk-usb-logging -- -DSHIELD="corne_left"
 ```
 
 ### Additional Config

--- a/docs/docs/features/studio.md
+++ b/docs/docs/features/studio.md
@@ -87,11 +87,11 @@ For a split keyboard, you should do this _only_ for your central/left side, e.g.
 ```yaml title="build.yaml"
 ---
 include:
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: corne_left
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: corne_right
 ```
 
@@ -100,7 +100,7 @@ include:
 When building locally, use the `-S` parameter to include the `studio-rpc-usb-uart` snippet. Instead of adding it to your config file, you can also append the `ZMK_STUDIO` Kconfig as an additional CMake argument, e.g.:
 
 ```bash
-west build -d build/cl_studio -b nice_nano_v2 \
+west build -d build/cl_studio -b nice_nano \
   -S studio-rpc-usb-uart -- -DSHIELD=corne_left -DCONFIG_ZMK_STUDIO=y
 ```
 

--- a/docs/docs/troubleshooting/connection-issues.mdx
+++ b/docs/docs/troubleshooting/connection-issues.mdx
@@ -30,11 +30,11 @@ If you are using GitHub Actions to build your firmware as described in the [user
 
 ```yml
 include:
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: corne_left
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: corne_right
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: settings_reset
 ```
 

--- a/docs/docs/troubleshooting/hardware-issues.mdx
+++ b/docs/docs/troubleshooting/hardware-issues.mdx
@@ -70,7 +70,7 @@ include:
   # -------------------
   # Your keyboards here
   # -------------------
-  - board: nice_nano_v2 # Replace with the Pro Micro-compatible board you're using
+  - board: nice_nano # Replace with the Pro Micro-compatible board you're using
     shield: tester_pro_micro
 ```
 
@@ -89,7 +89,7 @@ include:
   # -------------------
   # Your keyboards here
   # -------------------
-  - board: seeeduino_xiao_ble # Replace with the Xiao-compatible board you're using
+  - board: xiao_ble # Replace with the Xiao-compatible board you're using
     shield: tester_xiao
 ```
 


### PR DESCRIPTION
* These have been renamed, see Zephyr 4.1 update
* Blog untouched for historical reasons