### PR TITLE
feat(battery): implement power_on_sample_delay_us

### DIFF
--- a/app/module/drivers/sensor/battery/battery_voltage_divider.c
+++ b/app/module/drivers/sensor/battery/battery_voltage_divider.c
@@ -26,6 +26,7 @@ struct bvd_config {
     struct gpio_dt_spec power;
     uint32_t output_ohm;
     uint32_t full_ohm;
+    uint32_t sample_delay_us;
 };
 
 struct bvd_data {
@@ -59,7 +60,7 @@ static int bvd_sample_fetch(const struct device *dev, enum sensor_channel chan) 
     }
 
     // wait for any capacitance to charge up
-    k_sleep(K_MSEC(10));
+    k_sleep(K_USEC(drv_cfg->sample_delay_us));
 #endif // DT_INST_NODE_HAS_PROP(0, power_gpios)
 
     // Read ADC
@@ -167,6 +168,7 @@ static const struct bvd_config bvd_cfg = {
 #if DT_INST_NODE_HAS_PROP(0, power_gpios)
     .power = GPIO_DT_SPEC_INST_GET(0, power_gpios),
 #endif
+    .sample_delay_us = DT_INST_PROP(0, power_on_sample_delay_us),
     .output_ohm = DT_INST_PROP(0, output_ohms),
     .full_ohm = DT_INST_PROP(0, full_ohms),
 };


### PR DESCRIPTION
Zephyr 4.1 introduces a `power-on-sample-delay-us` property in the voltage divider. (https://docs.zephyrproject.org/4.1.0/build/dts/api/bindings/iio/afe/voltage-divider.html) This PR implements this in the voltage divider driver used in zmk. This is useful if you're using extra components for the battery voltage reading which may take a bit more time then usual to stabilize/power up (like a MOSFET). 

As the init time dropped from 10ms to 100us because of this change, I made sure to test this on a nice!nano. The voltage/percentage readings are the same as before this PR.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
