### PR TITLE
fix(pointing): emit scaled smooth scrolling values

### DIFF
--- a/app/src/pointing/input_listener.c
+++ b/app/src/pointing/input_listener.c
@@ -267,7 +267,7 @@ static void apply_resolution_scaling(struct input_listener_data *data, struct in
     int16_t val = evt->value + *remainder;
     int16_t scaled = val / (int16_t)div;
     *remainder = val - (scaled * (int16_t)div);
-    evt->value = val;
+    evt->value = scaled;
 }
 #endif // IS_ENABLED(CONFIG_ZMK_POINTING_SMOOTH_SCROLLING)
 


### PR DESCRIPTION
## What changed
`apply_resolution_scaling()` now emits the scaled wheel value instead of the unscaled accumulated value.

## Bug fixed
When `CONFIG_ZMK_POINTING_SMOOTH_SCROLLING` is enabled, the input listener computes a scaled wheel value and stores the remaining fractional part in `remainder`. Before this change, the function calculated `scaled` but assigned `evt->value = val`, so the accumulated unscaled value was emitted. This made scaling ineffective and allowed leftover remainder to affect later wheel events.

## Local testing
- `git diff --check` passed.
- `app/run-test.sh tests/pointing/mouse-scroll` passed in a clean upstream ZMK workspace initialized from this PR branch with Zephyr `v4.1.0+zmk-fixes`.
- `app/run-test.sh tests/pointing` passed in the same clean upstream ZMK workspace.
- Hardware reproduction was observed on a split pointing-device build where enabling smooth scrolling caused right-side trackball scroll output to continue/repeat unexpectedly. Removing smooth scrolling avoided the issue; this one-line fix addresses the underlying scaling bug.

## Requested testing
Additional testing with real hosts that negotiate HID resolution multipliers would be helpful.