### PR TITLE
feat: add RAINBOW_BREATHE underglow effect

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -331,7 +331,7 @@ config ZMK_RGB_UNDERGLOW_SPD_START
 
 config ZMK_RGB_UNDERGLOW_EFF_START
     int "RGB underglow start effect int value related to the effect enum list"
-    range 0 3
+    range 0 4
 
 config ZMK_RGB_UNDERGLOW_ON_START
     bool "RGB underglow starts on by default"

--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -49,6 +49,7 @@ enum rgb_underglow_effect {
     UNDERGLOW_EFFECT_BREATHE,
     UNDERGLOW_EFFECT_SPECTRUM,
     UNDERGLOW_EFFECT_SWIRL,
+    UNDERGLOW_EFFECT_RAINBOW_BREATHE,
     UNDERGLOW_EFFECT_NUMBER // Used to track number of underglow effects
 };
 
@@ -175,6 +176,24 @@ static void zmk_rgb_underglow_effect_swirl(void) {
     state.animation_step = state.animation_step % HUE_MAX;
 }
 
+static void zmk_rgb_underglow_effect_rainbow_breathe(void) {
+    /* Brightness oscillates 0→100→0 over 2400 steps (same as BREATHE). */
+    uint8_t brightness = abs((int)state.animation_step - 1200) / 12;
+
+    for (int i = 0; i < STRIP_NUM_PIXELS; i++) {
+        struct zmk_led_hsb hsb = state.color;
+        /* Each LED gets its own hue slice across the full 360° wheel. */
+        hsb.h = (HUE_MAX / STRIP_NUM_PIXELS * i + state.animation_step / 12) % HUE_MAX;
+        hsb.b = brightness;
+        pixels[i] = hsb_to_rgb(hsb_scale_zero_max(hsb));
+    }
+
+    state.animation_step += state.animation_speed * 10;
+    if (state.animation_step > 2400) {
+        state.animation_step = 0;
+    }
+}
+
 static void zmk_rgb_underglow_tick(struct k_work *work) {
     switch (state.current_effect) {
     case UNDERGLOW_EFFECT_SOLID:
@@ -188,6 +207,9 @@ static void zmk_rgb_underglow_tick(struct k_work *work) {
         break;
     case UNDERGLOW_EFFECT_SWIRL:
         zmk_rgb_underglow_effect_swirl();
+        break;
+    case UNDERGLOW_EFFECT_RAINBOW_BREATHE:
+        zmk_rgb_underglow_effect_rainbow_breathe();
         break;
     }
 


### PR DESCRIPTION
Adds UNDERGLOW_EFFECT_RAINBOW_BREATHE (index 4): each LED is assigned its own hue slice of the full 360 colour wheel, then all LEDs breathe together as one — a full rainbow that pulses in and out.

Extended ZMK_RGB_UNDERGLOW_EFF_START Kconfig range from [0,3] to [0,4].

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
