### PR TITLE
docs: remove new shield clean room warning

### DIFF
--- a/docs/docs/development/hardware-integration/new-shield.mdx
+++ b/docs/docs/development/hardware-integration/new-shield.mdx
@@ -59,6 +59,15 @@ Many of the above files will differ depending on whether your keyboard is a unib
 After adding ZMK support for a basic shield using this guide, check the sidebar for guides on adding any additional features (such as encoders) that your keyboard has.
 It may be helpful to review the upstream [shields documentation](https://docs.zephyrproject.org/4.1.0/hardware/porting/shields.html#shields) to get a proper understanding of the underlying system before continuing.
 
+:::info
+When writing your shield, please be aware of [licensing](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository):
+
+- If you reference code or other items that are under a copyleft license (e.g. GNU GPLv2, used by QMK) as a reference, you must license your shield under a compatible copyleft license.
+- If you license anything under a copyleft license, it cannot be referenced by anyone working on ZMK (see our [clean room policy](../contributing/clean-room.md)).
+
+We generally recommend licensing your shield under MIT, if you don't have a particular incentive to do otherwise.
+:::
+
 ## New ZMK Module Repository
 
 The first step to creating the shield is to create a new ZMK module repository from a template.


### PR DESCRIPTION
Adds a new info block further down. Closes #3117.