### PR TITLE
fix(ci): update West working directory

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -78,6 +78,7 @@ jobs:
           else
             echo "base_dir=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
           fi
+          echo "west_working_dir=${GITHUB_WORKSPACE}/$(dirname ${{ inputs.config_path }})" >> $GITHUB_ENV
 
           if [ -n "${snippet}" ]; then
             extra_west_args="-S \"${snippet}\""
@@ -103,11 +104,11 @@ jobs:
           cache_name: cache-zephyr-${{ env.zephyr_version }}-modules
         with:
           path: |
-            ${{ env.base_dir }}/modules/
-            ${{ env.base_dir }}/tools/
-            ${{ env.base_dir }}/zephyr/
-            ${{ env.base_dir }}/bootloader/
-            ${{ env.base_dir }}/zmk/
+            ${{ env.west_working_dir }}/modules/
+            ${{ env.west_working_dir }}/tools/
+            ${{ env.west_working_dir }}/zephyr/
+            ${{ env.west_working_dir }}/bootloader/
+            ${{ env.west_working_dir }}/zmk/
           key: ${{ runner.os }}-build-${{ env.cache_name }}-${{ hashFiles('**/west.yml', '**/build.yaml') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache_name }}-
@@ -119,22 +120,22 @@ jobs:
         run: west init -l "${{ env.base_dir }}/${{ inputs.config_path }}"
 
       - name: West Update
-        working-directory: ${{ env.base_dir }}
+        working-directory: ${{ env.west_working_dir }}
         run: west update --fetch-opt=--filter=tree:0
 
       - name: Check ZMK revision
-        working-directory: ${{ env.base_dir }}
+        working-directory: ${{ env.west_working_dir }}
         run: |
           zmk_revision=$(west list -f "{revision}" zmk)
           echo "zmk_revision=${zmk_revision}" >> $GITHUB_ENV
           echo "ZMK revision: ${zmk_revision}"
 
       - name: West Zephyr export
-        working-directory: ${{ env.base_dir }}
+        working-directory: ${{ env.west_working_dir }}
         run: west zephyr-export
 
       - name: West Build (${{ env.display_name }})
-        working-directory: ${{ env.base_dir }}
+        working-directory: ${{ env.west_working_dir }}
         shell: sh -x {0}
         run: west build -s zmk/app -d "${{ env.build_dir }}" -b "${{ matrix.board }}" ${{ env.extra_west_args }} -- -DZMK_CONFIG=${{ env.base_dir }}/${{ inputs.config_path }} ${{ env.extra_cmake_args }} ${{ matrix.cmake-args }}
 


### PR DESCRIPTION
Previously the workflow only works if `config_path` is a single directory. If we use something different, e.g., `config_path: "dot_config/zmk/config"`, West fails with

```
Run west init -l "/__w/dotfiles/dotfiles/dot_config/corne-zmk/config"
  west init -l "/__w/dotfiles/dotfiles/dot_config/corne-zmk/config"
  shell: sh -e {0}
  env:
    build_dir: /tmp/tmp.a9rTeptW6V
    base_dir: /__w/dotfiles/dotfiles
    zephyr_version: 4.1.0
    extra_west_args:
    extra_cmake_args: -DSHIELD="corne_right nice_view_adapter nice_view"
    display_name: corne_right nice_view_adapter nice_view - nice_nano_v2
    artifact_name: corne_right nice_view_adapter nice_view-nice_nano_v2-zmk
=== Initializing from existing manifest repository config
--- Creating /__w/dotfiles/dotfiles/dot_config/corne-zmk/.west and local configuration file
=== Initialized. Now run "west update" inside /__w/dotfiles/dotfiles/dot_config/corne-zmk.

Run west update --fetch-opt=--filter=tree:0
FATAL ERROR: no west workspace found from "/__w/dotfiles/dotfiles"; "west update" requires one.
Things to try:
  - Change directory to somewhere inside a west workspace and retry.
  - Set ZEPHYR_BASE to a zephyr repository path in a west workspace.
  - Run "west init" to set up a workspace here.
  - Run "west init -h" for additional information.
```

This commit fixes the issue by introducing `west_working_directory` that points to the dirname of `config_path`.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
