### PR TITLE
fix: ec11: replace macro removed in Zephyr 4.0

### DIFF
--- a/app/module/drivers/sensor/ec11/ec11.h
+++ b/app/module/drivers/sensor/ec11/ec11.h
@@ -33,7 +33,7 @@ struct ec11_data {
     const struct sensor_trigger *trigger;
 
 #if defined(CONFIG_EC11_TRIGGER_OWN_THREAD)
-    K_THREAD_STACK_MEMBER(thread_stack, CONFIG_EC11_THREAD_STACK_SIZE);
+    K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_EC11_THREAD_STACK_SIZE);
     struct k_sem gpio_sem;
     struct k_thread thread;
 #elif defined(CONFIG_EC11_TRIGGER_GLOBAL_THREAD)


### PR DESCRIPTION
Fixes broken `CONFIG_EC11_TRIGGER_OWN_THREAD` branch of ec11 sensor by replacing `K_THREAD_STACK_MEMBER` macro removed in Zephry 4.0 with recommended `K_KERNEL_STACK_MEMBER`.

c.f.  https://docs.zephyrproject.org/latest/releases/release-notes-4.0.html#removed-apis-in-this-release