### PR TITLE
fix(drivers): Fix missing pulses in EC11

### DIFF
--- a/app/module/drivers/sensor/ec11/CMakeLists.txt
+++ b/app/module/drivers/sensor/ec11/CMakeLists.txt
@@ -5,5 +5,4 @@ zephyr_include_directories(.)
 
 zephyr_library()
 
-zephyr_library_sources(ec11.c)
-zephyr_library_sources_ifdef(CONFIG_EC11_TRIGGER ec11_trigger.c)
+zephyr_library_sources(ec11.c ec11_trigger.c)

--- a/app/module/drivers/sensor/ec11/Kconfig
+++ b/app/module/drivers/sensor/ec11/Kconfig
@@ -13,27 +13,18 @@ if EC11
 
 choice EC11_TRIGGER_MODE
     prompt "Trigger mode"
-    default EC11_TRIGGER_NONE
     help
       Specify the type of triggering to be used by the driver.
-
-config EC11_TRIGGER_NONE
-    bool "No trigger"
 
 config EC11_TRIGGER_GLOBAL_THREAD
     bool "Use global thread"
     depends on GPIO
-    select EC11_TRIGGER
 
 config EC11_TRIGGER_OWN_THREAD
     bool "Use own thread"
     depends on GPIO
-    select EC11_TRIGGER
 
 endchoice
-
-config EC11_TRIGGER
-    bool
 
 config EC11_THREAD_PRIORITY
     int "Thread priority"

--- a/app/module/drivers/sensor/ec11/ec11.c
+++ b/app/module/drivers/sensor/ec11/ec11.c
@@ -20,46 +20,66 @@
 
 LOG_MODULE_REGISTER(EC11, CONFIG_SENSOR_LOG_LEVEL);
 
-static int ec11_get_ab_state(const struct device *dev) {
+static int ec11_read_pin(const struct device *dev, enum ec11_pin pin) {
     const struct ec11_config *drv_cfg = dev->config;
 
-    return (gpio_pin_get_dt(&drv_cfg->a) << 1) | gpio_pin_get_dt(&drv_cfg->b);
+    if (pin == EC11_PIN_A) {
+        return gpio_pin_get_dt(&drv_cfg->a);
+    } else {
+        return gpio_pin_get_dt(&drv_cfg->b);
+    }
 }
 
 static int ec11_sample_fetch(const struct device *dev, enum sensor_channel chan) {
     struct ec11_data *drv_data = dev->data;
     const struct ec11_config *drv_cfg = dev->config;
-    uint8_t val;
+    uint8_t inactive_pin_state;
+    uint8_t active_pin_state;
+    uint8_t state;
     int8_t delta;
+    enum ec11_pin inactive_pin = drv_data->active_pin == EC11_PIN_A ? EC11_PIN_B : EC11_PIN_A;
 
     __ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_ROTATION);
 
-    val = ec11_get_ab_state(dev);
+    inactive_pin_state = ec11_read_pin(dev, inactive_pin);
+    active_pin_state = drv_data->active_pin_state ^ 1;
+    state = active_pin_state << 2 | drv_data->inactive_pin_state << 1 | inactive_pin_state;
 
-    LOG_DBG("prev: %d, new: %d", drv_data->ab_state, val);
+    LOG_DBG("State: %01d%01d%01d", (state >> 2 & 1), (state >> 1 & 1), (state >> 0 & 1));
 
-    switch (val | (drv_data->ab_state << 2)) {
-    case 0b0010:
-    case 0b0100:
-    case 0b1101:
-    case 0b1011:
+    switch (state) {
+    case 0b100:
+    case 0b011:
         delta = -1;
         break;
-    case 0b0001:
-    case 0b0111:
-    case 0b1110:
-    case 0b1000:
+    case 0b000:
+    case 0b111:
         delta = 1;
         break;
+    case 0b010:
+    case 0b101:
+        delta = 2;
+        break;
+    case 0b110:
+    case 0b001:
+        delta = -2;
+        break;
     default:
+        LOG_WRN("Invalid state");
         delta = 0;
         break;
+    }
+
+    if (drv_data->active_pin == EC11_PIN_B) {
+        delta *= -1;
     }
 
     LOG_DBG("Delta: %d", delta);
 
     drv_data->pulses += delta;
-    drv_data->ab_state = val;
+    drv_data->active_pin = inactive_pin;
+    drv_data->inactive_pin_state = active_pin_state;
+    drv_data->active_pin_state = inactive_pin_state;
 
     // TODO: Temporary code for backwards compatibility to support
     // the sensor channel rotation reporting *ticks* instead of delta of degrees.
@@ -111,6 +131,7 @@ static const struct sensor_driver_api ec11_driver_api = {
 int ec11_init(const struct device *dev) {
     struct ec11_data *drv_data = dev->data;
     const struct ec11_config *drv_cfg = dev->config;
+    int pin_state;
 
     LOG_DBG("A: %s %d B: %s %d resolution %d", drv_cfg->a.port->name, drv_cfg->a.pin,
             drv_cfg->b.port->name, drv_cfg->b.pin, drv_cfg->resolution);
@@ -142,7 +163,14 @@ int ec11_init(const struct device *dev) {
     }
 #endif
 
-    drv_data->ab_state = ec11_get_ab_state(dev);
+    drv_data->active_pin = EC11_PIN_A;
+
+    // In the detent position, pin A is stable and we read its value but cannot do that for pin B
+    // since its value may be unstable. Instead, for the state machine, the correct value for pin B
+    // is the same as pin A
+    pin_state = ec11_read_pin(dev, drv_data->active_pin);
+    drv_data->inactive_pin_state = pin_state;
+    drv_data->active_pin_state = pin_state;
 
     return 0;
 }

--- a/app/module/drivers/sensor/ec11/ec11.c
+++ b/app/module/drivers/sensor/ec11/ec11.c
@@ -121,9 +121,7 @@ static int ec11_channel_get(const struct device *dev, enum sensor_channel chan,
 }
 
 static const struct sensor_driver_api ec11_driver_api = {
-#ifdef CONFIG_EC11_TRIGGER
     .trigger_set = ec11_trigger_set,
-#endif
     .sample_fetch = ec11_sample_fetch,
     .channel_get = ec11_channel_get,
 };
@@ -156,12 +154,10 @@ int ec11_init(const struct device *dev) {
         return -EIO;
     }
 
-#ifdef CONFIG_EC11_TRIGGER
     if (ec11_init_interrupt(dev) < 0) {
         LOG_DBG("Failed to initialize interrupt!");
         return -EIO;
     }
-#endif
 
     drv_data->active_pin = EC11_PIN_A;
 

--- a/app/module/drivers/sensor/ec11/ec11.h
+++ b/app/module/drivers/sensor/ec11/ec11.h
@@ -32,7 +32,6 @@ struct ec11_data {
     int8_t ticks;
     int8_t delta;
 
-#ifdef CONFIG_EC11_TRIGGER
     struct gpio_callback a_gpio_cb;
     struct gpio_callback b_gpio_cb;
     const struct device *dev;
@@ -47,14 +46,9 @@ struct ec11_data {
 #elif defined(CONFIG_EC11_TRIGGER_GLOBAL_THREAD)
     struct k_work work;
 #endif
-
-#endif /* CONFIG_EC11_TRIGGER */
 };
-
-#ifdef CONFIG_EC11_TRIGGER
 
 int ec11_trigger_set(const struct device *dev, const struct sensor_trigger *trig,
                      sensor_trigger_handler_t handler);
 
 int ec11_init_interrupt(const struct device *dev);
-#endif

--- a/app/module/drivers/sensor/ec11/ec11.h
+++ b/app/module/drivers/sensor/ec11/ec11.h
@@ -18,8 +18,16 @@ struct ec11_config {
     const uint8_t resolution;
 };
 
+enum ec11_pin {
+    EC11_PIN_A,
+    EC11_PIN_B,
+};
+
 struct ec11_data {
-    uint8_t ab_state;
+    enum ec11_pin active_pin;
+    uint8_t inactive_pin_state;
+    uint8_t active_pin_state;
+
     int8_t pulses;
     int8_t ticks;
     int8_t delta;

--- a/app/module/drivers/sensor/ec11/ec11_trigger.c
+++ b/app/module/drivers/sensor/ec11/ec11_trigger.c
@@ -19,17 +19,14 @@ extern struct ec11_data ec11_driver;
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(EC11, CONFIG_SENSOR_LOG_LEVEL);
 
-static inline void setup_int(const struct device *dev, bool enable) {
+static inline void setup_int(const struct device *dev, enum ec11_pin pin, bool enable) {
     const struct ec11_config *cfg = dev->config;
+    const struct gpio_dt_spec *pin_gpio = pin == EC11_PIN_A ? &cfg->a : &cfg->b;
 
     LOG_DBG("enabled %s", (enable ? "true" : "false"));
 
-    if (gpio_pin_interrupt_configure_dt(&cfg->a, enable ? GPIO_INT_EDGE_BOTH : GPIO_INT_DISABLE)) {
-        LOG_WRN("Unable to set A pin GPIO interrupt");
-    }
-
-    if (gpio_pin_interrupt_configure_dt(&cfg->b, enable ? GPIO_INT_EDGE_BOTH : GPIO_INT_DISABLE)) {
-        LOG_WRN("Unable to set A pin GPIO interrupt");
+    if (gpio_pin_interrupt_configure_dt(pin_gpio, enable ? GPIO_INT_EDGE_BOTH : GPIO_INT_DISABLE)) {
+        LOG_WRN("Unable to set %s pin GPIO interrupt", pin == EC11_PIN_A ? "A" : "B");
     }
 }
 
@@ -39,7 +36,7 @@ static void ec11_a_gpio_callback(const struct device *dev, struct gpio_callback 
 
     LOG_DBG("");
 
-    setup_int(drv_data->dev, false);
+    setup_int(drv_data->dev, EC11_PIN_A, false);
 
 #if defined(CONFIG_EC11_TRIGGER_OWN_THREAD)
     k_sem_give(&drv_data->gpio_sem);
@@ -54,7 +51,7 @@ static void ec11_b_gpio_callback(const struct device *dev, struct gpio_callback 
 
     LOG_DBG("");
 
-    setup_int(drv_data->dev, false);
+    setup_int(drv_data->dev, EC11_PIN_B, false);
 
 #if defined(CONFIG_EC11_TRIGGER_OWN_THREAD)
     k_sem_give(&drv_data->gpio_sem);
@@ -68,7 +65,7 @@ static void ec11_thread_cb(const struct device *dev) {
 
     drv_data->handler(dev, drv_data->trigger);
 
-    setup_int(dev, true);
+    setup_int(drv_data->dev, drv_data->active_pin, true);
 }
 
 #ifdef CONFIG_EC11_TRIGGER_OWN_THREAD
@@ -99,14 +96,14 @@ int ec11_trigger_set(const struct device *dev, const struct sensor_trigger *trig
                      sensor_trigger_handler_t handler) {
     struct ec11_data *drv_data = dev->data;
 
-    setup_int(dev, false);
+    setup_int(drv_data->dev, drv_data->active_pin, false);
 
     k_msleep(5);
 
     drv_data->trigger = trig;
     drv_data->handler = handler;
 
-    setup_int(dev, true);
+    setup_int(drv_data->dev, drv_data->active_pin, true);
 
     return 0;
 }

--- a/docs/docs/config/encoders.md
+++ b/docs/docs/config/encoders.md
@@ -23,7 +23,6 @@ If `CONFIG_EC11` is enabled, exactly one of the following options must be set to
 
 | Config                              | Type | Description                                     |
 | ----------------------------------- | ---- | ----------------------------------------------- |
-| `CONFIG_EC11_TRIGGER_NONE`          | bool | No trigger (encoders are disabled)              |
 | `CONFIG_EC11_TRIGGER_GLOBAL_THREAD` | bool | Process encoder interrupts on the global thread |
 | `CONFIG_EC11_TRIGGER_OWN_THREAD`    | bool | Process encoder interrupts on their own thread  |
 


### PR DESCRIPTION
The EC11 driver is flawed since it reads both pin states when any edge is detected. Unfortunate timing and a messy signal for a pin coming from the EC11 can thus cause a pulse to be lost.

Rework the driver to have only one pin (called the active pin) with interrupts enabled at a time. When an edge is detected on this pin, it is assumed to have flipped and the state of the inactive pin is read. These, along with the previous state of the inactive pin are used to determine the direction and magnitude of the pulse delta.

This implementation requires EC11 triggers so `CONFIG_EC11_TRIGGER_NONE` and `CONFIG_EC11_TRIGGER` are also removed. Based on my search on GitHub, I couldn't find a single user of EC11 with `CONFIG_EC11_TRIGGER_NONE=y`.

## Testing

I tested this on a Keychron Q3 Max with an EC11 that has 4 pulses between detents. It went from having occasional issues with pulses being lost to them never being lost. I don't have any other keyboards or EC11s but it'd be useful to test this with an EC11 that has 2 pulses between detents.

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
