### PR TITLE
fix(display): use the low priority work queue by default

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -651,6 +651,7 @@ if ZMK_LOW_PRIORITY_WORK_QUEUE
 
 config ZMK_LOW_PRIORITY_THREAD_STACK_SIZE
     int "Low priority thread stack size"
+    default 3072 if ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY
     default 768
 
 config ZMK_LOW_PRIORITY_THREAD_PRIORITY

--- a/app/Kconfig.defaults
+++ b/app/Kconfig.defaults
@@ -2,8 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
-    default 3072 if ZMK_DISPLAY
+    default 3072 if ZMK_DISPLAY_WORK_QUEUE_SYSTEM
     default 2048
+
+choice ZMK_DISPLAY_WORK_QUEUE
+    default ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY
+endchoice
 
 # Basic
 config BT_DEVICE_APPEARANCE

--- a/app/Kconfig.defaults
+++ b/app/Kconfig.defaults
@@ -5,10 +5,6 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
     default 3072 if ZMK_DISPLAY_WORK_QUEUE_SYSTEM
     default 2048
 
-choice ZMK_DISPLAY_WORK_QUEUE
-    default ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY
-endchoice
-
 # Basic
 config BT_DEVICE_APPEARANCE
     default 961

--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -51,8 +51,6 @@ endchoice
 
 choice ZMK_DISPLAY_WORK_QUEUE
     prompt "Work queue selection for UI updates"
-    default ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY
-
 config ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY
     bool "Use low priority work queue for UI updates"
     select ZMK_LOW_PRIORITY_WORK_QUEUE

--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -51,6 +51,11 @@ endchoice
 
 choice ZMK_DISPLAY_WORK_QUEUE
     prompt "Work queue selection for UI updates"
+    default ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY
+
+config ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY
+    bool "Use low priority work queue for UI updates"
+    select ZMK_LOW_PRIORITY_WORK_QUEUE
 
 config ZMK_DISPLAY_WORK_QUEUE_SYSTEM
     bool "Use default system work queue for UI updates"

--- a/app/src/display/Kconfig
+++ b/app/src/display/Kconfig
@@ -51,6 +51,7 @@ endchoice
 
 choice ZMK_DISPLAY_WORK_QUEUE
     prompt "Work queue selection for UI updates"
+
 config ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY
     bool "Use low priority work queue for UI updates"
     select ZMK_LOW_PRIORITY_WORK_QUEUE

--- a/app/src/display/main.c
+++ b/app/src/display/main.c
@@ -21,6 +21,7 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/event_manager.h>
 #include <zmk/events/activity_state_changed.h>
 #include <zmk/display/status_screen.h>
+#include <zmk/workqueue.h>
 
 static const struct device *display = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 
@@ -52,6 +53,8 @@ static struct k_work_q display_work_q;
 struct k_work_q *zmk_display_work_q() {
 #if IS_ENABLED(CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED)
     return &display_work_q;
+#elif IS_ENABLED(CONFIG_ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY)
+    return zmk_workqueue_lowprio_work_q();
 #else
     return &k_sys_work_q;
 #endif

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -35,18 +35,21 @@ If `CONFIG_ZMK_DISPLAY` is enabled, exactly zero or one of the following options
 | `CONFIG_ZMK_DISPLAY_STATUS_SCREEN_BUILT_IN` | Use the built-in status screen |
 | `CONFIG_ZMK_DISPLAY_STATUS_SCREEN_CUSTOM`   | Use a custom status screen     |
 
-If `CONFIG_ZMK_DISPLAY` is enabled, exactly zero or one of the following options must be set to `y`. The first option is used if none are set.
+If `CONFIG_ZMK_DISPLAY` is enabled, exactly zero or one of the following options must be set to `y`. The low priority work queue is used if none are set.
 
-| Config                                    | Description                               |
-| ----------------------------------------- | ----------------------------------------- |
-| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_SYSTEM`    | Use the system main thread for UI updates |
-| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED` | Use a dedicated thread for UI updates     |
+| Config                                         | Description                                      |
+| ---------------------------------------------- | ------------------------------------------------ |
+| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY`   | Use the shared low priority queue for UI updates |
+| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_SYSTEM`         | Use the system work queue for UI updates         |
+| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED`      | Use a dedicated thread for UI updates            |
 
-Using a dedicated thread requires more memory but prevents displays with slow updates (e.g. E-paper) from delaying key scanning and other processes. If enabled, the following options configure the thread:
+The low priority work queue is the default. It schedules UI updates below time-sensitive work while sharing a queue with other low priority tasks, such as battery reporting and RGB underglow. Its stack size defaults to 3072 bytes when selected for display updates.
+
+The system work queue preserves the previous behavior, but slow display updates can delay unrelated system work. Using a dedicated thread isolates display updates from other work queues at the cost of additional memory. If enabled, the following options configure the thread:
 
 | Config                                           | Type | Description                  | Default |
 | ------------------------------------------------ | ---- | ---------------------------- | ------- |
-| `CONFIG_ZMK_DISPLAY_DEDICATED_THREAD_STACK_SIZE` | int  | Stack size for the UI thread | 2048    |
+| `CONFIG_ZMK_DISPLAY_DEDICATED_THREAD_STACK_SIZE` | int  | Stack size for the UI thread | 3072    |
 | `CONFIG_ZMK_DISPLAY_DEDICATED_THREAD_PRIORITY`   | int  | Priority for the UI thread   | 5       |
 
 You must also configure the driver for your display. ZMK provides the following display drivers:

--- a/docs/docs/config/displays.md
+++ b/docs/docs/config/displays.md
@@ -37,11 +37,11 @@ If `CONFIG_ZMK_DISPLAY` is enabled, exactly zero or one of the following options
 
 If `CONFIG_ZMK_DISPLAY` is enabled, exactly zero or one of the following options must be set to `y`. The low priority work queue is used if none are set.
 
-| Config                                         | Description                                      |
-| ---------------------------------------------- | ------------------------------------------------ |
-| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY`   | Use the shared low priority queue for UI updates |
-| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_SYSTEM`         | Use the system work queue for UI updates         |
-| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED`      | Use a dedicated thread for UI updates            |
+| Config                                       | Description                                      |
+| -------------------------------------------- | ------------------------------------------------ |
+| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_LOW_PRIORITY` | Use the shared low priority queue for UI updates |
+| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_SYSTEM`       | Use the system work queue for UI updates         |
+| `CONFIG_ZMK_DISPLAY_WORK_QUEUE_DEDICATED`    | Use a dedicated thread for UI updates            |
 
 The low priority work queue is the default. It schedules UI updates below time-sensitive work while sharing a queue with other low priority tasks, such as battery reporting and RGB underglow. Its stack size defaults to 3072 bytes when selected for display updates.
 


### PR DESCRIPTION
This follows the suggestion in #3459 to use ZMK's existing low-priority work queue for display updates instead of the system work queue by default.

The change adds a low-priority display queue option, routes display work to `zmk_workqueue_lowprio_work_q()`, and keeps the existing system and dedicated options available.

The shared low-priority queue normally has a 768-byte stack, while display work currently relies on a 3072-byte stack. This PR keeps the 3072-byte default whenever the low-priority queue is selected for display updates, so changing the queue does not introduce a stack regression.

I ran ZMK's official Build, pre-commit, Docs Checks, Tests, and BLE Tests workflows against this branch in my fork; they all pass. The upstream Actions are waiting for maintainer approval because this is my first external contribution.