### PR TITLE
fix(split): correct async UART RX buffer definition

### DIFF
--- a/app/src/split/wired/central.c
+++ b/app/src/split/wired/central.c
@@ -87,7 +87,7 @@ K_WORK_DEFINE(publish_events, publish_events_work);
 
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_WIRED_UART_MODE_ASYNC)
 
-uint8_t async_rx_buf[RX_BUFFER_SIZE / 2][2];
+uint8_t async_rx_buf[2][RX_BUFFER_SIZE / 2];
 
 static struct zmk_split_wired_async_state async_state = {
     .process_tx_work = &publish_events,

--- a/app/src/split/wired/peripheral.c
+++ b/app/src/split/wired/peripheral.c
@@ -89,7 +89,7 @@ K_MSGQ_DEFINE(cmd_msg_queue, sizeof(struct zmk_split_transport_central_command),
 
 #if IS_ENABLED(CONFIG_ZMK_SPLIT_WIRED_UART_MODE_ASYNC)
 
-uint8_t async_rx_buf[RX_BUFFER_SIZE / 2][2];
+uint8_t async_rx_buf[2][RX_BUFFER_SIZE / 2];
 
 static struct zmk_split_wired_async_state async_state = {
     .rx_bufs = {async_rx_buf[0], async_rx_buf[1]},


### PR DESCRIPTION
The RX buffer was previously defined as [RX_BUFFER_SIZE/2][2], which created (RX_BUFFER_SIZE/2) small 2-byte buffers instead of the two (RX_BUFFER_SIZE/2)-byte buffers required for DMA ping-pong operation.

Update the buffer definition to [2][RX_BUFFER_SIZE/2] and apply the fix to both the central and peripheral wired split implementations.

This prevents potential DMA RX data corruption when using async UART.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
