### PR TITLE
fix(boards): Adjust defconfig check for Planck with HWMv2 changes

### DIFF
--- a/app/boards/olkb/planck/Kconfig.defconfig
+++ b/app/boards/olkb/planck/Kconfig.defconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2020 The ZMK Contributors
 # SPDX-License-Identifier: MIT
 
-if BOARD_PLANCK_REV6
+if BOARD_PLANCK
 
 config ZMK_KEYBOARD_NAME
     default "Planck V6"
@@ -11,4 +11,4 @@ config ZMK_KEYBOARD_NAME
 config ZMK_KSCAN_MATRIX_POLLING
     default y
 
-endif # BOARD_PLANCK_REV6
+endif # BOARD_PLANCK


### PR DESCRIPTION
Since we're now properly versionining our in-tree boards, adjust the defconfig checks for the Planck to ensure matrix polling is properly defaulted on.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [ ] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
