### PR TITLE
fix(behaviors): Ignore masked mods in key repeat

### DIFF
--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -342,6 +342,7 @@ struct zmk_hid_mouse_resolution_feature_report {
 #endif // IS_ENABLED(CONFIG_ZMK_POINTING)
 
 zmk_mod_flags_t zmk_hid_get_explicit_mods(void);
+zmk_mod_flags_t zmk_hid_get_masked_mods(void);
 int zmk_hid_register_mod(zmk_mod_t modifier);
 int zmk_hid_unregister_mod(zmk_mod_t modifier);
 bool zmk_hid_mod_is_pressed(zmk_mod_t modifier);

--- a/app/src/behaviors/behavior_key_repeat.c
+++ b/app/src/behaviors/behavior_key_repeat.c
@@ -95,7 +95,10 @@ static int key_repeat_keycode_state_changed_listener(const zmk_event_t *eh) {
         for (int u = 0; u < config->usage_pages_count; u++) {
             if (config->usage_pages[u] == ev->usage_page) {
                 memcpy(&data->last_keycode_pressed, ev, sizeof(struct zmk_keycode_state_changed));
-                data->last_keycode_pressed.implicit_modifiers |= zmk_hid_get_explicit_mods();
+                // Modifiers masked by an active behavior (e.g. the shift consumed by a mod-morph)
+                // aren't part of the output being repeated, so they must not be captured here.
+                data->last_keycode_pressed.implicit_modifiers |=
+                    zmk_hid_get_explicit_mods() & ~zmk_hid_get_masked_mods();
                 break;
             }
         }

--- a/app/src/hid.c
+++ b/app/src/hid.c
@@ -50,6 +50,8 @@ static zmk_mod_flags_t masked_modifiers = 0;
 
 zmk_mod_flags_t zmk_hid_get_explicit_mods(void) { return explicit_modifiers; }
 
+zmk_mod_flags_t zmk_hid_get_masked_mods(void) { return masked_modifiers; }
+
 int zmk_hid_register_mod(zmk_mod_t modifier) {
     explicit_modifier_counts[modifier]++;
     LOG_DBG("Modifier %d count %d", modifier, explicit_modifier_counts[modifier]);

--- a/app/tests/key-repeat/mod-morph-masked-modifiers/events.patterns
+++ b/app/tests/key-repeat/mod-morph-masked-modifiers/events.patterns
@@ -1,0 +1,8 @@
+s/.*hid_listener_keycode_pressed.*keycode/pressed: keycode/p
+s/.*hid_listener_keycode_released.*keycode/released: keycode/p
+s/.*hid_register_mod.*Modifiers set to /reg explicit: Modifiers set to /p
+s/.*hid_unregister_mod.*Modifiers set to /unreg explicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_press.*Modifiers set to /reg implicit: Modifiers set to /p
+s/.*hid_implicit_modifiers_release.*Modifiers set to /unreg implicit: Modifiers set to /p
+s/.*hid_masked_modifiers_set.*Modifiers set to /mask mods: Modifiers set to /p
+s/.*hid_masked_modifiers_clear.*Modifiers set to /unmask mods: Modifiers set to /p

--- a/app/tests/key-repeat/mod-morph-masked-modifiers/keycode_events.snapshot
+++ b/app/tests/key-repeat/mod-morph-masked-modifiers/keycode_events.snapshot
@@ -1,0 +1,16 @@
+pressed: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+reg explicit: Modifiers set to 0x02
+reg implicit: Modifiers set to 0x02
+mask mods: Modifiers set to 0x00
+pressed: keycode 0x33 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x00
+released: keycode 0x33 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x00
+unmask mods: Modifiers set to 0x02
+released: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
+unreg explicit: Modifiers set to 0x00
+unreg implicit: Modifiers set to 0x00
+pressed: keycode 0x33 implicit_mods 0x00 explicit_mods 0x00
+reg implicit: Modifiers set to 0x00
+released: keycode 0x33 implicit_mods 0x00 explicit_mods 0x00
+unreg implicit: Modifiers set to 0x00

--- a/app/tests/key-repeat/mod-morph-masked-modifiers/native_sim.keymap
+++ b/app/tests/key-repeat/mod-morph-masked-modifiers/native_sim.keymap
@@ -1,0 +1,36 @@
+#include <dt-bindings/zmk/keys.h>
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/kscan_mock.h>
+
+/ {
+    behaviors {
+        comma_morph: comma_morph {
+            compatible = "zmk,behavior-mod-morph";
+            #binding-cells = <0>;
+            bindings = <&kp COMMA>, <&kp SEMICOLON>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+        };
+    };
+
+    keymap {
+        compatible = "zmk,keymap";
+
+        default_layer {
+            bindings = <
+                &key_repeat &comma_morph
+                &kp LEFT_SHIFT &none
+            >;
+        };
+    };
+};
+
+&kscan {
+    events = <
+        ZMK_MOCK_PRESS(1,0,10)
+        ZMK_MOCK_PRESS(0,1,10)
+        ZMK_MOCK_RELEASE(0,1,10)
+        ZMK_MOCK_RELEASE(1,0,10)
+        ZMK_MOCK_PRESS(0,0,10)
+        ZMK_MOCK_RELEASE(0,0,10)
+    >;
+};


### PR DESCRIPTION
When a mod-morph consumes a modifier, it masks it via zmk_hid_masked_modifiers_set() so the morphed keycode is sent without it. The key repeat behavior, however, captured zmk_hid_get_explicit_mods() unfiltered and stored it as implicit modifiers, and implicit modifiers bypass the mask when the HID report is built.

Pressing shift, tapping a mod-morph that morphs to an unshifted keycode (e.g. COMMA -> SEMICOLON), releasing shift and then pressing &key_repeat therefore emitted ':' instead of a second ';'.

Expose the masked modifiers and exclude them when capturing, so only modifiers that actually contributed to the output are repeated.

Fixes #3368

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).