### PR TITLE
docs: reorganise supported hardware page

### DIFF
--- a/app/boards/interconnects/arduino_uno/arduino_uno.zmk.yml
+++ b/app/boards/interconnects/arduino_uno/arduino_uno.zmk.yml
@@ -9,10 +9,6 @@ description: |
   natural extension, once there were many shields designed for it, many other *boards* began to be developed
   that were compatible to leverage the extensive available shields. Today, many dev kits come with Uno
   headers to make it easy to work with them.
-
-  Note: ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, because Zephyr™ only
-  supports 32-bit and 64-bit platforms. As a result, boards like the original Arduino Uno Rev3 itself are
-  *not* supported by ZMK.
 node_labels:
   gpio: arduino_header
   i2c: arduino_i2c

--- a/app/boards/interconnects/pro_micro/pro_micro.zmk.yml
+++ b/app/boards/interconnects/pro_micro/pro_micro.zmk.yml
@@ -6,12 +6,8 @@ url: https://www.sparkfun.com/products/12640
 manufacturer: SparkFun
 description: |
   The SparkFun Pro Micro grew popular as a low cost ATmega32U4 board with sufficient GPIO and peripherals
-  to work for many keyboard needs. Since the original Pro Micro, many pin compatible boards have appeared,
-  with various changes or improvements, such as the Elite-C w/ USB-C, nice!nano with nRF52840 wireless.
-
-  Note: ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, because Zephyr™ only
-  supports 32-bit and 64-bit platforms. As a result, controllers like the SparkFun Pro Micro and the Elite-C
-  are *not* supported by ZMK.
+  to work for many keyboard needs. Since the original Pro Micro, many pin compatible boards have appeared
+  with various changes or improvements.
 node_labels:
   gpio: pro_micro
   i2c: pro_micro_i2c

--- a/docs/docs/hardware.mdx
+++ b/docs/docs/hardware.mdx
@@ -12,11 +12,6 @@ import { groupedMetadata } from "@site/src/components/hardware-utils";
 
 export const toc = [
   {
-    value: "Onboard Controller Keyboards",
-    id: "onboard",
-    level: 2,
-  },
-  {
     value: "Composite Keyboards",
     id: "composite",
     level: 2,
@@ -29,24 +24,31 @@ export const toc = [
       level: 3,
     })),
   {
-    value: "Other Hardware",
-    id: "other-hardware",
+    value: "Onboard Controller Keyboards",
+    id: "onboard",
     level: 2,
   },
   {
-    value: "Contributing",
-    id: "contributing",
+    value: "Other Hardware",
+    id: "other-hardware",
     level: 2,
   },
 ];
 
 With the solid technical foundation of Zephyr™ RTOS, ZMK can support a wide diversity of hardware targets,
 including but not limited to Nordic nRF52, Raspberry Pi RP2040/RP2350, most ST STM32 MCUs, and Microchip SAMD21.
-That being said, there are specific [boards / shields](hardware-integration/index.mdx#boards--shields) that have been implemented and tested by the ZMK contributors, listed below.
+That being said, there are specific boards / shields that have been implemented and tested by the ZMK contributors, listed below.
 
-:::note
+ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, because Zephyr™ only
+supports 32-bit and 64-bit platforms. As a result, controllers like the SparkFun Pro Micro, Elite-C,
+and Arduino Uno Rev3 are **NOT** supported by ZMK.
 
-With the [upgrade to Zephyr 4.1](/blog/2025/12/09/zephyr-4-1#zmk-board-variant), the ZMK project has moved all in-tree boards to use a `zmk` [board variant](https://docs.zephyrproject.org/4.1.0/glossary.html#term-variant), for consistency when distinguishing from stock boards that are actually in upstream Zephyr.
+Check out the [Hardware Integration](development/hardware-integration/index.mdx) section for more info on how to use ZMK on custom keyboards.
+
+:::info[Boards and Shields]
+
+ZMK uses the Zephyr concepts of "boards" and "shields" to refer to different parts of a keyboard build that in turn get combined during a firmware build.
+Please see the [explainer on boards & shields](development/hardware-integration/index.mdx#boards--shields) for more details.
 
 :::
 
@@ -57,8 +59,3 @@ With the [upgrade to Zephyr 4.1](/blog/2025/12/09/zephyr-4-1#zmk-board-variant),
 
 In addition to the basic keyboard functionality, there is also support for additional keyboard hardware such as encoders, RGB underglow, backlight and displays.
 Please see pages under the "Features" header in the sidebar for details.
-
-{/* prettier-ignore */}
-<Heading as="h2" id="contributing">Contributing</Heading>
-
-If you'd like to add support for a new keyboard shield, head over to the [New Keyboard Shield](hardware-integration/new-shield.mdx) documentation and note the [clean room design requirements](development/contributing/clean-room.md).

--- a/docs/docs/hardware.mdx
+++ b/docs/docs/hardware.mdx
@@ -35,19 +35,22 @@ export const toc = [
   },
 ];
 
-With the solid technical foundation of Zephyr™ RTOS, ZMK can support a wide diversity of hardware targets,
+With the solid technical foundation of Zephyr™ RTOS, ZMK can support a wide variety of hardware targets,
 including but not limited to Nordic nRF52, Raspberry Pi RP2040/RP2350, most ST STM32 MCUs, and Microchip SAMD21.
-That being said, there are specific boards / shields that have been implemented and tested by the ZMK contributors, listed below.
+ZMK has the potential to run on any hardware supported by Zephyr™, such as those on
+the [Zephyr™ supported boards](https://docs.zephyrproject.org/4.1.0/boards/index.html) page, though you may need to do some additional work to configure them for ZMK.
+That being said, there are specific boards that have been tested and pre-configured by the ZMK contributors, denoted by the `zmk` board variants below.
 
 ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, because Zephyr™ only
 supports 32-bit and 64-bit platforms. As a result, controllers like the SparkFun Pro Micro, Elite-C,
 and Arduino Uno Rev3 are **NOT** supported by ZMK.
 
-Check out the [Hardware Integration](development/hardware-integration/index.mdx) section for more info on how to use ZMK on custom keyboards.
+Making new keyboard designs? Check out the [Hardware Integration](development/hardware-integration/index.mdx) section
+for more information on how to configure ZMK to run on your custom hardware.
 
 :::info[Boards and Shields]
 
-ZMK uses the Zephyr concepts of "boards" and "shields" to refer to different parts of a keyboard build that in turn get combined during a firmware build.
+ZMK uses the Zephyr concepts of "boards" and "shields" to refer to different parts of a keyboard build that are then combined during a firmware build.
 Please see the [explainer on boards & shields](development/hardware-integration/index.mdx#boards--shields) for more details.
 
 :::

--- a/docs/docs/hardware.mdx
+++ b/docs/docs/hardware.mdx
@@ -41,7 +41,7 @@ ZMK has the potential to run on any hardware supported by Zephyr™, such as tho
 the [Zephyr™ supported boards](https://docs.zephyrproject.org/4.1.0/boards/index.html) page, though you may need to do some additional work to configure them for ZMK.
 That being said, there are specific boards that have been tested and pre-configured by the ZMK contributors, denoted by the `zmk` board variants below.
 
-Making new keyboard designs? Check out the [Hardware Integration](hardware-integration/index.mdx) section
+Designing a new keyboard? Check out the [Hardware Integration](hardware-integration/index.mdx) section
 for more information on how to configure ZMK to run on your custom hardware.
 
 :::info[Boards, Board Variants, and Shields]

--- a/docs/docs/hardware.mdx
+++ b/docs/docs/hardware.mdx
@@ -45,13 +45,13 @@ ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, be
 supports 32-bit and 64-bit platforms. As a result, controllers like the SparkFun Pro Micro, Elite-C,
 and Arduino Uno Rev3 are **NOT** supported by ZMK.
 
-Making new keyboard designs? Check out the [Hardware Integration](development/hardware-integration/index.mdx) section
+Making new keyboard designs? Check out the [Hardware Integration](hardware-integration/index.mdx) section
 for more information on how to configure ZMK to run on your custom hardware.
 
 :::info[Boards and Shields]
 
 ZMK uses the Zephyr concepts of "boards" and "shields" to refer to different parts of a keyboard build that are then combined during a firmware build.
-Please see the [explainer on boards & shields](development/hardware-integration/index.mdx#boards--shields) for more details.
+Please see the [explainer on boards & shields](hardware-integration/index.mdx#boards--shields) for more details.
 
 :::
 

--- a/docs/docs/hardware.mdx
+++ b/docs/docs/hardware.mdx
@@ -41,17 +41,15 @@ ZMK has the potential to run on any hardware supported by Zephyr™, such as tho
 the [Zephyr™ supported boards](https://docs.zephyrproject.org/4.1.0/boards/index.html) page, though you may need to do some additional work to configure them for ZMK.
 That being said, there are specific boards that have been tested and pre-configured by the ZMK contributors, denoted by the `zmk` board variants below.
 
-ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, because Zephyr™ only
-supports 32-bit and 64-bit platforms. As a result, controllers like the SparkFun Pro Micro, Elite-C,
-and Arduino Uno Rev3 are **NOT** supported by ZMK.
-
 Making new keyboard designs? Check out the [Hardware Integration](hardware-integration/index.mdx) section
 for more information on how to configure ZMK to run on your custom hardware.
 
-:::info[Boards and Shields]
+:::info[Boards, Board Variants, and Shields]
 
 ZMK uses the Zephyr concepts of "boards" and "shields" to refer to different parts of a keyboard build that are then combined during a firmware build.
 Please see the [explainer on boards & shields](hardware-integration/index.mdx#boards--shields) for more details.
+
+Zephyr boards come with minimal configuration. ZMK board variants add the necessary configuration to make the board usable out of the box with ZMK.
 
 :::
 
@@ -62,3 +60,7 @@ Please see the [explainer on boards & shields](hardware-integration/index.mdx#bo
 
 In addition to the basic keyboard functionality, there is also support for additional keyboard hardware such as encoders, RGB underglow, backlight and displays.
 Please see pages under the "Features" header in the sidebar for details.
+
+ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, because Zephyr™ only
+supports 32-bit and 64-bit platforms. As a result, controllers like the SparkFun Pro Micro, Elite-C,
+and Arduino Uno Rev3 are **NOT** supported by ZMK.

--- a/docs/docs/hardware.mdx
+++ b/docs/docs/hardware.mdx
@@ -12,11 +12,6 @@ import { groupedMetadata } from "@site/src/components/hardware-utils";
 
 export const toc = [
   {
-    value: "Onboard Controller Keyboards",
-    id: "onboard",
-    level: 2,
-  },
-  {
     value: "Composite Keyboards",
     id: "composite",
     level: 2,
@@ -29,24 +24,31 @@ export const toc = [
       level: 3,
     })),
   {
-    value: "Other Hardware",
-    id: "other-hardware",
+    value: "Onboard Controller Keyboards",
+    id: "onboard",
     level: 2,
   },
   {
-    value: "Contributing",
-    id: "contributing",
+    value: "Other Hardware",
+    id: "other-hardware",
     level: 2,
   },
 ];
 
 With the solid technical foundation of Zephyr™ RTOS, ZMK can support a wide diversity of hardware targets,
 including but not limited to Nordic nRF52, Raspberry Pi RP2040/RP2350, most ST STM32 MCUs, and Microchip SAMD21.
-That being said, there are specific [boards / shields](development/hardware-integration/index.mdx#boards--shields) that have been implemented and tested by the ZMK contributors, listed below.
+That being said, there are specific boards / shields that have been implemented and tested by the ZMK contributors, listed below.
 
-:::note
+ZMK doesn't support boards with AVR 8-bit processors, such as the ATmega32U4, because Zephyr™ only
+supports 32-bit and 64-bit platforms. As a result, controllers like the SparkFun Pro Micro, Elite-C,
+and Arduino Uno Rev3 are **NOT** supported by ZMK.
 
-With the [upgrade to Zephyr 4.1](/blog/2025/12/09/zephyr-4-1#zmk-board-variant), the ZMK project has moved all in-tree boards to use a `zmk` [board variant](https://docs.zephyrproject.org/4.1.0/glossary.html#term-variant), for consistency when distinguishing from stock boards that are actually in upstream Zephyr.
+Check out the [Hardware Integration](development/hardware-integration/index.mdx) section for more info on how to use ZMK on custom keyboards.
+
+:::info[Boards and Shields]
+
+ZMK uses the Zephyr concepts of "boards" and "shields" to refer to different parts of a keyboard build that in turn get combined during a firmware build.
+Please see the [explainer on boards & shields](development/hardware-integration/index.mdx#boards--shields) for more details.
 
 :::
 
@@ -57,8 +59,3 @@ With the [upgrade to Zephyr 4.1](/blog/2025/12/09/zephyr-4-1#zmk-board-variant),
 
 In addition to the basic keyboard functionality, there is also support for additional keyboard hardware such as encoders, RGB underglow, backlight and displays.
 Please see pages under the "Features" header in the sidebar for details.
-
-{/* prettier-ignore */}
-<Heading as="h2" id="contributing">Contributing</Heading>
-
-If you'd like to add support for a new keyboard shield, head over to the [New Keyboard Shield](development/hardware-integration/new-shield.mdx) documentation and note the [clean room design requirements](development/contributing/clean-room.md).

--- a/docs/src/components/hardware-list.tsx
+++ b/docs/src/components/hardware-list.tsx
@@ -85,6 +85,27 @@ function HardwareList({ items }: HardwareListProps) {
   return (
     <>
       <section>
+        <Heading as="h2" id="composite">
+          Composite Keyboards
+        </Heading>
+        <p>
+          Composite keyboards are composed of two main PCBs: a small controller
+          board with exposed pads, and a larger keyboard PCB (a shield, in ZMK
+          lingo) with switch footprints and a location where the controller is
+          added. This location is called an interconnect.
+        </p>
+        <p>
+          Designing a custom keyboard with an off-the-shelf controller board?
+          Check out the{" "}
+          <a href="/docs/development/hardware-integration/new-shield">
+            New Keyboard Shield
+          </a>{" "}
+          guide.
+        </p>
+
+        {Object.values(grouped.interconnects).map(mapInterconnect)}
+      </section>
+      <section>
         <Heading as="h2" id="onboard">
           Onboard Controller Keyboards
         </Heading>
@@ -93,6 +114,13 @@ function HardwareList({ items }: HardwareListProps) {
           the components of a keyboard, including the controller chip, switch
           footprints, etc.
         </p>
+        <p>
+          To run ZMK on your own keyboard with an onboard controller, follow the{" "}
+          <a href="/docs/development/hardware-integration/new-board">
+            New Board
+          </a>{" "}
+          guide.
+        </p>
         <ul>
           {grouped["onboard"]
             .sort((a, b) => a.name.localeCompare(b.name))
@@ -100,19 +128,6 @@ function HardwareList({ items }: HardwareListProps) {
               <HardwareLineItem key={s.id} item={s} />
             ))}
         </ul>
-      </section>
-      <section>
-        <Heading as="h2" id="composite">
-          Composite Keyboards
-        </Heading>
-        <p>
-          Composite keyboards are composed of two main PCBs: a small controller
-          board with exposed pads, and a larger keyboard PCB (a shield, in ZMK
-          lingo) with switch footprints and a location where the controller is
-          added. This location is called an interconnect. Multiple interconnects
-          can be found below.
-        </p>
-        {Object.values(grouped.interconnects).map(mapInterconnect)}
       </section>
     </>
   );

--- a/docs/src/components/hardware-list.tsx
+++ b/docs/src/components/hardware-list.tsx
@@ -95,8 +95,8 @@ function HardwareList({ items }: HardwareListProps) {
           added. This location is called an interconnect.
         </p>
         <p>
-          Designing a custom keyboard with an off-the-shelf controller board?
-          Check out the{" "}
+          Designing a custom composite keyboard with an off-the-shelf controller
+          board? Check out the{" "}
           <a href="/docs/development/hardware-integration/new-shield">
             New Keyboard Shield
           </a>{" "}
@@ -115,7 +115,7 @@ function HardwareList({ items }: HardwareListProps) {
           footprints, etc.
         </p>
         <p>
-          To run ZMK on your own keyboard with an onboard controller, follow the{" "}
+          Designing a custom keyboard with an onboard controller? Check out the{" "}
           <a href="/docs/development/hardware-integration/new-board">
             New Board
           </a>{" "}

--- a/docs/src/components/hardware-list.tsx
+++ b/docs/src/components/hardware-list.tsx
@@ -89,15 +89,22 @@ function HardwareList({ items }: HardwareListProps) {
           Composite Keyboards
         </Heading>
         <p>
-          Composite keyboards are composed of two main PCBs: a small controller
-          board with exposed pads, and a larger keyboard PCB (a shield, in ZMK
-          lingo) with switch footprints and a location where the controller is
-          added. This location is called an interconnect.
+          Composite keyboards are composed of two main PCBs: a small controller{" "}
+          <strong>board</strong> with exposed pads, and a larger keyboard PCB (a{" "}
+          <strong>shield</strong>, in ZMK lingo) with switch footprints. The
+          board and shield share the same <strong>interconnect</strong>{" "}
+          standard, which defines the physical and electrical specifications for
+          the PCB-to-PCB connection.
+        </p>
+        <p>
+          Boards and shields that share the same interconnect are usually
+          compatible with each other but not always. Check hardware
+          compatibility before connecting them.
         </p>
         <p>
           Designing a custom composite keyboard with an off-the-shelf controller
           board? Check out the{" "}
-          <a href="/docs/development/hardware-integration/new-shield">
+          <a href="/docs/hardware-integration/new-shield">
             New Keyboard Shield
           </a>{" "}
           guide.
@@ -116,10 +123,7 @@ function HardwareList({ items }: HardwareListProps) {
         </p>
         <p>
           Designing a custom keyboard with an onboard controller? Check out the{" "}
-          <a href="/docs/development/hardware-integration/new-board">
-            New Board
-          </a>{" "}
-          guide.
+          <a href="/docs/hardware-integration/new-board">New Board</a> guide.
         </p>
         <ul>
           {grouped["onboard"]


### PR DESCRIPTION
Related to #3361 

- Moved onboard section below composite, since composite keyboards seem more common.
- Added a few links to hardware integration pages to clearly signal "you can make your own".
- Removed "contributing" since it's not really applicable for shields anymore, and the "new board" page have all the necessary info on licensing and merging already.

- Made the "board / shield" link a dedicated admonition to bring more attention, since the terminology seems to be a common source of confusion for new users. 

- Removed Zephyr 4.1 upgrade note.
  IMHO, this note can be confusion. For new readers reading the page in current version, they don't need to know what changed _before_ the version they're starting from. For readers coming from a previous version, surely they would've read either change log or migration guide already.

- Moved unsupported boards from metadata to the page. Also removed some sections of interconnect descriptions.
  The `pro_micro` interconnect description mentions "Elite-C" which is an unsupported board.
  IMO all mentions of specific boards could be removed because right below the description is the list of boards.

-----

Preview: https://deploy-preview-3363--zmk.netlify.app/docs/hardware

-----

## PR check-list

N/A
