### PR TITLE
fix(studio): Allow setting UART RPC thread priority

### DIFF
--- a/app/src/studio/Kconfig
+++ b/app/src/studio/Kconfig
@@ -59,10 +59,19 @@ config ZMK_STUDIO_TRANSPORT_UART
     select RING_BUFFER
     default y if $(dt_chosen_enabled,$(DT_CHOSEN_ZMK_STUDIO_RPC_UART))
 
+if ZMK_STUDIO_TRANSPORT_UART
+
 config ZMK_STUDIO_TRANSPORT_UART_RX_STACK_SIZE
     int "RX Stack Size"
     depends on !UART_INTERRUPT_DRIVEN
     default 512
+
+config ZMK_STUDIO_TRANSPORT_UART_RX_PRIORITY
+    int "RX Thread Priority"
+    depends on !UART_INTERRUPT_DRIVEN
+    default 9
+
+endif
 
 config ZMK_STUDIO_TRANSPORT_BLE
     bool "BLE (GATT)"
@@ -71,8 +80,11 @@ config ZMK_STUDIO_TRANSPORT_BLE
     depends on ZMK_BLE
     default y
 
+
 config BT_CONN_TX_MAX
     default 64 if ZMK_STUDIO_TRANSPORT_BLE
+
+if ZMK_STUDIO_TRANSPORT_BLE
 
 config ZMK_STUDIO_TRANSPORT_BLE_PREF_LATENCY
     int "BLE Transport preferred latency"
@@ -80,6 +92,8 @@ config ZMK_STUDIO_TRANSPORT_BLE_PREF_LATENCY
     help
       When the studio UI is connected, a lower latency can be requested in order
       to make the interactions between keyboard and studio faster.
+
+endif
 
 endmenu
 

--- a/app/src/studio/uart_rpc_transport.c
+++ b/app/src/studio/uart_rpc_transport.c
@@ -65,7 +65,7 @@ static void uart_rx_main(void) {
 }
 
 K_THREAD_DEFINE(uart_transport_read_thread, CONFIG_ZMK_STUDIO_TRANSPORT_UART_RX_STACK_SIZE,
-                uart_rx_main, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
+                uart_rx_main, NULL, NULL, NULL, CONFIG_ZMK_STUDIO_TRANSPORT_UART_RX_PRIORITY, 0, 0);
 
 #endif
 


### PR DESCRIPTION
To ensure we can tune things when other threads may have priority, preventing UART processing in time for the studio UI requirements, adjust our default UART thread priority, and allow overriding as needed.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
