### PR TITLE
docs: Update hardware integration page with Zephyr 4.1 board setup

### DIFF
--- a/docs/docs/development/hardware-integration/index.mdx
+++ b/docs/docs/development/hardware-integration/index.mdx
@@ -68,9 +68,9 @@ values={[
 <TabItem value="self-contained">
 
 For a [self-contained keyboard](../../hardware.mdx#onboard) that includes the microprocessor, all of the above architecture components are included in the Zephyr _board_ definition and no shield is defined.
-You can see an example for the [Planck V6](https://github.com/zmkfirmware/zmk/tree/main/app/boards/arm/planck) board directory.
+You can see an example for the [Planck V6](https://github.com/zmkfirmware/zmk/tree/main/app/boards/olkb/planck) board directory.
 
-With this type of keyboard, the full ZMK definition for the keyboard exists in the `<board_root>/boards/<vendor or designer>/<keyboard_name>` directory where `<board_root>` is `zmk/app` or a [module](../../features/modules.mdx) root, e.g. `zmk/app/boards/arm/planck/`.
+With this type of keyboard, the full ZMK definition for the keyboard exists in the `<board_root>/boards/<vendor or designer>/<keyboard_name>` directory where `<board_root>` is `zmk/app` or a [module](../../features/modules.mdx) root, e.g. `zmk/app/boards/olkb/planck/`.
 In that directory you'll have the following files, where there can be multiples of files with `<board_name>`s, corresponding to each keyboard part for [split keyboards](../../features/split-keyboards.md):
 
 ```
@@ -107,7 +107,7 @@ These files include [base Kconfig files](https://docs.zephyrproject.org/4.1.0/bu
 And other miscellaneous ones:
 
 - A `board.cmake` file with CMake directives for how to flash to the device.
-- A `board.yml` file containing information about the board and variants.
+- A [`board.yml`](https://docs.zephyrproject.org/4.1.0/hardware/porting/board_porting.html#write-your-board-yaml) file containing information about the board and variants.
 - A `<keyboard_name>.zmk.yml` file containing [metadata](hardware-metadata-files.md) for the keyboard.
 
 See Zephyr's [board porting guide](https://docs.zephyrproject.org/4.1.0/hardware/porting/board_porting.html) for information on creating a new board.


### PR DESCRIPTION
Needed touchup of the composite keyboard section now that we're on Zephyr 4.1.