### PR TITLE
fix(mod-morph): send separate HID report after masked_modifiers_set

### DIFF
--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -9,6 +9,7 @@
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include <zmk/hid.h>
+#include <zmk/endpoints.h>
 #include <dt-bindings/zmk/modifiers.h>
 
 static struct zmk_hid_keyboard_report keyboard_report = {
@@ -281,14 +282,32 @@ int zmk_hid_masked_modifiers_set(zmk_mod_flags_t new_masked_modifiers) {
     masked_modifiers = new_masked_modifiers;
     zmk_mod_flags_t current = GET_MODIFIERS;
     SET_MODIFIERS(explicit_modifiers);
-    return current == GET_MODIFIERS ? 0 : 1;
+    int changed = current == GET_MODIFIERS ? 0 : 1;
+#if IS_ENABLED(CONFIG_ZMK_HID_SEPARATE_MOD_RELEASE_REPORT)
+    if (changed) {
+        int err = zmk_endpoint_send_report(HID_USAGE_KEY);
+        if (err < 0) {
+            LOG_ERR("Failed to flush masked modifier set (%d)", err);
+        }
+    }
+#endif
+    return changed;
 }
 
 int zmk_hid_masked_modifiers_clear(void) {
     masked_modifiers = 0;
     zmk_mod_flags_t current = GET_MODIFIERS;
     SET_MODIFIERS(explicit_modifiers);
-    return current == GET_MODIFIERS ? 0 : 1;
+    int changed = current == GET_MODIFIERS ? 0 : 1;
+#if IS_ENABLED(CONFIG_ZMK_HID_SEPARATE_MOD_RELEASE_REPORT)
+    if (changed) {
+        int err = zmk_endpoint_send_report(HID_USAGE_KEY);
+        if (err < 0) {
+            LOG_ERR("Failed to flush masked modifier clear (%d)", err);
+        }
+    }
+#endif
+    return changed;
 }
 
 int zmk_hid_keyboard_press(zmk_key_t code) {


### PR DESCRIPTION
## Summary

When a `mod-morph` fires with `masked_mods`, the modifier change set by
`zmk_hid_masked_modifiers_set()` is not flushed to the host on its own —
it's only included in the *next* HID report, which is normally produced
by the inner `&kp`'s press handler.

On macOS this causes the host to receive a single report containing both
the modifier release and the morphed key press at the same time. macOS
appears to evaluate key events before modifier changes within one
report, so e.g. `Ctrl+J` (mod-morphed to `DOWN`) is interpreted as
`Ctrl+DOWN` (Mission Control) instead of plain `DOWN`.

This change sends a HID report immediately after
`zmk_hid_masked_modifiers_set()` so the modifier release is observed by
the host **before** the morphed binding's key press arrives in a later
report. It mirrors the existing behavior gated by
`CONFIG_ZMK_HID_SEPARATE_MOD_RELEASE_REPORT` on the release path.

## Reproduction (before this fix)

- Host: macOS (any recent version)
- Keymap: `&mm DOWN J  LCTRL`  (Ctrl+J → DOWN via masked_mods = LCTRL)
- Hold `Ctrl`, then tap `J`
- Observed: Mission Control activates (== `Ctrl+DOWN`)
- Expected: cursor moves down (== plain `DOWN`)

## After this fix

- Same setup, Ctrl+J → plain `DOWN` as intended on macOS.
- Linux / Windows behavior unchanged in local testing.

## PR check-list

- [x] Branch has a clean commit history (single commit)
- [ ] Additional tests are included — *not added; mod-morph masked_mods
      timing is host-side observable rather than unit-testable in the
      existing harness. Happy to add a test if reviewers can point me to
      a suitable pattern.*
- [x] No new files; existing copyright headers untouched
- [ ] Pre-commit run — *not run locally (toolchain not installed);
      relying on CI. Diff is a single added line matching surrounding
      indentation.*
- [x] No documentation changes needed
