### PR TITLE
docs: fix Netlify ignore command skipping builds

### DIFF
--- a/docs/netlify-ignore-command.sh
+++ b/docs/netlify-ignore-command.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
 
 # We deploy main, version branches and deploy previews only
-if echo $HEAD | grep -E '^(main|v[[:digit:]]+\.([[:digit:]])+-branch)$' || echo $CONTEXT | grep '^deploy-preview$'
+if echo "$HEAD" | grep -qE '^(main|v[[:digit:]]+\.[[:digit:]]+-branch)$' \
+   || echo "$CONTEXT" | grep -q '^deploy-preview$'
 then
   echo "Head '$HEAD' matches a deployed branch, or context is deploy preview, checking for git changes."
-  git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../app/boards/
+
+  if [ "$CACHED_COMMIT_REF" = "$COMMIT_REF" ]; then
+    echo "No cached build to diff against (cache miss or rebuild), proceeding with build."
+    exit 1
+  fi
+
+  git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" . ../app/boards/
+  exit $?
 else
   echo "Head '$HEAD' does not match a deployed branch and is not a deploy preview"
   exit 0


### PR DESCRIPTION
When CACHED_COMMIT_REF == COMMIT_REF, `git diff --quiet` finds no changes and exits 0, causing Netlify to skip the build. Guard against this by exiting 1 (proceed with build) when the two refs are identical.

From https://docs.netlify.com/build/configure-builds/environment-variables/#git-metadata

> CACHED_COMMIT_REF: reference ID (also known as “SHA” or “hash”) of the last commit that we built before the current build. When a build runs without cache, CACHED_COMMIT_REF will be the same as the COMMIT_REF.

I don't have a netlify account so it's all reading and guessing with no testing.

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

N/A