### PR TITLE
feat(behaviors): add `&out OUT_NONE`

### DIFF
--- a/app/include/dt-bindings/zmk/outputs.h
+++ b/app/include/dt-bindings/zmk/outputs.h
@@ -7,3 +7,4 @@
 #define OUT_TOG 0
 #define OUT_USB 1
 #define OUT_BLE 2
+#define OUT_NONE 3

--- a/app/src/behaviors/behavior_outputs.c
+++ b/app/src/behaviors/behavior_outputs.c
@@ -65,6 +65,8 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
         return zmk_endpoint_set_preferred_transport(ZMK_TRANSPORT_USB);
     case OUT_BLE:
         return zmk_endpoint_set_preferred_transport(ZMK_TRANSPORT_BLE);
+    case OUT_NONE:
+        return zmk_endpoint_set_preferred_transport(ZMK_TRANSPORT_NONE);
     default:
         LOG_ERR("Unknown output command: %d", binding->param1);
     }

--- a/app/src/behaviors/behavior_outputs.c
+++ b/app/src/behaviors/behavior_outputs.c
@@ -42,6 +42,11 @@ static const struct behavior_parameter_value_metadata std_values[] = {
         .type = BEHAVIOR_PARAMETER_VALUE_TYPE_VALUE,
     },
 #endif // IS_ENABLED(CONFIG_ZMK_BLE)
+    {
+        .value = OUT_NONE,
+        .display_name = "No Output",
+        .type = BEHAVIOR_PARAMETER_VALUE_TYPE_VALUE,
+    },
 };
 
 static const struct behavior_parameter_metadata_set std_set = {

--- a/docs/docs/keymaps/behaviors/outputs.md
+++ b/docs/docs/keymaps/behaviors/outputs.md
@@ -29,11 +29,12 @@ header, which is added at the top of the keymap file:
 
 This allows you to reference the actions defined in this header:
 
-| Define    | Action                                          |
-| --------- | ----------------------------------------------- |
-| `OUT_USB` | Prefer sending to USB                           |
-| `OUT_BLE` | Prefer sending to the current bluetooth profile |
-| `OUT_TOG` | Toggle between USB and BLE                      |
+| Define     | Action                                          |
+| ---------- | ----------------------------------------------- |
+| `OUT_USB`  | Prefer sending to USB                           |
+| `OUT_BLE`  | Prefer sending to the current bluetooth profile |
+| `OUT_TOG`  | Toggle between USB and BLE                      |
+| `OUT_NONE` | Prevent from sending any output                 |
 
 ## Output Selection Behavior
 


### PR DESCRIPTION
#3140 introduced `ZMK_TRANSPORT_NONE` and mentions that it

> can be set as the preferred endpoint transport if you wish to prevent the keyboard from sending any output

but it doesn't provide a way to do it (as far as I can tell). This PR allows it with `&out OUT_NONE`. 