### PR TITLE
feat(behaviors): Add support for exclude-prior-idle-key-positions for hold-tap

### DIFF
--- a/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
+++ b/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml
@@ -28,6 +28,10 @@ properties:
   require-prior-idle-ms:
     type: int
     default: -1
+  exclude-prior-idle-key-positions:
+    type: array
+    required: false
+    default: []
   flavor:
     type: string
     required: false

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/1-basic/events.patterns
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/1-basic/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/1-basic/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/1-basic/keycode_events.snapshot
@@ -1,0 +1,14 @@
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (balanced decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (balanced decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/1-basic/native_posix_64.keymap
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/1-basic/native_posix_64.keymap
@@ -1,0 +1,21 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press exclude key (pos 2, in ht_a exclude list), then quickly press ht_a */
+        /* expect: idle timer cancelled by exclude key, ht_a goes through normal hold decision */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(0,0,400)
+        /* press non-exclude key (pos 3, NOT in ht_a exclude list), then quickly press ht_a */
+        /* expect: idle timer reset by non-exclude key, ht_a resolves as quick-tap */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/2-independent-configs/events.patterns
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/2-independent-configs/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/2-independent-configs/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/2-independent-configs/keycode_events.snapshot
@@ -1,0 +1,14 @@
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (balanced decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided tap (balanced decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/2-independent-configs/native_posix_64.keymap
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/2-independent-configs/native_posix_64.keymap
@@ -1,0 +1,21 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press pos 2 (D), which is in ht_a's exclude list but NOT in ht_b's */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        /* quickly press ht_a (pos 0): pos 2 cancels idle for ht_a, expect hold decision */
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(0,0,400)
+        /* press pos 2 (D) again, then quickly press ht_b */
+        /* pos 2 is NOT in ht_b's exclude list, expect quick-tap */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_PRESS(0,1,400)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_RELEASE(0,1,10)
+    >;
+};

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/events.patterns
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/keycode_events.snapshot
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/keycode_events.snapshot
@@ -1,0 +1,18 @@
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-interrupt (balanced decision moment other-key-up)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (balanced decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/native_posix_64.keymap
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/native_posix_64.keymap
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press non-exclude key (pos 3), then quickly press ht_a (pos 0) */
+        /* quick-tap deferred because exclude list is configured */
+        /* then press exclude key (pos 2, in ht_a exclude list) in combo */
+        /* expect: quick-tap bypassed, normal balanced decision: hold */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+        /* press non-exclude key (pos 3), then quickly press ht_a (pos 0) */
+        /* quick-tap deferred */
+        /* then press non-exclude key (pos 3) in combo */
+        /* expect: deferred quick-tap fires, ht_a resolves as tap */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_PRESS(1,1,400)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};

--- a/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/balanced/9-exclude-prior-idle-key-positions/behavior_keymap.dtsi
@@ -1,0 +1,36 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    behaviors {
+        ht_a: behavior_ht_a {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <300>;
+            require-prior-idle-ms = <100>;
+            exclude-prior-idle-key-positions = <2>;
+            bindings = <&kp>, <&kp>;
+        };
+        ht_b: behavior_ht_b {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "balanced";
+            tapping-term-ms = <300>;
+            require-prior-idle-ms = <100>;
+            exclude-prior-idle-key-positions = <3>;
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &ht_a LEFT_SHIFT F &ht_b LEFT_CONTROL C
+                &kp D &kp E>;
+        };
+    };
+};

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/1-basic/events.patterns
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/1-basic/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/1-basic/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/1-basic/keycode_events.snapshot
@@ -1,0 +1,14 @@
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (hold-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (hold-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/1-basic/native_posix_64.keymap
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/1-basic/native_posix_64.keymap
@@ -1,0 +1,21 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press exclude key (pos 2, in ht_a exclude list), then quickly press ht_a */
+        /* expect: idle timer cancelled by exclude key, ht_a goes through normal hold decision */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(0,0,400)
+        /* press non-exclude key (pos 3, NOT in ht_a exclude list), then quickly press ht_a */
+        /* expect: idle timer reset by non-exclude key, ht_a resolves as quick-tap */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/events.patterns
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/keycode_events.snapshot
@@ -1,0 +1,14 @@
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (hold-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided tap (hold-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/native_posix_64.keymap
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/native_posix_64.keymap
@@ -1,0 +1,21 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press pos 2 (D), which is in ht_a's exclude list but NOT in ht_b's */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        /* quickly press ht_a (pos 0): pos 2 cancels idle for ht_a, expect hold decision */
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(0,0,400)
+        /* press pos 2 (D) again, then quickly press ht_b */
+        /* pos 2 is NOT in ht_b's exclude list, expect quick-tap */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_PRESS(0,1,400)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_RELEASE(0,1,10)
+    >;
+};

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/events.patterns
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/keycode_events.snapshot
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/keycode_events.snapshot
@@ -1,0 +1,18 @@
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-interrupt (hold-preferred decision moment other-key-down)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (hold-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/native_posix_64.keymap
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/native_posix_64.keymap
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press non-exclude key (pos 3), then quickly press ht_a (pos 0) */
+        /* quick-tap deferred because exclude list is configured */
+        /* then press exclude key (pos 2, in ht_a exclude list) in combo */
+        /* expect: quick-tap bypassed, normal hold-preferred decision: hold on other-key-down */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+        /* press non-exclude key (pos 3), then quickly press ht_a (pos 0) */
+        /* quick-tap deferred */
+        /* then press non-exclude key (pos 3) in combo */
+        /* expect: deferred quick-tap fires, ht_a resolves as tap */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_PRESS(1,1,400)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};

--- a/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/hold-preferred/9-exclude-prior-idle-key-positions/behavior_keymap.dtsi
@@ -1,0 +1,36 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    behaviors {
+        ht_a: behavior_ht_a {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "hold-preferred";
+            tapping-term-ms = <300>;
+            require-prior-idle-ms = <100>;
+            exclude-prior-idle-key-positions = <2>;
+            bindings = <&kp>, <&kp>;
+        };
+        ht_b: behavior_ht_b {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "hold-preferred";
+            tapping-term-ms = <300>;
+            require-prior-idle-ms = <100>;
+            exclude-prior-idle-key-positions = <3>;
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &ht_a LEFT_SHIFT F &ht_b LEFT_CONTROL C
+                &kp D &kp E>;
+        };
+    };
+};

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/1-basic/events.patterns
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/1-basic/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/1-basic/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/1-basic/keycode_events.snapshot
@@ -1,0 +1,14 @@
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (tap-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/1-basic/native_posix_64.keymap
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/1-basic/native_posix_64.keymap
@@ -1,0 +1,21 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press exclude key (pos 2, in ht_a exclude list), then quickly press ht_a */
+        /* expect: idle timer cancelled by exclude key, ht_a goes through normal hold decision */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(0,0,400)
+        /* press non-exclude key (pos 3, NOT in ht_a exclude list), then quickly press ht_a */
+        /* expect: idle timer reset by non-exclude key, ht_a resolves as quick-tap */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/events.patterns
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/keycode_events.snapshot
@@ -1,0 +1,14 @@
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (tap-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided tap (tap-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/native_posix_64.keymap
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/2-independent-configs/native_posix_64.keymap
@@ -1,0 +1,21 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press pos 2 (D), which is in ht_a's exclude list but NOT in ht_b's */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        /* quickly press ht_a (pos 0): pos 2 cancels idle for ht_a, expect hold decision */
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(0,0,400)
+        /* press pos 2 (D) again, then quickly press ht_b */
+        /* pos 2 is NOT in ht_b's exclude list, expect quick-tap */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_PRESS(0,1,400)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_RELEASE(0,1,10)
+    >;
+};

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/events.patterns
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/keycode_events.snapshot
@@ -1,0 +1,18 @@
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-timer (tap-preferred decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-preferred decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/native_posix_64.keymap
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/3-deferred-quick-tap/native_posix_64.keymap
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press non-exclude key (pos 3), then quickly press ht_a (pos 0) */
+        /* quick-tap deferred because exclude list is configured */
+        /* then press exclude key (pos 2, in ht_a exclude list) in combo */
+        /* expect: quick-tap bypassed, normal tap-preferred decision: hold on timer */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,400)
+        ZMK_MOCK_RELEASE(0,0,10)
+        /* press non-exclude key (pos 3), then quickly press ht_a (pos 0) */
+        /* quick-tap deferred */
+        /* then press non-exclude key (pos 3) in combo */
+        /* expect: deferred quick-tap fires, ht_a resolves as tap */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_PRESS(1,1,400)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};

--- a/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-preferred/9-exclude-prior-idle-key-positions/behavior_keymap.dtsi
@@ -1,0 +1,36 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    behaviors {
+        ht_a: behavior_ht_a {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "tap-preferred";
+            tapping-term-ms = <300>;
+            require-prior-idle-ms = <100>;
+            exclude-prior-idle-key-positions = <2>;
+            bindings = <&kp>, <&kp>;
+        };
+        ht_b: behavior_ht_b {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "tap-preferred";
+            tapping-term-ms = <300>;
+            require-prior-idle-ms = <100>;
+            exclude-prior-idle-key-positions = <3>;
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &ht_a LEFT_SHIFT F &ht_b LEFT_CONTROL C
+                &kp D &kp E>;
+        };
+    };
+};

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/1-basic/events.patterns
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/1-basic/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/1-basic/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/1-basic/keycode_events.snapshot
@@ -1,0 +1,14 @@
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-unless-interrupted decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-unless-interrupted decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/1-basic/native_posix_64.keymap
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/1-basic/native_posix_64.keymap
@@ -1,0 +1,21 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press exclude key (pos 2, in ht_a exclude list), then quickly press ht_a */
+        /* expect: idle timer cancelled by exclude key, ht_a goes through normal hold decision */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(0,0,400)
+        /* press non-exclude key (pos 3, NOT in ht_a exclude list), then quickly press ht_a */
+        /* expect: idle timer reset by non-exclude key, ht_a resolves as quick-tap */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/2-independent-configs/events.patterns
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/2-independent-configs/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/2-independent-configs/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/2-independent-configs/keycode_events.snapshot
@@ -1,0 +1,14 @@
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-unless-interrupted decision moment timer)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 1 new undecided hold_tap
+ht_decide: 1 decided tap (tap-unless-interrupted decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x06 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 1 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/2-independent-configs/native_posix_64.keymap
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/2-independent-configs/native_posix_64.keymap
@@ -1,0 +1,21 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press pos 2 (D), which is in ht_a's exclude list but NOT in ht_b's */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        /* quickly press ht_a (pos 0): pos 2 cancels idle for ht_a, expect hold decision */
+        ZMK_MOCK_PRESS(0,0,400)
+        ZMK_MOCK_RELEASE(0,0,400)
+        /* press pos 2 (D) again, then quickly press ht_b */
+        /* pos 2 is NOT in ht_b's exclude list, expect quick-tap */
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_PRESS(0,1,400)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_RELEASE(0,1,10)
+    >;
+};

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/3-deferred-quick-tap/events.patterns
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/3-deferred-quick-tap/events.patterns
@@ -1,0 +1,6 @@
+s/.*hid_listener_keycode/kp/p
+s/.*mo_keymap_binding/mo/p
+s/.*on_hold_tap_binding/ht_binding/p
+s/.*decide_hold_tap/ht_decide/p
+s/.*update_hold_status_for_retro_tap/update_hold_status_for_retro_tap/p
+s/.*decide_retro_tap/decide_retro_tap/p

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/3-deferred-quick-tap/keycode_events.snapshot
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/3-deferred-quick-tap/keycode_events.snapshot
@@ -1,0 +1,18 @@
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided hold-interrupt (tap-unless-interrupted decision moment other-key-down)
+kp_pressed: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x07 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_pressed: 0 new undecided hold_tap
+ht_decide: 0 decided tap (tap-unless-interrupted decision moment quick-tap)
+kp_pressed: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+kp_pressed: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x08 implicit_mods 0x00 explicit_mods 0x00
+kp_released: usage_page 0x07 keycode 0x09 implicit_mods 0x00 explicit_mods 0x00
+ht_binding_released: 0 cleaning up hold-tap

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/3-deferred-quick-tap/native_posix_64.keymap
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/3-deferred-quick-tap/native_posix_64.keymap
@@ -1,0 +1,29 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+#include "../behavior_keymap.dtsi"
+
+&kscan {
+    events = <
+        /* press non-exclude key (pos 3), then quickly press ht_a (pos 0) */
+        /* quick-tap deferred because exclude list is configured */
+        /* then press exclude key (pos 2, in ht_a exclude list) in combo */
+        /* expect: quick-tap bypassed, normal tap-unless-interrupted decision: hold on other-key-down */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+        /* press non-exclude key (pos 3), then quickly press ht_a (pos 0) */
+        /* quick-tap deferred */
+        /* then press non-exclude key (pos 3) in combo */
+        /* expect: deferred quick-tap fires, ht_a resolves as tap */
+        ZMK_MOCK_PRESS(1,1,10)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_PRESS(1,1,400)
+        ZMK_MOCK_RELEASE(1,1,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};

--- a/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/behavior_keymap.dtsi
+++ b/app/tests/hold-tap/tap-unless-interrupted/7-exclude-prior-idle-key-positions/behavior_keymap.dtsi
@@ -1,0 +1,36 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    behaviors {
+        ht_a: behavior_ht_a {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "tap-unless-interrupted";
+            tapping-term-ms = <300>;
+            require-prior-idle-ms = <100>;
+            exclude-prior-idle-key-positions = <2>;
+            bindings = <&kp>, <&kp>;
+        };
+        ht_b: behavior_ht_b {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            flavor = "tap-unless-interrupted";
+            tapping-term-ms = <300>;
+            require-prior-idle-ms = <100>;
+            exclude-prior-idle-key-positions = <3>;
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &ht_a LEFT_SHIFT F &ht_b LEFT_CONTROL C
+                &kp D &kp E>;
+        };
+    };
+};

--- a/docs/docs/config/behaviors.md
+++ b/docs/docs/config/behaviors.md
@@ -72,19 +72,20 @@ Definition file: [zmk/app/dts/bindings/behaviors/zmk,behavior-hold-tap.yaml](htt
 
 Applies to: `compatible = "zmk,behavior-hold-tap"`
 
-| Property                      | Type     | Description                                                                                                   | Default            |
-| ----------------------------- | -------- | ------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `#binding-cells`              | int      | Must be `<2>`                                                                                                 |                    |
-| `bindings`                    | phandles | A list of two behaviors (without parameters): one for hold and one for tap                                    |                    |
-| `flavor`                      | string   | Adjusts how the behavior chooses between hold and tap                                                         | `"hold-preferred"` |
-| `tapping-term-ms`             | int      | How long in milliseconds the key must be held to trigger a hold                                               |                    |
-| `quick-tap-ms`                | int      | Tap twice within this period (in milliseconds) to trigger a tap, even when held                               | -1 (disabled)      |
-| `require-prior-idle-ms`       | int      | Triggers a tap immediately if any non-modifier key was pressed within `require-prior-idle-ms` of the hold-tap | -1 (disabled)      |
-| `retro-tap`                   | bool     | Triggers the tap behavior on release if no other key was pressed during a hold                                | false              |
-| `hold-while-undecided`        | bool     | Triggers the hold behavior immediately on press and releases before a tap                                     | false              |
-| `hold-while-undecided-linger` | bool     | Continues to hold the hold behavior until after the tap is released                                           | false              |
-| `hold-trigger-key-positions`  | array    | If set, pressing the hold-tap and then any key position _not_ in the list triggers a tap                      |                    |
-| `hold-trigger-on-release`     | bool     | If set, delays the evaluation of `hold-trigger-key-positions` until key release                               | false              |
+| Property                          | Type     | Description                                                                                                   | Default            |
+| --------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `#binding-cells`                  | int      | Must be `<2>`                                                                                                 |                    |
+| `bindings`                        | phandles | A list of two behaviors (without parameters): one for hold and one for tap                                    |                    |
+| `flavor`                          | string   | Adjusts how the behavior chooses between hold and tap                                                         | `"hold-preferred"` |
+| `tapping-term-ms`                 | int      | How long in milliseconds the key must be held to trigger a hold                                               |                    |
+| `quick-tap-ms`                    | int      | Tap twice within this period (in milliseconds) to trigger a tap, even when held                               | -1 (disabled)      |
+| `require-prior-idle-ms`           | int      | Triggers a tap immediately if any non-modifier key was pressed within `require-prior-idle-ms` of the hold-tap | -1 (disabled)      |
+| `exclude-prior-idle-key-positions` | array    | Key positions excluded from the `require-prior-idle-ms` idle timer: cancel the timer when pressed before the hold-tap, and bypass quick-tap when pressed after |                    |
+| `retro-tap`                       | bool     | Triggers the tap behavior on release if no other key was pressed during a hold                                | false              |
+| `hold-while-undecided`            | bool     | Triggers the hold behavior immediately on press and releases before a tap                                     | false              |
+| `hold-while-undecided-linger`     | bool     | Continues to hold the hold behavior until after the tap is released                                           | false              |
+| `hold-trigger-key-positions`      | array    | If set, pressing the hold-tap and then any key position _not_ in the list triggers a tap                      |                    |
+| `hold-trigger-on-release`         | bool     | If set, delays the evaluation of `hold-trigger-key-positions` until key release                               | false              |
 
 This behavior forwards the first parameter it receives to the parameter of the first behavior specified in `bindings`, and second parameter to the parameter of the second behavior.
 

--- a/docs/docs/keymaps/behaviors/hold-tap.mdx
+++ b/docs/docs/keymaps/behaviors/hold-tap.mdx
@@ -362,6 +362,29 @@ However, if the hold behavior isn't used during fast typing, then it can be an e
 
   </details>
 
+#### `exclude-prior-idle-key-positions`
+
+By default, `require-prior-idle-ms` considers _all_ non-modifier key presses when determining idle time, and applies its quick-tap decision regardless of which key is pressed next. `exclude-prior-idle-key-positions` allows you to specify key positions that are excluded from the prior-idle system entirely:
+
+- **Before the hold-tap**: Pressing a key in this list cancels the idle timer (equivalent to the timer having already expired), so the next hold-tap activation will go through the normal hold/tap decision process regardless of how recently other keys were pressed.
+- **After the hold-tap**: If a key in this list is pressed as the next key in combination with the hold-tap, the quick-tap decision is bypassed and normal hold/tap flavor logic proceeds — as if `require-prior-idle-ms` was never set for that interaction.
+
+This is useful for home-row mods where opposite-hand keys should never be affected by the idle timer. For example, if your hold-tap is on the left hand, you can exclude all right-hand key positions so that right-hand keys always allow the hold behavior to activate, even during fast typing.
+
+Note that each hold-tap behavior instance has its own exclude list, so different hold-taps can exclude different positions.
+
+```dts
+rpi: require_prior_idle {
+    compatible = "zmk,behavior-hold-tap";
+    #binding-cells = <2>;
+    flavor = "tap-preferred";
+    tapping-term-ms = <200>;
+    require-prior-idle-ms = <125>;
+    exclude-prior-idle-key-positions = <3 4 5>; // e.g. opposite-hand keys
+    bindings = <&kp>, <&kp>;
+};
+```
+
 ### Positional hold-tap and `hold-trigger-key-positions`
 
 Including `hold-trigger-key-positions` in your hold-tap definition turns on the positional hold-tap feature. With positional hold-tap enabled, if you press any key **not** listed in `hold-trigger-key-positions` before `tapping-term-ms` expires, it will produce a tap.


### PR DESCRIPTION
Adds a new exclude-prior-idle-key-positions property to hold-tap behaviors, allowing specific key positions to be excluded from require-prior-idle-ms idle timer behavior. This enables users to press certain keys (e.g. Backspace) without suppressing hold behavior on the next hold-tap activation.

Addresses #2400

Key behavior:
- Pressing an excluded key before the hold-tap cancels any existing timer for the hold-tap.
- Pressing an excluded key as part of the hold-tap combo ignores the timer, and behaves as if no timer is set.
- Each hold-tap maintains its own exclusion list, so different hold-taps can exclude different positions.

This is particularly useful for home-row mods like Shift, where it's useful to specify an idle timer for fast typing, but you also want certain keys to both cancel the timer (eg. Space, where the next word is commonly a capital) and not be affected by the timer (eg. `/`, where you may want to immediately Shift to `?` after a word).

This feature works well with all existing hold-tap behaviors. I've tested quite thoroughly and have found good use combining this with hold-trigger-key-positions too.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
