### PR TITLE
Add option to disable BLE HID host advertising

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -194,6 +194,15 @@ config ZMK_BLE_PASSKEY_ENTRY
     bool "Require passkey entry on the keyboard to complete pairing"
     select RING_BUFFER
 
+# Modifying Start: Disable BLE HID host advertising for USB dongle receivers.
+config ZMK_BLE_DISABLE_HOST_ADV
+    bool "Disable BLE HID host advertising"
+    help
+      Disable BLE HID advertising to host devices while keeping BLE enabled.
+      This is useful for USB dongle receivers that still need BLE split central
+      communication with peripherals.
+# End of Modifying
+
 config BT_SMP_ALLOW_UNAUTH_OVERWRITE
     imply ZMK_BLE_PASSKEY_ENTRY
 

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -180,6 +180,15 @@ int update_advertising(void) {
     struct bt_conn *conn;
     enum advertising_type desired_adv = ZMK_ADV_NONE;
 
+    /* Modifying Start: Disable BLE HID host advertising for USB dongle receivers. */
+    if (IS_ENABLED(CONFIG_ZMK_BLE_DISABLE_HOST_ADV)) {
+        if (advertising_status != ZMK_ADV_NONE) {
+            CHECKED_ADV_STOP();
+        }
+        return 0;
+    }
+    /* End of Modifying */
+
     if (zmk_ble_active_profile_is_open()) {
         desired_adv = ZMK_ADV_CONN;
     } else if (!zmk_ble_active_profile_is_connected()) {


### PR DESCRIPTION
## Summary

Add `CONFIG_ZMK_BLE_DISABLE_HOST_ADV` to allow disabling BLE HID host advertising while keeping BLE enabled.

This is useful for USB dongle receiver builds that need BLE for split central communication with peripherals, but should not advertise themselves as a pairable BLE HID device to host computers.

## Details

When `CONFIG_ZMK_BLE_DISABLE_HOST_ADV` is enabled, `update_advertising()` stops any active host advertising and returns without starting BLE HID advertising.

BLE itself remains enabled, so split central behavior can continue to scan for and connect to split peripherals.

## Use Case

A USB dongle receiver may need to:

- communicate with split keyboard halves over BLE
- output HID reports to the host over USB
- avoid appearing as a BLE keyboard available for host pairing

This option supports that setup without requiring `CONFIG_ZMK_BLE=n`, which would also disable the BLE functionality needed for split communication.

## Testing

Built and tested with a USB dongle receiver configuration using BLE split central communication.