### PR TITLE
fix(studio): Fix saving issue with >190 keys

### DIFF
--- a/app/src/keymap.c
+++ b/app/src/keymap.c
@@ -640,7 +640,7 @@ static int keymap_track_changed_bindings(const char *key, size_t len, settings_r
             return -EINVAL;
         }
 
-        uint8_t key_position = strtoul(endptr + 1, &endptr, 10);
+        uint32_t key_position = strtoul(endptr + 1, &endptr, 10);
 
         if (*endptr != '\0') {
             LOG_WRN("Invalid key_position number: %s with endptr %s", next, endptr);
@@ -875,7 +875,7 @@ static int keymap_handle_set(const char *name, size_t len, settings_read_cb read
             return -EINVAL;
         }
 
-        uint8_t key_position = strtoul(endptr + 1, &endptr, 10);
+        uint32_t key_position = strtoul(endptr + 1, &endptr, 10);
 
         if (*endptr != '\0') {
             LOG_WRN("Invalid key_position number: %s with endptr %s", next, endptr);


### PR DESCRIPTION
Currently there is a bug when trying to save keys > index ~190 they will be scrambled, pushed back to overwrite earlier keys and all sorts of chaos. strtoul returns a uint32_t so the type of key_position should match. 

Similar issue to #3205 

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] Additional tests are included, if changing behaviors/core code that is testable.
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
