### PR TITLE
docs: fix board examples to use zmk variant

### DIFF
--- a/docs/docs/development/local-toolchain/build-flash.mdx
+++ b/docs/docs/development/local-toolchain/build-flash.mdx
@@ -43,7 +43,7 @@ with an onboard MCU or one that uses an MCU board add-on.
     you can build ZMK with the following:
 
     ```sh
-    west build -b planck_rev6
+    west build -b planck//zmk
     ```
 
   </TabItem>
@@ -79,7 +79,7 @@ arguments afterward. The previous section shows one example of this with
 `-DSHIELD=kyria_left`. Another example use case is passing Kconfig flags:
 
 ```sh
-west build -b planck_rev6 -- -DCONFIG_ZMK_SLEEP=y
+west build -b planck//zmk -- -DCONFIG_ZMK_SLEEP=y
 ```
 
 :::tip
@@ -114,7 +114,7 @@ west config build.cmake-args \
 When building for a new board and/or shield after having built one previously, you may need to enable the pristine build option. This option removes all existing files in the build directory before regenerating them, and can be enabled by adding either --pristine or -p to the command:
 
 ```sh
-west build -p -b nice_nano -- -DSHIELD=kyria_left
+west build -p -b nice_nano//zmk -- -DSHIELD=kyria_left
 ```
 
 ### Building For Split Keyboards
@@ -126,13 +126,13 @@ For split keyboards, you will have to build and flash each side separately the f
 By default, the `build` command outputs a single .uf2 file named `zmk.uf2` so building left and then right immediately after will overwrite your left firmware. In addition, you will need to pristine build each side to ensure the correct files are used. To avoid having to pristine build every time and separate the left and right build files, we recommend setting up separate build directories for each half. You can do this by using the `-d` parameter and first building left into `build/left`:
 
 ```sh
-west build -d build/left -b nice_nano -- -DSHIELD=kyria_left
+west build -d build/left -b nice_nano//zmk -- -DSHIELD=kyria_left
 ```
 
 and then building right into `build/right`:
 
 ```sh
-west build -d build/right -b nice_nano -- -DSHIELD=kyria_right
+west build -d build/right -b nice_nano//zmk -- -DSHIELD=kyria_right
 ```
 
 This produces `left` and `right` subfolders under the `build` directory and two separate .uf2 files. For future work on a specific half, use the `-d` parameter again to ensure you are building into the correct location.
@@ -148,13 +148,13 @@ ZMK supports loading additional boards, shields, code, etc. from [external ZMK m
 For instance, building with the `my-vendor-keebs-module` checked out to your documents directory, you would build like:
 
 ```
-west build -b nice_nano -- -DSHIELD=vendor_shield -DZMK_EXTRA_MODULES="C:/Users/myUser/Documents/my-vendor-keebs-module"
+west build -b nice_nano//zmk -- -DSHIELD=vendor_shield -DZMK_EXTRA_MODULES="C:/Users/myUser/Documents/my-vendor-keebs-module"
 ```
 
 When adding multiple modules, make sure they are separated by a semicolon, e.g.:
 
 ```
-west build -b nice_nano -- -DSHIELD=vendor_shield -DZMK_EXTRA_MODULES="C:/Users/myUser/Documents/my-vendor-keebs-module;C:/Users/myUser/Documents/my-other-keebs-module"
+west build -b nice_nano//zmk -- -DSHIELD=vendor_shield -DZMK_EXTRA_MODULES="C:/Users/myUser/Documents/my-vendor-keebs-module;C:/Users/myUser/Documents/my-other-keebs-module"
 ```
 
 ### Building from `zmk-config` Folder
@@ -169,7 +169,7 @@ For instance, building kyria firmware from a user `myUser`'s `zmk-config` folder
 on Windows may look something like this:
 
 ```sh
-west build -b nice_nano -- -DSHIELD=kyria_left \
+west build -b nice_nano//zmk -- -DSHIELD=kyria_left \
   -DZMK_CONFIG="C:/Users/myUser/Documents/Github/zmk-config/config"
 ```
 

--- a/docs/docs/development/usb-logging.mdx
+++ b/docs/docs/development/usb-logging.mdx
@@ -28,7 +28,7 @@ requires adding a `snippet: zmk-usb-logging` to your `build.yaml` file for any b
 ```yaml
 ---
 include:
-  - board: nice_nano
+  - board: nice_nano//zmk
     shield: corne_left
     snippet: zmk-usb-logging
 ```
@@ -36,7 +36,7 @@ include:
 When building locally, the `-S`/`--snippet` flag can be passed to `west build` to enable the snippet, e.g.
 
 ```sh
-west build -b nice_nano -S zmk-usb-logging -- -DSHIELD="corne_left"
+west build -b nice_nano//zmk -S zmk-usb-logging -- -DSHIELD="corne_left"
 ```
 
 ### Additional Config

--- a/docs/docs/features/studio.md
+++ b/docs/docs/features/studio.md
@@ -87,11 +87,11 @@ For a split keyboard, you should do this _only_ for your central/left side, e.g.
 ```yaml title="build.yaml"
 ---
 include:
-  - board: nice_nano
+  - board: nice_nano//zmk
     shield: corne_left
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano
+  - board: nice_nano//zmk
     shield: corne_right
 ```
 
@@ -100,7 +100,7 @@ include:
 When building locally, use the `-S` parameter to include the `studio-rpc-usb-uart` snippet. Instead of adding it to your config file, you can also append the `ZMK_STUDIO` Kconfig as an additional CMake argument, e.g.:
 
 ```bash
-west build -d build/cl_studio -b nice_nano \
+west build -d build/cl_studio -b nice_nano//zmk \
   -S studio-rpc-usb-uart -- -DSHIELD=corne_left -DCONFIG_ZMK_STUDIO=y
 ```
 

--- a/docs/docs/troubleshooting/building-issues.md
+++ b/docs/docs/troubleshooting/building-issues.md
@@ -75,7 +75,7 @@ If you are building locally, this file can be found inside the build folder at `
 Additionally, the build command (in "West Build (`<keyboard>`)" step in GitHub Actions) logs what configuration files were found and used in the build:
 
 ```
-+ west build -s zmk/app -d /tmp/tmp.8cJefinXCb -b corneish_zen_left@2 -- -DZMK_CONFIG=/tmp/zmk-config/config -DZMK_EXTRA_MODULES=/__w/zmk-config/zmk-config
++ west build -s zmk/app -d /tmp/tmp.8cJefinXCb -b corneish_zen_left//zmk -- -DZMK_CONFIG=/tmp/zmk-config/config -DZMK_EXTRA_MODULES=/__w/zmk-config/zmk-config
 ...
 -- ZMK Config Kconfig: /tmp/zmk-config/config/corneish_zen.conf
 ...
@@ -96,7 +96,7 @@ If you are building locally, this file can be found inside the build folder at `
 Additionally, the build command (in "West Build (`<keyboard>`)" step in GitHub Actions) logs what devicetree files were found and used in the build:
 
 ```
-+ west build -s zmk/app -d /tmp/tmp.8cJefinXCb -b corneish_zen_left@2 -- -DZMK_CONFIG=/tmp/zmk-config/config -DZMK_EXTRA_MODULES=/__w/zmk-config/zmk-config
++ west build -s zmk/app -d /tmp/tmp.8cJefinXCb -b corneish_zen_left//zmk -- -DZMK_CONFIG=/tmp/zmk-config/config -DZMK_EXTRA_MODULES=/__w/zmk-config/zmk-config
 ...
 -- Found BOARD.dts: /tmp/zmk-config/zmk/app/boards/lowprokb/corneish_zen/corneish_zen_left.dts
 -- Found devicetree overlay: /tmp/zmk-config/zmk/app/boards/lowprokb/corneish_zen/corneish_zen_left_2_0_0.overlay


### PR DESCRIPTION
Some references to boards don't have the zmk variant. Update them to show zmk variant.

## PR check-list

N/A