### PR TITLE
fix(split): Use correct Kconfig for bumping TX buffers for discovery

### DIFF
--- a/app/src/split/bluetooth/Kconfig
+++ b/app/src/split/bluetooth/Kconfig
@@ -22,8 +22,8 @@ config ZMK_SPLIT_ROLE_CENTRAL
     select BT_SCAN_WITH_IDENTITY
 
 # Bump this value needed for concurrent GATT discovery of splits
-config BT_L2CAP_TX_BUF_COUNT
-    default 5 if ZMK_SPLIT_ROLE_CENTRAL
+config BT_ATT_TX_COUNT
+    default 10 if ZMK_SPLIT_ROLE_CENTRAL
 
 if ZMK_SPLIT_ROLE_CENTRAL
 


### PR DESCRIPTION
Newer Zephyr uses a different Kconfig value to control buffers for GATT client discovery, so adjust our defaults to bump the correct value

Fixes: #3156

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
