### PR TITLE
fix(ci): Better safeguards for ZMK variant build check

### DIFF
--- a/.github/workflows/build-user-config.yml
+++ b/.github/workflows/build-user-config.yml
@@ -149,13 +149,18 @@ jobs:
 
       - name: Check if building a board without explicit ZMK compat
         if: always()
-        working-directory: ${{ env.base_dir }}/zmk/app
+        working-directory: "${{ env.base_dir }}/${{ inputs.config_path }}"
         run: |
           if ! (grep "CONFIG_ZMK_BOARD_COMPAT=y" "${{ env.build_dir }}/zephyr/.config" > /dev/null)
           then
             original_board=$(echo "${{ matrix.board }}" | sed -e 's$/.*$$')
-            west boards --board-root module --board-root . --board "${original_board}" --format "{qualifiers}" | grep "zmk" > /dev/null
+            west_board=$(west boards --board-root ${{ env.base_dir }}/zmk/app/module --board-root ${{ env.base_dir }}/zmk/app --board "${original_board}")
+            if [ -z "$west_board" ]; then
+              echo "Not found the board listed with west boards. Skipping further checking."
+              exit 0
+            fi
 
+            west boards --board-root ${{ env.base_dir }}/zmk/app/module --board-root ${{ env.base_dir }}/zmk/app --board "${original_board}" --format "{qualifiers}" | grep "zmk" > /dev/null
             if [ $? -ne 0 ]
             then
               echo "::warning file=build/zephyr/.config,title=Missing ZMK Compat::The selected board does not report explicit ZMK compat. Please verify you've selected the correct board and ZMK variant if one exists"


### PR DESCRIPTION
Add an early guard to bail during the board compat check to ensure we don't error out for out-of-tree boards with no ZMK variant.

Can see this working against this workflow: https://github.com/petejohanson/vootington-zmk-module/actions/runs/22784672298/job/66098703527

which previously failed/errored out.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
