### PR TITLE
docs: Add warning to changes in board variants in zephyr 4.1

### DIFF
--- a/docs/docs/development/local-toolchain/build-flash.mdx
+++ b/docs/docs/development/local-toolchain/build-flash.mdx
@@ -68,6 +68,13 @@ with an onboard MCU or one that uses an MCU board add-on.
   </TabItem>
 </Tabs>
 
+:::warning
+Since Zephyr 4.1 the argument `-b` needs to be set according to the new board
+variants. E.g. instead of `planck_rev6` it should be `planck//zmk`. Read more about
+board variants at
+[Zephyr 4.1 Update](https://zmk.dev/blog/2025/12/09/zephyr-4-1#zmk-board-variant) blog.
+:::
+
 ### CMake Arguments
 
 For creating a build system, the `west build` command uses

--- a/docs/docs/development/local-toolchain/build-flash.mdx
+++ b/docs/docs/development/local-toolchain/build-flash.mdx
@@ -71,7 +71,7 @@ with an onboard MCU or one that uses an MCU board add-on.
 :::warning
 Since moving to Zephyr 4.1, the board IDs for boards in ZMK need to use the ZMK board
 variants. E.g. instead of `planck_rev6` it should be `planck//zmk`. Read more about
-board variants in the 
+board variants in the
 [Zephyr 4.1 Update](https://zmk.dev/blog/2025/12/09/zephyr-4-1#zmk-board-variant) blog post.
 :::
 

--- a/docs/docs/development/local-toolchain/build-flash.mdx
+++ b/docs/docs/development/local-toolchain/build-flash.mdx
@@ -69,10 +69,10 @@ with an onboard MCU or one that uses an MCU board add-on.
 </Tabs>
 
 :::warning
-Since Zephyr 4.1 the argument `-b` needs to be set according to the new board
+Since moving to Zephyr 4.1, the board IDs for boards in ZMK need to use the ZMK board
 variants. E.g. instead of `planck_rev6` it should be `planck//zmk`. Read more about
-board variants at
-[Zephyr 4.1 Update](https://zmk.dev/blog/2025/12/09/zephyr-4-1#zmk-board-variant) blog.
+board variants in the 
+[Zephyr 4.1 Update](https://zmk.dev/blog/2025/12/09/zephyr-4-1#zmk-board-variant) blog post.
 :::
 
 ### CMake Arguments


### PR DESCRIPTION
<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).

The docs made no reference to the new board variants in zephyr which will end up in failed builds when using Zephyr 4.1.  (#3297)

I added a warning calling attention to it in "Local Toolchain/Building and Flashing" page. Although I'm guessing the project is moving on with the new version of zephyr so probably all the examples should be rewritten to reflect the new way to reference boards.