### PR TITLE
fix(split): Allocate array of peripheral indexes for BAS proxying.

### DIFF
--- a/app/src/split/bluetooth/central_bas_proxy.c
+++ b/app/src/split/bluetooth/central_bas_proxy.c
@@ -58,9 +58,14 @@ static const struct bt_gatt_cpf aux_level_cpf = {
 // The second generated attribute is the one used to send GATT notifications
 #define PERIPH_BATT_LEVEL_ATTR_NOTIFY_IDX 1
 
+#define PERIPH_IDX(i, _) i
+
+static const uint8_t peripheral_indexes[] = {
+    LISTIFY(CONFIG_ZMK_SPLIT_BLE_CENTRAL_PERIPHERALS, PERIPH_IDX, ())};
+
 #define PERIPH_BATT_LEVEL_ATTRS(i, _)                                                              \
     BT_GATT_CHARACTERISTIC(BT_UUID_BAS_BATTERY_LEVEL, BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,     \
-                           BT_GATT_PERM_READ, read_blvl, NULL, ((uint8_t[]){i})),                  \
+                           BT_GATT_PERM_READ, read_blvl, NULL, (void *)(peripheral_indexes + i)),  \
         BT_GATT_CCC(blvl_ccc_cfg_changed, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),                 \
         BT_GATT_CPF(&aux_level_cpf), BT_GATT_CUD(PERIPH_CUD(i), BT_GATT_PERM_READ),
 


### PR DESCRIPTION
Properly pass address of static peripheral index array to the `BT_GATT_CHARACTERISTIC` to ensure we read the correct battery level when requested.

Draft for now, just a guess for a nagging issues that's caused issues for split reliability. Paging @caksoylar for testing.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
