### PR TITLE
Clarify combos interact with hold-tap's hold-while-undecided

### DIFF
--- a/docs/docs/keymaps/behaviors/hold-tap.mdx
+++ b/docs/docs/keymaps/behaviors/hold-tap.mdx
@@ -438,7 +438,7 @@ If enabled, the hold behavior will immediately be held on hold-tap press, and wi
 ```
 
 :::warning[Interactions with combos]
-If the key is _also_ used in any combos, the `hold-while-undecided` behavior isn't immediate with key-down, but waits until all those combo timeouts have expired.
+If the key position that has the hold-tap assigned is _also_ used in any combos, the `hold-while-undecided` behavior isn't immediate with key-down, but waits until all those combo timeouts have expired.
 :::
 
 #### `hold-while-undecided-linger`

--- a/docs/docs/keymaps/behaviors/hold-tap.mdx
+++ b/docs/docs/keymaps/behaviors/hold-tap.mdx
@@ -437,6 +437,10 @@ If enabled, the hold behavior will immediately be held on hold-tap press, and wi
 };
 ```
 
+:::warning[Interactions with combos]
+If the key is *also* used in any combos, the `hold-while-undecided` behavior isn't immediate with key-down, but waits until all those combo timeouts have expired.
+:::
+
 #### `hold-while-undecided-linger`
 
 If your tap behavior activates the same modifier as the hold behavior, and you want to avoid a double tap when transitioning from the hold to the tap, you can use `hold-while-undecided-linger`. When enabled, the hold behavior will continue to be held until _after_ the tap behavior is released.

--- a/docs/docs/keymaps/behaviors/hold-tap.mdx
+++ b/docs/docs/keymaps/behaviors/hold-tap.mdx
@@ -438,7 +438,7 @@ If enabled, the hold behavior will immediately be held on hold-tap press, and wi
 ```
 
 :::warning[Interactions with combos]
-If the key is *also* used in any combos, the `hold-while-undecided` behavior isn't immediate with key-down, but waits until all those combo timeouts have expired.
+If the key is _also_ used in any combos, the `hold-while-undecided` behavior isn't immediate with key-down, but waits until all those combo timeouts have expired.
 :::
 
 #### `hold-while-undecided-linger`


### PR DESCRIPTION
This caught me out with a rarely used four-key combo for my boot-loader with a long timeout causing a matching delay to the hold behaviour. Issue diagnosed on ZMK Discord.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
