### PR TITLE
feat(ble): auto-unpair the peer on BT_SECURITY_ERR_PIN_OR_KEY_MISSING

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -223,6 +223,26 @@ config ZMK_BLE_MOUSE_REPORT_QUEUE_SIZE
 config ZMK_BLE_CLEAR_BONDS_ON_START
     bool "Configuration that clears all bond information from the keyboard on startup."
 
+config ZMK_BLE_AUTO_UNPAIR_ON_KEY_MISSING
+    bool "Auto-unpair the peer when its security handshake reports a missing key"
+    default n
+    help
+      When the BLE peer rejects security elevation with
+      BT_SECURITY_ERR_PIN_OR_KEY_MISSING (i.e. it no longer holds, or
+      never held, a bond matching ours), automatically call bt_unpair
+      and bt_conn_disconnect so the next advert initiates a fresh
+      pairing exchange.
+
+      Without this, dongle / split setups can get wedged in a
+      reconnect-and-fail loop after one side's bond is wiped (e.g.
+      after a partial settings reset or NVS corruption on one peer):
+      every reconnect triggers the same security error, which user
+      input alone cannot recover from short of clearing both bonds
+      and re-pairing.
+
+      Disabled by default to preserve the current behaviour, which
+      surfaces the error to the user without taking action.
+
 # HID GATT notifications sent this way are *not* picked up by Linux, and possibly others.
 config BT_GATT_NOTIFY_MULTIPLE
     default n

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -562,6 +562,17 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
         LOG_DBG("Security changed: %s level %u", addr, level);
     } else {
         LOG_ERR("Security failed: %s level %u err %d", addr, level, err);
+#if IS_ENABLED(CONFIG_ZMK_BLE_AUTO_UNPAIR_ON_KEY_MISSING)
+        if (err == BT_SECURITY_ERR_PIN_OR_KEY_MISSING) {
+            // Peer holds a different (or no) bond for us, so the handshake
+            // will loop on every reconnect until something resets state.
+            // Drop our half of the bond and disconnect; the next advert
+            // initiates a fresh pairing exchange.
+            LOG_WRN("Stale bond detected, clearing and disconnecting");
+            bt_unpair(BT_ID_DEFAULT, bt_conn_get_dst(conn));
+            bt_conn_disconnect(conn, BT_HCI_ERR_AUTH_FAIL);
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
## What

Add `CONFIG_ZMK_BLE_AUTO_UNPAIR_ON_KEY_MISSING` (default `n`). When
enabled, the `security_changed` handler reacts to
`BT_SECURITY_ERR_PIN_OR_KEY_MISSING` by calling `bt_unpair` and
`bt_conn_disconnect`, so the next advert initiates a fresh pairing
exchange instead of looping on the same handshake failure.

## Why

In a split / dongle keyboard setup, if one side's bond is wiped
(partial settings reset, NVS corruption, or reflashing one peer
without rebonding the other), every subsequent reconnect ends in
`security_changed` with `PIN_OR_KEY_MISSING`. The connection stays
up but is unusable, and the loop is not recoverable without manually
wiping bonds on both sides and going through the pairing flow again.

The existing handler logs the error and otherwise does nothing,
which means there is no firmware-side recovery path for the
asymmetric-bond case that is easy to hit on dongle setups.

## How

The new branch sits inside the existing `else` arm of
`security_changed`, guarded by the Kconfig. When the peer reports
`PIN_OR_KEY_MISSING`, drop our half of the bond and disconnect with
`BT_HCI_ERR_AUTH_FAIL`. The endpoint goes back to discoverable +
unpaired, and the next advert/scan cycle re-establishes a fresh
pairing without user intervention.

Default-off so the current behaviour (surface the error, take no
action) is preserved for users who would rather notice and act
manually.

## Testing

Tested in production on a dongle-based BLE split
(XIAO BLE central + two `assimilator-bt` peripherals). Reproduced
the loop by wiping one peripheral's bond settings while the central
retains theirs; with the option enabled, the central self-recovers
into a fresh pair on the next reconnect attempt; with the option
disabled (or this patch absent), the loop persists until both bonds
are wiped manually.

Downstream use: [akira-toriyama/canon](https://github.com/akira-toriyama/canon)
runs this fix as an out-of-tree patch ([`patches/zmk/security-changed-auto-unpair.patch`](https://github.com/akira-toriyama/canon/blob/main/patches/zmk/security-changed-auto-unpair.patch))
pending this upstream PR.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable. *(no zmk-side test harness for BLE security handshakes; happy to add one if pointed at an existing pattern)*
- [x] Proper Copyright + License headers added to applicable files
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation). *(no public docs page on bond recovery semantics; can add a brief mention if maintainers prefer)*