### PR TITLE
fix: Add "optional" folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.west
 /bootloader
 /modules
+/optional
 /tools
 /zephyr
 /zmk-config


### PR DESCRIPTION
Zephyr now has some modules that get placed under /optional/modules instead of /modules. Added that to .gitignore so Git doesn't try to treat those like Git modules.