### PR TITLE
feat(iqs5xx): add Azoteq IQS5xx i2c driver, DT bindings and TKL board overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ __pycache__
 .venv
 
 # clangd
+.cache/
 app/.cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,160 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ZMK (Zephyr Mechanical Keyboard) Firmware is an open source keyboard firmware built on the Zephyr RTOS. It provides modern, wireless keyboard support free of licensing issues.
+
+**Key Architecture:**
+- Built on Zephyr RTOS (v4.1.0+zmk-fixes)
+- Uses `west` (Zephyr's meta-tool) for build and dependency management
+- West workspace structure: `app/` contains the main ZMK application, `zephyr/` is the Zephyr RTOS, `modules/` contains additional dependencies
+- Configuration via Kconfig (Zephyr's configuration system) and devicetree (DTS) files
+
+## Repository Structure
+
+- `app/` - Main ZMK firmware application
+  - `src/` - Core firmware source code (behaviors, HID, keymap, BLE, etc.)
+  - `boards/` - Board definitions and shield configurations (as `.yml` files)
+  - `tests/` - Native simulation tests (one per feature/behavior)
+  - `dts/` - Devicetree source files
+  - `include/` - Public headers
+  - `CMakeLists.txt` - Main build configuration
+  - `Kconfig`, `Kconfig.behaviors` - Kconfig symbols
+- `docs/` - Documentation (Docusaurus site)
+- `modules/` - Additional Zephyr modules (HAL, libraries, etc.)
+- `zephyr/` - Zephyr RTOS (managed by west)
+- `schema/` - JSON schemas for board/shield configuration validation
+
+## Common Commands
+
+### Building Firmware
+
+ZMK uses the `west` build system. From the repository root:
+
+```bash
+# Build for a specific board (replace with your board)
+west build -b <board> -- -DSHIELD=<shield>
+
+# Example: build for corneish keyboard
+west build -b nice_nano_v2 -- -DSHIELD=corneish_left
+
+# Clean build
+west build -b <board> -p -- -DSHIELD=<shield>
+```
+
+### Running Tests
+
+Tests are run using native simulation (native_sim board):
+
+```bash
+# From app/ directory
+./run-test.sh <path/to/testcase>
+./run-test.sh all                    # Run all tests
+./run-test.sh tests/hold-tap         # Run specific test directory
+
+# Run tests in parallel (default 4 jobs)
+J=8 ./run-test.sh all
+
+# Auto-accept new test snapshots (for updating tests)
+ZMK_TESTS_AUTO_ACCEPT=1 ./run-test.sh <path>
+
+# Run BLE tests
+./run-ble-test.sh <path/to/testcase>
+```
+
+Each test case has a `native_sim.keymap` file, `events.patterns` file, and `keycode_events.snapshot` for validation.
+
+### Code Formatting
+
+```bash
+# Format C/C++ code (clang-format)
+clang-format -i <files>
+
+# Format board YAML files
+cd app && npm run prettier:format
+
+# Format documentation
+cd docs && npm run prettier:format
+```
+
+### Linting
+
+```bash
+# Lint documentation
+cd docs && npm run lint
+
+# Check formatting without applying changes
+cd app && npm run prettier:check
+cd docs && npm run prettier:check
+```
+
+### Pre-commit Hooks
+
+Install pre-commit hooks for automatic formatting:
+
+```bash
+pip3 install pre-commit
+pre-commit install
+```
+
+The `.pre-commit-config.yaml` includes: clang-format, prettier, remove-tabs, gitlint, and other checks.
+
+### Documentation
+
+```bash
+# From docs/ directory
+npm ci           # Install dependencies
+npm start        # Start dev server (http://0.0.0.0:3000)
+npm run build    # Build static site
+npm run typecheck  # TypeScript type checking
+```
+
+## Architecture Notes
+
+### Behaviors System
+ZMK's behaviors are modular key handlers in `app/src/behaviors/`. Each behavior implements a standard interface and is registered via Kconfig. Key behaviors include:
+- `behavior_key_press.c` - Basic key press
+- `behavior_hold_tap.c` - Hold/tap modulation
+- `behavior_layer_*.c` - Layer switching
+- `behavior_sticky_key.c` - Sticky keys
+- `behavior_macro.c` - Macro execution
+
+### Event System
+ZMK uses an event-driven architecture with events in `app/src/events/`. The event manager (`event_manager.c`) coordinates event propagation between components.
+
+### Split Keyboards
+Split keyboard support is in `app/src/split/`. The central role processes all key events and sends state updates to peripheral nodes.
+
+### HID Subsystem
+HID functionality spans multiple files:
+- `hid.c` - Core HID state management
+- `hid_listener.c` - Event listener for HID state changes
+- `usb_hid.c` - USB HID output
+- `hog.c` - Bluetooth HID over GATT (HOG)
+
+### Keymap and Physical Layouts
+- `keymap.c` - Keymap layer management and behavior lookup
+- `physical_layouts.c` - Physical-to-logical key position mapping
+- `matrix_transform.c` - Matrix scan to position transformation
+
+## Kconfig System
+
+ZMK heavily uses Kconfig for feature selection. Important files:
+- `app/Kconfig` - Main configuration symbols
+- `app/Kconfig.behaviors` - Behavior-specific symbols
+- `app/Kconfig.defaults` - Default configurations
+
+Configuration is done via `app/prj.conf` or board-specific overlays.
+
+## Devicetree
+
+Hardware configuration uses Zephyr devicetree:
+- Board-specific files in `app/dts/boards/`
+- Shield definitions in `app/boards/shields/`
+- Key bindings use devicetree property syntax
+
+## Testing Philosophy
+
+Tests are snapshot-based: each test defines a key sequence and expected HID output events. Tests run under native simulation (POSIX) and can be executed without hardware.

--- a/app/boards/shields/tkl_nrf52832/Kconfig.shield
+++ b/app/boards/shields/tkl_nrf52832/Kconfig.shield
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config SHIELD_TKL_NRF52832
+    def_bool $(shields_list_contains,tkl_nrf52832)

--- a/app/boards/shields/tkl_nrf52832/REALISTIC_TKL_8x14.csv
+++ b/app/boards/shields/tkl_nrf52832/REALISTIC_TKL_8x14.csv
@@ -1,0 +1,128 @@
+# TKL Keyboard Matrix - REALISTIC 8x14 for nRF52832
+# Total: 8 rows × 14 columns = 112 positions (enough for TKL + numpad)
+# Matrix uses 22 GPIOs, leaving 10 for peripherals
+
+# GPIO Assignment:
+# Rows: P0.03-P0.10 (8 pins)
+# Cols: P0.11-P0.21, P0.22, P0.23, P0.24 (14 pins)
+# I2C: P0.26, P0.27
+# Battery: P0.29
+# VBUS: P0.02
+# Trackpad INT: P0.28
+# LED: P0.30
+# UART: P0.25 (TX), P0.31 (RX) - if needed
+
+# Row 0 - Function row
+0,0,ESC,Escape
+0,1,F1,F1
+0,2,F2,F2
+0,3,F3,F3
+0,4,F4,F4
+0,5,F5,F5
+0,6,F6,F6
+0,7,F7,F7
+0,8,F8,F8
+0,9,F9,F9
+0,10,F10,F10
+0,11,F11,F11
+0,12,F12,F12
+0,13,DEL,Delete
+
+# Row 1 - Number row
+1,0,GRAVE,Grave
+1,1,KP_1,1
+1,2,KP_2,2
+1,3,KP_3,3
+1,4,KP_4,4
+1,5,KP_5,5
+1,6,KP_6,6
+1,7,KP_7,7
+1,8,KP_8,8
+1,9,KP_9,9
+1,10,KP_0,0
+1,11,MINUS,Minus
+1,12,EQUAL,Equal
+1,13,BKSP,Backspace
+
+# Row 2 - QWERTY row
+2,0,TAB,Tab
+2,1,Q,Q
+2,2,W,W
+2,3,E,E
+2,4,R,R
+2,5,T,T
+2,6,Y,Y
+2,7,U,U
+2,8,I,I
+2,9,O,O
+2,10,P,P
+2,11,LBKT,Left Bracket
+2,12,RBKT,Right Bracket
+2,13,BSLS,Backslash
+
+# Row 3 - Home row
+3,0,CAPS,Caps Lock
+3,1,A,A
+3,2,S,S
+3,3,D,D
+3,4,F,F
+3,5,G,G
+3,6,H,H
+3,7,J,J
+3,8,K,K
+3,9,L,L
+3,10,SEMICOLON,Semicolon
+3,11,QUOTE,Quote
+3,12,RET,Enter
+
+# Row 4 - Modifier row
+4,0,LSHIFT,Left Shift
+4,1,Z,Z
+4,2,X,X
+4,3,C,C
+4,4,V,V
+4,5,B,B
+4,6,N,N
+4,7,M,M
+4,8,COMMA,Comma
+4,9,DOT,Period
+4,10,FSLASH,Slash
+4,11,RSHIFT,Right Shift
+4,12,UP,Up
+
+# Row 5 - Space row
+5,0,LCTRL,Left Ctrl
+5,1,LGUI,Left Win
+5,2,LALT,Left Alt
+5,3,SPACE,Space
+5,4,RALT,Right Alt
+5,5,RGUI,Right Win
+5,6,MENU,Menu
+5,7,RCTRL,Right Ctrl
+5,8,LEFT,Left
+5,9,DOWN,Down
+5,10,RIGHT,Right
+
+# Row 6 - Numpad top
+6,0,NLCK,Num Lock
+6,1,KPSLS,Num /
+6,2,KP_ASTERISK,Num *
+6,3,KP_MINUS,Num -
+6,4,KP_7,Num 7
+6,5,KP_8,Num 8
+6,6,KP_9,Num 9
+6,7,KP_PLUS,Num +
+6,8,HOME,Home
+6,9,PGUP,Page Up
+
+# Row 7 - Numpad bottom
+7,0,KP_0,Num 0
+7,1,KP_DOT,Num Dot
+7,2,KP_EQUAL,Num Equal
+7,3,KP_1,Num 1
+7,4,KP_2,Num 2
+7,5,KP_3,Num 3
+7,6,KP_4,Num 4
+7,7,INS,Insert
+7,8,END,End
+7,9,PGDN,Page Down

--- a/app/boards/shields/tkl_nrf52832/nrf52832_gpio_wiring.py
+++ b/app/boards/shields/tkl_nrf52832/nrf52832_gpio_wiring.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""
+nRF52832 QFAAB GPIO Pin Assignment for TKL Keyboard
+===================================================
+
+Package: QFN48 (6x6mm, 48 pins)
+Total GPIOs: 32 (P0.00 - P0.31)
+Architecture: ARM Cortex-M4F @ 64MHz
+Memory: 256KB Flash, 64KB RAM
+
+Wiring Requirements for TKL Keyboard with Azoteq Trackpad
+"""
+
+import sys
+from pathlib import Path
+
+# nRF52832 QFAAB Pin Capabilities
+NRF52832_PINS = {
+    # Pin  : Functions
+    "P0.00": ["XL1", "GPIO"],  # 32kHz crystal X1
+    "P0.01": ["XL2", "GPIO"],  # 32kHz crystal X2
+    "P0.02": ["ADC1", "GPIO", "UART_CTS", "I2C_SCL"],  # ADC AIN1 - Use for VBUS sense
+    "P0.03": ["ADC2", "GPIO"],  # ADC AIN2 - ROW 0
+    "P0.04": ["ADC3", "GPIO"],  # ADC AIN3 - ROW 1
+    "P0.05": ["ADC4", "GPIO"],  # ADC AIN4 - ROW 2
+    "P0.06": ["ADC5", "GPIO"],  # ADC AIN5 - ROW 3 (also SWD trace data)
+    "P0.07": ["ADC6", "GPIO"],  # ADC AIN6 - ROW 4
+    "P0.08": ["ADC7", "GPIO"],  # ADC AIN7 - ROW 5
+    "P0.09": ["ADC2", "GPIO"],  # ADC AIN2 duplicate - ROW 6
+    "P0.10": ["ADC3", "GPIO"],  # ADC AIN3 duplicate - ROW 7
+    "P0.11": ["GPIO"],          # COL 0
+    "P0.12": ["GPIO"],          # COL 1
+    "P0.13": ["GPIO"],          # COL 2
+    "P0.14": ["GPIO"],          # COL 3
+    "P0.15": ["GPIO"],          # COL 4
+    "P0.16": ["GPIO"],          # COL 5
+    "P0.17": ["GPIO"],          # COL 6
+    "P0.18": ["GPIO"],          # COL 7
+    "P0.19": ["GPIO"],          # COL 8
+    "P0.20": ["GPIO"],          # COL 9
+    "P0.21": ["GPIO"],          # COL 10
+    "P0.22": ["GPIO"],          # COL 11
+    "P0.23": ["GPIO", "UART_TX"],  # COL 12 / UART TX
+    "P0.24": ["GPIO", "UART_RX"],  # COL 13 / UART RX
+    "P0.25": ["GPIO"],          # COL 14
+    "P0.26": ["GPIO", "I2C_SDA"],  # COL 15 / I2C SDA (for Azoteq)
+    "P0.27": ["GPIO", "I2C_SCL"],  # I2C SCL (for Azoteq)
+    "P0.28": ["GPIO"],          # Trackpad Interrupt
+    "P0.29": ["ADC7", "GPIO"],  # Battery voltage sense (AIN7)
+    "P0.30": ["GPIO"],          # LED / Status
+    "P0.31": ["GPIO"],          # Reset / SWDCLK (or use dedicated SWD pins)
+}
+
+# Recommended GPIO Assignment
+TKL_GPIO_ASSIGNMENT = {
+    "Keyboard Matrix (8x16)": {
+        "Rows": {
+            "ROW0": "P0.03",
+            "ROW1": "P0.04",
+            "ROW2": "P0.05",
+            "ROW3": "P0.06",
+            "ROW4": "P0.07",
+            "ROW5": "P0.08",
+            "ROW6": "P0.09",
+            "ROW7": "P0.10",
+        },
+        "Columns": {
+            "COL0":  "P0.11",
+            "COL1":  "P0.12",
+            "COL2":  "P0.13",
+            "COL3":  "P0.14",
+            "COL4":  "P0.15",
+            "COL5":  "P0.16",
+            "COL6":  "P0.17",
+            "COL7":  "P0.18",
+            "COL8":  "P0.19",
+            "COL9":  "P0.20",
+            "COL10": "P0.21",
+            "COL11": "P0.22",
+            "COL12": "P0.23",
+            "COL13": "P0.24",
+            "COL14": "P0.25",
+            "COL15": "P0.26",  # Can share with I2C SDA if careful
+        },
+    },
+    "Peripherals": {
+        "I2C (Azoteq Trackpad)": {
+            "SDA": "P0.26",  # SPIM/SPIS/TWI - Use TWI0
+            "SCL": "P0.27",
+        },
+        "UART (Debug)": {
+            "TX": "P0.25",   # Alternative TX pin
+            "RX": "P0.31",   # Use P0.31 if available (not in matrix)
+        },
+        "Power Management": {
+            "VBUS_SENSE": "P0.02",   # USB power detection (ADC AIN1)
+            "BATTERY_ADC": "P0.29",  # Battery voltage (ADC AIN7)
+        },
+        "Trackpad": {
+            "INTERRUPT": "P0.28",
+        },
+        "Status": {
+            "LED": "P0.30",
+        },
+        "Debug": {
+            "SWDIO": "SWDIO",  # Dedicated SWD pin (not in GPIO numbering)
+            "SWDCLK": "SWCLK", # Dedicated SWD pin
+        },
+    },
+    "Reserved / Not Recommended": {
+        "Crystal": ["P0.00", "P0.01"],  # 32kHz crystal for RTC
+        "Reset": "RESET",  # Dedicated reset pin
+    },
+}
+
+# Hardware Connections
+HARDWARE_CONNECTIONS = """
+Hardware Wiring for nRF52832 TKL Keyboard
+==========================================
+
+POWER SUPPLY
+------------
+VDD  -> 3.3V (from DC/DC regulator or LDO)
+VSS  -> GND
+VDDH -> Battery/USB input (for DC/DC mode)
+
+DC/DC Converter Requirements:
+- Input: 3.0V - 5.5V (from USB LiPo charger or battery)
+- Output: 3.3V, capable of 50mA+ (TX at 0dBm)
+- Inductor: 4.7µH - 10µH (follow nRF52832 PS)
+- Decoupling: 0.1µF ceramic near each VDD pin
+- Bulk capacitance: 4.7µF - 10µF
+
+CRYSTAL OSCILLATOR
+------------------
+32.768 kHz Crystal:
+- P0.00 (XL1) -> Crystal pin 1
+- P0.01 (XL2) -> Crystal pin 2
+- Load capacitors: 2x 12pF (or per crystal spec)
+
+32 MHz High-Speed Oscillator:
+- Internal, no external crystal needed for most apps
+
+USB (Type-C)
+------------
+D+ -> P0.30 (through USB D+ pin, varies by package)
+D- -> P0.31 (through USB D- pin, varies by package)
+VBUS -> P0.02 (for sensing, through divider)
+
+Type-C CC pins:
+- CC1, CC2 -> 5.1k resistors to GND
+- Use USB PD controller or simple resistive detection
+
+KEYBOARD MATRIX (8x16)
+----------------------
+Rows (8 pins): P0.03 - P0.10
+Cols (16 pins): P0.11 - P0.21, P0.22 - P0.25, P0.26
+
+Diode direction: Column to Row (col2row in ZMK)
+Diode type: 1N4148 or equivalent
+
+AZOTEQ TRACKPAD (I2C)
+---------------------
+I2C Bus: TWI0 (nRF52832)
+- SDA -> P0.26 (with 4.7k pull-up to 3.3V)
+- SCL -> P0.27 (with 4.7k pull-up to 3.3V)
+- INT -> P0.28 (optional, for interrupt-driven mode)
+- VDD -> 3.3V
+- GND -> GND
+
+I2C Address: Typically 0x74 (check datasheet)
+
+BATTERY MONITORING
+------------------
+ADC input: P0.29 (AIN7)
+- Voltage divider: Battery+ -> 100k -> AIN7 -> 200k -> GND
+- Capacitor: 1µF from AIN7 to GND (filtering)
+
+UART (Optional, for debugging)
+-------------------------------
+UART0:
+- TX -> P0.23
+- RX -> P0.24
+- Baud: 115200 (typical)
+- Level shifter to 3.3V if connecting to 5V system
+
+SWD DEBUG INTERFACE
+-------------------
+SWDIO -> SWDIO pin (dedicated)
+SWCLK -> SWCLK pin (dedicated)
+GND   -> GND
+VDD   -> 3.3V (optional, for powering from debugger)
+
+STATUS LED
+----------
+LED -> P0.30 (with current-limiting resistor)
+- Forward current: 2-20mA typical
+- Resistor: (3.3V - Vf) / If
+- Example: (3.3 - 2.0) / 0.01 = 130Ω
+
+ANTENNA
+-------
+For BLE (2.4 GHz):
+- PCB antenna: 50Ω trace to antenna pad
+- Chip antenna: Follow manufacturer layout
+- Keep area clear of ground plane
+
+PCB LAYOUT GUIDELINES
+---------------------
+1. RF Section:
+   - Keep antenna area clear
+   - 50Ω impedance matched trace
+   - No ground plane under antenna
+   - Crystal away from RF section
+
+2. Power Supply:
+   - Short, wide traces for VDD/GND
+   - Decoupling capacitors close to pins
+   - Star ground for GND connections
+
+3. I2C:
+   - Pull-ups near nRF52832
+   - Keep traces short
+
+4. Keyboard Matrix:
+   - Diodes oriented correctly
+   - No crossed traces if possible
+   - Columns with pull-downs
+
+TESTING CHECKLIST
+-----------------
+[ ] Power supply voltage (3.3V)
+[ ] Crystal oscillation (32.768 kHz)
+[ ] USB enumeration
+[ ] SWD programming
+[ ] Matrix scan (all keys)
+[ ] I2C communication (trackpad)
+[ ] Battery voltage reading
+[ ] BLE advertising
+[ ] BLE pairing and data
+
+ZMK CONFIGURATION
+-----------------
+Enable in Kconfig.defconfig:
+- CONFIG_ZMK_USB=y
+- CONFIG_ZMK_BLE=y
+- CONFIG_ZMK_POINTING=y (for trackpad)
+- CONFIG_I2C=y
+- CONFIG_ADC=y
+
+Add to devicetree:
+- I2C node for TWI0
+- ADC node for battery
+- Pointing device node for trackpad
+"""
+
+def print_assignment():
+    """Print the GPIO assignment summary."""
+    print("=" * 80)
+    print("nRF52832 QFAAB GPIO Pin Assignment - TKL Keyboard + Azoteq Trackpad")
+    print("=" * 80)
+
+    print("\n📌 SUMMARY")
+    print("-" * 80)
+    total_matrix = 8 + 16  # rows + cols
+    total_peripherals = 2 + 2 + 2 + 1 + 1 + 1  # I2C + UART + Power + INT + LED + SWD
+    total_used = total_matrix + total_peripherals
+    print(f"Total GPIOs available: 32 (P0.00 - P0.31)")
+    print(f"Matrix pins: {total_matrix} (8 rows + 16 columns)")
+    print(f"Peripheral pins: {total_peripherals}")
+    print(f"Total used: {total_used}")
+    print(f"Available: {32 - total_used}")
+
+    print("\n🔌 MATRIX PINS (8x16 = 128 positions)")
+    print("-" * 80)
+    print("ROWS (8 pins):")
+    for row, pin in TKL_GPIO_ASSIGNMENT["Keyboard Matrix (8x16)"]["Rows"].items():
+        print(f"  {row:6s} -> {pin}")
+    print("\nCOLUMNS (16 pins):")
+    for col, pin in TKL_GPIO_ASSIGNMENT["Keyboard Matrix (8x16)"]["Columns"].items():
+        print(f"  {col:6s} -> {pin}")
+
+    print("\n🔧 PERIPHERAL PINS")
+    print("-" * 80)
+    for periph, pins in TKL_GPIO_ASSIGNMENT["Peripherals"].items():
+        print(f"\n{periph}:")
+        for name, pin in pins.items():
+            print(f"  {name:12s} -> {pin}")
+
+    print("\n⚠️  RESERVED PINS")
+    print("-" * 80)
+    for periph, pins in TKL_GPIO_ASSIGNMENT["Reserved / Not Recommended"].items():
+        print(f"{periph}: {pins}")
+
+    print("\n📋 DTS FRAGMENT")
+    print("-" * 80)
+    print("""
+/* nRF52832 TKL Keyboard with Azoteq Trackpad */
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan;
+        zmk,matrix_transform = &transform;
+    };
+
+    kscan: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        diode-direction = "col2row";
+
+        row-gpios =
+            <&gpio0 3 GPIO_ACTIVE_HIGH>,   /* ROW0 */
+            <&gpio0 4 GPIO_ACTIVE_HIGH>,   /* ROW1 */
+            <&gpio0 5 GPIO_ACTIVE_HIGH>,   /* ROW2 */
+            <&gpio0 6 GPIO_ACTIVE_HIGH>,   /* ROW3 */
+            <&gpio0 7 GPIO_ACTIVE_HIGH>,   /* ROW4 */
+            <&gpio0 8 GPIO_ACTIVE_HIGH>,   /* ROW5 */
+            <&gpio0 9 GPIO_ACTIVE_HIGH>,   /* ROW6 */
+            <&gpio0 10 GPIO_ACTIVE_HIGH>;  /* ROW7 */
+
+        col-gpios =
+            <&gpio0 11 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL0 */
+            <&gpio0 12 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL1 */
+            <&gpio0 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL2 */
+            <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL3 */
+            <&gpio0 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL4 */
+            <&gpio0 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL5 */
+            <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL6 */
+            <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL7 */
+            <&gpio0 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL8 */
+            <&gpio0 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL9 */
+            <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL10 */
+            <&gpio0 22 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL11 */
+            <&gpio0 23 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL12 */
+            <&gpio0 24 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL13 */
+            <&gpio0 25 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL14 */
+            <&gpio0 26 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;  /* COL15 */
+    };
+};
+
+/* I2C for Azoteq Trackpad */
+&i2c0 {
+    status = "okay";
+    sda-pin = <26>;
+    scl-pin = <27>;
+
+    azoteq_trackpad: trackpad@74 {
+        compatible = "azoteq,iqs550";
+        reg = <0x74>;
+    };
+};
+""")
+
+    print("\n📖 HARDWARE CONNECTIONS")
+    print("-" * 80)
+    print(HARDWARE_CONNECTIONS)
+
+if __name__ == "__main__":
+    print_assignment()

--- a/app/boards/shields/tkl_nrf52832/tkl_matrix.csv
+++ b/app/boards/shields/tkl_nrf52832/tkl_matrix.csv
@@ -1,0 +1,114 @@
+# TKL Keyboard Matrix Layout
+# Standard ANSI TKL (Tenkeyless) Layout
+# Row,Column,Key Name,Physical Position
+
+# Row 0 - Number Row (Esc, F1-F12, ~, 1-0, -, =, Backspace)
+0,0,ESC,Top Left
+0,1,F1,F1
+0,2,F2,F2
+0,3,F3,F3
+0,4,F4,F4
+0,5,F5,F5
+0,6,F6,F6
+0,7,F7,F7
+0,8,F8,F8
+0,9,F9,F9
+0,10,F10,F10
+0,11,F11,F11
+0,12,F12,F12
+0,13,GRAVE,Grave/Accent
+0,14,KP_1,1
+0,15,KP_2,2
+0,16,KP_3,3
+0,17,KP_4,4
+0,18,KP_5,5
+0,19,KP_6,6
+0,20,KP_7,7
+0,21,KP_8,8
+0,22,KP_9,9
+0,23,KP_0,0
+0,24,MINUS,Minus
+0,25,EQUAL,Equal
+0,26,BKSP,Backspace
+
+# Row 1 - QWERTY Row (Tab, Q-P, [, ], \)
+1,0,TAB,Tab
+1,1,Q,Q
+1,2,W,W
+1,3,E,E
+1,4,R,R
+1,5,T,T
+1,6,Y,Y
+1,7,U,U
+1,8,I,I
+1,9,O,O
+1,10,P,P
+1,11,LBKT,Left Bracket
+1,12,RBKT,Right Bracket
+1,13,BSLS,Backslash
+1,14,INS,Insert
+1,15,HOME,Home
+1,16,PGUP,Page Up
+1,17,NLCK,Num Lock
+1,18,KPSLS,Num /
+1,19,KP_9,Num 9
+1,20,KP_8,Num 8
+1,21,KP_7,Num 7
+1,22,KP_MINUS,Num -
+1,23,KP_4,Num 4
+1,24,KP_5,Num 5
+1,25,KP_6,Num 6
+1,26,KP_PLUS,Num +
+
+# Row 2 - Home Row (Caps, A-L, ;, ', Enter)
+2,0,CAPS,Caps Lock
+2,1,A,A
+2,2,S,S
+2,3,D,D
+2,4,F,F
+2,5,G,G
+2,6,H,H
+2,7,J,J
+2,8,K,K
+2,9,L,L
+2,10,SEMICOLON,Semicolon
+2,11,QUOTE,Single Quote
+2,12,RET,Enter
+2,13,DEL,Delete
+2,14,END,End
+2,15,PGDN,Page Down
+2,16,KP_ASTERISK,Num *
+2,17,KP_1,Num 1
+2,18,KP_2,Num 2
+2,19,KP_3,Num 3
+2,20,KP_EQUAL,Num (near 0)
+2,21,KP_0,Num 0
+2,22,KP_DOT,Num .
+
+# Row 3 - Modifiers Row (LShift, Z-M, ,, ., /, RShift)
+3,0,LSHIFT,Left Shift
+3,1,Z,Z
+3,2,X,X
+3,3,C,C
+3,4,V,V
+3,5,B,B
+3,6,N,N
+3,7,M,M
+3,8,COMMA,Comma
+3,9,DOT,Period
+3,10,FSLASH,Forward Slash
+3,11,RSHIFT,Right Shift
+3,12,UP,Arrow Up
+3,13,KP_PLUS,Num +
+3,14,KP_DOT,Num .
+
+# Row 4 - Bottom Row (LCtrl, Win, LAlt, Space, RAlt, Fn/Meta, RCtrl, Arrows)
+4,0,LCTRL,Left Ctrl
+4,1,LGUI,Left Win/Meta
+4,2,LALT,Left Alt
+4,3,SPACE,Spacebar
+4,4,RALT,Right Alt
+4,5,RCTRL,Right Ctrl
+4,6,LEFT,Arrow Left
+4,7,DOWN,Arrow Down
+4,8,RIGHT,Arrow Right

--- a/app/boards/shields/tkl_nrf52832/tkl_matrix_8x16.csv
+++ b/app/boards/shields/tkl_nrf52832/tkl_matrix_8x16.csv
@@ -1,0 +1,129 @@
+# TKL Keyboard Matrix Layout - 8 Rows x 16 Columns (128 positions)
+# Optimized for nRF52832 QFAAB (32 GPIOs)
+# GPIO Usage: 8 rows + 16 cols + 8 peripherals = 32 GPIOs
+
+# Pin Assignment:
+# Rows: P0.03-P0.10 (8 pins)
+# Cols: P0.11-P0.21, P1.00-P1.04 (11 pins from P0, 4 pins from P1 if available, otherwise P0.22-P0.25)
+# I2C: P0.26, P0.27
+# UART: P0.23, P0.24
+# Battery: P0.29
+# VBUS: P0.02
+
+# Row 0 - ESC, F1-F12, PrintScreen, ScrollLock, Pause
+0,0,ESC,Escape
+0,1,F1,F1
+0,2,F2,F2
+0,3,F3,F3
+0,4,F4,F4
+0,5,F5,F5
+0,6,F6,F6
+0,7,F7,F7
+0,8,F8,F8
+0,9,F9,F9
+0,10,F10,F10
+0,11,F11,F11
+0,12,F12,F12
+0,13,PSCRN,Print Screen
+0,14,SLCK,Scroll Lock
+0,15,PAUSE,Break/Pause
+
+# Row 1 - Grave, 1-0, Minus, Equal, Backspace, Insert, Home, PageUp
+1,0,GRAVE,Grave/Accent
+1,1,KP_1,1
+1,2,KP_2,2
+1,3,KP_3,3
+1,4,KP_4,4
+1,5,KP_5,5
+1,6,KP_6,6
+1,7,KP_7,7
+1,8,KP_8,8
+1,9,KP_9,9
+1,10,KP_0,0
+1,11,MINUS,Minus
+1,12,EQUAL,Equal
+1,13,BKSP,Backspace
+1,14,INS,Insert
+1,15,PGUP,Page Up
+
+# Row 2 - Tab, Q-P, [, ], \, Delete, End, PageDown
+2,0,TAB,Tab
+2,1,Q,Q
+2,2,W,W
+2,3,E,E
+2,4,R,R
+2,5,T,T
+2,6,Y,Y
+2,7,U,U
+2,8,I,I
+2,9,O,O
+2,10,P,P
+2,11,LBKT,Left Bracket
+2,12,RBKT,Right Bracket
+2,13,BSLS,Backslash
+2,14,DEL,Delete
+2,15,PGDN,Page Down
+
+# Row 3 - Caps, A-L, ;, ', Enter
+3,0,CAPS,Caps Lock
+3,1,A,A
+3,2,S,S
+3,3,D,D
+3,4,F,F
+3,5,G,G
+3,6,H,H
+3,7,J,J
+3,8,K,K
+3,9,L,L
+3,10,SEMICOLON,Semicolon
+3,11,QUOTE,Single Quote
+3,12,RET,Enter
+
+# Row 4 - LShift, Z-M, ,, ., /, RShift (ISO key support)
+4,0,LSHIFT,Left Shift
+4,1,Z,Z
+4,2,X,X
+4,3,C,C
+4,4,V,V
+4,5,B,B
+4,6,N,N
+4,7,M,M
+4,8,COMMA,Comma
+4,9,DOT,Period
+4,10,FSLASH,Forward Slash
+4,11,RSHIFT,Right Shift
+4,12,NON_US_BSLS,ISO Backslash (optional)
+
+# Row 5 - LCtrl, LGUI, LAlt, Space, RAlt, RGUI (Fn), Menu, RCtrl
+5,0,LCTRL,Left Ctrl
+5,1,LGUI,Left Win/Meta
+5,2,LALT,Left Alt
+5,3,SPACE,Spacebar
+5,4,RALT,Right Alt
+5,5,RGUI,Right Win/Meta
+5,6,K_MENU,Menu/Application
+5,7,RCTRL,Right Ctrl
+
+# Row 6 - Arrow keys
+6,0,UP,Arrow Up
+6,1,LEFT,Arrow Left
+6,2,DOWN,Arrow Down
+6,3,RIGHT,Arrow Right
+
+# Row 7 - Numpad (if using numpad variant)
+7,0,NLCK,Num Lock
+7,1,KPSLS,Num /
+7,2,KP_ASTERISK,Num *
+7,3,KP_MINUS,Num -
+7,4,KP_7,Num 7
+7,5,KP_8,Num 8
+7,6,KP_9,Num 9
+7,7,KP_PLUS,Num +
+7,8,KP_4,Num 4
+7,9,KP_5,Num 5
+7,10,KP_6,Num 6
+7,11,KP_1,Num 1
+7,12,KP_2,Num 2
+7,13,KP_3,Num 3
+7,14,KP_0,Num 0
+7,15,KP_DOT,Num .

--- a/app/boards/shields/tkl_nrf52832/tkl_nrf52832.conf
+++ b/app/boards/shields/tkl_nrf52832/tkl_nrf52832.conf
@@ -1,0 +1,33 @@
+# TKL Keyboard Configuration for nRF52832
+# NOTE: nRF52832 does NOT have built-in USB peripheral
+# For USB connectivity, use external USB-to-UART bridge chip
+
+# Output Configuration
+CONFIG_ZMK_USB=n
+CONFIG_ZMK_BLE=y
+
+# Bluetooth Configuration
+CONFIG_BT_MAX_CONN=5
+CONFIG_BT_MAX_PAIRED=5
+CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START=n
+
+# Multiple BLE Profiles (for pairing to multiple devices)
+CONFIG_ZMK_SPLIT_BLE_CENTRAL_PERIPHERALS=2
+
+# I2C Configuration for Trackpad/Sensors
+# NOTE: When using nrf52dk board, I2C is already configured on P0.26/P0.27
+# When using nice_nano or other boards, I2C pins may differ
+CONFIG_I2C=y
+
+# Azoteq IQS5xx Trackpad Driver
+CONFIG_INPUT=y
+CONFIG_INPUT_AZOTEQ_IQS5XX=y
+
+# Pointing Device Support
+CONFIG_ZMK_MOUSE=y
+
+# Increase key limit for TKL (99 keys)
+CONFIG_ZMK_KSCAN_EVENT_QUEUE_SIZE=40
+
+# Enable display for future OLED support (optional)
+# CONFIG_ZMK_DISPLAY=y

--- a/app/boards/shields/tkl_nrf52832/tkl_nrf52832.dtsi
+++ b/app/boards/shields/tkl_nrf52832/tkl_nrf52832.dtsi
@@ -1,0 +1,120 @@
+/* Custom TKL nRF52832 Keyboard with Azoteq Trackpad
+ *
+ * Matrix: 8 rows × 14 columns = 112 positions (99 keys defined)
+ * GPIO: Uses P0.03-P0.24 (22 pins) for matrix
+ * Peripherals: I2C (P0.26/27), Battery (P0.29), VBUS (P0.02), INT (P0.28), LED (P0.30)
+ */
+
+#include <dt-bindings/zmk/matrix_transform.h>
+
+/ {
+    chosen {
+        zmk,kscan = &kscan;
+        zmk,matrix_transform = &transform;
+    };
+
+    /* TKL Keyboard Matrix - 8x14 configuration
+     * Optimized for nRF52832 QFAAB (32 GPIOs)
+     * Rows: P0.03-P0.10 (8 pins)
+     * Columns: P0.11-P0.24 (14 pins)
+     */
+    kscan: kscan {
+        compatible = "zmk,kscan-gpio-matrix";
+        label = "KSCAN";
+        diode-direction = "col2row";
+
+        /* ROW GPIO PINS */
+        row-gpios =
+            <&gpio0 3 GPIO_ACTIVE_HIGH>,   /* ROW0 */
+            <&gpio0 4 GPIO_ACTIVE_HIGH>,   /* ROW1 */
+            <&gpio0 5 GPIO_ACTIVE_HIGH>,   /* ROW2 */
+            <&gpio0 6 GPIO_ACTIVE_HIGH>,   /* ROW3 */
+            <&gpio0 7 GPIO_ACTIVE_HIGH>,   /* ROW4 */
+            <&gpio0 8 GPIO_ACTIVE_HIGH>,   /* ROW5 */
+            <&gpio0 9 GPIO_ACTIVE_HIGH>,   /* ROW6 */
+            <&gpio0 10 GPIO_ACTIVE_HIGH>;  /* ROW7 */
+
+        /* COLUMN GPIO PINS */
+        col-gpios =
+            <&gpio0 11 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL0 */
+            <&gpio0 12 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL1 */
+            <&gpio0 13 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL2 */
+            <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL3 */
+            <&gpio0 15 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL4 */
+            <&gpio0 16 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL5 */
+            <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL6 */
+            <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL7 */
+            <&gpio0 19 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL8 */
+            <&gpio0 20 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL9 */
+            <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL10 */
+            <&gpio0 22 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL11 */
+            <&gpio0 23 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>,  /* COL12 */
+            <&gpio0 24 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;  /* COL13 */
+    };
+
+    /* Matrix Transform - Maps physical keys to keymap positions
+     * 8 rows × 14 columns = 112 positions
+     * Maps 99 keys for TKL + Numpad layout
+     */
+    transform: matrix_transform {
+        compatible = "zmk,matrix-transform";
+        rows = <8>;
+        columns = <14>;
+
+        map = <
+            /* Row 0: ESC, F1-F12, DEL */
+            RC(0,0) RC(0,1) RC(0,2) RC(0,3) RC(0,4) RC(0,5) RC(0,6) RC(0,7) RC(0,8) RC(0,9) RC(0,10) RC(0,11) RC(0,12) RC(0,13)
+
+            /* Row 1: Grave, 1-0, Minus, Equal, Backspace */
+            RC(1,0) RC(1,1) RC(1,2) RC(1,3) RC(1,4) RC(1,5) RC(1,6) RC(1,7) RC(1,8) RC(1,9) RC(1,10) RC(1,11) RC(1,12) RC(1,13)
+
+            /* Row 2: Tab, Q-P, [, ], \ */
+            RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5) RC(2,6) RC(2,7) RC(2,8) RC(2,9) RC(2,10) RC(2,11) RC(2,12) RC(2,13)
+
+            /* Row 3: Caps, A-L, ;, ', Enter */
+            RC(3,0) RC(3,1) RC(3,2) RC(3,3) RC(3,4) RC(3,5) RC(3,6) RC(3,7) RC(3,8) RC(3,9) RC(3,10) RC(3,11) RC(3,12)
+
+            /* Row 4: LShift, Z-M, ,, ., /, RShift, Up */
+            RC(4,0) RC(4,1) RC(4,2) RC(4,3) RC(4,4) RC(4,5) RC(4,6) RC(4,7) RC(4,8) RC(4,9) RC(4,10) RC(4,11) RC(4,12)
+
+            /* Row 5: LCtrl, LGUI, LAlt, Space, RAlt, RGUI, Menu, RCtrl, Left, Down, Right */
+            RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5) RC(5,6) RC(5,7) RC(5,8) RC(5,9) RC(5,10)
+
+            /* Row 6: NumLock, /, *, -, 7, 8, 9, +, Home, PgUp */
+            RC(6,0) RC(6,1) RC(6,2) RC(6,3) RC(6,4) RC(6,5) RC(6,6) RC(6,7) RC(6,8) RC(6,9)
+
+            /* Row 7: 0, ., =, 1, 2, 3, 4, Ins, End, PgDn */
+            RC(7,0) RC(7,1) RC(7,2) RC(7,3) RC(7,4) RC(7,5) RC(7,6) RC(7,7) RC(7,8) RC(7,9)
+        >;
+    };
+};
+
+/* I2C for Trackpad/Sensors
+ *
+ * For nrf52dk board: I2C is pre-configured on P0.26 (SDA) / P0.27 (SCL)
+ * The board definition already has pinctrl configured and i2c0 enabled.
+ *
+ * To add a pointing device, enable CONFIG_ZMK_POINTING in the .conf file
+ * and add a device node under &i2c0:
+ *
+ * &i2c0 {
+ *     // Supported Zephyr pointing devices:
+ *     // - cirque,pinnacle-i2c (Cirque Pinnacle trackpad)
+ *     // - pixart,pat912x (Optical navigation sensor)
+ *     // - cypress,cy8cmbr3xxx (Cypress trackpad)
+ *
+ *     trackpad: trackpad@2a {
+ *         compatible = "cirque,pinnacle-i2c";
+ *         reg = <0x2a>;
+ *         interrupt-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+ *     };
+ * };
+ *
+ * NOTE: Azoteq IQS550 requires a custom Zephyr driver since it's not
+ * natively supported. Consider using Cirque Pinnacle or another supported device.
+ */
+
+/* Enable GPIO */
+&gpio0 {
+    status = "okay";
+};

--- a/app/boards/shields/tkl_nrf52832/tkl_nrf52832.keymap
+++ b/app/boards/shields/tkl_nrf52832/tkl_nrf52832.keymap
@@ -1,0 +1,193 @@
+/*
+ * TKL Keyboard with Bluetooth & System Switching
+ * 
+ * Features:
+ * - BLE Profiles: Switch between 5 paired devices (F13-F17)
+ * - Output Toggle: BLE/USB switching (F18)
+ * - Bluetooth Clear: Clear current profile pairing (F19)
+ * - Layer switching for additional functions
+ */
+
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
+
+/ {
+    /* System-Specific Behaviors for Windows, Mac, Linux, Android */
+    behaviors {
+        // OS Mode Toggle: Tap to switch between Windows/Mac modes
+        os_mode: os_mode_toggle {
+            compatible = "zmk,behavior-tap-dance";
+            #binding-cells = <0>;
+            tapping-term-ms = <200>;
+            bindings = <&to 0>, <&to 2>;  // Toggle between default and Mac layer
+        };
+
+        // Windows/Linux Copy (Ctrl+C)
+        win_copy: windows_copy {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp C>, <&kp LC(C)>;
+            mods = <(MOD_LCTL|MOD_RCTL)>;
+        };
+
+        // Mac Copy (Cmd+C)
+        mac_copy: mac_copy {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp C>, <&kp LG(C)>;
+            mods = <(MOD_LGUI|MOD_RGUI)>;
+        };
+
+        // Smart GUI/ALT key for cross-platform
+        smart_gui: smart_gui_key {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp LGUI>, <&kp LALT>;
+            mods = <(MOD_LSFT)>;
+        };
+    };
+System Mode Switching:
+         * F9  = Windows/Linux Mode (Layer 0)
+         * F10 = Mac Mode (Layer 2)
+         * F11 = Android Mode (Layer 3)
+         * 
+         * Bluetooth Profile Selection:
+         * F1 = BLE Profile 0 (Device 1)
+         * F2 = BLE Profile 1 (Device 2)
+         * F3 = BLE Profile 2 (Device 3)
+         * F4 = BLE Profile 3 (Device 4)
+         * F5 = BLE Profile 4 (Device 5)
+         * F6 = Toggle Output (BLE/USB)
+         * F7 = Clear current BLE profile
+         * F8 = Clear ALL BLE profiles
+         */
+        function_layer {
+            bindings = <
+                /* Row 0: ESC, BT Controls + OS Mode Switching, DEL */
+                &trans    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &out OUT_TOG  &bt BT_CLR  &bt BT_CLR_ALL  &to 0  &to 2  &to 3  &trans  &trans
+
+                /* Row 1: Media controls */
+                &trans    &kp C_MUTE  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_PP  &kp C_NEXT  &kp C_BRI_DN  &kp C_BRI_UP  &trans  &trans  &trans  &trans  &trans
+
+                /* Row 2: Additional controls */
+                &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
+
+                /* Row 3 */
+                &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
+
+                /* Row 4 */
+                &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
+
+                /* Row 5 */
+                &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
+
+                /* Row 6 */
+                &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
+
+                /* Row 7 */
+                &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
+            >;
+        };
+
+        /* Layer 2: Mac Mode
+         * Optimized for macOS with Cmd key behavior
+         * GUI and Alt keys are swapped for Mac layout
+         */
+        mac_layer {
+            bindings = <
+                /* Row 0: ESC, F1-F12, DEL */
+                &kp ESC   &kp F1    &kp F2    &kp F3    &kp F4    &kp F5    &kp F6    &kp F7    &kp F8    &kp F9    &kp F10   &kp F11   &kp F12   &kp DEL
+
+                /* Row 1: Grave, 1-0, Minus, Equal, Backspace */
+                &kp GRAVE &kp N1    &kp N2    &kp N3    &kp N4    &kp N5    &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp MINUS &kp EQUAL &kp BSPC
+
+                /* Row 2: Tab, Q-P, [, ], \ */
+                &kp TAB   &kp Q     &kp W     &kp E     &kp R     &kp T     &kp Y     &kp U     &kp I     &kp O     &kp P     &kp LBKT  &kp RBKT  &kp BSLH
+
+                /* Row 3: Caps, A-L, ;, ', Enter */
+                &kp CAPS  &kp A     &kp S     &kp D     &kp F     &kp G     &kp H     &kp J     &kp K     &kp L     &kp SEMI  &kp SQT   &kp RET
+
+                /* Row 4: LShift, Z-M, ,, ., /, RShift, Up */
+                &kp LSHFT &kp Z     &kp X     &kp C     &kp V     &kp B     &kp N     &kp M     &kp COMMA &kp DOT   &kp FSLH  &kp RSHFT &kp UP
+
+                /* Row 5: LCtrl, LALT (Mac Option), LGUI (Mac Cmd), Space, RGUI (Mac Cmd), RALT, Menu, RCtrl, Navigation */
+                &kp LCTRL &kp LALT  &kp LGUI  &kp SPACE &kp RGUI  &kp RALT  &mo 1     &kp RCTRL &kp LEFT  &kp DOWN  &kp RIGHT
+
+                /* Row 6: NumLock, /, *, -, 7, 8, 9, +, Home, PgUp */
+                &kp KP_NUM &kp KP_DIVIDE &kp KP_MULTIPLY &kp KP_MINUS &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS &kp HOME &kp PG_UP
+
+                /* Row 7: 0, ., =, 1, 2, 3, 4, Ins, End, PgDn */
+                &kp KP_N0 &kp KP_DOT &kp EQUAL &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_N4 &kp INS &kp END &kp PG_DN
+            >;
+        };
+
+        /* Layer 3: Android/Chrome OS Mode
+         * Optimized for Android devices and Chromebooks
+         * Similar to Windows but with Android-specific shortcuts
+         */
+        android_layer {
+            bindings = <
+                /* Row 0: ESC, F1-F12, DEL */
+                &kp ESC   &kp F1    &kp F2    &kp F3    &kp F4    &kp F5    &kp F6    &kp F7    &kp F8    &kp F9    &kp F10   &kp F11   &kp F12   &kp DEL
+
+                /* Row 1: Grave, 1-0, Minus, Equal, Backspace */
+                &kp GRAVE &kp N1    &kp N2    &kp N3    &kp N4    &kp N5    &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp MINUS &kp EQUAL &kp BSPC
+
+                /* Row 2: Tab, Q-P, [, ], \ */
+                &kp TAB   &kp Q     &kp W     &kp E     &kp R     &kp T     &kp Y     &kp U     &kp I     &kp O     &kp P     &kp LBKT  &kp RBKT  &kp BSLH
+
+                /* Row 3: Caps, A-L, ;, ', Enter */
+                &kp CAPS  &kp A     &kp S     &kp D     &kp F     &kp G     &kp H     &kp J     &kp K     &kp L     &kp SEMI  &kp SQT   &kp RET
+
+                /* Row 4: LShift, Z-M, ,, ., /, RShift, Up */
+                &kp LSHFT &kp Z     &kp X     &kp C     &kp V     &kp B     &kp N     &kp M     &kp COMMA &kp DOT   &kp FSLH  &kp RSHFT &kp UP
+
+                /* Row 5: LCtrl, LGUI (Search), LAlt, Space, RAlt, RGUI, Menu, RCtrl, Navigation */
+                &kp LCTRL &kp LGUI  &kp LALT  &kp SPACE &kp RALT  &kp RGUI  &mo 1     &kp RCTRL &kp LEFT  &kp DOWN  &kp RIGHT
+
+                /* Row 6: NumLock, /, *, -, 7, 8, 9, +, Home, PgUp */
+                &kp KP_NUM &kp KP_DIVIDE &kp KP_MULTIPLY &kp KP_MINUS &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS &kp HOME &kp PG_UP
+
+                /* Row 7: 0, ., =, 1, 2, 3, 4, Ins, End, PgDn */
+                &kp KP_N0 &kp KP_DOT &kp EQUAL &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_N4 &kp INS &kp END &kp PG_DN
+            >;
+        };
+    };
+                /* Row 5 */
+                &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
+
+                /* Row 6 */
+                &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
+
+                /* Row 7 */
+                &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans    &trans
+            >;
+        };
+    };
+
+    /* Conditional Layers for OS-Specific Behaviors (Optional)
+     * Uncomment and configure if you need different key behaviors per OS
+     */
+    
+    /* 
+    behaviors {
+        // Windows/Linux GUI key
+        win_gui: windows_gui {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp LGUI>, <&kp LALT>;
+            mods = <(MOD_LCTL)>;
+        };
+        
+        // Mac Command key behavior
+        mac_cmd: mac_command {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp LGUI>, <&kp LALT>;
+            mods = <(MOD_LALT)>;
+        };
+    };
+    */
+};

--- a/app/boards/shields/tkl_nrf52832/tkl_nrf52832.overlay
+++ b/app/boards/shields/tkl_nrf52832/tkl_nrf52832.overlay
@@ -1,0 +1,58 @@
+/* Custom TKL nRF52832 Keyboard Board Overlay */
+
+#include "tkl_nrf52832.dtsi"
+
+/ {
+    model = "Custom TKL nRF52832 Keyboard";
+    compatible = "tkl,nrf52832";
+
+    /* Input listener for trackpad */
+    trackpad_listener: trackpad_listener {
+        compatible = "zmk,input-listener";
+        device = <&trackpad>;
+    };
+};
+
+/* nRF52832 QFAA (or QFAAB) configuration */
+&pinctrl {
+    compatible = "nordic,nrf-pinctrl";
+};
+
+/* I2C Configuration for Azoteq IQS5xx Trackpad */
+&i2c0 {
+    compatible = "nordic,nrf-twi";
+    status = "okay";
+
+    trackpad: iqs5xx@74 {
+        compatible = "azoteq,iqs5xx";
+        reg = <0x74>;
+        status = "okay";
+        
+        /* GPIO Pins:
+         * - RDY (Data Ready): P0.28 (interrupt pin, active high)
+         * - RESET: P0.25 (optional hardware reset, active low)
+         */
+        rdy-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
+        reset-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+        
+        /* Gesture Configuration */
+        one-finger-tap;           // Single tap → Left click
+        press-and-hold;           // Press & hold → Drag (left click held)
+        press-and-hold-time = <250>;  // Hold time in ms
+        two-finger-tap;           // Two finger tap → Right click
+        
+        /* Scrolling */
+        scroll;                   // Enable scroll gestures
+        natural-scroll-y;         // Natural vertical scrolling
+        // natural-scroll-x;      // Uncomment for natural horizontal scroll
+        
+        /* Axes Configuration */
+        // switch-xy;             // Uncomment to swap X/Y axes
+        // flip-x;                // Uncomment to invert X axis
+        // flip-y;                // Uncomment to invert Y axis
+        
+        /* Sensitivity Tuning */
+        bottom-beta = <5>;        // Filtering: 0=smooth/laggy, 255=responsive/jittery
+        stationary-threshold = <5>; // Movement threshold in pixels
+    };
+};

--- a/app/boards/shields/tkl_nrf52832/tkl_nrf52832.zmk.yml
+++ b/app/boards/shields/tkl_nrf52832/tkl_nrf52832.zmk.yml
@@ -1,0 +1,8 @@
+file_format: "1"
+id: tkl_nrf52832
+name: Custom TKL nRF52832 Keyboard
+type: shield
+url: https://github.com/zmkfirmware/zmk
+features:
+  - keys
+  - trackpad

--- a/app/boards/shields/tkl_nrf52832/validate_matrix.py
+++ b/app/boards/shields/tkl_nrf52832/validate_matrix.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""
+ZMK TKL Matrix Validation Script
+
+Validates:
+1. Matrix CSV format and completeness
+2. GPIO pin assignments for nRF52832
+3. Duplicate key detection
+4. Row/Column consistency
+5. DTS file generation
+"""
+
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+# nRF52832 QFAAB GPIO Pin Mapping (P0.00 - P0.31)
+# Source: Nordic nRF52832 Product Specification
+NRF52832_GPIO_PINS = {
+    # Port 0 pins (0-31)
+    0: "P0.00", 1: "P0.01", 2: "P0.02", 3: "P0.03", 4: "P0.04", 5: "P0.05", 6: "P0.06", 7: "P0.07",
+    8: "P0.08", 9: "P0.09", 10: "P0.10", 11: "P0.11", 12: "P0.12", 13: "P0.13", 14: "P0.14", 15: "P0.15",
+    16: "P0.16", 17: "P0.17", 18: "P0.18", 19: "P0.19", 20: "P0.20", 21: "P0.21", 22: "P0.22", 23: "P0.23",
+    24: "P0.24", 25: "P0.25", 26: "P0.26", 27: "P0.27", 28: "P0.28", 29: "P0.29", 30: "P0.30", 31: "P0.31"
+}
+
+# Reserved pins for nRF52832 (cannot use for matrix)
+RESERVED_PINS = {
+    # Crystal/OSC
+    0, 1,  # XL1, XL2 (32kHz crystal)
+    # SWD Debug
+    None,  # SWDIO, SWCLK determined by board, but typical pins
+    # USB (if using USB peripheral)
+    None,  # VBUS, D+, D- pins vary by package
+}
+
+# Recommended pin assignments for TKL
+# For 8x14 matrix (pins 3-24 used), use remaining pins for peripherals
+TKL_RECOMMENDED_GPIO = {
+    # I2C for Azoteq Trackpad (use TWI0: P0.26, P0.27)
+    "I2C_SDA": 26,  # P0.26
+    "I2C_SCL": 27,  # P0.27
+
+    # UART for debugging (optional, use pins outside matrix range)
+    "UART_TX": 25,   # P0.25
+    "UART_RX": 31,   # P0.31
+
+    # Battery ADC
+    "BATTERY_ADC": 29,  # P0.29 (AIN7 - ADC input)
+
+    # Trackpad Interrupt
+    "TRACKPAD_INT": 28,  # P0.28
+
+    # VBUS sensing (USB power detection)
+    "VBUS_SENSE": 2,  # P0.02
+
+    # Status LED
+    "STATUS_LED": 30,  # P0.30
+}
+
+class MatrixValidator:
+    def __init__(self, csv_path: str):
+        self.csv_path = Path(csv_path)
+        self.keys: List[Dict] = []
+        self.positions: Set[Tuple[int, int]] = set()
+        self.used_pins: Set[int] = set()
+        self.errors: List[str] = []
+        self.warnings: List[str] = []
+
+    def load_csv(self) -> bool:
+        """Load and parse the matrix CSV file."""
+        try:
+            with open(self.csv_path, 'r') as f:
+                reader = csv.DictReader(f, fieldnames=['row', 'col', 'key', 'position'])
+                for line_num, row in enumerate(reader, 1):
+                    # Skip comments
+                    if row['row'].strip().startswith('#'):
+                        continue
+
+                    # Parse row and column
+                    try:
+                        row_idx = int(row['row'].strip())
+                        col_idx = int(row['col'].strip())
+                    except ValueError:
+                        self.errors.append(f"Line {line_num}: Invalid row/column values: {row['row']}, {row['col']}")
+                        continue
+
+                    self.keys.append({
+                        'row': row_idx,
+                        'col': col_idx,
+                        'key': row['key'].strip(),
+                        'position': row.get('position', '').strip(),
+                        'line': line_num
+                    })
+
+                    self.positions.add((row_idx, col_idx))
+
+            return True
+        except FileNotFoundError:
+            self.errors.append(f"CSV file not found: {self.csv_path}")
+            return False
+        except Exception as e:
+            self.errors.append(f"Error reading CSV: {e}")
+            return False
+
+    def validate_duplicates(self):
+        """Check for duplicate positions."""
+        seen = {}
+        for key_data in self.keys:
+            pos = (key_data['row'], key_data['col'])
+            if pos in seen:
+                self.errors.append(
+                    f"Duplicate position ({pos[0]},{pos[1]}): "
+                    f"'{seen[pos]['key']}' and '{key_data['key']}' at lines {seen[pos]['line']}, {key_data['line']}"
+                )
+            else:
+                seen[pos] = {'key': key_data['key'], 'line': key_data['line']}
+
+    def validate_matrix_dimensions(self):
+        """Validate matrix dimensions and report statistics."""
+        if not self.keys:
+            self.errors.append("No keys found in CSV")
+            return
+
+        max_row = max(k['row'] for k in self.keys) + 1
+        max_col = max(k['col'] for k in self.keys) + 1
+
+        print(f"\n✓ Matrix Dimensions: {max_row} rows × {max_col} columns = {max_row * max_col} positions")
+        print(f"✓ Total Keys Defined: {len(self.keys)}")
+
+        # Check for gaps
+        for r in range(max_row):
+            for c in range(max_col):
+                if (r, c) not in self.positions:
+                    self.warnings.append(f"Empty position at ({r}, {c})")
+
+    def validate_gpio_pins(self, row_gpios: List[int], col_gpios: List[int]):
+        """Validate GPIO pin assignments for nRF52832."""
+        all_pins = row_gpios + col_gpios
+
+        # Check for duplicates
+        if len(all_pins) != len(set(all_pins)):
+            duplicates = [pin for pin in all_pins if all_pins.count(pin) > 1]
+            self.errors.append(f"Duplicate GPIO pins: {duplicates}")
+
+        # Check pin range
+        for pin in all_pins:
+            if pin < 0 or pin > 31:
+                self.errors.append(f"Invalid GPIO pin number: {pin} (must be 0-31)")
+
+        # Check against reserved pins
+        reserved = [p for p in all_pins if p in RESERVED_PINS and RESERVED_PINS[p] is not None]
+        if reserved:
+            self.warnings.append(f"Using potentially reserved pins: {reserved}")
+
+        # Check total pin count
+        total_pins = len(all_pins)
+        if total_pins > 24:  # Reasonable limit for matrix
+            self.warnings.append(f"High pin count: {total_pins} GPIOs used for matrix")
+
+        # Add to used pins
+        self.used_pins.update(all_pins)
+
+        print(f"✓ Row GPIOs: {row_gpios} ({len(row_gpios)} pins)")
+        print(f"✓ Column GPIOs: {col_gpios} ({len(col_gpios)} pins)")
+        print(f"✓ Total Matrix Pins: {total_pins}")
+
+    def check_peripheral_conflicts(self):
+        """Check for conflicts with peripheral GPIO assignments."""
+        for peripheral, pin in TKL_RECOMMENDED_GPIO.items():
+            if pin in self.used_pins:
+                self.errors.append(f"GPIO conflict: {peripheral} uses pin {pin}, which is also used for matrix")
+
+    def generate_dts(self, row_gpios: List[int], col_gpios: List[int]) -> str:
+        """Generate DTS kscan and transform nodes."""
+        rows = len(row_gpios)
+        cols = len(col_gpios)
+
+        # Generate kscan node
+        kscan_lines = [
+            "    kscan: kscan {",
+            "        compatible = \"zmk,kscan-gpio-matrix\";",
+            "        label = \"KSCAN\";",
+            "        diode-direction = \"col2row\";",
+            "",
+            "        row-gpios =",
+        ]
+
+        for i, pin in enumerate(row_gpios):
+            comma = "," if i < len(row_gpios) - 1 else ";"
+            kscan_lines.append(f"            <&gpio0 {pin} GPIO_ACTIVE_HIGH>{comma}")
+            if pin in self.used_pins:
+                pass  # Already tracked
+
+        kscan_lines.append("")
+        kscan_lines.append("        col-gpios =")
+
+        for i, pin in enumerate(col_gpios):
+            comma = "," if i < len(col_gpios) - 1 else ";"
+            kscan_lines.append(f"            <&gpio0 {pin} (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>{comma}")
+
+        kscan_lines.append("    };")
+
+        # Generate matrix transform
+        max_row = max(k['row'] for k in self.keys) + 1
+        max_col = max(k['col'] for k in self.keys) + 1
+
+        transform_lines = [
+            "",
+            "    transform: matrix_transform {",
+            f"        compatible = \"zmk,matrix-transform\";",
+            f"        rows = <{rows}>;",
+            f"        columns = <{cols}>;",
+            "",
+            "        map = <",
+        ]
+
+        # Generate RC mappings
+        current_row = -1
+        for key_data in sorted(self.keys, key=lambda k: (k['row'], k['col'])):
+            if key_data['row'] != current_row:
+                if current_row >= 0:
+                    transform_lines[-1] += "    "  # Add alignment for readability
+                transform_lines.append("            ")
+                current_row = key_data['row']
+
+            transform_lines[-1] += f"RC({key_data['row']},{key_data['col']}) "
+            if key_data['col'] == max_col - 1 and key_data['row'] < max_row - 1:
+                transform_lines[-1] = transform_lines[-1].rstrip() + "\n"
+
+        transform_lines.append("        >;")
+
+        # Close braces
+        transform_lines.extend(["    };", ""])
+
+        return "\n".join(kscan_lines) + "\n" + "\n".join(transform_lines)
+
+    def run_validation(self, row_gpios: List[int], col_gpios: List[int]):
+        """Run all validation checks."""
+        print(f"🔍 Validating ZMK Matrix: {self.csv_path.name}")
+        print("=" * 60)
+
+        if not self.load_csv():
+            print("\n❌ Failed to load CSV")
+            return False
+
+        print("\n📋 CSV loaded successfully")
+
+        # Run validations
+        self.validate_duplicates()
+        self.validate_matrix_dimensions()
+        self.validate_gpio_pins(row_gpios, col_gpios)
+        self.check_peripheral_conflicts()
+
+        # Print results
+        print("\n" + "=" * 60)
+
+        if self.warnings:
+            print(f"\n⚠️  WARNINGS ({len(self.warnings)}):")
+            for warning in self.warnings:
+                print(f"   {warning}")
+
+        if self.errors:
+            print(f"\n❌ ERRORS ({len(self.errors)}):")
+            for error in self.errors:
+                print(f"   {error}")
+            return False
+
+        print("\n✅ Validation PASSED!")
+        return True
+
+    def print_summary(self):
+        """Print a summary of the matrix."""
+        print("\n📊 Matrix Summary:")
+        print("-" * 60)
+
+        max_row = max(k['row'] for k in self.keys) + 1
+        max_col = max(k['col'] for k in self.keys) + 1
+
+        # Create grid visualization
+        for r in range(max_row):
+            row_keys = []
+            for c in range(max_col):
+                key = next((k for k in self.keys if k['row'] == r and k['col'] == c), None)
+                if key:
+                    row_keys.append(key['key'][:6].ljust(6))
+                else:
+                    row_keys.append("------")
+            print(f"Row {r}: {' '.join(row_keys)}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python validate_matrix.py <csv_file> [row_pins...] [--col col_pins...]")
+        print("\nExample:")
+        print("  python validate_matrix.py tkl_matrix.csv 3 4 5 6 7 8 9 10 --col 11 12 13 14 15 16 17 18")
+        print("\nFor TKL (8x8 matrix):")
+        print("  python validate_matrix.py tkl_matrix.csv 3 4 5 6 7 8 9 10 --col 11 12 13 14 15 16 17 18")
+        sys.exit(1)
+
+    csv_file = sys.argv[1]
+
+    # Parse GPIO arguments
+    try:
+        separator_idx = sys.argv.index('--col')
+        row_gpios = list(map(int, sys.argv[2:separator_idx]))
+        col_gpios = list(map(int, sys.argv[separator_idx + 1:]))
+    except ValueError:
+        print("❌ Error: Use '--col' to separate row and column GPIOs")
+        sys.exit(1)
+
+    validator = MatrixValidator(csv_file)
+
+    if validator.run_validation(row_gpios, col_gpios):
+        validator.print_summary()
+
+        # Generate DTS
+        print("\n📝 Generated DTS:")
+        print("=" * 60)
+        print(validator.generate_dts(row_gpios, col_gpios))
+        print("=" * 60)
+
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/boards/shields/tkl_nrf52832/zmk_keycodes.csv
+++ b/app/boards/shields/tkl_nrf52832/zmk_keycodes.csv
@@ -1,0 +1,207 @@
+Keycode,ShortNames,Description,Category,Compatibility
+A,"A",a and A,Letters,All platforms
+B,"B",b and B,Letters,All platforms
+C,"C",c and C,Letters,All platforms
+D,"D",d and D,Letters,All platforms
+E,"E",e and E,Letters,All platforms
+F,"F",f and F,Letters,All platforms
+G,"G",g and G,Letters,All platforms
+H,"H",h and H,Letters,All platforms
+I,"I",i and I,Letters,All platforms
+J,"J",j and J,Letters,All platforms
+K,"K",k and K,Letters,All platforms
+L,"L",l and L,Letters,All platforms
+M,"M",m and M,Letters,All platforms
+N,"N",n and N,Letters,All platforms
+O,"O",o and O,Letters,All platforms
+P,"P",p and P,Letters,All platforms
+Q,"Q",q and Q,Letters,All platforms
+R,"R",r and R,Letters,All platforms
+S,"S",s and S,Letters,All platforms
+T,"T",t and T,Letters,All platforms
+U,"U",u and U,Letters,All platforms
+V,"V",v and V,Letters,All platforms
+W,"W",w and W,Letters,All platforms
+X,"X",x and X,Letters,All platforms
+Y,"Y",y and Y,Letters,All platforms
+Z,"Z",z and Z,Letters,All platforms
+NUMBER_1,"N1",1 and ! Exclamation,Numbers,All platforms
+NUMBER_2,"N2",2 and @ At Sign,Numbers,All platforms
+NUMBER_3,"N3",3 and # Hash / Pound,Numbers,All platforms
+NUMBER_4,"N4",4 and $ Dollar,Numbers,All platforms
+NUMBER_5,"N5",5 and % Percent,Numbers,All platforms
+NUMBER_6,"N6",6 and ^ Caret,Numbers,All platforms
+NUMBER_7,"N7",7 and & Ampersand,Numbers,All platforms
+NUMBER_8,"N8",8 and * Asterisk / Star,Numbers,All platforms
+NUMBER_9,"N9",9 and ( Left Parenthesis,Numbers,All platforms
+NUMBER_0,"N0",0 and ) Right Parenthesis,Numbers,All platforms
+EXCLAMATION,"EXCL",! Exclamation,Symbols,All platforms
+AT_SIGN,"AT",@ At Sign,Symbols,All platforms
+HASH,"POUND",# Hash / Pound,Symbols,All platforms
+DOLLAR,"DLLR",$ Dollar,Symbols,All platforms
+PERCENT,"PRCNT",% Percent,Symbols,All platforms
+CARET,"",^ Caret,Symbols,All platforms
+AMPERSAND,"AMPS",& Ampersand,Symbols,All platforms
+ASTERISK,"ASTRK,STAR",* Asterisk / Star,Symbols,All platforms
+LEFT_PARENTHESIS,"LPAR",( Left Parenthesis,Symbols,All platforms
+RIGHT_PARENTHESIS,"RPAR",) Right Parenthesis,Symbols,All platforms
+EQUAL,"",= Equal and + Plus,Symbols,All platforms
+PLUS,"",+ Plus,Symbols,All platforms
+MINUS,"",- Minus and _ Underscore,Symbols,All platforms
+UNDERSCORE,"UNDER",_ Underscore,Symbols,All platforms
+SLASH,"FSLH",/ Forward Slash and ? Question Mark,Symbols,All platforms
+QUESTION,"QMARK",? Question Mark,Symbols,All platforms
+BACKSLASH,"BSLH",\ Backslash and | Pipe,Symbols,All platforms
+PIPE,"",| Pipe,Symbols,All platforms
+NON_US_BACKSLASH,"NON_US_BSLH,NUBS",Non-US \ Backslash and | Pipe,Symbols,All platforms
+PIPE2,"",| Pipe,Symbols,All platforms
+SEMICOLON,"SEMI","; Semicolon and : Colon",Symbols,All platforms
+COLON,"",": Colon",Symbols,All platforms
+SINGLE_QUOTE,"SQT,APOSTROPHE,APOS","' Apostrophe and \" Quote (Double)",Symbols,All platforms
+DOUBLE_QUOTES,"DQT","\" Quote (Double)",Symbols,All platforms
+COMMA,"","Comma and < Less Than",Symbols,All platforms
+LESS_THAN,"LT",< Less Than,Symbols,All platforms
+PERIOD,"DOT",. Period and > Greater Than,Symbols,All platforms
+GREATER_THAN,"GT",> Greater Than,Symbols,All platforms
+LEFT_BRACKET,"LBKT",[ Left Bracket and { Left Brace,Symbols,All platforms
+LEFT_BRACE,"LBRC",{ Left Brace,Symbols,All platforms
+RIGHT_BRACKET,"RBKT",] Right Bracket and } Right Brace,Symbols,All platforms
+RIGHT_BRACE,"RBRC",} Right Brace,Symbols,All platforms
+GRAVE,"",` Grave Accent and ~ Tilde,Symbols,All platforms
+TILDE,"",~ Tilde,Symbols,All platforms
+NON_US_HASH,"NUHS",Non-US # Hash/Pound and ~ Tilde,Symbols,All platforms
+TILDE2,"",~ Tilde,Symbols,All platforms
+ESCAPE,"ESC",Escape,Control,All platforms
+RETURN,"ENTER,RET",Return (Enter),Control,All platforms
+RETURN2,"RET2",Return,Control,Linux only
+SPACE,"",Space,Control,All platforms
+TAB,"",Tab,Control,All platforms
+BACKSPACE,"BSPC",Backspace,Control,All platforms
+DELETE,"DEL",Delete,Control,All platforms
+INSERT,"INS",Insert,Control,All platforms
+HOME,"",Home,Navigation,All platforms
+END,"",End,Navigation,All platforms
+PAGE_UP,"PG_UP",Page Up,Navigation,All platforms
+PAGE_DOWN,"PG_DN",Page Down,Navigation,All platforms
+UP_ARROW,"UP",⬆ Up Arrow,Navigation,All platforms
+DOWN_ARROW,"DOWN",⬇ Down Arrow,Navigation,All platforms
+LEFT_ARROW,"LEFT",⬅ Left Arrow,Navigation,All platforms
+RIGHT_ARROW,"RIGHT",⮕ Right Arrow,Navigation,All platforms
+K_APPLICATION,"K_APP,K_CONTEXT_MENU,K_CMENU",Application (Context Menu),Navigation,All platforms (iOS limited)
+CAPSLOCK,"CAPS,CLCK",Caps Lock,Locks,All platforms
+LOCKING_CAPS,"LCAPS",Locking Caps Lock,Locks,Windows only
+SCROLLLOCK,"SLCK",Scroll Lock,Locks,All platforms
+LOCKING_SCROLL,"LSLCK",Locking Scroll Lock,Locks,Windows only
+LOCKING_NUM,"LNLCK",Locking Num Lock,Locks,Linux only
+F1,"",F1,F-Keys,All platforms
+F2,"",F2,F-Keys,All platforms
+F3,"",F3,F-Keys,All platforms
+F4,"",F4,F-Keys,All platforms
+F5,"",F5,F-Keys,All platforms
+F6,"",F6,F-Keys,All platforms
+F7,"",F7,F-Keys,All platforms
+F8,"",F8,F-Keys,All platforms
+F9,"",F9,F-Keys,All platforms
+F10,"",F10,F-Keys,All platforms
+F11,"",F11,F-Keys,All platforms
+F12,"",F12,F-Keys,All platforms
+F13,"",F13,F-Keys,All platforms except Android
+F14,"",F14,F-Keys,All platforms except Android
+F15,"",F15,F-Keys,All platforms except Android
+F16,"",F16,F-Keys,All platforms except Android
+F17,"",F17,F-Keys,All platforms except Android
+F18,"",F18,F-Keys,All platforms except Android
+F19,"",F19,F-Keys,All platforms except Android
+F20,"",F20,F-Keys,All platforms except Android
+F21,"",F21,F-Keys,All platforms except Android
+F22,"",F22,F-Keys,All platforms except Android
+F23,"",F23,F-Keys,All platforms except Android
+F24,"",F24,F-Keys,All platforms except Android
+INTERNATIONAL_1,"INT1,INT_RO",ろ (International 1),International,Linux only
+INTERNATIONAL_2,"INT2,INT_KATAKANAHIRAGANA,INT_KANA",かな (International 2),International,Linux only
+INTERNATIONAL_3,"INT3,INT_YEN",¥ (International 3),International,Linux only
+INTERNATIONAL_4,"INT4,INT_HENKAN",変換 (International 4),International,Linux only
+INTERNATIONAL_5,"INT5,INT_MUHENKAN",無変換 (International 5),International,Linux only
+INTERNATIONAL_6,"INT6,INT_KPJPCOMMA",,カンマ (International 6),International,Linux only
+LANGUAGE_1,"LANG1,LANG_HANGEUL",한/영 (Language 1),Language,Windows and Linux
+LANGUAGE_2,"LANG2,LANG_HANJA",한자 (Language 2),Language,Windows and Linux
+LANGUAGE_3,"LANG3,LANG_KATAKANA",カタカナ (Language 3),Language,Linux only
+LANGUAGE_4,"LANG4,LANG_HIRAGANA",ひらがな (Language 4),Language,Linux only
+LANGUAGE_5,"LANG5,LANG_ZENKAKUHANKAKU",半角/全角 (Language 5),Language,Linux only
+PRINTSCREEN,"PSCRN",Print Screen,Miscellaneous,All platforms
+PAUSE_BREAK,"",Pause / Break,Miscellaneous,All platforms
+LEFT_SHIFT,"LSHIFT,LSHFT,LS",Left Shift ⇧,Modifiers,All platforms
+RIGHT_SHIFT,"RSHIFT,RSHFT,RS",Right Shift ⇧,Modifiers,All platforms
+LEFT_CONTROL,"LCTRL,LC",Left Control,Modifiers,All platforms
+RIGHT_CONTROL,"RCTRL,RC",Right Control,Modifiers,All platforms
+LEFT_ALT,"LALT,LA",Left Alt,Modifiers,All platforms
+RIGHT_ALT,"RALT,RA",Right Alt,Modifiers,All platforms
+LEFT_GUI,"LGUI,LG,LEFT_WIN,LWIN,LEFT_COMMAND,LCMD,LEFT_META,LMETA",Left GUI (Windows / Command / Meta),Modifiers,All platforms
+RIGHT_GUI,"RGUI,RG,RIGHT_WIN,RWIN,RIGHT_COMMAND,RCMD,RIGHT_META,RMETA",Right GUI (Windows / Command / Meta),Modifiers,All platforms
+KP_NUMLOCK,"KP_NUM,KP_NLCK",Numlock and Clear,Keypad,Windows Linux Android
+KP_CLEAR,"",Clear,Keypad,Linux only
+CLEAR2,"",Clear,Keypad,Linux only
+KP_ENTER,"",Enter,Keypad,All platforms
+KP_NUMBER_1,"KP_N1",Keypad 1 and End,Keypad,All platforms
+KP_NUMBER_2,"KP_N2",Keypad 2 and Down Arrow,Keypad,All platforms
+KP_NUMBER_3,"KP_N3",Keypad 3 and Page Down,Keypad,All platforms
+KP_NUMBER_4,"KP_N4",Keypad 4 and Left Arrow,Keypad,All platforms
+KP_NUMBER_5,"KP_N5",Keypad 5,Keypad,All platforms
+KP_NUMBER_6,"KP_N6",Keypad 6 and Right Arrow,Keypad,All platforms
+KP_NUMBER_7,"KP_N7",Keypad 7 and Home,Keypad,All platforms
+KP_NUMBER_8,"KP_N8",Keypad 8 and Up Arrow,Keypad,All platforms
+KP_NUMBER_9,"KP_N9",Keypad 9 and Page Up,Keypad,All platforms
+KP_NUMBER_0,"KP_N0",Keypad 0 and Insert,Keypad,All platforms
+KP_PLUS,"",+ Plus,Keypad,All platforms
+KP_MINUS,"KP_SUBTRACT",- Minus,Keypad,All platforms
+KP_MULTIPLY,"KP_ASTERISK",* Multiply,Keypad,All platforms
+KP_DIVIDE,"KP_SLASH",/ Divide,Keypad,All platforms
+KP_EQUAL,"",= Equal,Keypad,Linux Android macOS
+KP_DOT,"",. Dot and Delete,Keypad,All platforms
+KP_COMMA,"",, Comma,Keypad,Linux Android
+C_AC_CUT,"",Cut Consumer AC,Editing,Linux only
+K_CUT,"",Cut Keyboard,Editing,Linux macOS
+C_AC_COPY,"",Copy Consumer AC,Editing,Linux only
+K_COPY,"",Copy Keyboard,Editing,Linux macOS
+C_AC_PASTE,"",Paste Consumer AC,Editing,Linux only
+K_PASTE,"",Paste Keyboard,Editing,Linux macOS
+C_AC_UNDO,"",Undo Consumer AC,Editing,Linux only
+K_UNDO,"",Undo Keyboard,Editing,Linux macOS
+C_AC_REDO,"",Redo / Repeat Consumer AC,Editing,Linux only
+K_AGAIN,"K_REDO",Again Keyboard,Editing,Linux macOS
+C_VOLUME_UP,"C_VOL_UP",Volume Up Consumer,Media,All platforms
+K_VOLUME_UP,"K_VOL_UP",Volume Up Keyboard,Media,Linux Android macOS
+C_VOLUME_DOWN,"C_VOL_DN",Volume Down Consumer,Media,All platforms
+K_VOLUME_DOWN,"K_VOL_DN",Volume Down Keyboard,Media,Linux Android macOS
+C_MUTE,"",Mute Consumer,Media,All platforms
+K_MUTE,"",Mute Keyboard,Media,Linux Android macOS
+C_BRIGHTNESS_INC,"C_BRI_INC,C_BRI_UP",Increase Brightness Consumer,Media,All platforms
+C_BRIGHTNESS_DEC,"C_BRI_DEC,C_BRI_DN",Decrease Brightness Consumer,Media,All platforms
+C_PLAY_PAUSE,"C_PP",Play / Pause Consumer,Media,All platforms
+K_PLAY_PAUSE,"K_PP",Play / Pause Keyboard,Media,Linux Android
+C_NEXT,"",Next Consumer,Media,All platforms
+K_NEXT,"",Next Keyboard,Media,Linux Android
+C_PREVIOUS,"C_PREV",Previous Consumer,Media,All platforms
+K_PREVIOUS,"K_PREV",Previous Keyboard,Media,Linux Android
+C_FAST_FORWARD,"C_FF",Fast Forward Consumer,Media,All platforms
+C_REWIND,"C_RW",Rewind Consumer,Media,All platforms
+K_MENU,"",Menu Keyboard,Applications,Linux only
+C_AC_BACK,"",Back Consumer AC,Applications,All platforms
+K_BACK,"",Back Keyboard,Applications,Linux Android
+C_AC_FORWARD,"",Forward Consumer AC,Applications,All platforms
+K_FORWARD,"",Forward Keyboard,Applications,Linux Android
+C_AC_REFRESH,"",Refresh Consumer AC,Applications,Linux only
+K_REFRESH,"",Refresh Keyboard,Applications,Linux Android
+C_AC_SEARCH,"",Search Consumer AC,Applications,All platforms
+C_AL_WWW,"",Internet Browser Consumer AL,Applications,Linux Android
+K_WWW,"",Internet Browser Keyboard,Applications,Linux Android
+C_AL_EMAIL,"C_AL_MAIL",Email Reader Consumer AL,Applications,Linux Android
+C_AL_CALCULATOR,"C_AL_CALC",Calculator Consumer AL,Applications,Linux Android
+K_CALCULATOR,"K_CALC",Calculator Keyboard,Applications,Linux Android
+C_AC_BOOKMARKS,"C_AC_FAVORITES,C_AC_FAVOURITES",Bookmarks Consumer AC,Applications,All platforms
+C_POWER,"C_PWR",Power Consumer,Power,Linux macOS iOS
+K_POWER,"K_PWR",Power Keyboard,Power,Android macOS iOS
+C_SLEEP,"",Sleep Consumer,Power,Linux only
+K_SLEEP,"",Sleep Keyboard,Power,Linux Android
+C_AL_LOCK,"C_AL_SCREENSAVER,C_AL_COFFEE",Terminal Lock / Screensaver Consumer AL,Power,Linux Android
+K_LOCK,"K_SCREENSAVER,K_COFFEE",Lock Keyboard,Power,Linux Android

--- a/app/module/drivers/input/CMakeLists.txt
+++ b/app/module/drivers/input/CMakeLists.txt
@@ -4,3 +4,4 @@
 zephyr_library_amend()
 
 zephyr_library_sources_ifdef(CONFIG_ZMK_INPUT_MOCK input_mock.c)
+zephyr_library_sources_ifdef(CONFIG_INPUT_AZOTEQ_IQS5XX iqs5xx.c)

--- a/app/module/drivers/input/Kconfig
+++ b/app/module/drivers/input/Kconfig
@@ -6,4 +6,25 @@ config ZMK_INPUT_MOCK
     default y
     depends on DT_HAS_ZMK_INPUT_MOCK_ENABLED
 
+menuconfig INPUT_AZOTEQ_IQS5XX
+    bool "Azoteq IQS5xx trackpads"
+    default y
+    depends on GPIO
+    depends on I2C
+    depends on INPUT
+    depends on DT_HAS_AZOTEQ_IQS5XX_ENABLED
+    help
+      Enable driver for Azoteq IQS5xx trackpads.
+
+if INPUT_AZOTEQ_IQS5XX
+
+config INPUT_AZOTEQ_IQS5XX_INIT_PRIORITY
+    int "Azoteq IQS5xx initialization priority"
+    default INPUT_INIT_PRIORITY
+    help
+      Driver initialization priority for the IQS5xx driver.
+      Lower values initialize earlier.
+
+endif # INPUT_AZOTEQ_IQS5XX
+
 endif

--- a/app/module/drivers/input/iqs5xx.c
+++ b/app/module/drivers/input/iqs5xx.c
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2025 Mariano Uvalle
+ * SPDX-License-Identifier: MIT
+ */
+
+#define DT_DRV_COMPAT azoteq_iqs5xx
+
+#include <stdlib.h>
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/input/input.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include "iqs5xx.h"
+
+LOG_MODULE_REGISTER(iqs5xx, CONFIG_INPUT_LOG_LEVEL);
+
+static int iqs5xx_read_reg16(const struct device *dev, uint16_t reg, uint16_t *val) {
+    const struct iqs5xx_config *config = dev->config;
+    uint8_t buf[2];
+    uint8_t reg_buf[2] = {reg >> 8, reg & 0xFF};
+    int ret;
+
+    ret = i2c_write_read_dt(&config->i2c, reg_buf, sizeof(reg_buf), buf, sizeof(buf));
+    if (ret < 0) {
+        return ret;
+    }
+
+    *val = (buf[0] << 8) | buf[1];
+    return 0;
+}
+
+static int iqs5xx_write_reg16(const struct device *dev, uint16_t reg, uint16_t val) {
+    const struct iqs5xx_config *config = dev->config;
+    uint8_t buf[4] = {reg >> 8, reg & 0xFF, val >> 8, val & 0xFF};
+
+    return i2c_write_dt(&config->i2c, buf, sizeof(buf));
+}
+
+static int iqs5xx_read_reg8(const struct device *dev, uint16_t reg, uint8_t *val) {
+    const struct iqs5xx_config *config = dev->config;
+    uint8_t reg_buf[2] = {reg >> 8, reg & 0xFF};
+
+    return i2c_write_read_dt(&config->i2c, reg_buf, sizeof(reg_buf), val, 1);
+}
+
+static int iqs5xx_write_reg8(const struct device *dev, uint16_t reg, uint8_t val) {
+    const struct iqs5xx_config *config = dev->config;
+    uint8_t buf[3] = {reg >> 8, reg & 0xFF, val};
+
+    return i2c_write_dt(&config->i2c, buf, sizeof(buf));
+}
+
+static int iqs5xx_end_comm_window(const struct device *dev) {
+    const struct iqs5xx_config *config = dev->config;
+    uint8_t buf[3] = {IQS5XX_END_COMM_WINDOW >> 8, IQS5XX_END_COMM_WINDOW & 0xFF, 0x00};
+
+    return i2c_write_dt(&config->i2c, buf, sizeof(buf));
+}
+
+static void iqs5xx_button_release_work_handler(struct k_work *work) {
+    struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+    struct iqs5xx_data *data = CONTAINER_OF(dwork, struct iqs5xx_data, button_release_work);
+
+    // TODO: This loop should only deactivate one button.
+    // Log a warning when that is not the case.
+    for (int i = 0; i < 3; i++) {
+        LOG_INF("Releasing synthetic button");
+        if (data->buttons_pressed & BIT(i)) {
+            input_report_key(data->dev, INPUT_BTN_0 + i, 0, true, K_FOREVER);
+            // Turn off the bit.
+            // NOTE: This is a potential race.
+            data->buttons_pressed &= ~BIT(i);
+        }
+    }
+}
+
+static void iqs5xx_work_handler(struct k_work *work) {
+    struct iqs5xx_data *data = CONTAINER_OF(work, struct iqs5xx_data, work);
+    const struct device *dev = data->dev;
+    const struct iqs5xx_config *config = dev->config;
+    uint8_t sys_info_0, sys_info_1, gesture_events_0, gesture_events_1, num_fingers;
+    int ret;
+
+    // Read system info registers.
+    ret = iqs5xx_read_reg8(dev, IQS5XX_SYSTEM_INFO_0, &sys_info_0);
+    if (ret < 0) {
+        LOG_ERR("Failed to read system info 0: %d", ret);
+        goto end_comm;
+    }
+
+    ret = iqs5xx_read_reg8(dev, IQS5XX_SYSTEM_INFO_1, &sys_info_1);
+    if (ret < 0) {
+        LOG_ERR("Failed to read system info 1: %d", ret);
+        goto end_comm;
+    }
+
+    ret = iqs5xx_read_reg8(dev, IQS5XX_GESTURE_EVENTS_0, &gesture_events_0);
+    if (ret < 0) {
+        LOG_ERR("Failed to read gesture events: %d", ret);
+        goto end_comm;
+    }
+
+    ret = iqs5xx_read_reg8(dev, IQS5XX_GESTURE_EVENTS_1, &gesture_events_1);
+    if (ret < 0) {
+        LOG_ERR("Failed to read gesture events 1: %d", ret);
+        goto end_comm;
+    }
+
+    // Handle reset indication.
+    if (sys_info_0 & IQS5XX_SHOW_RESET) {
+        LOG_INF("Device reset detected");
+        // Acknowledge reset.
+        iqs5xx_write_reg8(dev, IQS5XX_SYSTEM_CONTROL_0, IQS5XX_ACK_RESET);
+        goto end_comm;
+    }
+
+    bool tp_movement = (sys_info_1 & IQS5XX_TP_MOVEMENT) != 0;
+    bool scroll = (gesture_events_1 & IQS5XX_SCROLL) != 0;
+    if (!scroll) {
+        // Clear accumulators if we're not actively scrolling.
+        data->scroll_x_acc = 0;
+        data->scroll_y_acc = 0;
+    }
+
+    uint16_t button_code;
+    bool button_pressed = false;
+    if (gesture_events_0 & IQS5XX_SINGLE_TAP) {
+        button_pressed = true;
+        button_code = INPUT_BTN_0;
+    } else if (gesture_events_1 & IQS5XX_TWO_FINGER_TAP) {
+        button_pressed = true;
+        button_code = INPUT_BTN_1;
+    }
+
+    bool hold_became_active = (gesture_events_0 & IQS5XX_PRESS_AND_HOLD) && !data->active_hold;
+    bool hold_released = !(gesture_events_0 & IQS5XX_PRESS_AND_HOLD) && data->active_hold;
+
+    int16_t rel_x, rel_y;
+    if (tp_movement || scroll) {
+        ret = iqs5xx_read_reg16(dev, IQS5XX_REL_X, (uint16_t *)&rel_x);
+        if (ret < 0) {
+            LOG_ERR("Failed to read relative X: %d", ret);
+            goto end_comm;
+        }
+
+        ret = iqs5xx_read_reg16(dev, IQS5XX_REL_Y, (uint16_t *)&rel_y);
+        if (ret < 0) {
+            LOG_ERR("Failed to read relative Y: %d", ret);
+            goto end_comm;
+        }
+    }
+
+    // Handle movement and gestures.
+    //
+    // Each one of these branches needs to send the last report it makes as
+    // sync to ensure that the input subsystem processes things in order.
+    if (hold_became_active) {
+        LOG_INF("Hold became active");
+        input_report_key(dev, LEFT_BUTTON_CODE, 1, true, K_FOREVER);
+        data->active_hold = true;
+    } else if (hold_released) {
+        LOG_INF("Hold became inactive");
+        input_report_key(dev, LEFT_BUTTON_CODE, 0, true, K_FOREVER);
+        data->active_hold = false;
+    } else if (button_pressed) {
+        // Cancel any pending release.
+        k_work_cancel_delayable(&data->button_release_work);
+
+        // Press the button immediately.
+        input_report_key(dev, button_code, 1, true, K_FOREVER);
+        data->buttons_pressed |= BIT(button_code - INPUT_BTN_0);
+
+        // Schedule release after 100ms.
+        k_work_schedule(&data->button_release_work, K_MSEC(100));
+    } else if (scroll) {
+        // TODO: Expose this divisor.
+        int16_t scroll_div = 32;
+
+        // Only one scrolling direction is valid at a time.
+        // End the communication right after reporting the movement.
+        if (rel_x != 0) {
+            // By default the x axis is already "natural".
+            if (!config->natural_scroll_x) {
+                rel_x *= -1;
+            }
+            data->scroll_x_acc += rel_x;
+            if (abs(data->scroll_x_acc) >= scroll_div) {
+                input_report_rel(dev, INPUT_REL_HWHEEL, data->scroll_x_acc / scroll_div, true,
+                                 K_FOREVER);
+                data->scroll_x_acc %= scroll_div;
+            }
+            goto end_comm;
+        }
+        if (rel_y != 0) {
+            if (config->natural_scroll_y) {
+                rel_y *= -1;
+            }
+            data->scroll_y_acc += rel_y;
+            if (abs(data->scroll_y_acc) >= scroll_div) {
+                input_report_rel(dev, INPUT_REL_WHEEL, data->scroll_y_acc / scroll_div, true,
+                                 K_FOREVER);
+                data->scroll_y_acc %= scroll_div;
+            }
+
+            goto end_comm;
+        }
+    } else if (tp_movement) {
+        ret = iqs5xx_read_reg8(dev, IQS5XX_NUM_FINGERS, &num_fingers);
+        if (ret < 0) {
+            LOG_ERR("Failed to read number of fingers: %d", ret);
+            goto end_comm;
+        }
+
+        if (rel_x != 0 || rel_y != 0) {
+            input_report_rel(dev, INPUT_REL_X, rel_x, false, K_FOREVER);
+            input_report_rel(dev, INPUT_REL_Y, rel_y, true, K_FOREVER);
+        }
+    }
+
+end_comm:
+    // End communication window.
+    iqs5xx_end_comm_window(dev);
+}
+
+static void iqs5xx_rdy_handler(const struct device *port, struct gpio_callback *cb,
+                               gpio_port_pins_t pins) {
+    struct iqs5xx_data *data = CONTAINER_OF(cb, struct iqs5xx_data, rdy_cb);
+
+    k_work_submit(&data->work);
+}
+
+static int iqs5xx_setup_device(const struct device *dev) {
+    const struct iqs5xx_config *config = dev->config;
+    int ret;
+
+    // Enable event mode and trackpad events.
+    ret = iqs5xx_write_reg8(dev, IQS5XX_SYSTEM_CONFIG_1,
+                            IQS5XX_EVENT_MODE | IQS5XX_TP_EVENT | IQS5XX_GESTURE_EVENT);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure event mode: %d", ret);
+        return ret;
+    }
+
+    ret = iqs5xx_write_reg8(dev, IQS5XX_BOTTOM_BETA, config->bottom_beta);
+    if (ret < 0) {
+        LOG_ERR("Failed to set bottom beta: %d", ret);
+        return ret;
+    }
+
+    ret = iqs5xx_write_reg8(dev, IQS5XX_STATIONARY_THRESH, config->stationary_threshold);
+    if (ret < 0) {
+        LOG_ERR("Failed to set bottom stationary threshold: %d", ret);
+        return ret;
+    }
+
+    // TODO: Expose these through dts bindings.
+    // Set filter settings with:
+    // - IIR filter enabled
+    // - MAV filter enabled
+    // - IIR select disabled (dynamic IIR)
+    // - ALP count filter enabled
+    ret = iqs5xx_write_reg8(dev, IQS5XX_FILTER_SETTINGS,
+                            IQS5XX_IIR_FILTER | IQS5XX_MAV_FILTER | IQS5XX_ALP_COUNT_FILTER);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure filter settings: %d", ret);
+        return ret;
+    }
+
+    uint8_t single_finger_gestures = 0;
+    single_finger_gestures |= config->one_finger_tap ? IQS5XX_SINGLE_TAP : 0;
+    single_finger_gestures |= config->press_and_hold ? IQS5XX_PRESS_AND_HOLD : 0;
+    // Configure single finger gestures.
+    ret = iqs5xx_write_reg8(dev, IQS5XX_SINGLE_FINGER_GESTURES_CONF, single_finger_gestures);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure single finger gestures: %d", ret);
+        return ret;
+    }
+
+    // Configure the hold time for the press and hold gesture.
+    ret = iqs5xx_write_reg16(dev, IQS5XX_HOLD_TIME, config->press_and_hold_time);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure the hold time: %d", ret);
+        return ret;
+    }
+
+    uint8_t two_finger_gestures = 0;
+    two_finger_gestures |= config->two_finger_tap ? IQS5XX_TWO_FINGER_TAP : 0;
+    two_finger_gestures |= config->scroll ? IQS5XX_SCROLL : 0;
+    // Configure multi finger gestures.
+    ret = iqs5xx_write_reg8(dev, IQS5XX_MULTI_FINGER_GESTURES_CONF, two_finger_gestures);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure multi finger gestures: %d", ret);
+        return ret;
+    }
+
+    // Configure axes.
+    uint8_t xy_config = 0;
+    xy_config |= config->flip_x ? IQS5XX_FLIP_X : 0;
+    xy_config |= config->flip_y ? IQS5XX_FLIP_Y : 0;
+    xy_config |= config->switch_xy ? IQS5XX_SWITCH_XY_AXIS : 0;
+    ret = iqs5xx_write_reg8(dev, IQS5XX_XY_CONFIG_0, xy_config);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure axes: %d", ret);
+        return ret;
+    }
+
+    // Configure system settings.
+    ret = iqs5xx_write_reg8(dev, IQS5XX_SYSTEM_CONFIG_0, IQS5XX_SETUP_COMPLETE | IQS5XX_WDT);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure system: %d", ret);
+        return ret;
+    }
+
+    // End communication window.
+    ret = iqs5xx_end_comm_window(dev);
+    if (ret < 0) {
+        LOG_ERR("Failed to end comm window during initialization: %d", ret);
+        return ret;
+    }
+
+    return 0;
+}
+
+static int iqs5xx_init(const struct device *dev) {
+    const struct iqs5xx_config *config = dev->config;
+    struct iqs5xx_data *data = dev->data;
+    int ret;
+
+    if (!i2c_is_ready_dt(&config->i2c)) {
+        LOG_ERR("I2C device not ready");
+        return -ENODEV;
+    }
+
+    data->dev = dev;
+    k_work_init(&data->work, iqs5xx_work_handler);
+    k_work_init_delayable(&data->button_release_work, iqs5xx_button_release_work_handler);
+
+    // Configure reset GPIO if available.
+    if (config->reset_gpio.port) {
+        if (!gpio_is_ready_dt(&config->reset_gpio)) {
+            LOG_ERR("Reset GPIO not ready");
+            return -ENODEV;
+        }
+
+        ret = gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_ACTIVE);
+        if (ret < 0) {
+            LOG_ERR("Failed to configure reset GPIO: %d", ret);
+            return ret;
+        }
+
+        // Reset the device.
+        gpio_pin_set_dt(&config->reset_gpio, 1);
+        k_msleep(1);
+        gpio_pin_set_dt(&config->reset_gpio, 0);
+        k_msleep(10);
+    }
+
+    // Configure RDY GPIO.
+    if (!gpio_is_ready_dt(&config->rdy_gpio)) {
+        LOG_ERR("RDY GPIO not ready");
+        return -ENODEV;
+    }
+
+    ret = gpio_pin_configure_dt(&config->rdy_gpio, GPIO_INPUT);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure RDY GPIO: %d", ret);
+        return ret;
+    }
+
+    gpio_init_callback(&data->rdy_cb, iqs5xx_rdy_handler, BIT(config->rdy_gpio.pin));
+    ret = gpio_add_callback(config->rdy_gpio.port, &data->rdy_cb);
+    if (ret < 0) {
+        LOG_ERR("Failed to add RDY callback: %d", ret);
+        return ret;
+    }
+
+    ret = gpio_pin_interrupt_configure_dt(&config->rdy_gpio, GPIO_INT_EDGE_RISING);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure RDY interrupt: %d", ret);
+        return ret;
+    }
+
+    // Wait for device to be ready.
+    k_msleep(100);
+
+    // Setup device configuration.
+    ret = iqs5xx_setup_device(dev);
+    if (ret < 0) {
+        LOG_ERR("Failed to setup device: %d", ret);
+        return ret;
+    }
+
+    data->initialized = true;
+    LOG_INF("IQS5xx trackpad initialized");
+
+    return 0;
+}
+
+// Replace CONFIG_INPUT_INIT_PRIORITY with the azoteq specific value.
+#define IQS5XX_INIT(n)                                                                             \
+    static struct iqs5xx_data iqs5xx_data_##n;                                                     \
+    static const struct iqs5xx_config iqs5xx_config_##n = {                                        \
+        .i2c = I2C_DT_SPEC_INST_GET(n),                                                            \
+        .rdy_gpio = GPIO_DT_SPEC_INST_GET(n, rdy_gpios),                                           \
+        .reset_gpio = GPIO_DT_SPEC_INST_GET_OR(n, reset_gpios, {0}),                              \
+        .one_finger_tap = DT_INST_PROP(n, one_finger_tap),                                         \
+        .press_and_hold = DT_INST_PROP(n, press_and_hold),                                         \
+        .two_finger_tap = DT_INST_PROP(n, two_finger_tap),                                         \
+        .scroll = DT_INST_PROP(n, scroll),                                                         \
+        .natural_scroll_x = DT_INST_PROP(n, natural_scroll_x),                                     \
+        .natural_scroll_y = DT_INST_PROP(n, natural_scroll_y),                                     \
+        .press_and_hold_time = DT_INST_PROP_OR(n, press_and_hold_time, 250),                       \
+        .switch_xy = DT_INST_PROP(n, switch_xy),                                                   \
+        .flip_x = DT_INST_PROP(n, flip_x),                                                         \
+        .flip_y = DT_INST_PROP(n, flip_y),                                                         \
+        .bottom_beta = DT_INST_PROP_OR(n, bottom_beta, 5),                                         \
+        .stationary_threshold = DT_INST_PROP_OR(n, stationary_threshold, 5),                       \
+    };                                                                                             \
+    DEVICE_DT_INST_DEFINE(n, iqs5xx_init, NULL, &iqs5xx_data_##n, &iqs5xx_config_##n, POST_KERNEL, \
+                          CONFIG_INPUT_INIT_PRIORITY, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(IQS5XX_INIT)

--- a/app/module/drivers/input/iqs5xx.h
+++ b/app/module/drivers/input/iqs5xx.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2025 Mariano Uvalle
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ZEPHYR_DRIVERS_INPUT_IQS5XX_H_
+#define ZEPHYR_DRIVERS_INPUT_IQS5XX_H_
+
+#include <zephyr/device.h>
+
+#define IQS5XX_NUM_FINGERS 0x0011
+#define IQS5XX_REL_X 0x0012          // 2 bytes.
+#define IQS5XX_REL_Y 0x0014          // 2 bytes.
+#define IQS5XX_ABS_X 0x0016          // 2 bytes.
+#define IQS5XX_ABS_Y 0x0018          // 2 bytes.
+#define IQS5XX_TOUCH_STRENGTH 0x001A // 2 bytes.
+#define IQS5XX_TOUCH_AREA 0x001C
+
+#define IQS5XX_BOTTOM_BETA 0x0637
+#define IQS5XX_STATIONARY_THRESH 0x0672
+
+#define IQS5XX_END_COMM_WINDOW 0xEEEE
+
+#define IQS5XX_SYSTEM_CONTROL_0 0x0431
+// System Control 0 bits.
+#define IQS5XX_ACK_RESET BIT(7)
+#define IQS5XX_AUTO_ATI BIT(5)
+#define IQS5XX_ALP_RESEED BIT(4)
+#define IQS5XX_RESEED BIT(3)
+
+#define IQS5XX_SYSTEM_CONFIG_0 0x058E
+// System Config 0 bits.
+#define IQS5XX_MANUAL_CONTROL BIT(7)
+#define IQS5XX_SETUP_COMPLETE BIT(6)
+#define IQS5XX_WDT BIT(5)
+#define IQS5XX_SW_INPUT_EVENT BIT(4)
+#define IQS5XX_ALP_REATI BIT(3)
+#define IQS5XX_REATI BIT(2)
+#define IQS5XX_SW_INPUT_SELECT BIT(1)
+#define IQS5XX_SW_INPUT BIT(0)
+
+#define IQS5XX_SYSTEM_CONFIG_1 0x058F
+// System Config 1 bits.
+#define IQS5XX_EVENT_MODE BIT(0)
+#define IQS5XX_GESTURE_EVENT BIT(1)
+#define IQS5XX_TP_EVENT BIT(2)
+#define IQS5XX_REATI_EVENT BIT(3)
+#define IQS5XX_ALP_PROX_EVENT BIT(4)
+#define IQS5XX_SNAP_EVENT BIT(5)
+#define IQS5XX_TOUCH_EVENT BIT(6)
+#define IQS5XX_PROX_EVENT BIT(7)
+
+// Filter settings register.
+#define IQS5XX_FILTER_SETTINGS 0x0632
+// Filter settings bits.
+#define IQS5XX_IIR_FILTER BIT(0)
+#define IQS5XX_MAV_FILTER BIT(1)
+#define IQS5XX_IIR_SELECT BIT(2)
+#define IQS5XX_ALP_COUNT_FILTER BIT(3)
+
+#define IQS5XX_SYSTEM_INFO_0 0x000F
+// System Info 0 bits.
+#define IQS5XX_SHOW_RESET BIT(7)
+#define IQS5XX_ALP_REATI_OCCURRED BIT(6)
+#define IQS5XX_ALP_ATI_ERROR BIT(5)
+#define IQS5XX_REATI_OCCURRED BIT(4)
+#define IQS5XX_ATI_ERROR BIT(3)
+
+#define IQS5XX_SYSTEM_INFO_1 0x0010
+// System Info 1 bits.
+#define IQS5XX_SWITCH_STATE BIT(5)
+#define IQS5XX_SNAP_TOGGLE BIT(4)
+#define IQS5XX_RR_MISSED BIT(3)
+#define IQS5XX_TOO_MANY_FINGERS BIT(2)
+#define IQS5XX_PALM_DETECT BIT(1)
+#define IQS5XX_TP_MOVEMENT BIT(0)
+
+// These 2 registers have the same bit map.
+// The first one configures the gestures,
+// the second one reports gesture events at runtime.
+#define IQS5XX_SINGLE_FINGER_GESTURES_CONF 0x06B7
+#define IQS5XX_GESTURE_EVENTS_0 0x000D
+// Single finger gesture identifiers.
+#define IQS5XX_SINGLE_TAP BIT(0)
+#define IQS5XX_PRESS_AND_HOLD BIT(1)
+#define IQS5XX_SWIPE_LEFT BIT(2)
+#define IQS5XX_SWIPE_RIGHT BIT(3)
+#define IQS5XX_SWIPE_UP BIT(4)
+#define IQS5XX_SWIPE_DOWN BIT(5)
+
+// Time in ms, 2 registers wide.
+// Hold time + tap time is used as
+// a threshold for the press and
+// hold gesture.
+#define IQS5XX_HOLD_TIME 0x06BD
+// TODO: Make hold time configurable with KConfig.
+
+// Mouse button helpers.
+#define LEFT_BUTTON_BIT BIT(0)
+#define RIGHT_BUTTON_BIT BIT(1)
+#define MIDDLE_BUTTON_BIT BIT(2)
+#define LEFT_BUTTON_CODE INPUT_BTN_0
+#define RIGHT_BUTTON_CODE INPUT_BTN_0 + 1
+#define MIDDLE_BUTTON_CODE INPUT_BTN_0 + 2
+
+// These 2 registers have the same bit map.
+// The first one configures the gestures,
+// the second one reports gesture events at runtime.
+#define IQS5XX_MULTI_FINGER_GESTURES_CONF 0x06B8
+#define IQS5XX_GESTURE_EVENTS_1 0x000E
+// Multi finger gesture identifiers.
+#define IQS5XX_TWO_FINGER_TAP BIT(0)
+#define IQS5XX_SCROLL BIT(1)
+#define IQS5XX_ZOOM BIT(2)
+
+// Axes configuration.
+#define IQS5XX_XY_CONFIG_0 0x0669
+#define IQS5XX_FLIP_X BIT(0)
+#define IQS5XX_FLIP_Y BIT(1)
+#define IQS5XX_SWITCH_XY_AXIS BIT(2)
+
+struct iqs5xx_config {
+    struct i2c_dt_spec i2c;
+    struct gpio_dt_spec rdy_gpio;
+    struct gpio_dt_spec reset_gpio;
+
+    // Gesture configuration.
+    bool one_finger_tap;
+    bool press_and_hold;
+    bool two_finger_tap;
+    uint16_t press_and_hold_time;
+
+    // Scrolling configuration.
+    bool scroll;
+    bool natural_scroll_x;
+    bool natural_scroll_y;
+
+    // Axes configuration.
+    bool switch_xy;
+    bool flip_x;
+    bool flip_y;
+
+    // Sensitivity. configuration.
+    uint8_t bottom_beta;
+    uint8_t stationary_threshold;
+};
+
+struct iqs5xx_data {
+    const struct device *dev;
+    struct gpio_callback rdy_cb;
+    struct k_work work;
+    struct k_work_delayable button_release_work;
+    // TODO: Pack flags into a bitfield to save space.
+    bool initialized;
+    // Flag to indicate if the button was pressed in a previous cycle.
+    uint8_t buttons_pressed;
+    bool active_hold;
+    // Scroll accumulators.
+    int16_t scroll_x_acc;
+    int16_t scroll_y_acc;
+};
+
+#endif /* ZEPHYR_DRIVERS_INPUT_IQS5XX_H_ */

--- a/app/module/dts/bindings/input/azoteq,iqs5xx-common.yaml
+++ b/app/module/dts/bindings/input/azoteq,iqs5xx-common.yaml
@@ -1,0 +1,64 @@
+properties:
+  rdy-gpios:
+    type: phandle-array
+    required: true
+    description: "Data Ready pin for the Azoteq IQS5xx trackpad"
+  
+  reset-gpios:
+    type: phandle-array
+    description: "Reset pin for the Azoteq IQS5xx trackpad"
+
+  one-finger-tap:
+    type: boolean
+    description: "Register single finger tap gestures and report them as a left click"
+
+  press-and-hold:
+    type: boolean
+    description: "Register press and hold gestures and report them as a left click until released"
+  
+  press-and-hold-time:
+    type: int
+    description: "Time in ms (in addition to the tap time) it takes to register a press and hold gesture"
+    default: 250
+
+  two-finger-tap:
+    type: boolean
+    description: "Register two finger tap gestures and report them as a right click"
+  
+  scroll:
+    type: boolean
+    description: "Register and report scroll gestures, both vertical and horizontal scroll is supported"
+
+  natural-scroll-x:
+    type: boolean
+    description: "Whether content should track finger movement when scrolling on the x axis."
+
+  natural-scroll-y:
+    type: boolean
+    description: "Whether content should track finger movement when scrolling on the y axis."
+
+  switch-xy:
+    type: boolean
+    description: "Flip x and y axes"
+  
+  flip-x:
+    type: boolean
+    description: "Invert the direction of the x axis"
+
+  flip-y:
+    type: boolean
+    description: "Invert the direction of the y axis"
+
+  bottom-beta:
+    type: int
+    description: |
+      Amount of filtering applied at slow speeds.
+      0: Most filtering, smoother, but laggier.
+      255: Least filtering, least smooth, more responsive.
+    default: 5
+  
+  stationary-threshold:
+    type: int
+    description: |
+      How far a finger must move (in pixels) to not be considered stationary.
+    default: 5

--- a/app/module/dts/bindings/input/azoteq,iqs5xx-i2c.yaml
+++ b/app/module/dts/bindings/input/azoteq,iqs5xx-i2c.yaml
@@ -1,0 +1,6 @@
+description: |
+  Sensor driver for Azoteq IQS5XX trackpads, using the I2C interface
+
+compatible: "azoteq,iqs5xx"
+
+include: ["i2c-device.yaml", "azoteq,iqs5xx-common.yaml"]

--- a/zmk conversation.md
+++ b/zmk conversation.md
@@ -1,0 +1,1147 @@
+***You***: Skip to main content
+ZMK Logo
+ZMK Firmware
+Docs
+Blog
+Tools
+
+Pre-Release
+
+ZMK Studio
+
+    Getting Started
+
+Supported Hardware
+FAQs
+Installing ZMK
+Customizing ZMK
+ZMK CLI
+Troubleshooting
+Features
+Keymaps
+Configuration
+
+    Development
+
+You're viewing the documentation for the development version of ZMK. You may want the latest release v0.3.
+Supported Hardware
+
+With the solid technical foundation of Zephyr™ RTOS, ZMK can support a wide diversity of hardware targets, including but not limited to Nordic nRF52, Raspberry Pi RP2040/RP2350, most ST STM32 MCUs, and Microchip SAMD21. That being said, there are specific boards / shields that have been implemented and tested by the ZMK contributors, listed below.
+Onboard Controller Keyboards
+
+Keyboards with onboard controllers are single PCBs that contain all the components of a keyboard, including the controller chip, switch footprints, etc.
+
+    Advantage 360 Pro (Boards: adv360pro_left, adv360pro_right)
+    BDN9 (Rev2) (Board: bdn9)
+    BT60 V1 Hotswap (Board: bt60_hs)
+    BT60 V2 (Board: bt60)
+    BT65 (Board: bt65)
+    BT75 V1 (Board: bt75)
+    Corneish Zen (Boards: corneish_zen_left, corneish_zen_right)
+    Ferris 0.2 (Board: ferris)
+    Glove80 (Boards: glove80_lh, glove80_rh)
+    KBDfans Tofu65 2.0 (Board: tofu65)
+    nice!60 (Board: nice60)
+    Planck (Rev6) (Board: planck)
+    Preonic Rev3 (Board: preonic)
+    S40NC (Board: s40nc)
+
+Composite Keyboards
+
+Composite keyboards are composed of two main PCBs: a small controller board with exposed pads, and a larger keyboard PCB (a shield, in ZMK lingo) with switch footprints and a location where the controller is added. This location is called an interconnect. Multiple interconnects can be found below.
+Pro Micro Interconnect
+
+The SparkFun Pro Micro grew popular as a low cost ATmega32U4 board with sufficient GPIO and peripherals to work for many keyboard needs. Since the original Pro Micro, many pin compatible boards have appeared, with various changes or improvements, such as the Elite-C w/ USB-C, nice!nano with nRF52840 wireless. Note: ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, because Zephyr™ only supports 32-bit and 64-bit platforms. As a result, controllers like the SparkFun Pro Micro and the Elite-C are *not* supported by ZMK.
+Boards
+
+    Adafruit KB2040 (Board: adafruit_kb2040)
+    BoardSource blok (Board: boardsource_blok)
+    nRFMicro (nRF52833) (Board: nrfmicro/nrf52833)
+    nRFMicro nRF52840 (flipped) (Board: nrfmicro/nrf52840/flipped)
+    nRFMicro (nRF52840) 1.1/1.2/1.3 (Board: nrfmicro/nrf52840)
+    BlueMicro840 v1 (Board: bluemicro840)
+    Puchi-BLE V1 (Board: puchi_ble)
+    nice!nano (Board: nice_nano)
+    QMK Proton-C (Board: proton_c)
+    SparkFun Pro Micro RP2040 (Board: sparkfun_pro_micro_rp2040)
+    Mikoto (Board: mikoto)
+
+Shields
+
+    A. Dux (Shields: a_dux_left, a_dux_right)
+    BAT43 (Shield: bat43)
+    BFO-9000 (Shields: bfo9000_left, bfo9000_right)
+    Boardsource 3x4 Macropad (Shield: boardsource3x4)
+    Boardsource 5x12 (Shield: boardsource5x12)
+    Chalice (Shield: chalice)
+    Clog (Shields: clog_left, clog_right)
+    Contra (Shield: contra)
+    Corne (Shields: corne_left, corne_right)
+    Cradio/Sweep (Shields: cradio_left, cradio_right)
+    CRBN Featherlight (Shield: crbn)
+    eek! (Shield: eek)
+    Elephant42 (Shields: elephant42_left, elephant42_right)
+    Ergodash (Shields: ergodash_left, ergodash_right)
+    Eternal Keypad Lefty (Shield: eternal_keypad_lefty)
+    Eternal Keypad (Shield: eternal_keypad)
+    Fourier Rev. 1 (Shields: fourier_left, fourier_right)
+    Helix (Shields: helix_left, helix_right)
+    Iris (Shields: iris_left, iris_right)
+    Jian (Shields: jian_left, jian_right)
+    Jiran (Shields: jiran_left, jiran_right)
+    Jorne (Shields: jorne_left, jorne_right)
+    Knob Goblin (Shield: knob_goblin)
+    Kyria Rev2 (Shields: kyria_rev2_left, kyria_rev2_right)
+    Kyria Rev3 (Shields: kyria_rev3_left, kyria_rev3_right)
+    Kyria (Shields: kyria_left, kyria_right)
+    Leeloo-Micro (Shields: leeloo_micro_left, leeloo_micro_right)
+    Leeloo v2 (Shields: leeloo_rev2_left, leeloo_rev2_right)
+    Leeloo (Shields: leeloo_left, leeloo_right)
+    Lily58 (Shields: lily58_left, lily58_right)
+    Lotus58 (Shields: lotus58_left, lotus58_right)
+    Microdox V2 (Shields: microdox_v2_left, microdox_v2_right)
+    Microdox (Shields: microdox_left, microdox_right)
+    MurphPad (Shield: murphpad)
+    Naked60 (Shield: naked60)
+    Nibble (Shield: nibble)
+    Osprette (Shield: osprette)
+    Pancake (Shield: pancake)
+    QAZ (Shield: qaz)
+    Quefrency Rev. 1 (Shields: quefrency_left, quefrency_right)
+    Redox (Shields: redox_left, redox_right)
+    REVIUNG34 (Shield: reviung34)
+    REVIUNG41 (Shield: reviung41)
+    REVIUNG5 (Shield: reviung5)
+    REVIUNG53 (Shield: reviung53)
+    Romac+ Macropad (Shield: romac_plus)
+    Romac Macropad (Shield: romac)
+    SNAP (Shields: snap_left, snap_right)
+    Sofle (Shields: sofle_left, sofle_right)
+    splitkb.com Aurora Corne (Shields: splitkb_aurora_corne_left, splitkb_aurora_corne_right)
+    splitkb.com Aurora Helix (Shields: splitkb_aurora_helix_left, splitkb_aurora_helix_right)
+    splitkb.com Aurora Lily58 (Shields: splitkb_aurora_lily58_left, splitkb_aurora_lily58_right)
+    splitkb.com Aurora Sofle (Shields: splitkb_aurora_sofle_left, splitkb_aurora_sofle_right)
+    splitkb.com Aurora Sweep (Shields: splitkb_aurora_sweep_left, splitkb_aurora_sweep_right)
+    Splitreus62 (Shields: splitreus62_left, splitreus62_right)
+    TesterProMicro (Shield: tester_pro_micro)
+    TG4x (Shield: tg4x)
+    Tidbit Numpad (Shield: tidbit)
+    2% Milk (Shield: two_percent_milk)
+    Waterfowl (Shields: waterfowl_left, waterfowl_right)
+    Zodiark (Shields: zodiark_left, zodiark_right)
+
+Seeed XIAO Interconnect
+
+The Seeed Studio XIAO is a popular smaller format micro-controller, that has gained popularity as an alternative to the SparkFun Pro Micro. Since its creation, several pin compatible controllers, such as the Seeed Studio XIAO nRF52840 (also known as XIAO BLE), Adafruit QT Py and Adafruit QT Py RP2040, have become available.
+Boards
+
+    Adafruit QT Py RP2040 (Board: adafruit_qt_py_rp2040)
+    Seeed Studio XIAO SAMD21 (Board: seeeduino_xiao)
+    Seeed Studio XIAO nRF52840 (Board: xiao_ble)
+    Seeed Studio XIAO RP2040 (Board: xiao_rp2040)
+
+Shields
+
+    Hummingbird (Shield: hummingbird)
+    TesterXiao (Shield: tester_xiao)
+
+Arduino Uno Rev3 Interconnect
+
+The Arduino Uno Rev3 is a board who's popularity lead to countless shields being developed for it. By natural extension, once there were many shields designed for it, many other *boards* began to be developed that were compatible to leverage the extensive available shields. Today, many dev kits come with Uno headers to make it easy to work with them. Note: ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, because Zephyr™ only supports 32-bit and 64-bit platforms. As a result, boards like the original Arduino Uno Rev3 itself are *not* supported by ZMK.
+Boards
+
+    Nordic nRF52840 DK (Board: nrf52840dk/nrf52840)
+    Nordic nRF5340 DK (Board: nrf5340dk/nrf5340/cpuapp)
+
+Shields
+
+    ZMK Uno (Shield: zmk_uno)
+
+BlackPill Interconnect
+
+The WeAct Studio BlackPill has grown in popularity due to its low price, availability, and utilization of the powerful STM32F4x1CEU6 microcontroller. The BlackPill features more GPIO than most other boards, but also has a comparatively larger footprint as a result. Many clones and variations of the original BlackPill are available on the market as an affordable and more powerful alternative to many popular boards. The official WeAct variations of the WeAct Studio BlackPill are powered by the STM32F411CEU6 and STM32F401CEU6 microcontrollers.
+Boards
+
+    PillBug (Board: pillbug)
+    BlackPill F401CC (Board: blackpill_f401cc)
+    BlackPill F401CE (Board: blackpill_f401ce)
+    BlackPill F411CE (Board: blackpill_f411ce)
+
+Shields
+
+MakerDiary nRF52840 M.2 Interconnect
+
+The MakerDiary nRF52840 M.2 module is a module using the M.2/NGFF form factor to expose a large number of GPIO pins, allowing use of a variety of peripherals such using I2C, SPI, etc.
+Boards
+
+    nRF52840 M.2 Module (Board: nrf52840_m2)
+
+Shields
+
+    MakerDiary m60 (Shield: m60)
+
+Other Hardware
+
+In addition to the basic keyboard functionality, there is also support for additional keyboard hardware such as encoders, RGB underglow, backlight and displays. Please see pages under the "Features" header in the sidebar for details.
+Contributing
+
+If you'd like to add support for a new keyboard shield, head over to the New Keyboard Shield documentation and note the clean room design requirements.
+Edit this page
+Previous
+Introduction
+Next
+FAQs
+
+    Onboard Controller Keyboards
+    Composite Keyboards
+        Pro Micro Interconnect
+        Seeed XIAO Interconnect
+        Arduino Uno Rev3 Interconnect
+        BlackPill Interconnect
+        MakerDiary nRF52840 M.2 Interconnect
+    Other Hardware
+    Contributing
+
+Docs
+
+    Getting Started
+    Development
+
+Community
+
+    Discord
+    Mastodon
+    Twitter
+
+More
+
+    Blog
+    GitHub
+    Deploys by Netlify 
+
+Copyright © 2026 ZMK Project Contributors. Creative Commons License
+
+if I wish to make a custom pcb/board using nRF52832 QFAAB0, will I have to add it as a shield?
+***ChatGPT***: Short answer: **yes — in almost all sane cases, you should add it as a shield** ✅
+
+…but let me explain why, and when you wouldn’t.
+
+ 
+
+
+## How ZMK thinks about hardware (important mental model)
+
+ZMK (built on **Zephyr**) splits hardware into two layers:
+
+  1. 
+**Board** → the microcontroller itself
+
+  2. 
+**Shield** → the keyboard wiring (matrix, encoders, LEDs, etc.)
+
+This separation is **intentional** and very powerful.
+
+ 
+
+
+## Your case: custom PCB with **Nordic Semiconductor nRF52832 QFAAB0**
+
+
+### What you are actually building
+
+You’re making:
+
+  - 
+a **custom MCU carrier** (nRF52832 + power + crystal + SWD + antenna)
+
+  - 
+plus a **keyboard PCB** (matrix, switches, peripherals)
+
+Even if they are on **one physical PCB**, ZMK still prefers:
+Physical realityZMK abstractionOne PCBBoard + ShieldTwo PCBsBoard + ShieldHand-wiredBoard + Shield
+➡️ **So yes: you add your keyboard as a shield.**
+
+ 
+
+
+## Why you should NOT make it a board (unless you really must)
+
+Creating a **board** means:
+
+  - 
+Writing full Zephyr board support
+
+  - 
+Defining clocks, flash, RAM, pinmux
+
+  - 
+Maintaining DTS, Kconfig, defconfig
+
+  - 
+Tracking Zephyr changes forever
+
+That’s a **lot of work** and zero benefit unless:
+
+  - 
+you’re upstreaming to ZMK core, or
+
+  - 
+your hardware is truly reusable as a general MCU dev board
+
+For a keyboard? ❌ Overkill.
+
+ 
+
+
+## Correct architecture for your project
+
+
+### 1️⃣ Reuse an existing nRF52832 board
+
+ZMK already supports nRF52 families. You typically:
+
+  - 
+pick a close existing board (or create a minimal private one)
+
+  - 
+keep it generic (power, clock, radio)
+
+
+### 2️⃣ Create **your own shield**
+
+Your shield defines:
+
+  - 
+key matrix GPIOs
+
+  - 
+rows / columns
+
+  - 
+encoders
+
+  - 
+trackpad (I²C / SPI)
+
+  - 
+LEDs
+
+  - 
+battery pins
+
+This is exactly what shields are for.
+
+ 
+
+
+## Directory structure you’ll end up with
+
+
+Build example:
+
+
+ 
+
+
+## When would you NOT use a shield?
+
+Only if:
+
+  - 
+your PCB is a **general-purpose nRF52832 dev board**
+
+  - 
+you expect many keyboards to reuse it
+
+  - 
+you want it upstreamed as a controller like `nice!nano`
+
+That’s when you make a **board**.
+Otherwise: **shield only**.
+
+ 
+
+
+## Practical recommendation for you (based on your goals)
+
+Given your past work with:
+
+  - 
+nRF52 BLE HID
+
+  - 
+custom keyboards + trackpads
+
+  - 
+productization mindset
+
+💡 **Best path**
+
+  - 
+Treat your nRF52832 PCB as a controller
+
+  - 
+Put all keyboard logic in a shield
+
+  - 
+You can later reuse the same controller with:
+
+    - 
+macropads
+
+    - 
+split keyboards
+
+    - 
+trackpad variants
+
+
+That flexibility is exactly why ZMK is designed this way.
+
+ 
+
+If you want, next I can:
+
+  - 
+map **nRF52832 QFAAB0 pins → ZMK DTS**
+
+  - 
+help you choose a **closest existing board**
+
+  - 
+generate a **starter shield DTS + keymap**
+
+  - 
+sanity-check your schematic for ZMK compatibility
+
+Just tell me which step you want to do next.
+***You***: give me a tutorial to follow
+***ChatGPT***: Below is a **clean, end-to-end tutorial** you can **follow linearly** to get from blank nRF52832 PCB → working ZMK keyboard firmware, using **the correct ZMK mental model (board + shield)**.
+This is written assuming:
+
+  - 
+**MCU**: nRF52832 QFAAB0
+
+  - 
+**You are making a custom PCB**
+
+  - 
+**You want ZMK (BLE HID)**
+
+  - 
+**You are NOT upstreaming yet**
+
+
+ 
+
+
+## ZMK Custom nRF52832 Keyboard — Step-by-Step Tutorial
+
+
+
+ 
+
+
+## STEP 0 — What you are building (fix this in your head)
+
+ZMK (built on **Zephyr**) splits hardware into:
+LayerPurposeYou write this**Board**MCU, flash, clock, radio❌ (reuse / minimal)**Shield**Keys, matrix, encoders✅ YES
+👉 Even if **everything is on one PCB**, you **still create a shield**.
+
+ 
+
+
+## STEP 1 — Hardware checklist (must-have)
+
+Before firmware, confirm your PCB includes **all of these**:
+
+### Required for nRF52832
+
+
+  - 
+nRF52832 QFAAB0
+
+  - 
+32 MHz crystal + load caps (recommended)
+
+  - 
+SWDIO + SWCLK + GND pads
+
+  - 
+Decoupling caps (0.1 µF near every VDD)
+
+  - 
+VDD supply (LDO or battery + regulator)
+
+  - 
+Antenna (chip or PCB trace)
+
+⚠️ If **SWD is missing**, stop. You cannot debug ZMK.
+
+ 
+
+
+## STEP 2 — Prepare ZMK environment
+
+
+Verify:
+
+
+ 
+
+
+## STEP 3 — Choose a base board (DO NOT create one yet)
+
+You have 3 sane options:
+OptionWhenReuse existing nRF52 boardMost commonMinimal private boardCustom PCBUpstream boardLater
+
+### For nRF52832
+
+Start by **cloning an existing nRF52 board** (private):
+
+Edit:
+
+Rename inside files:
+
+⚠️ **Do NOT add matrix pins here**
+
+Board = MCU only.
+
+ 
+
+
+## STEP 4 — Create your keyboard SHIELD (this is the main work)
+
+
+
+### 4.1 `Kconfig.shield`
+
+
+
+ 
+
+
+### 4.2 `my_keyboard.dtsi` (matrix definition)
+
+
+👉 Replace GPIO numbers with **your PCB pins**.
+
+ 
+
+
+### 4.3 `my_keyboard.overlay`
+
+
+
+ 
+
+
+### 4.4 `my_keyboard.keymap`
+
+
+
+ 
+
+
+### 4.5 `my_keyboard.conf`
+
+
+
+ 
+
+
+## STEP 5 — Build firmware
+
+
+If successful:
+
+
+ 
+
+
+## STEP 6 — Flash firmware
+
+
+### Using J-Link
+
+
+
+### Or Nordic tools
+
+
+
+ 
+
+
+## STEP 7 — Verify BLE
+
+
+  1. 
+Reset board
+
+  2. 
+Device advertises as:
+
+
+  3. 
+Pair from PC / phone
+
+  4. 
+Open text editor
+
+  5. 
+Press keys 🎉
+
+
+ 
+
+
+## STEP 8 — Debug checklist (important)
+
+SymptomCauseNo BLEWrong clock / powerNo keysWrong GPIO mappingRandom resetsBad decouplingWon’t flashSWD wiring
+Enable logs:
+
+
+ 
+
+
+## STEP 9 — Next upgrades (when ready)
+
+
+  - 
+Split keyboard → `*_left.overlay`, `*_right.overlay`
+
+  - 
+Trackpad → I²C device node
+
+  - 
+Battery → `zmk,battery`
+
+  - 
+Encoder → `zmk,behavior-encoder`
+
+
+ 
+
+
+## Mental rule you should remember forever
+
+
+**Boards describe silicon.
+Shields describe keyboards.
+Physical PCBs don’t matter.**
+
+
+ 
+
+If you want, next I can:
+
+  - 
+generate a **pin-correct DTS from your schematic**
+
+  - 
+add **trackpad (Cirque / Azoteq)**
+
+  - 
+create a **split BLE setup**
+
+  - 
+review your **actual PCB design**
+
+  - 
+give you a **production-ready template repo**
+
+Just say which one you want next.
+***You***: west build -s app -b    
+      nrf52dk/nrf52832 -- -DSHIELD=tkl_nrf52832?
+***ChatGPT***: Almost correct 👍 — you’re **95% there**. Let’s fix the last 5% and explain why.
+
+ 
+
+
+## ✅ Correct `west build` command (for your case)
+
+
+
+### ❌ What was wrong in your command
+
+
+The `?` **must not be there**.
+
+ZMK / CMake does **exact string matching** on shield names.
+
+ 
+
+
+## What each part means (so you can reason about errors)
+
+
+→ Zephyr build system (used by ZMK)
+
+→ Source directory = `app/` (this is where ZMK’s `CMakeLists.txt` lives)
+
+→ **Board**
+
+  - 
+Uses the Nordic nRF52 DK definition
+
+  - 
+Safe choice for nRF52832 bring-up
+
+
+→ **Shield**
+
+  - 
+Must match:
+
+
+
+ 
+
+
+## Required folder check (VERY IMPORTANT)
+
+Before building, this **must exist**:
+
+If the folder name or files don’t match **exactly**, ZMK will fail silently or with confusing errors.
+
+ 
+
+
+## How to verify ZMK sees your shield
+
+Run:
+
+If you **do not see** `tkl_nrf52832` in the list → ZMK cannot see your shield.
+
+ 
+
+
+## Common failure modes (check these if it breaks)
+
+ErrorMeaning`Unknown SHIELD`Folder name mismatch`No kscan chosen`Missing `chosen { zmk,kscan = ... }``dtc error`Bad GPIO syntax`undefined reference to kscan`DTS not included
+
+ 
+
+
+## If you want this to be your own board later
+
+Right now:
+
+Later (custom PCB):
+
+Shield stays the same — **that’s the whole point**.
+
+ 
+
+
+## Minimal sanity test (recommended)
+
+If this builds:
+
+Then:
+
+  - 
+Your environment is correct
+
+  - 
+Any failure is **inside your shield**
+
+
+ 
+
+If you want, paste:
+
+  - 
+the **exact error**
+
+  - 
+or your **shield directory tree**
+
+  - 
+or your **.overlay / .dtsi**
+
+and I’ll pinpoint it in one reply.
+***You***: if I want to add i2c trackpad, azoteq ones. what to do?
+***ChatGPT***: Below is a **follow-this-exactly tutorial** for adding an **Azoteq I²C trackpad** to your **ZMK + nRF52832** keyboard.
+This is written for **Azoteq IQS5xx series** (IQS550 / IQS572 / IQS5xx), which are the **best-supported trackpads in ZMK** today.
+
+ 
+
+
+## Adding an Azoteq I²C Trackpad to ZMK (Step-by-Step)
+
+
+
+ 
+
+
+## STEP 0 — What ZMK already supports (important)
+
+ZMK **already has a driver** for Azoteq trackpads via:
+
+  - 
+`zmk,input-processor-azoteq`
+
+So you **do NOT** write a driver.
+
+You only:
+
+  1. 
+Wire it correctly
+
+  2. 
+Declare it in **DTS**
+
+  3. 
+Enable it in **config**
+
+
+ 
+
+
+## STEP 1 — Hardware wiring (non-negotiable)
+
+
+### Minimum required connections
+
+Trackpad PinnRF52832**VDD**3.3 V**GND**GND**SDA**Any GPIO (I²C SDA)**SCL**Any GPIO (I²C SCL)**RDY / INT**Optional (recommended)**RST**Optional
+⚠️ **Important**
+
+  - 
+Pull-ups on SDA/SCL **required** (2.2k–4.7k)
+
+  - 
+Azoteq runs at **3.3 V only**
+
+  - 
+I²C speed: **100 kHz** (safe default)
+
+
+ 
+
+
+## STEP 2 — Pick GPIOs (example)
+
+Example mapping (replace with your PCB pins):
+FunctionGPIOSDAP0.26SCLP0.27INTP0.28
+
+ 
+
+
+## STEP 3 — Enable I²C on your board (if not already)
+
+In your **board DTS or overlay** (not shield yet):
+
+If `i2c0` doesn’t exist, use `i2c1`.
+
+ 
+
+
+## STEP 4 — Add the trackpad to your SHIELD DTS
+
+📁 `app/boards/shields/tkl_nrf52832/tkl_nrf52832.dtsi`
+
+
+Most Azoteq modules use `0x74`.
+
+If unsure, scan I²C later.
+
+
+ 
+
+
+## STEP 5 — Tell ZMK to use it as a pointing device
+
+Add to the **same DTS**:
+
+This is **mandatory**.
+
+ 
+
+
+## STEP 6 — Enable mouse support in config
+
+📁 `tkl_nrf52832.conf`
+
+Optional tuning:
+
+
+ 
+
+
+## STEP 7 — Add mouse bindings to your keymap
+
+📁 `tkl_nrf52832.keymap`
+
+Example layer snippet:
+
+
+ 
+
+
+## STEP 8 — Build
+
+
+
+ 
+
+
+## STEP 9 — Debug checklist (very important)
+
+
+### If cursor doesn’t move
+
+Enable logs:
+
+Watch for:
+
+
+### I²C scan (optional but powerful)
+
+Add temporarily:
+
+Then in shell:
+
+
+ 
+
+
+## Common failure modes (read this)
+
+SymptomCauseNo cursorMissing `chosen zmk,pointing-device`Build errorWrong compatible stringRandom jumpsMissing pull-upsLagI²C too slow / power noiseNot detectedWrong I²C address
+
+ 
+
+
+## Azoteq vs Cirque (quick truth)
+
+FeatureAzoteqCirqueGesture quality⭐⭐⭐⭐⭐⭐⭐⭐⭐ZMK support✅ Native⚠ PartialConfig flexibilityHighMediumProduct readiness**Best**Good
+👉 You picked the **right one** for a product.
+
+ 
+
+
+## What I can do next (high value)
+
+If you want, I can:
+
+  - 
+generate **pin-accurate DTS** from your schematic
+
+  - 
+tune **gesture curves** (Mac-like feel)
+
+  - 
+add **tap-to-click / scroll zones**
+
+  - 
+help with **PCB layout rules for Azoteq**
+
+  - 
+make this **production-stable** (ESD, noise, firmware guards)
+
+Just tell me what you want next.
+***You***: Bash(source ~/.zshrc && conda activate zmk && cd ~/zmk && rm -rf build && west build -s app -b    timeout: 5m 
+      nrf52dk/nrf52832 -- -DSHIELD=tkl_nrf52832 2>&1 | tail -40)                                    0s
+
+  ⎿   See https://zmk.dev/docs/development/hardware-integration/new-shield and                             
+      https://zmk.dev/docs/development/module-creation for more information.
+    Call Stack (most recent call first):
+      /Users/chaitanyamalhotra/zmk/zephyr/cmake/modules/zephyr_module.cmake:126 (include)
+      /Users/chaitanyamalhotra/zmk/zephyr/cmake/modules/zephyr_default.cmake:134 (include)
+      /Users/chaitanyamalhotra/zmk/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
+      /Users/chaitanyamalhotra/zmk/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:92
+    (include_boilerplate)
+      CMakeLists.txt:9 (find_package)
+
+
+    -- Board: nrf52dk, qualifiers: nrf52832
+    -- Shield(s): tkl_nrf52832
+    Checking /Users/chaitanyamalhotra/zmk/app
+    found /Users/chaitanyamalhotra/zmk/app
+    -- ZMK Config directory: /Users/chaitanyamalhotra/zmk-config
+    nrf52dk_nrf52832 for _nrf52832 for nrf52dk with version
+    -- Using keymap file: /Users/chaitanyamalhotra/zmk-config/tkl_nrf52832.keymap
+    Checking /Users/chaitanyamalhotra/zmk-config
+    Checking /Users/chaitanyamalhotra/zmk/zephyr
+    -- Found host-tools: zephyr 0.17.4 (/Users/chaitanyamalhotra/zephyr-sdk-0.17.4)
+    -- Found toolchain: zephyr 0.17.4 (/Users/chaitanyamalhotra/zephyr-sdk-0.17.4)
+    -- Found Dtc: /opt/homebrew/bin/dtc (found suitable version "1.7.2", minimum required is "1.4.6")
+    -- Found BOARD.dts: /Users/chaitanyamalhotra/zmk/zephyr/boards/nordic/nrf52dk/nrf52dk_nrf52832.dts
+    -- Found devicetree overlay:
+    /Users/chaitanyamalhotra/zmk/app/boards/shields/tkl_nrf52832/tkl_nrf52832.overlay
+    -- Found devicetree overlay: /Users/chaitanyamalhotra/zmk-config/tkl_nrf52832.keymap
+    devicetree error: /Users/chaitanyamalhotra/zmk-config/tkl_nrf52832.keymap:13 (column 439): parse error:
+     expected number or parenthesized expression
+    CMake Error at /Users/chaitanyamalhotra/zmk/zephyr/cmake/modules/dts.cmake:303 (execute_process):
+      execute_process failed command indexes:
+
+        1: "Child return code: 1"
+
+    Call Stack (most recent call first):
+      /Users/chaitanyamalhotra/zmk/zephyr/cmake/modules/zephyr_default.cmake:134 (include)
+      /Users/chaitanyamalhotra/zmk/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
+      /Users/chaitanyamalhotra/zmk/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:92
+    (include_boilerplate)
+      CMakeLists.txt:9 (find_package)
+
+
+    -- Configuring incomplete, errors occurred!
+    FATAL ERROR: command exited with status 1: /opt/homebrew/bin/cmake
+    -DWEST_PYTHON=/opt/miniconda3/envs/zmk/bin/python3.11 -B/Users/chaitanyamalhotra/zmk/build -GNinja
+    -DBOARD=nrf52dk/nrf52832 -DSHIELD=tkl_nrf52832 -S/Users/chaitanyamalhotra/zmk/app
+***ChatGPT***: Good news first: **your build setup is correct** ✅
+
+Bad news (also good): this is a **pure syntax error in your .keymap**, not ZMK, not Zephyr, not your board.
+Let’s fix it cleanly.
+
+ 
+
+
+## What the error actually means
+
+
+Key facts:
+
+  - 
+`.keymap` files are **devicetree (DTS)**, not C
+
+  - 
+The parser choked at **line 13**
+
+  - 
+Column 439 = **a very long bindings = < ... >; line**
+
+  - 
+This almost always means:
+
+    - 
+missing `&`
+
+    - 
+missing `< >`
+
+    - 
+stray comma
+
+    - 
+comment in the wrong place
+
+    - 
+mouse bindings written incorrectly
+
+
+
+ 
+
+
+## 99% likely cause (based on what you added)
+
+You recently added **mouse / trackpad bindings**, and this is the most common mistake:
+❌ **WRONG**
+
+DTS **requires phandles**, so **every behavior MUST start with &**.
+
+ 
+
+
+## Correct minimal keymap (COPY THIS EXACTLY)
+
+Open:
+
+Replace the entire contents with this **known-good** version:
+
+Now build again:
+
+👉 If this builds, we have **confirmed the issue is inside your bindings**, not infrastructure.
+
+ 
+
+
+## Correct mouse / trackpad bindings (safe syntax)
+
+When you re-add the trackpad, use **this exact format**:
+
+
+### Rules you must follow (DTS rules, not ZMK rules)
+
+
+  1. 
+✅ Every behavior starts with `&`
+
+  2. 
+✅ No commas inside `< >`
+
+  3. 
+✅ Comments only use `/* */`, not `//`
+
+  4. 
+✅ Line breaks are allowed, commas are not
+
+  5. 
+❌ No trailing junk after `>;`
+
+
+ 
+
+
+## Very common hidden mistakes (check these)
+
+
+### ❌ Trailing comma
+
+
+
+### ❌ Inline `//` comment
+
+
+
+### ❌ Missing angle brackets
+
+
+
+### ❌ Parentheses (DTS is NOT C)
+
+
+
+ 
+
+
+## Why the error column is huge (column 439)
+
+Devicetree treats:
+
+as **one giant token stream**.
+
+One bad token anywhere → error reported at the end.
+That’s why DTS errors feel “unhelpful” — but they’re deterministic.
+
+ 
+
+
+## Next step (do this in order)
+
+
+  1. 
+✅ Build with **minimal keymap** (above)
+
+  2. 
+✅ Confirm build succeeds
+
+  3. 
+✅ Re-add mouse bindings **exactly as shown**
+
+  4. 
+❌ Do NOT edit DTS casually — it is very strict
+
+
+ 
+
+
+## If it still fails
+
+Paste **only this file** here:
+
+I’ll spot the exact bad token in one glance and tell you the precise fix.
+You’re very close — this is the last annoying Zephyr hurdle, not a real problem.


### PR DESCRIPTION
Adds an Azoteq IQS5xx I2C driver with device-tree bindings, CMake/Kconfig entries, and a TKL nRF52832 board overlay/keymap with trackpad support.\n\nFiles added:\n - app/module/drivers/input/iqs5xx.c/h\n - app/module/dts/bindings/input/azoteq,iqs5xx-*.yaml\n - app/module/drivers/input/CMakeLists.txt, Kconfig updates\n - app/boards/shields/tkl_nrf52832/* (overlay, dtsi, keymap, conf)\n\nPlease review driver initialization, DT properties and pin assignments (RDY/RESET) before merging. (I can make follow-up fixes if needed).