### PR TITLE
feat(split): optionally clear stale split bond on PIN/key mismatch

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -223,6 +223,27 @@ config ZMK_BLE_MOUSE_REPORT_QUEUE_SIZE
 config ZMK_BLE_CLEAR_BONDS_ON_START
     bool "Configuration that clears all bond information from the keyboard on startup."
 
+config ZMK_SPLIT_AUTO_UNPAIR_ON_KEY_MISMATCH
+    bool "Automatically clear a stale split bond when the peripheral reports a PIN/key mismatch"
+    depends on ZMK_SPLIT_ROLE_CENTRAL
+    help
+      When enabled on a split central, ZMK clears the bond and disconnects
+      the peripheral if the security exchange with that peripheral fails
+      with BT_SECURITY_ERR_PIN_OR_KEY_MISSING. The next advertising window
+      then re-pairs from scratch without manual intervention.
+
+      This handles the asymmetric stale-bond case in a split setup: the
+      central no longer has a usable LTK for that peripheral (e.g. the
+      central was flashed with a settings_reset image, or the central
+      hardware was swapped while the peripherals were kept), but the
+      peripheral keeps replaying its old LTK, so the link cannot complete
+      without user action. It is particularly useful for dongle-style
+      centrals, which have no keymap from which to trigger recovery
+      behaviors.
+
+      Off by default because clearing a bond is destructive and cannot be
+      undone; only enable on deployments that are known to benefit.
+
 # HID GATT notifications sent this way are *not* picked up by Linux, and possibly others.
 config BT_GATT_NOTIFY_MULTIPLE
     default n

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -562,6 +562,14 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
         LOG_DBG("Security changed: %s level %u", addr, level);
     } else {
         LOG_ERR("Security failed: %s level %u err %d", addr, level, err);
+#if IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL) && \
+    IS_ENABLED(CONFIG_ZMK_SPLIT_AUTO_UNPAIR_ON_KEY_MISMATCH)
+        if (err == BT_SECURITY_ERR_PIN_OR_KEY_MISSING) {
+            LOG_WRN("Stale split bond detected, clearing and disconnecting");
+            bt_unpair(BT_ID_DEFAULT, bt_conn_get_dst(conn));
+            bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
## What

Add `CONFIG_ZMK_SPLIT_AUTO_UNPAIR_ON_KEY_MISMATCH` (off by default,
depends on `ZMK_SPLIT_ROLE_CENTRAL`). When enabled, a split central
that receives `BT_SECURITY_ERR_PIN_OR_KEY_MISSING` from a peripheral
calls `bt_unpair()` + `bt_conn_disconnect()` so the next advertising
window re-pairs from scratch.

## Why

In a split setup (one central + N peripherals), the central's bond
record for one peripheral can become invalid while the peripheral
still holds the old LTK. Once that happens the next reconnection
sits in an infinite `PIN_OR_KEY_MISSING` loop and cannot recover
without manual intervention — which on a dongle-style central is
particularly painful because the dongle has no keymap from which to
issue any recovery behavior.

Concrete situations that produce this state:

- A `settings_reset` UF2 is flashed on the central (or, less
  commonly, on the peripheral) while the other side keeps its bond.
- The central hardware is swapped (e.g. a different XIAO BLE) while
  the peripherals are kept as-is.
- USB-level reset of the dongle — observed on hardware as one of
  the two peripherals occasionally landing in this state on KVM
  switch-over and recovering automatically once the patch is active
  (I can't fully attribute the KVM trigger to NVS state yet, only
  that the symptom is the same `PIN_OR_KEY_MISSING` loop and the
  same `bt_unpair()` clears it).

In all three the symptom is the same: the central's LTK is gone or
shifted for that peripheral, the peripheral still replays the old
LTK, and the link cannot complete without user action.

## Scope and gating

- Strictly the **split central** path: gated on
  `IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL)`. The new behavior
  cannot fire on the central ↔ host pairing path.
- Strictly **opt-in**: `ZMK_SPLIT_AUTO_UNPAIR_ON_KEY_MISMATCH` is
  off by default. Clearing a bond is destructive; only deployments
  that are known to benefit (typically dongle setups) should enable
  it.
- Strictly the exact error code
  `BT_SECURITY_ERR_PIN_OR_KEY_MISSING`. Other security failures are
  left alone.

## Testing

Verified on hardware via akira-toriyama/canon (Cyboard Imprint:
XIAO BLE dongle as central, both halves as peripherals):

- Builds clean on `xiao_ble/nrf52840/zmk + imprint_dongle`.
- With the flag off, existing behavior is byte-identical.
- With the flag enabled, dongle + peripherals operate as before
  under normal use, and a previously-reproducible failure where
  one peripheral half stopped responding after a KVM USB switch-over
  no longer reproduces in the user's setup. A few switch cycles
  tested; not claimed as exhaustive given KVM-USB enumeration
  variability.

## Related

- #805 — same `Security failed: ... err 2` =
  `BT_SECURITY_ERR_PIN_OR_KEY_MISSING` pattern in a different
  (host-side) scenario. This PR doesn't claim to close it; the
  split flag is unrelated to the host pair path by design.

## Notes for maintainers

- Happy to rename (`ZMK_SPLIT_DROP_STALE_BOND`, etc.) if there's a
  preferred convention.
- I considered also covering the symmetric peripheral-side case
  (peripheral keeps its bond, central LTK shifted) but left it out
  of this PR to keep the scope tight. Happy to follow up if you'd
  like it included here.
