### PR TITLE
Add serial VCOM inversion for Nice! View

### DIFF
--- a/app/boards/shields/nice_view/Kconfig.defconfig
+++ b/app/boards/shields/nice_view/Kconfig.defconfig
@@ -3,6 +3,9 @@
 
 if SHIELD_NICE_VIEW
 
+config LS0XX_VCOM_THREAD_PRIO
+    default 11
+
 config LV_Z_VDB_SIZE
     default 100
 

--- a/app/boards/shields/nice_view/nice_view.overlay
+++ b/app/boards/shields/nice_view/nice_view.overlay
@@ -12,6 +12,8 @@
         reg = <0>;
         width = <160>;
         height = <68>;
+        serial-vcom-inversion;
+        serial-vcom-interval = <33>;
     };
 };
 


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).

This is as requested by @petejohanson in https://github.com/zmkfirmware/zephyr/pull/54 and will resolve the DC biased state Nice! View displays were previously in. VCOM inversion thread priority is set to 11 to keep priority below most other threads and prevent latency. Command interval is set to 17ms as a rough approximation of the 60 Hz VCOM toggle frequency recommended by Sharp in the display [datasheet for the similar LS013B7DH05](https://cdn-shop.adafruit.com/product-files/3502/Data+sheet.pdf). 

cc// @Nicell 
edit history – changed interval because I'd misunderstood the datasheet