### PR TITLE
One tick KScan wait on RP2350 as for RP2040

### DIFF
--- a/app/module/drivers/kscan/Kconfig
+++ b/app/module/drivers/kscan/Kconfig
@@ -61,7 +61,7 @@ config ZMK_KSCAN_MATRIX_WAIT_BEFORE_INPUTS
 
 config ZMK_KSCAN_MATRIX_WAIT_BETWEEN_OUTPUTS
     int "Ticks to wait between each output when scanning"
-    default 1 if SOC_RP2040
+    default 1 if SOC_RP2040 || SOC_RP2350A_M33
     default 0
     help
         When iterating over each output to drive it active, read inputs, then set

--- a/app/module/drivers/kscan/Kconfig
+++ b/app/module/drivers/kscan/Kconfig
@@ -61,7 +61,7 @@ config ZMK_KSCAN_MATRIX_WAIT_BEFORE_INPUTS
 
 config ZMK_KSCAN_MATRIX_WAIT_BETWEEN_OUTPUTS
     int "Ticks to wait between each output when scanning"
-    default 1 if SOC_RP2040 || SOC_RP2350A_M33
+    default 1 if SOC_RP2040 || SOC_SERIES_RP2350
     default 0
     help
         When iterating over each output to drive it active, read inputs, then set


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).

Based on an observation made on the ZMK Discord, I tested this change on my diode-free Slump52 keyboard using active low with open drain (a recent change which seems to be working fine with  the RP2040).

RP2350 on Base ZMK - single key presses worked, but some like Qwerty M and L triggered a nearby key as well.

RP2350 With this change - all single key presses seemed to work

Test built here: https://github.com/peterjc/zmk-keyboard-graph-theory/commit/630b77f8a5d8bcec6579d0a3fbd353716b549397