### PR TITLE
fix(backlight): Retrieve only brightness from settings when CONFIG_ZMK_BACKLIGHT_ON_START disabled

### DIFF
--- a/app/src/backlight.c
+++ b/app/src/backlight.c
@@ -67,7 +67,11 @@ static int backlight_settings_load_cb(const char *name, size_t len, settings_rea
 
         int rc = read_cb(cb_arg, &state, sizeof(state));
         if (rc >= 0) {
+#if CONFIG_ZMK_BACKLIGHT_ON_START
             rc = zmk_backlight_update();
+#else
+            state.on = false;
+#endif // CONFIG_ZMK_BACKLIGHT_ON_START
         }
 
         return MIN(rc, 0);


### PR DESCRIPTION
On startup, when the settings subsystem loads the most recent backlight brightness and on-state, it overrides the effect of the `CONFIG_ZMK_BACKLIGHT_ON_START` Kconfig.

This PR creates congruency between the settings subsystem and this Kconfig by not calling `zmk_backlight_update()` and setting the backlight state to `false` when `CONFIG_ZMK_BACKLIGHT_ON_START=n`.

Tested on custom board.