### PR TITLE
fix(studio): avoid decoding buffer overflow

### DIFF
--- a/app/src/studio/rpc.c
+++ b/app/src/studio/rpc.c
@@ -87,7 +87,7 @@ static bool rpc_read_cb(pb_istream_t *stream, uint8_t *buf, size_t count) {
 
     do {
         uint8_t *buffer;
-        uint32_t len = ring_buf_get_claim(&rpc_rx_buf, &buffer, count);
+        uint32_t len = ring_buf_get_claim(&rpc_rx_buf, &buffer, count - write_offset);
 
         if (len > 0) {
             for (int i = 0; i < len; i++) {


### PR DESCRIPTION
This patch fixes studio rpc bug that protobuf decoding buffer can overflow in rpc_read_cb.
Such situation happened when I sent multiple requests to the keyboard very quickly from my custom rpc client and custom protocol.
I confirmed that the patch doesn't cause issue with official ZMK Studio UI at least, although I couldn't reproduce the same issue with ZMK Studio.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
