### PR TITLE
feat(usb-hid): queue and replay HID reports across USB not-ready windows

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -154,6 +154,66 @@ config USB_NUMOF_EP_WRITE_RETRIES
 config USB_HID_POLL_INTERVAL_MS
     default 1
 
+config ZMK_USB_HID_REPLAY_ON_READY
+    bool "Queue HID reports while USB is not ready and replay on resume"
+    default n
+    help
+      Buffer HID reports that arrive while the USB endpoint is in
+      USB_DC_SUSPEND (or other not-ready states), then flush them
+      shortly after USB transitions to USB_DC_CONFIGURED / USB_DC_RESUME.
+
+      Without this option, zmk_usb_hid_send_report drops every report
+      issued during suspend/disconnect windows. The user-visible
+      symptom is "first keypress lost on host sleep resume / dongle
+      replug, and several presses needed after USB selective-suspend
+      wake". This is most visible on USB-dongle keyboard setups (BLE
+      central forwarding HID over USB) and on macOS hosts (which also
+      drop the first input report from a freshly bound interface).
+
+      The fix queues dropped reports in a small ring buffer and
+      replays them once USB is ready again, after a brief delay that
+      lets the host finish HID interface binding before the resend.
+
+      Adds a small static ring buffer
+      (CONFIG_ZMK_USB_HID_REPLAY_QUEUE_DEPTH entries of
+      CONFIG_ZMK_USB_HID_REPLAY_REPORT_MAX_LEN bytes each) plus one
+      delayable work and one mutex. Disabled by default to preserve
+      existing behaviour.
+
+if ZMK_USB_HID_REPLAY_ON_READY
+
+config ZMK_USB_HID_REPLAY_QUEUE_DEPTH
+    int "Depth of the pending HID report replay queue"
+    default 8
+    range 1 64
+    help
+      Number of HID reports buffered while USB is not ready. On overflow
+      the oldest entry is dropped. Each entry consumes
+      CONFIG_ZMK_USB_HID_REPLAY_REPORT_MAX_LEN bytes of RAM.
+
+config ZMK_USB_HID_REPLAY_REPORT_MAX_LEN
+    int "Maximum bytes per buffered HID report"
+    default 16
+    range 8 64
+    help
+      Upper bound on the size of a queued report. Reports larger than
+      this are not buffered (a warning is logged). Match this to the
+      largest HID report your build generates (keyboard / consumer /
+      mouse / smooth-scrolling, etc.).
+
+config ZMK_USB_HID_REPLAY_FLUSH_DELAY_MS
+    int "Delay (ms) before flushing the replay queue on USB ready"
+    default 100
+    range 0 1000
+    help
+      Wait this long after USB transitions to a ready state before
+      flushing buffered reports. The delay absorbs the host-side HID
+      interface binding race: macOS, in particular, drops the first
+      input report from a freshly bound interface as a quirk. Setting
+      this longer than needed only delays the first replayed event.
+
+endif # ZMK_USB_HID_REPLAY_ON_READY
+
 endif # ZMK_USB
 
 menuconfig ZMK_BLE

--- a/app/src/usb_hid.c
+++ b/app/src/usb_hid.c
@@ -24,6 +24,10 @@
 
 #include <zmk/event_manager.h>
 
+#if IS_ENABLED(CONFIG_ZMK_USB_HID_REPLAY_ON_READY)
+#include <zmk/events/usb_conn_state_changed.h>
+#endif
+
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 static const struct device *hid_dev;
@@ -184,16 +188,160 @@ static const struct hid_ops ops = {
     .set_report = set_report_cb,
 };
 
+#if IS_ENABLED(CONFIG_ZMK_USB_HID_REPLAY_ON_READY)
+
+// Queue HID reports that arrive while the USB endpoint is not ready, then
+// flush them shortly after USB transitions back to a ready state. Without
+// queueing, USB_DC_SUSPEND drops every report (returns usb_wakeup_request)
+// and the host HID stack additionally drops the first input report from a
+// freshly bound interface as a binding-race quirk. The flush delay covers
+// the host-side binding race by letting the host attach before we resend.
+
+#define ZMK_USB_HID_REPLAY_QUEUE_DEPTH       CONFIG_ZMK_USB_HID_REPLAY_QUEUE_DEPTH
+#define ZMK_USB_HID_REPLAY_REPORT_MAX_LEN    CONFIG_ZMK_USB_HID_REPLAY_REPORT_MAX_LEN
+
+struct pending_report {
+    uint8_t data[ZMK_USB_HID_REPLAY_REPORT_MAX_LEN];
+    uint8_t len;
+};
+
+static struct pending_report pending_queue[ZMK_USB_HID_REPLAY_QUEUE_DEPTH];
+static uint8_t pending_head;
+static uint8_t pending_tail;
+static K_MUTEX_DEFINE(pending_mutex);
+
+static void enqueue_pending_report(const uint8_t *report, size_t len) {
+    if (len > ZMK_USB_HID_REPLAY_REPORT_MAX_LEN) {
+        LOG_WRN("HID report too large to queue (%zu B), dropped", len);
+        return;
+    }
+    k_mutex_lock(&pending_mutex, K_FOREVER);
+    uint8_t next = (pending_tail + 1) % ZMK_USB_HID_REPLAY_QUEUE_DEPTH;
+    if (next == pending_head) {
+        // queue full: advance head to drop oldest
+        pending_head = (pending_head + 1) % ZMK_USB_HID_REPLAY_QUEUE_DEPTH;
+    }
+    memcpy(pending_queue[pending_tail].data, report, len);
+    pending_queue[pending_tail].len = (uint8_t)len;
+    pending_tail = next;
+    k_mutex_unlock(&pending_mutex);
+}
+
+static void flush_pending_reports(struct k_work *_work);
+K_WORK_DELAYABLE_DEFINE(pending_flush_dwork, flush_pending_reports);
+
+static void flush_pending_reports(struct k_work *_work) {
+    bool retry = false;
+    k_mutex_lock(&pending_mutex, K_FOREVER);
+    while (pending_head != pending_tail) {
+        struct pending_report *slot = &pending_queue[pending_head];
+        // Advisory take, mirroring the normal send path (which ignores the
+        // take result). A bus reset aborts an armed IN transfer without
+        // raising the write-complete callback (usb_dc_nrfx EP_ABORTED is
+        // log-only), stranding the semaphore at 0; blocking on it here
+        // would abandon the queue for the whole wake cycle. Proceeding
+        // lets the next completed write re-give the semaphore.
+        int took = k_sem_take(&hid_sem, K_MSEC(50));
+        int err = hid_int_ep_write(hid_dev, slot->data, slot->len, NULL);
+        if (err) {
+            if (took == 0) {
+                k_sem_give(&hid_sem);
+            }
+            retry = true;
+            break;
+        }
+        pending_head = (pending_head + 1) % ZMK_USB_HID_REPLAY_QUEUE_DEPTH;
+    }
+    k_mutex_unlock(&pending_mutex);
+
+    // -EAGAIN here usually means mid-enumeration (reset seen, not yet
+    // configured) or a transfer still armed. Retry on a short timer while
+    // the bus is active instead of waiting for a status change that may
+    // never come; during suspend the next wake reschedules us anyway.
+    if (retry) {
+        switch (zmk_usb_get_status()) {
+        case USB_DC_CONFIGURED:
+        case USB_DC_RESUME:
+        case USB_DC_CLEAR_HALT:
+            k_work_reschedule(&pending_flush_dwork,
+                              K_MSEC(CONFIG_ZMK_USB_HID_REPLAY_FLUSH_DELAY_MS));
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+static int usb_hid_conn_state_listener(const zmk_event_t *eh) {
+    const struct zmk_usb_conn_state_changed *ev = as_zmk_usb_conn_state_changed(eh);
+    if (!ev) {
+        return 0;
+    }
+    switch (zmk_usb_get_status()) {
+    case USB_DC_CONFIGURED:
+    case USB_DC_RESUME:
+        // reschedule (not schedule): k_work_schedule on an already-pending
+        // work keeps the OLD deadline, so a RESUME -> RESET -> CONFIGURED
+        // cluster would fire the flush ~0ms after CONFIGURED — inside the
+        // host's HID binding race the delay exists to avoid. Restart the
+        // grace window from the last transition instead.
+        if (zmk_usb_is_hid_ready()) {
+            k_work_reschedule(&pending_flush_dwork,
+                              K_MSEC(CONFIG_ZMK_USB_HID_REPLAY_FLUSH_DELAY_MS));
+        }
+        break;
+    case USB_DC_DISCONNECTED:
+        // Physically unplugged: drop pending reports. Replaying hours-old
+        // keystrokes on replug is phantom input, not recovery. (RESET /
+        // CONNECTED keep the queue — they are transient on the wake path.)
+        k_work_cancel_delayable(&pending_flush_dwork);
+        k_mutex_lock(&pending_mutex, K_FOREVER);
+        pending_head = pending_tail;
+        k_mutex_unlock(&pending_mutex);
+        break;
+    default:
+        // USB_DC_SUSPEND still maps to ZMK_USB_CONN_HID with is_configured
+        // true; scheduling a flush on suspend entry is useless and feeds
+        // the deadline-collapse above.
+        break;
+    }
+    return 0;
+}
+
+ZMK_LISTENER(usb_hid_conn_state_listener, usb_hid_conn_state_listener);
+ZMK_SUBSCRIPTION(usb_hid_conn_state_listener, zmk_usb_conn_state_changed);
+
+#endif // CONFIG_ZMK_USB_HID_REPLAY_ON_READY
+
 static int zmk_usb_hid_send_report(const uint8_t *report, size_t len) {
     switch (zmk_usb_get_status()) {
     case USB_DC_SUSPEND:
+#if IS_ENABLED(CONFIG_ZMK_USB_HID_REPLAY_ON_READY)
+        enqueue_pending_report(report, len);
+#endif
         return usb_wakeup_request();
     case USB_DC_ERROR:
     case USB_DC_RESET:
     case USB_DC_DISCONNECTED:
     case USB_DC_UNKNOWN:
+    case USB_DC_CONNECTED:
+#if IS_ENABLED(CONFIG_ZMK_USB_HID_REPLAY_ON_READY)
+        enqueue_pending_report(report, len);
+#endif
         return -ENODEV;
     default:
+#if IS_ENABLED(CONFIG_ZMK_USB_HID_REPLAY_ON_READY)
+        // Don't overtake reports still queued from a not-ready window: a
+        // live release racing past its queued press would leave that key
+        // logically held on the host. Append and let the flush deliver
+        // both in order (k_work_schedule keeps an already-pending grace
+        // deadline; schedules immediately when none is pending).
+        if (pending_head != pending_tail) {
+            enqueue_pending_report(report, len);
+            k_work_schedule(&pending_flush_dwork, K_NO_WAIT);
+            return 0;
+        }
+#endif
         k_sem_take(&hid_sem, K_MSEC(30));
         int err = hid_int_ep_write(hid_dev, report, len, NULL);
 


### PR DESCRIPTION
## What

Add `CONFIG_ZMK_USB_HID_REPLAY_ON_READY` (default `n`). When enabled,
`zmk_usb_hid_send_report` enqueues HID reports issued during any USB
not-ready state (`SUSPEND`, `ERROR`, `RESET`, `DISCONNECTED`,
`UNKNOWN`, `CONNECTED`) into a small static ring buffer, and a
listener on `zmk_usb_conn_state_changed` schedules a delayable work
item to flush the queue shortly after USB transitions back to a ready
state.

## Why

`zmk_usb_hid_send_report` currently drops every report issued while
the USB endpoint is not ready:

- `USB_DC_SUSPEND` → returns `usb_wakeup_request()` (the report itself
  is discarded).
- `USB_DC_DISCONNECTED` / `RESET` / `UNKNOWN` / `ERROR` → returns `-ENODEV`.
- `USB_DC_CONNECTED` → falls into the default branch, where
  `hid_int_ep_write` is attempted on a not-yet-configured bus and
  fails silently.

The host HID stack additionally drops the first input report from a
freshly bound interface — a binding-race quirk observed on macOS.
Together these surface as:

- "First key after dongle replug is ignored."
- "First key on host sleep resume is lost or needs an extra press" —
  intermittent, because the user's press lands on a transient USB
  state (`SUSPEND`/`RESET`/`CONNECTED`) on the resume path, and macOS
  re-enumerates with one or more extra bus resets on deep wake.

This is especially visible on USB-dongle keyboard setups where a BLE
central forwards HID over USB — the host-side resume latency is on
the order of hundreds of ms and traverses several short-lived USB
device-controller states, so the user's first keystrokes fall inside
that window.

Related: #2686 (the BLE deep-sleep variant of the same symptom class —
out of scope here; a peripheral powered off in deep sleep consumes its
wake keypress at the hardware level before firmware runs).

## How

Every not-ready case in `zmk_usb_hid_send_report` enqueues the report
bytes before returning its existing error. A new ZMK listener on
`zmk_usb_conn_state_changed` schedules a delayable work item when USB
reaches a ready state; the flush worker drains the ring buffer via
`hid_int_ep_write`. The configurable flush delay defaults to 100 ms,
which experimentally is enough on macOS to let the host finish HID
interface binding before the resend.

The flush path is hardened against deep-wake re-enumeration hazards
found during on-hardware testing:

- **Advisory semaphore take in the flush** (mirroring the normal send
  path, which ignores its take result): a bus reset aborts an armed IN
  transfer without raising the write-complete callback
  (`usb_dc_nrfx` `EP_ABORTED` is log-only), stranding the semaphore at
  0; blocking on it would abandon the queue for the whole wake cycle.
- **Retry on a short timer** while the bus is active when a flush
  write fails (e.g. `-EAGAIN` mid-enumeration), instead of waiting for
  a status-change event that may never come.
- **`k_work_reschedule` in the listener**: `k_work_schedule` on an
  already-pending work keeps the old deadline, so a
  `RESUME → RESET → CONFIGURED` cluster would otherwise fire the flush
  ~0 ms after `CONFIGURED` — inside the host binding race the delay
  exists to avoid. Suspend entry (which still maps to a HID-ready conn
  state) no longer schedules a pointless flush.
- **Ordering**: HID reports are absolute state snapshots, so a live
  release racing past its queued press would leave that key logically
  held on the host. While the queue is non-empty, ready-path reports
  append and flush in order.
- **Queue cleared on `USB_DC_DISCONNECTED`**: replaying hours-old
  keystrokes on replug is phantom input, not recovery.

Queue sizing is configurable so embedded targets can trade RAM for
robustness:

- `CONFIG_ZMK_USB_HID_REPLAY_QUEUE_DEPTH` — default 8, range 1..64
- `CONFIG_ZMK_USB_HID_REPLAY_REPORT_MAX_LEN` — default 16 B, range 8..64
- `CONFIG_ZMK_USB_HID_REPLAY_FLUSH_DELAY_MS` — default 100 ms, range 0..1000

Overflow drops the oldest entry. Oversized reports are dropped at
enqueue with a `LOG_WRN`. Default-off so the static memory cost
(`depth × max_len` + one mutex + one delayable work item) is only
paid by firmwares that opt in.

## Testing

Tested in production on a dongle-based BLE split setup (XIAO BLE
central + two `assimilator-bt` peripherals forwarding HID over USB)
on macOS. With the option enabled:

- Dongle physical unplug → replug → first key arrives immediately.
- PC sleep → resume → no extra keypress needed beyond the wake key
  that macOS itself consumes by design (its HID pipeline cancels
  key-downs within 500 ms of wake and while the display is off — that
  part is host behaviour common to all keyboards, not fixable in
  firmware).
- No stuck keys, phantom repeats, or latency regressions in normal
  typing, including immediately after resume.

Default-off path is byte-identical (`#if`-guarded), verified by
building the same target with and without the option enabled.

Downstream use: [akira-toriyama/canon](https://github.com/akira-toriyama/canon)
runs this change as an out-of-tree patch ([`patches/zmk/usb-hid-prime-on-ready.patch`](https://github.com/akira-toriyama/canon/blob/main/patches/zmk/usb-hid-prime-on-ready.patch))
pending this PR.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable. *(no zmk-side test harness for USB HID lifecycle; happy to add one if pointed at an existing pattern)*
- [x] Proper Copyright + License headers added to applicable files
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation). *(can add a docs mention if maintainers prefer)*