### PR TITLE
docs: Fix up board IDs in the Zephyr 4.1 blog post to add ZMK variant

### DIFF
--- a/docs/blog/2025-12-09-zephyr-4-1.md
+++ b/docs/blog/2025-12-09-zephyr-4-1.md
@@ -80,36 +80,36 @@ As a result, all board definitions found in the ZMK tree now must be used with a
 As part of this change, ZMK is now using board/shield revisions, rather than duplicate board/shield definitions. This means that instead of having e.g. `nice_nano`, and `nice_nano_v2`, we only have `nice_nano`, which by default points to the `2.0.0` revision. To point to the original Nice!Nano V1, you would need to use `nice_nano@1.0.0` where you would have previously used `nice_nano`. Of course, you could also put `nice_nano@2.0.0` if you wished to make that explicit, instead of merely replacing `nice_nano_v2` with `nice_nano`. Some boards, such as the `nrfmicro`, also have additional _board qualifiers_ such as the choice between multiple SoCs. Board qualifiers must always be specified, and do not have defaults. See [Zephyr's overview](https://docs.zephyrproject.org/4.1.0/hardware/porting/board_porting.html#board-terminology) for more information on board qualifiers. The below table provides an overview of some of the differences in in-tree boards we have in ZMK, and how they are selected in the new build system. The shorthand shows the minimum needed to build with a specific board, taking into account defaults.
 
 - nice!nano (`nice_nano`)
-  - `nice_nano` -> `nice_nano@1.0.0` (short: `nice_nano@1`)
-  - `nice_nano_v2` -> `nice_nano@2.0.0` (short: `nice_nano`)
+  - `nice_nano` -> `nice_nano@1.0.0//zmk` (short: `nice_nano@1//zmk`)
+  - `nice_nano_v2` -> `nice_nano@2.0.0//zmk` (short: `nice_nano//zmk`)
 - nRFMicro (`nrfmicro/nrf52840`)
-  - `nrfmicro_11` -> `nrfmicro@1.1.0/nrf52840` (short: `nrfmicro@1.1/nrf52840`)
-  - `nrfmicro_11_flipped` -> `nrfmicro@1.1.0/nrf52840/flipped` (short: `nrfmicro@1.1/nrf52840/flipped`)
-  - `nrfmicro_13` -> `nrfmicro@1.3.0/nrf52840` (short: `nrfmicro/nrf52840`)
-  - `nrfmicro_13_52833` -> `nrfmicro@1.3.0/nrf52833` (short: `nrfmicro/nrf52833`)
+  - `nrfmicro_11` -> `nrfmicro@1.1.0/nrf52840/zmk` (short: `nrfmicro@1.1/nrf52840/zmk`)
+  - `nrfmicro_11_flipped` -> `nrfmicro@1.1.0/nrf52840/flipped_zmk` (short: `nrfmicro@1.1/nrf52840/flipped_zmk`)
+  - `nrfmicro_13` -> `nrfmicro@1.3.0/nrf52840/zmk` (short: `nrfmicro/nrf52840/zmk`)
+  - `nrfmicro_13_52833` -> `nrfmicro@1.3.0/nrf52833/zmk` (short: `nrfmicro/nrf52833/zmk`)
 - Mikoto (`mikoto`)
-  - `mikoto` -> `mikoto@5.20.0` (short: `mikoto`)
-  - `mikoto@6.1` -> `mikoto@6.1.0` (short: `mikoto@6`)
-  - `mikoto@7.2` -> `mikoto@7.2.0` (short: `mikoto@7`)
+  - `mikoto` -> `mikoto@5.20.0//zmk` (short: `mikoto//zmk`)
+  - `mikoto@6.1` -> `mikoto@6.1.0//zmk` (short: `mikoto@6//zmk`)
+  - `mikoto@7.2` -> `mikoto@7.2.0//zmk` (short: `mikoto@7//zmk`)
 - XIAO RP2040 (`xiao_rp2040`)
-  - `seeeduino_xiao_rp2040` -> `xiao_rp2040`
+  - `seeeduino_xiao_rp2040` -> `xiao_rp2040//zmk`
 - XIAO nRF52840/BLE (`xiao_ble`)
-  - `seeeduino_xiao_ble` -> `xiao_ble`
+  - `seeeduino_xiao_ble` -> `xiao_ble//zmk`
 - BT60 (`bt60`)
-  - `bt60_v1` -> `bt60@1.0.0`
-  - `bt60_v2` -> `bt60@2.0.0`
-  - `bt60_hs` -> `bt60_hs`
+  - `bt60_v1` -> `bt60@1.0.0//zmk`
+  - `bt60_v2` -> `bt60@2.0.0//zmk`
+  - `bt60_hs` -> `bt60_hs//zmk`
 - Planck (`planck`)
-  - `planck_rev6` -> `planck`
+  - `planck_rev6` -> `planck//zmk`
 - BDN9 (`bdn9`)
-  - `bdn9_rev2` -> `bdn9`
+  - `bdn9_rev2` -> `bdn9//zmk`
 - Ferris Rev2 (`ferris`)
-  - `ferris_rev02` -> `ferris@2.0.0` (short: `ferris`)
+  - `ferris_rev02` -> `ferris@2.0.0//zmk` (short: `ferris//zmk`)
 - Corne-ish Zen (`corneish_zen`)
-  - `corneish_zen_v2_left` -> `corneish_zen_left@2.0.0` (short: `corneish_zen_left`)
-  - `corneish_zen_v2_right` -> `corneish_zen_right@2.0.0` (short: `corneish_zen_right`)
-  - `corneish_zen_v1_left` -> `corneish_zen_left@1.0.0` (short: `corneish_zen_left@1`)
-  - `corneish_zen_v1_right` -> `corneish_zen_right@1.0.0` (short: `corneish_zen_right@1`)
+  - `corneish_zen_v2_left` -> `corneish_zen_left@2.0.0//zmk` (short: `corneish_zen_left//zmk`)
+  - `corneish_zen_v2_right` -> `corneish_zen_right@2.0.0//zmk` (short: `corneish_zen_right//zmk`)
+  - `corneish_zen_v1_left` -> `corneish_zen_left@1.0.0//zmk` (short: `corneish_zen_left@1//zmk`)
+  - `corneish_zen_v1_right` -> `corneish_zen_right@1.0.0//zmk` (short: `corneish_zen_right@1//zmk`)
 
 The boards above are those which have changed in ZMK's tree, with the addition of the very popular XIAO series. For other boards in Zephyr's tree, please refer to the Zephyr documentation or source files directly.
 


### PR DESCRIPTION
Update the board revision/ID migration section of the Zephyr 4.1 blog post to include the ZMK variant (`//zmk`).

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
