### PR TITLE
fix(rgb): set ext_power during init and settings restoration

### DIFF
--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -222,7 +222,24 @@ static int rgb_settings_set(const char *name, size_t len, settings_read_cb read_
         rc = read_cb(cb_arg, &state, sizeof(state));
         if (rc >= 0) {
             if (state.on) {
+#if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
+                if (ext_power != NULL) {
+                    int rc = ext_power_enable(ext_power);
+                    if (rc != 0) {
+                        LOG_ERR("Unable to enable EXT_POWER: %d", rc);
+                    }
+                }
+#endif
                 k_timer_start(&underglow_tick, K_NO_WAIT, K_MSEC(50));
+            } else {
+#if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
+                if (ext_power != NULL) {
+                    int rc = ext_power_disable(ext_power);
+                    if (rc != 0) {
+                        LOG_ERR("Unable to disable EXT_POWER: %d", rc);
+                    }
+                }
+#endif
             }
 
             return 0;
@@ -269,12 +286,30 @@ static int zmk_rgb_underglow_init(void) {
     k_work_init_delayable(&underglow_save_work, zmk_rgb_underglow_save_state_work);
 #endif
 
-#if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_AUTO_OFF_USB)
+#if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_AUTO_OFF_USB) &&                                           \
+    !IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
     state.on = zmk_usb_is_powered();
 #endif
 
     if (state.on) {
+#if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
+        if (ext_power != NULL) {
+            int rc = ext_power_enable(ext_power);
+            if (rc != 0) {
+                LOG_ERR("Unable to enable EXT_POWER: %d", rc);
+            }
+        }
+#endif
         k_timer_start(&underglow_tick, K_NO_WAIT, K_MSEC(50));
+    } else {
+#if IS_ENABLED(CONFIG_ZMK_RGB_UNDERGLOW_EXT_POWER)
+        if (ext_power != NULL) {
+            int rc = ext_power_disable(ext_power);
+            if (rc != 0) {
+                LOG_ERR("Unable to disable EXT_POWER: %d", rc);
+            }
+        }
+#endif
     }
 
     return 0;


### PR DESCRIPTION
Depends on https://github.com/zmkfirmware/zmk/pull/3155

This PR ensures that the External Power (ext_power) state is correctly set with the RGB Underglow state. It addresses two distinct issues:

- Pre-existing Bug: The initial RGB state was not being correctly applied to the hardware after a settings_reset or a bootloader flash when `CONFIG_ZMK_RGB_UNDERGLOW_ON_START=n` is set as ext_power defaults to on.
- Regression (from #3155): A side effect of the linked PR caused the ext_power state to fail to initialize correctly after a simple power cycle (On/Off). Again, as ext_power defaults to on.

I still need to verify these changes across different scenarios to ensure no other side effects were introduced so I'm opening this as a draft for now.

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
