### PR TITLE
feats: prevent sleep while active BT profile connected and allow sleep while USB power connected

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -415,14 +415,14 @@ config ZMK_IDLE_SLEEP_TIMEOUT
     int "Milliseconds of inactivity before entering deep sleep"
     default 900000
 
-config ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED
+config ZMK_SLEEP_PREVENT_WHILE_BLE_CONNECTED
     bool "Prevent sleeping while the active BT profile is connected"
     depends on ZMK_BLE
     default n
 
-config ZMK_USB_ALLOW_SLEEP_WHILE_POWERED
-    bool "Allow sleeping while USB power is connected"
-    default n
+config ZMK_SLEEP_PREVENT_WHILE_USB_POWERED
+    bool "Prevent sleeping while USB power is connected"
+    default y
 
 endif # ZMK_SLEEP
 

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -418,7 +418,6 @@ config ZMK_IDLE_SLEEP_TIMEOUT
 config ZMK_SLEEP_PREVENT_WHILE_BLE_CONNECTED
     bool "Prevent sleeping while the active BT profile is connected"
     depends on ZMK_BLE
-    default n
 
 config ZMK_SLEEP_PREVENT_WHILE_USB_POWERED
     bool "Prevent sleeping while USB power is connected"

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -420,6 +420,10 @@ config ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED
     depends on ZMK_BLE
     default n
 
+config ZMK_USB_ALLOW_SLEEP_WHILE_POWERED
+    bool "Allow sleeping while USB power is connected"
+    default n
+
 endif # ZMK_SLEEP
 
 config ZMK_EXT_POWER

--- a/app/Kconfig
+++ b/app/Kconfig
@@ -415,6 +415,11 @@ config ZMK_IDLE_SLEEP_TIMEOUT
     int "Milliseconds of inactivity before entering deep sleep"
     default 900000
 
+config ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED
+    bool "Prevent sleeping while the active BT profile is connected"
+    depends on ZMK_BLE
+    default n
+
 endif # ZMK_SLEEP
 
 config ZMK_EXT_POWER

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -82,12 +82,11 @@ void activity_work_handler(struct k_work *work) {
     bool prevent_sleep = 
 	!IS_ENABLED(CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED) && is_usb_power_present();
     #if IS_ENABLED(CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED)
-        prevent_sleep = prevent_sleep ||
-            #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
-                prevent_sleep |= zmk_ble_active_profile_is_connected();
-            #else
-                prevent_sleep |= zmk_split_bt_peripheral_is_connected();
-            #endif
+        #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+            prevent_sleep |= zmk_ble_active_profile_is_connected();
+        #else
+            prevent_sleep |= zmk_split_bt_peripheral_is_connected();
+        #endif
     #endif
     if (inactive_time > MAX_SLEEP_MS && !prevent_sleep) {
         // Put devices in suspend power mode before sleeping

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -78,7 +78,7 @@ static int activity_event_listener(const zmk_event_t *eh) { return note_activity
 void activity_work_handler(struct k_work *work) {
     int32_t current = k_uptime_get();
     int32_t inactive_time = current - activity_last_uptime;
-#if IS_ENABLED(CONFIG_ZMK_SLEEP) \
+#if IS_ENABLED(CONFIG_ZMK_SLEEP)
     bool prevent_sleep =
 	    !IS_ENABLED(CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED) && is_usb_power_present();
     #if IS_ENABLED(CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED)

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -79,7 +79,7 @@ void activity_work_handler(struct k_work *work) {
     int32_t current = k_uptime_get();
     int32_t inactive_time = current - activity_last_uptime;
 #if IS_ENABLED(CONFIG_ZMK_SLEEP)
-    bool prevent_sleep = is_usb_power_present();
+    bool prevent_sleep = !IS_ENABLED(CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED) && is_usb_power_present();
     #if IS_ENABLED(CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED)
     prevent_sleep = prevent_sleep ||
         #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -80,14 +80,14 @@ void activity_work_handler(struct k_work *work) {
     int32_t inactive_time = current - activity_last_uptime;
 #if IS_ENABLED(CONFIG_ZMK_SLEEP)
     bool prevent_sleep =
-	    IS_ENABLED(CONFIG_ZMK_SLEEP_PREVENT_WHILE_USB_POWERED) && is_usb_power_present();
-    #if IS_ENABLED(CONFIG_ZMK_SLEEP_PREVENT_WHILE_BLE_CONNECTED)
-        #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
-            prevent_sleep |= zmk_ble_active_profile_is_connected();
-        #else
-            prevent_sleep |= zmk_split_bt_peripheral_is_connected();
-        #endif
-    #endif
+        IS_ENABLED(CONFIG_ZMK_SLEEP_PREVENT_WHILE_USB_POWERED) && is_usb_power_present();
+#if IS_ENABLED(CONFIG_ZMK_SLEEP_PREVENT_WHILE_BLE_CONNECTED)
+#if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    prevent_sleep |= zmk_ble_active_profile_is_connected();
+#else
+    prevent_sleep |= zmk_split_bt_peripheral_is_connected();
+#endif
+#endif
     if (inactive_time > MAX_SLEEP_MS && !prevent_sleep) {
         // Put devices in suspend power mode before sleeping
         set_state(ZMK_ACTIVITY_SLEEP);

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -26,6 +26,10 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/usb.h>
 #endif
 
+#if IS_ENABLED(CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED)
+#include <zmk/ble.h>
+#endif
+
 #if IS_ENABLED(CONFIG_ZMK_POINTING)
 #include <zephyr/input/input.h>
 #endif
@@ -75,7 +79,16 @@ void activity_work_handler(struct k_work *work) {
     int32_t current = k_uptime_get();
     int32_t inactive_time = current - activity_last_uptime;
 #if IS_ENABLED(CONFIG_ZMK_SLEEP)
-    if (inactive_time > MAX_SLEEP_MS && !is_usb_power_present()) {
+    bool prevent_sleep = is_usb_power_present();
+    #if IS_ENABLED(CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED)
+    prevent_sleep = prevent_sleep ||
+        #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+            prevent_sleep |= zmk_ble_active_profile_is_connected();
+        #else
+            prevent_sleep |= zmk_split_bt_peripheral_is_connected();
+        #endif
+    #endif
+    if (inactive_time > MAX_SLEEP_MS && !prevent_sleep) {
         // Put devices in suspend power mode before sleeping
         set_state(ZMK_ACTIVITY_SLEEP);
 

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -79,14 +79,15 @@ void activity_work_handler(struct k_work *work) {
     int32_t current = k_uptime_get();
     int32_t inactive_time = current - activity_last_uptime;
 #if IS_ENABLED(CONFIG_ZMK_SLEEP)
-    bool prevent_sleep = !IS_ENABLED(CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED) && is_usb_power_present();
+    bool prevent_sleep = 
+	!IS_ENABLED(CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED) && is_usb_power_present();
     #if IS_ENABLED(CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED)
-    prevent_sleep = prevent_sleep ||
-        #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
-            prevent_sleep |= zmk_ble_active_profile_is_connected();
-        #else
-            prevent_sleep |= zmk_split_bt_peripheral_is_connected();
-        #endif
+        prevent_sleep = prevent_sleep ||
+            #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+                prevent_sleep |= zmk_ble_active_profile_is_connected();
+            #else
+                prevent_sleep |= zmk_split_bt_peripheral_is_connected();
+            #endif
     #endif
     if (inactive_time > MAX_SLEEP_MS && !prevent_sleep) {
         // Put devices in suspend power mode before sleeping

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -26,7 +26,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/usb.h>
 #endif
 
-#if IS_ENABLED(CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED)
+#if IS_ENABLED(CONFIG_ZMK_SLEEP_PREVENT_WHILE_BLE_CONNECTED)
 #include <zmk/ble.h>
 #endif
 
@@ -80,8 +80,8 @@ void activity_work_handler(struct k_work *work) {
     int32_t inactive_time = current - activity_last_uptime;
 #if IS_ENABLED(CONFIG_ZMK_SLEEP)
     bool prevent_sleep =
-	    !IS_ENABLED(CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED) && is_usb_power_present();
-    #if IS_ENABLED(CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED)
+	    IS_ENABLED(CONFIG_ZMK_SLEEP_PREVENT_WHILE_USB_POWERED) && is_usb_power_present();
+    #if IS_ENABLED(CONFIG_ZMK_SLEEP_PREVENT_WHILE_BLE_CONNECTED)
         #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
             prevent_sleep |= zmk_ble_active_profile_is_connected();
         #else

--- a/app/src/activity.c
+++ b/app/src/activity.c
@@ -78,9 +78,9 @@ static int activity_event_listener(const zmk_event_t *eh) { return note_activity
 void activity_work_handler(struct k_work *work) {
     int32_t current = k_uptime_get();
     int32_t inactive_time = current - activity_last_uptime;
-#if IS_ENABLED(CONFIG_ZMK_SLEEP)
-    bool prevent_sleep = 
-	!IS_ENABLED(CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED) && is_usb_power_present();
+#if IS_ENABLED(CONFIG_ZMK_SLEEP) \
+    bool prevent_sleep =
+	    !IS_ENABLED(CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED) && is_usb_power_present();
     #if IS_ENABLED(CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED)
         #if !IS_ENABLED(CONFIG_ZMK_SPLIT) || IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
             prevent_sleep |= zmk_ble_active_profile_is_connected();

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -15,11 +15,12 @@ Configuration for entering [low power states](../features/low-power-states.md) w
 Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
 
 | Config                          | Type | Description                                                         | Default |
-| ------------------------------- | ---- | ------------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_IDLE_TIMEOUT`       | int  | Milliseconds of inactivity before entering idle state               | 30000   |
-| `CONFIG_ZMK_SLEEP`              | bool | Enable deep sleep support                                           | n       |
-| `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT` | int  | Milliseconds of inactivity before entering deep sleep               | 900000  |
-| `CONFIG_ZMK_PM_SOFT_OFF`        | bool | Enable soft off functionality from the keymap or dedicated hardware | n       |
+| ----------------------------------------------------- | ---- | ------------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_IDLE_TIMEOUT`       			| int  | Milliseconds of inactivity before entering idle state               | 30000   |
+| `CONFIG_ZMK_SLEEP`              			| bool | Enable deep sleep support                                           | n       |
+| `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT` 			| int  | Milliseconds of inactivity before entering deep sleep               | 900000  |
+| `CONFIG_ZMK_PM_SOFT_OFF`        			| bool | Enable soft off functionality from the keymap or dedicated hardware | n       |
+| `CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED` | bool | Prevent sleeping while the active BT profile is connected	     | n       |
 
 ## External Power Control
 

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -14,7 +14,7 @@ Configuration for entering [low power states](../features/low-power-states.md) w
 
 Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
 
-| Config                          | Type | Description                                                         | Default |
+| Config                                                | Type | Description                                                         | Default |
 | ----------------------------------------------------- | ---- | ------------------------------------------------------------------- | ------- |
 | `CONFIG_ZMK_IDLE_TIMEOUT`                             | int  | Milliseconds of inactivity before entering idle state               | 30000   |
 | `CONFIG_ZMK_SLEEP`                                    | bool | Enable deep sleep support                                           | n       |

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -21,7 +21,7 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 | `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`                       | int  | Milliseconds of inactivity before entering deep sleep               | 900000  |
 | `CONFIG_ZMK_PM_SOFT_OFF`                              | bool | Enable soft off functionality from the keymap or dedicated hardware | n       |
 | `CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED` | bool | Prevent sleeping while the active BT profile is connected           | n       |
-| `CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED`            | bool | Allow sleeping while USB power is present                           | n       |
+| `CONFIG_ZMK_USB_PREVENT_SLEEP_WHILE_POWERED`          | bool | Prevent sleeping while USB power is connected                       | y       |
 
 ## External Power Control
 

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -16,12 +16,12 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 
 | Config                          | Type | Description                                                         | Default |
 | ----------------------------------------------------- | ---- | ------------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_IDLE_TIMEOUT`       			| int  | Milliseconds of inactivity before entering idle state               | 30000   |
-| `CONFIG_ZMK_SLEEP`              			| bool | Enable deep sleep support                                           | n       |
-| `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT` 			| int  | Milliseconds of inactivity before entering deep sleep               | 900000  |
-| `CONFIG_ZMK_PM_SOFT_OFF`        			| bool | Enable soft off functionality from the keymap or dedicated hardware | n       |
-| `CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED` | bool | Prevent sleeping while the active BT profile is connected	     | n       |
-| `CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED` 		| bool | Allow sleeping while USB power is present			     | n       |
+| `CONFIG_ZMK_IDLE_TIMEOUT`                             | int  | Milliseconds of inactivity before entering idle state               | 30000   |
+| `CONFIG_ZMK_SLEEP`                                    | bool | Enable deep sleep support                                           | n       |
+| `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`                       | int  | Milliseconds of inactivity before entering deep sleep               | 900000  |
+| `CONFIG_ZMK_PM_SOFT_OFF`                              | bool | Enable soft off functionality from the keymap or dedicated hardware | n       |
+| `CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED` | bool | Prevent sleeping while the active BT profile is connected           | n       |
+| `CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED`            | bool | Allow sleeping while USB power is present                           | n       |
 
 ## External Power Control
 

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -1,3 +1,5 @@
+
+
 ---
 title: Power Management Configuration
 sidebar_label: Power Management
@@ -14,14 +16,14 @@ Configuration for entering [low power states](../features/low-power-states.md) w
 
 Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
 
-| Config                                                | Type | Description                                                         | Default |
-| ----------------------------------------------------- | ---- | ------------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_IDLE_TIMEOUT`                             | int  | Milliseconds of inactivity before entering idle state               | 30000   |
-| `CONFIG_ZMK_SLEEP`                                    | bool | Enable deep sleep support                                           | n       |
-| `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`                       | int  | Milliseconds of inactivity before entering deep sleep               | 900000  |
-| `CONFIG_ZMK_PM_SOFT_OFF`                              | bool | Enable soft off functionality from the keymap or dedicated hardware | n       |
-| `CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED` | bool | Prevent sleeping while the active BT profile is connected           | n       |
-| `CONFIG_ZMK_USB_PREVENT_SLEEP_WHILE_POWERED`          | bool | Prevent sleeping while USB power is connected                       | y       |
+| Config                                                | Type | Description                                                                                                                                | Default |
+| ----------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `CONFIG_ZMK_IDLE_TIMEOUT`                             | int  | Milliseconds of inactivity before entering idle state                                                                                      | 30000   |
+| `CONFIG_ZMK_SLEEP`                                    | bool | Enable deep sleep support                                                                                                                  | n       |
+| `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`                       | int  | Milliseconds of inactivity before entering deep sleep                                                                                      | 900000  |
+| `CONFIG_ZMK_PM_SOFT_OFF`                              | bool | Enable soft off functionality from the keymap or dedicated hardware                                                                        | n       |
+| `CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED` | bool | Prevent sleeping while the active BT profile is connected. If the device loses connection after the sleep timer, it will sleep immediately | n       |
+| `CONFIG_ZMK_USB_PREVENT_SLEEP_WHILE_POWERED`          | bool | Prevent sleeping while USB power is connected                                                                                              | y       |
 
 ## External Power Control
 

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -1,5 +1,3 @@
-
-
 ---
 title: Power Management Configuration
 sidebar_label: Power Management
@@ -16,14 +14,14 @@ Configuration for entering [low power states](../features/low-power-states.md) w
 
 Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/app/Kconfig)
 
-| Config                                                | Type | Description                                                                                                                                | Default |
-| ----------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `CONFIG_ZMK_IDLE_TIMEOUT`                             | int  | Milliseconds of inactivity before entering idle state                                                                                      | 30000   |
-| `CONFIG_ZMK_SLEEP`                                    | bool | Enable deep sleep support                                                                                                                  | n       |
-| `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`                       | int  | Milliseconds of inactivity before entering deep sleep                                                                                      | 900000  |
-| `CONFIG_ZMK_PM_SOFT_OFF`                              | bool | Enable soft off functionality from the keymap or dedicated hardware                                                                        | n       |
-| `CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED` | bool | Prevent sleeping while the active BT profile is connected. If the device loses connection after the sleep timer, it will sleep immediately | n       |
-| `CONFIG_ZMK_USB_PREVENT_SLEEP_WHILE_POWERED`          | bool | Prevent sleeping while USB power is connected                                                                                              | y       |
+| Config                                         | Type | Description                                                                                                                                | Default |
+| ---------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `CONFIG_ZMK_IDLE_TIMEOUT`                      | int  | Milliseconds of inactivity before entering idle state                                                                                      | 30000   |
+| `CONFIG_ZMK_SLEEP`                             | bool | Enable deep sleep support                                                                                                                  | n       |
+| `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT`                | int  | Milliseconds of inactivity before entering deep sleep                                                                                      | 900000  |
+| `CONFIG_ZMK_PM_SOFT_OFF`                       | bool | Enable soft off functionality from the keymap or dedicated hardware                                                                        | n       |
+| `CONFIG_ZMK_SLEEP_PREVENT_WHILE_BLE_CONNECTED` | bool | Prevent sleeping while the active BT profile is connected. If the device loses connection after the sleep timer, it will sleep immediately | n       |
+| `CONFIG_ZMK_SLEEP_PREVENT_WHILE_USB_POWERED`   | bool | Prevent sleeping while USB power is connected                                                                                              | y       |
 
 ## External Power Control
 

--- a/docs/docs/config/power.md
+++ b/docs/docs/config/power.md
@@ -21,6 +21,7 @@ Definition file: [zmk/app/Kconfig](https://github.com/zmkfirmware/zmk/blob/main/
 | `CONFIG_ZMK_IDLE_SLEEP_TIMEOUT` 			| int  | Milliseconds of inactivity before entering deep sleep               | 900000  |
 | `CONFIG_ZMK_PM_SOFT_OFF`        			| bool | Enable soft off functionality from the keymap or dedicated hardware | n       |
 | `CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED` | bool | Prevent sleeping while the active BT profile is connected	     | n       |
+| `CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED` 		| bool | Allow sleeping while USB power is present			     | n       |
 
 ## External Power Control
 


### PR DESCRIPTION
I'm closing my [previous PR](https://github.com/zmkfirmware/zmk/pull/3286) in favor of this one, which has some fixes applied and should have proper commit messages/clean commit history. 

In short, I've added two flags: 
`CONFIG_ZMK_BLE_PREVENT_SLEEP_WHILE_ACTIVE_CONNECTED` and `CONFIG_ZMK_USB_ALLOW_SLEEP_WHILE_POWERED`
The first allows the user to disable sleeping when the active BT profile is connected, related to [issue 2198](https://github.com/zmkfirmware/zmk/issues/2198). The second arose naturally as I was testing my work on the first, but I believe it has merit as a means of increasing battery life for peripherals on devices that have the "main" device plugged in, whether it be a dongle or just a split.

pre-commit doesn't seem to like my formatting but I believe it's getting confused by the broken up lines, which are added for readability.

Like with my last PR, I am a new contributor (and new to open source as a whole) so any and all advice is appreciated!

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
