### PR TITLE
fix(keymap): Guard against unresolvable saved bindings

### DIFF
--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -512,6 +512,14 @@ static int save_bindings(void) {
                     .param2 = binding->param2,
                 };
 
+                if (binding_setting.behavior_local_id == UINT16_MAX) {
+                    LOG_ERR("Not persisting binding at layer %d key %d: no local ID found for "
+                            "behavior %s",
+                            l, kp, binding->behavior_dev);
+                    WRITE_BIT(pending[kp / 8], kp % 8, 0);
+                    continue;
+                }
+
                 // We can skip any trailing zero params, regardless of the behavior
                 // and if those params are meaningful.
                 size_t len = sizeof(binding_setting);
@@ -943,23 +951,25 @@ static int keymap_handle_set(const char *name, size_t len, settings_read_cb read
 };
 
 static int keymap_handle_commit(void) {
-#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_LOCAL_IDS_IN_BINDINGS)
     for (int l = 0; l < ZMK_KEYMAP_LAYERS_LEN; l++) {
         for (int p = 0; p < ZMK_KEYMAP_LEN; p++) {
             struct zmk_behavior_binding *binding = &zmk_keymap[l][p];
 
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_LOCAL_IDS_IN_BINDINGS)
             if (binding->local_id > 0 && !binding->behavior_dev) {
                 binding->behavior_dev =
                     zmk_behavior_find_behavior_name_from_local_id(binding->local_id);
+            }
+#endif
 
-                if (!binding->behavior_dev) {
-                    LOG_ERR("Failed to finding device for local ID %d after settings load",
-                            binding->local_id);
-                }
+            if (!binding->behavior_dev) {
+                LOG_ERR("No behavior found for binding at layer %d position %d after settings "
+                        "load, restoring stock binding",
+                        l, p);
+                *binding = zmk_stock_keymap[l][p];
             }
         }
     }
-#endif
 
     return 0;
 }


### PR DESCRIPTION
## Summary

When restoring saved keymap entries from settings, a stored binding whose behavior local ID cannot be resolved is currently still installed with a NULL `behavior_dev` (after only a warning log). The result is a permanently dead key position: the broken entry is reloaded on every boot, survives reflashing, and can only be cleared by erasing the settings partition.

This PR adds two guards:

- **Load (`keymap_handle_commit`)**: after settings load, any key position whose behavior could not be resolved is restored to its stock (compiled) binding, with an error log, instead of being left dead. The existing local-ID re-resolution for `CONFIG_ZMK_BEHAVIOR_LOCAL_IDS_IN_BINDINGS` is unchanged; the fallback also covers the non-`IN_BINDINGS` path, where the set handler assigns `behavior_dev = NULL` directly.
- **Save (`save_bindings`)**: bindings whose behavior has no local ID (`zmk_behavior_get_local_id` returns `UINT16_MAX`) are skipped with an error log rather than persisted as unresolvable entries.

With both in place, the worst case for a bad saved entry becomes "key reverts to the stock keymap on next boot" rather than "key is dead until the user factory-resets".

## How this was found

Hit in the wild on a MoErgo Go60 running a ZMK Studio-enabled build (MoErgo's ZMK distribution, which carries this file unchanged from upstream): after editing a key bound to a keymap-defined hold-tap in Studio and saving, the saved entry failed to resolve on reboot and the key position went dead. Reflashing did not help (the settings entry persisted); only a settings reset recovered it.

## Testing

- Verified the guarded firmware builds and runs on Go60 hardware (both fixes applied to MoErgo's distribution, which has identical keymap.c logic in these paths).
- With the guards in place, an unresolvable stored binding logs an error and the key reverts to its compiled behavior after a power cycle, instead of going dead.