### PR TITLE
feat(boards): Add Kconfig for nrf52840dongle ZMK board variant

### DIFF
--- a/app/boards/nordic/nrf52840dongle/Kconfig.nrf52840dongle
+++ b/app/boards/nordic/nrf52840dongle/Kconfig.nrf52840dongle
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+config BOARD_NRF52840DONGLE
+    select ZMK_BOARD_COMPAT if BOARD_NRF52840DONGLE_NRF52840_ZMK


### PR DESCRIPTION
Add Kconfig for nrf52840dongle ZMK board variant

I was trying to use nrf52840dongle for Totem keyboard and this missing config was failing the CI

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
