### PR TITLE
docs: update arm to <vendor> to align with the new Zephyr 4.1.0 update

### DIFF
--- a/docs/docs/config/index.md
+++ b/docs/docs/config/index.md
@@ -30,12 +30,12 @@ When using a [split keyboard](../features/split-keyboards.md), you can use a sin
 
 ZMK will search for config files in:
 
-- [`zmk/app/boards/arm/<board>`](https://github.com/zmkfirmware/zmk/tree/main/app/boards/arm)
-- `zmk-config/boards/arm/<board>`
-- `<module>/boards/arm/<board>`
-- `zmk-config/config/boards/arm/<board>` (For backwards compatibility only, do not use.)
+- [`zmk/app/boards/<vendor>/<board>`](https://github.com/zmkfirmware/zmk/tree/main/app/boards)
+- `zmk-config/boards/<vendor>/<board>`
+- `<module>/boards/<vendor>/<board>`
+- `zmk-config/config/boards/<vendor>/<board>` (For backwards compatibility only, do not use.)
 
-...where `<board>` is the name of the board and `<module>` is the root directory of any [included module](../features/modules.mdx). These files describe the hardware of the board.
+...where `<vendor>` is the name of the creator or vendor, `<board>` is the name of the board and `<module>` is the root directory of any [included module](../features/modules.mdx). These files describe the hardware of the board.
 
 ZMK will search the board folder for the following config files _in addition_ to [Zephyr board-defining files](https://docs.zephyrproject.org/4.1.0/hardware/porting/board_porting.html#create-your-board-directory):
 


### PR DESCRIPTION
Hardware Model V2 moved arm boards to their specific vendor. This PR updates to docs to accommodate for this change.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
