### PR TITLE
docs: make editUrl link to blob instead of edit

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -197,12 +197,12 @@ module.exports = {
           // It is recommended to set document id as docs home page (`docs/` path).
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
-          editUrl: "https://github.com/zmkfirmware/zmk/edit/main/docs/",
+          editUrl: "https://github.com/zmkfirmware/zmk/blob/main/docs/",
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
-          editUrl: "https://github.com/zmkfirmware/zmk/edit/main/docs/",
+          editUrl: "https://github.com/zmkfirmware/zmk/blob/main/docs/",
           blogSidebarCount: "ALL",
         },
         theme: {


### PR DESCRIPTION
While it is the "edit url", linking to actual edit page is less useful than linking to the "blob" page.

For people without write access, the edit page shows a "need to fork" message without content and without any button to view the content. The only way to read the file is by manully changing the `edit` in url to `blob`. 

Example: [`https://github.com/git/git/edit/master/Documentation/git-add.adoc`](https://github.com/git/git/edit/master/Documentation/git-add.adoc)

Everyone can view the blob page, and from there they can click the "edit" button if they really meant to edit the file.



<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

N/A
