### PR TITLE
fix(pointing): Support multiple temp layer instances

### DIFF
--- a/app/src/pointing/input_processor_temp_layer.c
+++ b/app/src/pointing/input_processor_temp_layer.c
@@ -91,7 +91,11 @@ K_MSGQ_DEFINE(temp_layer_action_msgq, sizeof(struct layer_state_action),
 
 static void deactivate_if_matching(const struct device *dev, uint8_t layer) {
     struct temp_layer_data *data = (struct temp_layer_data *)dev->data;
-    k_mutex_lock(&data->lock, K_FOREVER);
+    int ret = k_mutex_lock(&data->lock, K_FOREVER);
+    if (ret < 0) {
+        LOG_ERR("Error locking for deactivating %d", ret);
+        return;
+    }
     if (data->state.is_active && data->state.toggle_layer == layer) {
         update_layer_state(&data->state, false);
     }


### PR DESCRIPTION
Previously, the `input-processor-temp-layer` driver failed to support multiple instances because the background work queue callback (`layer_action_work_cb`) was hardcoded to operate only on the first driver instance (instance 0). This caused actions from secondary instances to either be ignored or incorrectly apply state changes to the first instance.

This commit fixes the issue by:
- Adding a `dev` pointer to the `layer_state_action` struct to identify the originating device instance for each event.
- Updating the work callback to use the specific device instance from the action payload.
- Implementing a lookup mechanism for timeout-based deactivation to find and update the correct active instance managing the expiring layer.
- Fixing macro expansion errors in `DT_INST_FOREACH_STATUS_OKAY` usage.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
