### PR TITLE
feat(underglow): add update hook called immediately before writing to strip

### DIFF
--- a/app/include/zmk/rgb_underglow.h
+++ b/app/include/zmk/rgb_underglow.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <zephyr/types.h>
+#include <zephyr/drivers/led_strip.h>
+
 struct zmk_led_hsb {
     uint16_t h;
     uint8_t s;
@@ -27,3 +30,4 @@ int zmk_rgb_underglow_change_sat(int direction);
 int zmk_rgb_underglow_change_brt(int direction);
 int zmk_rgb_underglow_change_spd(int direction);
 int zmk_rgb_underglow_set_hsb(struct zmk_led_hsb color);
+__attribute__((weak)) void zmk_rgb_underglow_update_hook(struct led_rgb *pixels, size_t count);

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -130,6 +130,8 @@ static struct led_rgb hsb_to_rgb(struct zmk_led_hsb hsb) {
     return rgb;
 }
 
+void zmk_rgb_underglow_update_hook(struct led_rgb *pixels, size_t count) { /* no op */ }
+
 static void zmk_rgb_underglow_effect_solid(void) {
     for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
         pixels[i] = hsb_to_rgb(hsb_scale_min_max(state.color));
@@ -191,6 +193,7 @@ static void zmk_rgb_underglow_tick(struct k_work *work) {
         break;
     }
 
+    zmk_rgb_underglow_update_hook(pixels, STRIP_NUM_PIXELS);
     int err = led_strip_update_rgb(led_strip, pixels, STRIP_NUM_PIXELS);
     if (err < 0) {
         LOG_ERR("Failed to update the RGB strip (%d)", err);


### PR DESCRIPTION
Adds a hook that is called immediately before pixels are written to the led strip in `rgb_underglow.c`. The hook is implemented by a `weak` function to allow ZMK modules to overwrite it . The hook can perform modifications of the `struct led_rgb` array, e.g., to deactivate specific LEDs (see e.g., [zmk-rgb-underglow-mask-leds](https://github.com/jkorinth/zmk-rgb-underglow-mask-leds) for a working example). 

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
