### PR TITLE
fix(studio): reject RX writes exceeding ring space

### DIFF
--- a/app/src/studio/gatt_rpc_transport.c
+++ b/app/src/studio/gatt_rpc_transport.c
@@ -4,13 +4,25 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <zephyr/device.h>
-#include <zephyr/init.h>
+#include <errno.h>
 #include <sys/types.h>
-#include <zephyr/sys/atomic.h>
-#include <zephyr/kernel.h>
+
 #include <zephyr/bluetooth/gatt.h>
 #include <zephyr/sys/ring_buffer.h>
+
+#include "gatt_rpc_transport.h"
+
+#ifdef ZMK_STUDIO_GATT_RPC_RX_TEST
+
+struct ring_buf *zmk_rpc_get_rx_buf(void);
+void zmk_rpc_rx_notify(void);
+
+#else
+
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
 
 #include <zmk/ble.h>
 #include <zmk/event_manager.h>
@@ -23,7 +35,20 @@
 
 LOG_MODULE_DECLARE(zmk_studio, CONFIG_ZMK_STUDIO_LOG_LEVEL);
 
+#endif /* ZMK_STUDIO_GATT_RPC_RX_TEST */
+
 static bool handling_rx = false;
+
+ssize_t zmk_studio_rpc_rx_write(struct ring_buf *rpc_buf, const uint8_t *buf, uint32_t len) {
+    if (ring_buf_space_get(rpc_buf) < len) {
+        return -ENOMEM;
+    }
+
+    uint32_t written = ring_buf_put(rpc_buf, buf, len);
+    return written == len ? (ssize_t)len : -EIO;
+}
+
+#ifndef ZMK_STUDIO_GATT_RPC_RX_TEST
 
 static K_SEM_DEFINE(indicate_sem, 1, 1);
 static atomic_t notify_size;
@@ -61,30 +86,40 @@ static ssize_t read_rpc_resp(struct bt_conn *conn, const struct bt_gatt_attr *at
     return 0;
 }
 
+#endif /* ZMK_STUDIO_GATT_RPC_RX_TEST */
+
 static ssize_t write_rpc_req(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf,
                              uint16_t len, uint16_t offset, uint8_t flags) {
+    if (offset != 0) {
+        return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
+    }
+
     if (!handling_rx) {
         return len;
     }
 
-    uint32_t copied = 0;
     struct ring_buf *rpc_buf = zmk_rpc_get_rx_buf();
-    while (copied < len) {
-        uint8_t *buffer;
-        uint32_t claim_len = ring_buf_put_claim(rpc_buf, &buffer, len - copied);
-
-        if (claim_len > 0) {
-            memcpy(buffer, ((uint8_t *)buf) + copied, claim_len);
-            copied += claim_len;
-        }
-
-        ring_buf_put_finish(rpc_buf, claim_len);
+    ssize_t ret = zmk_studio_rpc_rx_write(rpc_buf, buf, len);
+    if (ret < 0) {
+        return BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES);
     }
 
     zmk_rpc_rx_notify();
 
-    return len;
+    return ret;
 }
+
+#ifdef CONFIG_ZTEST
+
+void zmk_studio_gatt_rpc_rx_set_active_for_test(bool active) { handling_rx = active; }
+
+ssize_t zmk_studio_gatt_rpc_rx_write_for_test(const void *buf, uint16_t len, uint16_t offset) {
+    return write_rpc_req(NULL, NULL, buf, len, offset, 0);
+}
+
+#endif /* CONFIG_ZTEST */
+
+#ifndef ZMK_STUDIO_GATT_RPC_RX_TEST
 
 BT_GATT_SERVICE_DEFINE(
     rpc_interface, BT_GATT_PRIMARY_SERVICE(BT_UUID_DECLARE_128(ZMK_STUDIO_BT_SERVICE_UUID)),
@@ -230,3 +265,5 @@ static int gatt_rpc_listener(const zmk_event_t *eh) {
 
 ZMK_LISTENER(gatt_rpc_listener, gatt_rpc_listener);
 ZMK_SUBSCRIPTION(gatt_rpc_listener, zmk_ble_active_profile_changed);
+
+#endif /* ZMK_STUDIO_GATT_RPC_RX_TEST */

--- a/app/src/studio/gatt_rpc_transport.h
+++ b/app/src/studio/gatt_rpc_transport.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#ifdef CONFIG_ZTEST
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <zephyr/sys/ring_buffer.h>
+
+ssize_t zmk_studio_rpc_rx_write(struct ring_buf *rpc_buf, const uint8_t *buf, uint32_t len);
+void zmk_studio_gatt_rpc_rx_set_active_for_test(bool active);
+ssize_t zmk_studio_gatt_rpc_rx_write_for_test(const void *buf, uint16_t len, uint16_t offset);
+
+#endif

--- a/app/tests/studio/gatt-rpc-rx/CMakeLists.txt
+++ b/app/tests/studio/gatt-rpc-rx/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(studio_gatt_rpc_rx)
+
+target_include_directories(app PRIVATE ../../../include ../../../src/studio)
+target_sources(app PRIVATE src/main.c ../../../src/studio/gatt_rpc_transport.c)
+set_source_files_properties(
+  ../../../src/studio/gatt_rpc_transport.c
+  PROPERTIES COMPILE_DEFINITIONS ZMK_STUDIO_GATT_RPC_RX_TEST
+)

--- a/app/tests/studio/gatt-rpc-rx/prj.conf
+++ b/app/tests/studio/gatt-rpc-rx/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/app/tests/studio/gatt-rpc-rx/src/main.c
+++ b/app/tests/studio/gatt-rpc-rx/src/main.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <errno.h>
+
+#include <zephyr/bluetooth/att.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/sys/ring_buffer.h>
+#include <zephyr/ztest.h>
+
+#include "gatt_rpc_transport.h"
+
+static uint8_t ring_data[8];
+static struct ring_buf ring;
+static const uint8_t payload[9] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+static uint32_t notify_count;
+static uint32_t ring_size_at_notify;
+
+struct ring_buf *zmk_rpc_get_rx_buf(void) { return &ring; }
+
+void zmk_rpc_rx_notify(void) {
+    ring_size_at_notify = ring_buf_size_get(&ring);
+    notify_count++;
+}
+
+static void before(void *fixture) {
+    ARG_UNUSED(fixture);
+
+    ring_buf_init(&ring, sizeof(ring_data), ring_data);
+    notify_count = 0;
+    ring_size_at_notify = 0;
+    zmk_studio_gatt_rpc_rx_set_active_for_test(true);
+}
+
+ZTEST(studio_gatt_rx, test_exact_free_space_is_accepted) {
+    zassert_equal(zmk_studio_rpc_rx_write(&ring, payload, 8), 8);
+    zassert_equal(ring_buf_size_get(&ring), 8);
+}
+
+ZTEST(studio_gatt_rx, test_free_plus_one_is_rejected_without_partial_enqueue) {
+    zassert_equal(zmk_studio_rpc_rx_write(&ring, payload, 9), -ENOMEM);
+    zassert_equal(ring_buf_size_get(&ring), 0);
+}
+
+ZTEST(studio_gatt_rx, test_full_ring_rejects_in_bounded_time) {
+    ring_buf_put(&ring, payload, 8);
+    zassert_equal(zmk_studio_rpc_rx_write(&ring, payload, 1), -ENOMEM);
+    zassert_equal(ring_buf_size_get(&ring), 8);
+}
+
+ZTEST(studio_gatt_rx, test_gatt_write_rejects_nonzero_offset_without_enqueue_or_notify) {
+    zassert_equal(zmk_studio_gatt_rpc_rx_write_for_test(payload, 1, 1),
+                  BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET));
+    zassert_equal(ring_buf_size_get(&ring), 0);
+    zassert_equal(notify_count, 0);
+}
+
+ZTEST(studio_gatt_rx, test_gatt_write_maps_oversize_to_att_error_without_enqueue_or_notify) {
+    zassert_equal(zmk_studio_gatt_rpc_rx_write_for_test(payload, 9, 0),
+                  BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES));
+    zassert_equal(ring_buf_size_get(&ring), 0);
+    zassert_equal(notify_count, 0);
+}
+
+ZTEST(studio_gatt_rx, test_gatt_write_notifies_once_after_full_enqueue) {
+    zassert_equal(zmk_studio_gatt_rpc_rx_write_for_test(payload, 8, 0), 8);
+    zassert_equal(ring_buf_size_get(&ring), 8);
+    zassert_equal(notify_count, 1);
+    zassert_equal(ring_size_at_notify, 8);
+}
+
+ZTEST_SUITE(studio_gatt_rx, NULL, NULL, before, NULL, NULL);

--- a/app/tests/studio/gatt-rpc-rx/testcase.yaml
+++ b/app/tests/studio/gatt-rpc-rx/testcase.yaml
@@ -1,0 +1,7 @@
+tests:
+  zmk.studio.gatt_rpc_rx:
+    platform_allow:
+      - native_sim
+    tags:
+      - zmk
+      - studio


### PR DESCRIPTION
## Summary

- reject Studio GATT RPC writes that exceed available RX ring-buffer space
- reject nonzero GATT write offsets
- enqueue accepted writes atomically and notify only after full enqueue
- add focused native_sim coverage for exact-fit, overflow, full-ring, offset, ATT error, and notification behavior

## Security impact

Prevents oversized or fragmented BLE writes from spinning indefinitely or partially corrupting the RPC receive stream.

## Tests

- `west twister -T app/tests/studio/gatt-rpc-rx -p native_sim --inline-logs`
- `git diff --check origin/main..HEAD`
