### PR TITLE
fix(underglow): avoid saving automatic state changes

### DIFF
--- a/app/src/rgb_underglow.c
+++ b/app/src/rgb_underglow.c
@@ -297,7 +297,7 @@ int zmk_rgb_underglow_get_state(bool *on_off) {
     return 0;
 }
 
-int zmk_rgb_underglow_on(void) {
+static int zmk_rgb_underglow_on_immediate(void) {
     if (!led_strip)
         return -ENODEV;
 
@@ -314,6 +314,15 @@ int zmk_rgb_underglow_on(void) {
     state.animation_step = 0;
     k_timer_start(&underglow_tick, K_NO_WAIT, K_MSEC(50));
 
+    return 0;
+}
+
+int zmk_rgb_underglow_on(void) {
+    int ret = zmk_rgb_underglow_on_immediate();
+    if (ret < 0) {
+        return ret;
+    }
+
     return zmk_rgb_underglow_save_state();
 }
 
@@ -327,7 +336,7 @@ static void zmk_rgb_underglow_off_handler(struct k_work *work) {
 
 K_WORK_DEFINE(underglow_off_work, zmk_rgb_underglow_off_handler);
 
-int zmk_rgb_underglow_off(void) {
+static int zmk_rgb_underglow_off_immediate(void) {
     if (!led_strip)
         return -ENODEV;
 
@@ -344,6 +353,15 @@ int zmk_rgb_underglow_off(void) {
 
     k_timer_stop(&underglow_tick);
     state.on = false;
+
+    return 0;
+}
+
+int zmk_rgb_underglow_off(void) {
+    int ret = zmk_rgb_underglow_off_immediate();
+    if (ret < 0) {
+        return ret;
+    }
 
     return zmk_rgb_underglow_save_state();
 }
@@ -481,13 +499,13 @@ static int rgb_underglow_auto_state(bool target_wake_state) {
 
     if (sleep_state.is_awake) {
         if (sleep_state.rgb_state_before_sleeping) {
-            return zmk_rgb_underglow_on();
+            return zmk_rgb_underglow_on_immediate();
         } else {
-            return zmk_rgb_underglow_off();
+            return zmk_rgb_underglow_off_immediate();
         }
     } else {
         sleep_state.rgb_state_before_sleeping = state.on;
-        return zmk_rgb_underglow_off();
+        return zmk_rgb_underglow_off_immediate();
     }
 }
 


### PR DESCRIPTION
## Summary

- Add internal non-persistent underglow on/off helpers.
- Use those helpers for idle and USB automatic state changes.
- Keep the public on/off APIs persistent for user-triggered changes.

## Root cause

The automatic state handler called the public `zmk_rgb_underglow_on()` and
`zmk_rgb_underglow_off()` APIs. Both APIs schedule the complete underglow
state for storage, so an automatic idle transition persisted `on=false` as
if the user had explicitly disabled underglow.

This supersedes #1667 and follows the auto-state work in #2244 and #2284.

## Validation

- Ran the repository pre-commit hooks, including clang-format and gitlint.
- Built `hw75_dynamic@A` and `hw75_keyboard_f303cc@1.1` with the change.
- Flashed and tested the change on an STM32F405RG-based HW75 Dynamic module.
- Used J-Link breakpoints to confirm idle auto-off reached the internal off
  helper with underglow on and activity idle, without subsequently entering
  the underglow settings save work.
- Read the FCB storage partition after auto-off and confirmed the latest
  `rgb/underglow/state` record remained `on=true`.
- Confirmed the public on API still scheduled and persisted a state update.

## PR check-list

- [x] Branch has a clean commit history.
- [x] Additional tests are included, if changing behavior/core code that is testable.
- [x] Proper copyright and license headers are present on applicable files.
- [x] Pre-commit was used to check formatting and the commit message.
- [x] No documentation changes are required.
