### PR TITLE
fix(keymap): Fix null dereference with debug logging

### DIFF
--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -767,7 +767,7 @@ int zmk_keymap_sensor_event(uint8_t sensor_index,
         struct zmk_behavior_binding *binding = &zmk_sensor_keymap[layer_id][sensor_index];
 
         LOG_DBG("layer idx: %d, layer id: %d sensor_index: %d, binding name: %s", layer_idx,
-                layer_id, sensor_index, binding->behavior_dev);
+                layer_id, sensor_index, binding->behavior_dev ? binding->behavior_dev : "(null)");
 
         const struct device *behavior = zmk_behavior_get_binding(binding->behavior_dev);
         if (!behavior) {


### PR DESCRIPTION
If a layer contains fewer sensor bindings than there are sensors declared, `binding->behavior_dev` is null when a sensor without a behavior in an active layer's bindings is triggered. Fix this by logging a placeholder name if the binding does not exist.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
