### PR TITLE
chore: enhance west command with safety check for init

### DIFF
--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -11,3 +11,12 @@ if [ -d "$WORKSPACE_DIR/tools/bsim" ]; then
   export BSIM_OUT_PATH="$WORKSPACE_DIR/tools/bsim/"
   export BSIM_COMPONENTS_PATH="$WORKSPACE_DIR/tools/bsim/components/"
 fi
+
+west() {
+  if [[ "$1" == "init" && "$*" != *" -l "* ]]; then
+    echo "STOP: Are you sure you don't want 'west init -l app/'?"
+    echo "Run 'command west $*' if you really meant it."
+  else
+    command west "$@"
+  fi
+}


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## Summary

After cloning the ZMK repository, developers must run `west init` with the `-l app/` option to correctly specify the local manifest repository (see [docs](https://zmk.dev/docs/development/local-toolchain/setup/native?operating-systems=ubuntu&python-environment=venv)). Omitting this option results in Zephyr being initialized in the wrong directory, leading to a misconfigured environment that is cumbersome and error-prone to clean up.

This PR introduces a safety check to the `west` command by modifying the `.bashrc` inside the `devcontainer`. The modification ensures that when running `west init`, users are reminded to include the `-l app/` option, unless explicitly overridden.

## Key Changes

If `west init` is run without the `-l` option, a warning message is displayed giving the user the option to bypass the check if needed:

```
root@c97ed173883e:/workspaces/zmk# west init
STOP: Are you sure you don't want 'west init -l app/'?
Run 'command west init' if you really meant it.
```

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
