### PR TITLE
fix(hid): initialize missing d_scroll_x field in mouse report

### DIFF
--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -29,7 +29,7 @@ static uint8_t keys_held = 0;
 
 static struct zmk_hid_mouse_report mouse_report = {
     .report_id = ZMK_HID_REPORT_ID_MOUSE,
-    .body = {.buttons = 0, .d_x = 0, .d_y = 0, .d_scroll_y = 0}};
+    .body = {.buttons = 0, .d_x = 0, .d_y = 0, .d_scroll_y = 0, .d_scroll_x = 0}};
 
 #endif // IS_ENABLED(CONFIG_ZMK_POINTING)
 


### PR DESCRIPTION
The zmk_hid_mouse_report_body structure contains five fields (buttons, d_x, d_y, d_scroll_y, d_scroll_x), but d_scroll_x was left uninitialized.

Initialize d_scroll_x to 0 to ensure all fields in the mouse report are properly initialized and avoid potential undefined behavior.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
