### PR TITLE
fix(ble): resolve RPA profile lookups for HOG callbacks

### DIFF
--- a/app/include/zmk/ble.h
+++ b/app/include/zmk/ble.h
@@ -9,6 +9,8 @@
 #include <zmk/keys.h>
 #include <zmk/ble/profile.h>
 
+struct bt_conn;
+
 #define ZMK_BLE_IS_CENTRAL                                                                         \
     (IS_ENABLED(CONFIG_ZMK_SPLIT_BLE) && IS_ENABLED(CONFIG_ZMK_SPLIT_ROLE_CENTRAL))
 
@@ -28,6 +30,8 @@ int zmk_ble_prof_disconnect(uint8_t index);
 
 int zmk_ble_active_profile_index(void);
 int zmk_ble_profile_index(const bt_addr_le_t *addr);
+int zmk_ble_profile_index_from_conn(const struct bt_conn *conn);
+const bt_addr_le_t *zmk_ble_conn_get_identity_addr(const struct bt_conn *conn);
 bt_addr_le_t *zmk_ble_profile_address(uint8_t index);
 
 bt_addr_le_t *zmk_ble_active_profile_addr(void);

--- a/app/src/ble.c
+++ b/app/src/ble.c
@@ -118,6 +118,69 @@ void set_profile_address(uint8_t index, const bt_addr_le_t *addr) {
     k_work_submit(&raise_profile_changed_event_work);
 }
 
+const bt_addr_le_t *zmk_ble_conn_get_identity_addr(const struct bt_conn *conn) {
+    if (conn == NULL) {
+        return NULL;
+    }
+    struct bt_conn_info info;
+    if (bt_conn_get_info(conn, &info) == 0 && info.type == BT_CONN_TYPE_LE) {
+        if (info.le.dst != NULL && bt_addr_le_cmp(info.le.dst, BT_ADDR_LE_ANY) != 0) {
+            return info.le.dst;
+        }
+    }
+    return bt_conn_get_dst(conn);
+}
+
+static bool is_peripheral_conn(const struct bt_conn *conn) {
+    if (conn == NULL) {
+        return false;
+    }
+    struct bt_conn_info info;
+    return (bt_conn_get_info(conn, &info) == 0 && info.role == BT_CONN_ROLE_PERIPHERAL);
+}
+
+int zmk_ble_profile_index_from_conn(const struct bt_conn *conn) {
+    if (!is_peripheral_conn(conn)) {
+        return -ENODEV;
+    }
+    int idx = zmk_ble_profile_index(zmk_ble_conn_get_identity_addr(conn));
+    if (idx < 0) {
+        idx = zmk_ble_active_profile_index();
+    }
+    return idx;
+}
+
+struct conn_lookup_data {
+    const bt_addr_le_t *addr;
+    struct bt_conn *match;
+};
+
+static void find_conn_by_identity_addr(struct bt_conn *conn, void *data) {
+    struct conn_lookup_data *query = data;
+    if (query->match != NULL || !is_peripheral_conn(conn)) {
+        return;
+    }
+    const bt_addr_le_t *remote = zmk_ble_conn_get_identity_addr(conn);
+    if (remote && bt_addr_le_cmp(remote, query->addr) == 0) {
+        query->match = bt_conn_ref(conn);
+    }
+}
+
+static struct bt_conn *lookup_conn_by_profile_addr(const bt_addr_le_t *addr) {
+    struct bt_conn *conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr);
+    if (conn != NULL) {
+        return conn;
+    }
+
+    struct conn_lookup_data query = {
+        .addr = addr,
+        .match = NULL,
+    };
+
+    bt_conn_foreach(BT_CONN_TYPE_LE, find_conn_by_identity_addr, &query);
+    return query.match;
+}
+
 bool zmk_ble_active_profile_is_connected(void) {
     return zmk_ble_profile_is_connected(active_profile);
 }
@@ -131,7 +194,7 @@ bool zmk_ble_profile_is_connected(uint8_t index) {
     bt_addr_le_t *addr = &profiles[index].peer;
     if (!bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
         return false;
-    } else if ((conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr)) == NULL) {
+    } else if ((conn = lookup_conn_by_profile_addr(addr)) == NULL) {
         return false;
     }
 
@@ -152,7 +215,7 @@ bool zmk_ble_profile_is_connected(uint8_t index) {
 
 #define CHECKED_DIR_ADV()                                                                          \
     addr = zmk_ble_active_profile_addr();                                                          \
-    conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr);                                            \
+    conn = lookup_conn_by_profile_addr(addr);                                                      \
     if (conn != NULL) { /* TODO: Check status of connection */                                     \
         LOG_DBG("Skipping advertising, profile host is already connected");                        \
         bt_conn_unref(conn);                                                                       \
@@ -253,6 +316,9 @@ void zmk_ble_clear_all_bonds(void) {
 int zmk_ble_active_profile_index(void) { return active_profile; }
 
 int zmk_ble_profile_index(const bt_addr_le_t *addr) {
+    if (addr == NULL) {
+        return -ENODEV;
+    }
     for (int i = 0; i < ZMK_BLE_PROFILE_COUNT; i++) {
         if (bt_addr_le_cmp(addr, &profiles[i].peer) == 0) {
             return i;
@@ -325,7 +391,7 @@ int zmk_ble_prof_disconnect(uint8_t index) {
 
     if (!bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
         return -ENODEV;
-    } else if ((conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr)) == NULL) {
+    } else if ((conn = lookup_conn_by_profile_addr(addr)) == NULL) {
         return -ENODEV;
     }
 
@@ -345,7 +411,7 @@ struct bt_conn *zmk_ble_active_profile_conn(void) {
     if (!bt_addr_le_cmp(addr, BT_ADDR_LE_ANY)) {
         LOG_WRN("Not sending, no active address for current profile");
         return NULL;
-    } else if ((conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, addr)) == NULL) {
+    } else if ((conn = lookup_conn_by_profile_addr(addr)) == NULL) {
         LOG_WRN("Not sending, not connected to active profile");
         return NULL;
     }
@@ -384,10 +450,6 @@ int zmk_ble_put_peripheral_addr(const bt_addr_le_t *addr) {
         if (bt_addr_le_cmp(&peripheral_addrs[i], addr) == 0) {
             LOG_DBG("Found existing peripheral address in slot %d", i);
             return i;
-        } else {
-            char addr_str[BT_ADDR_LE_STR_LEN];
-            bt_addr_le_to_str(&peripheral_addrs[i], addr_str, sizeof(addr_str));
-            LOG_DBG("peripheral slot %d occupied by %s", i, addr_str);
         }
 
         // If the peripheral address slot is open, store new peripheral in the
@@ -494,18 +556,29 @@ static struct settings_handler profiles_handler = {
 #endif /* IS_ENABLED(CONFIG_SETTINGS) */
 
 static bool is_conn_active_profile(const struct bt_conn *conn) {
-    return bt_addr_le_cmp(bt_conn_get_dst(conn), &profiles[active_profile].peer) == 0;
+    if (conn == NULL) {
+        return false;
+    }
+    return bt_addr_le_cmp(zmk_ble_conn_get_identity_addr(conn), &profiles[active_profile].peer) ==
+           0;
+}
+
+static void notify_profile_changed_if_active(const struct bt_conn *conn) {
+    if (!is_peripheral_conn(conn)) {
+        return;
+    }
+    const bt_addr_le_t *identity = zmk_ble_conn_get_identity_addr(conn);
+    if (bt_addr_le_cmp(identity, &profiles[active_profile].peer) == 0) {
+        k_work_submit(&raise_profile_changed_event_work);
+    }
 }
 
 static void connected(struct bt_conn *conn, uint8_t err) {
     char addr[BT_ADDR_LE_STR_LEN];
-    struct bt_conn_info info;
     LOG_DBG("Connected thread: %p", k_current_get());
 
-    bt_conn_get_info(conn, &info);
-
-    if (info.role != BT_CONN_ROLE_PERIPHERAL) {
-        LOG_DBG("SKIPPING FOR ROLE %d", info.role);
+    if (!is_peripheral_conn(conn)) {
+        LOG_DBG("SKIPPING NON-PERIPHERAL");
         return;
     }
 
@@ -522,24 +595,18 @@ static void connected(struct bt_conn *conn, uint8_t err) {
 
     update_advertising();
 
-    if (is_conn_active_profile(conn)) {
-        LOG_DBG("Active profile connected");
-        k_work_submit(&raise_profile_changed_event_work);
-    }
+    notify_profile_changed_if_active(conn);
 }
 
 static void disconnected(struct bt_conn *conn, uint8_t reason) {
     char addr[BT_ADDR_LE_STR_LEN];
-    struct bt_conn_info info;
 
     bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
     LOG_DBG("Disconnected from %s (reason 0x%02x)", addr, reason);
 
-    bt_conn_get_info(conn, &info);
-
-    if (info.role != BT_CONN_ROLE_PERIPHERAL) {
-        LOG_DBG("SKIPPING FOR ROLE %d", info.role);
+    if (!is_peripheral_conn(conn)) {
+        LOG_DBG("SKIPPING NON-PERIPHERAL");
         return;
     }
 
@@ -547,10 +614,19 @@ static void disconnected(struct bt_conn *conn, uint8_t reason) {
     // connection for a profile as active, and not start advertising yet.
     k_work_submit(&update_advertising_work);
 
-    if (is_conn_active_profile(conn)) {
-        LOG_DBG("Active profile disconnected");
-        k_work_submit(&raise_profile_changed_event_work);
-    }
+    notify_profile_changed_if_active(conn);
+}
+
+static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
+                              const bt_addr_le_t *identity) {
+    char rpa_str[BT_ADDR_LE_STR_LEN];
+    char id_str[BT_ADDR_LE_STR_LEN];
+    bt_addr_le_to_str(rpa, rpa_str, sizeof(rpa_str));
+    bt_addr_le_to_str(identity, id_str, sizeof(id_str));
+
+    LOG_DBG("Identity resolved: %s -> %s", rpa_str, id_str);
+
+    notify_profile_changed_if_active(conn);
 }
 
 static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_security_err err) {
@@ -560,6 +636,7 @@ static void security_changed(struct bt_conn *conn, bt_security_t level, enum bt_
 
     if (!err) {
         LOG_DBG("Security changed: %s level %u", addr, level);
+        notify_profile_changed_if_active(conn);
     } else {
         LOG_ERR("Security failed: %s level %u err %d", addr, level, err);
     }
@@ -578,6 +655,7 @@ static struct bt_conn_cb conn_callbacks = {
     .connected = connected,
     .disconnected = disconnected,
     .security_changed = security_changed,
+    .identity_resolved = identity_resolved,
     .le_param_updated = le_param_updated,
 };
 
@@ -624,8 +702,7 @@ static void auth_cancel(struct bt_conn *conn) {
 
 static bool pairing_allowed_for_current_profile(struct bt_conn *conn) {
     return zmk_ble_active_profile_is_open() ||
-           (IS_ENABLED(CONFIG_BT_SMP_ALLOW_UNAUTH_OVERWRITE) &&
-            bt_addr_le_cmp(zmk_ble_active_profile_addr(), bt_conn_get_dst(conn)) == 0);
+           (IS_ENABLED(CONFIG_BT_SMP_ALLOW_UNAUTH_OVERWRITE) && is_conn_active_profile(conn));
 }
 
 static enum bt_security_err auth_pairing_accept(struct bt_conn *conn,
@@ -645,9 +722,9 @@ static enum bt_security_err auth_pairing_accept(struct bt_conn *conn,
 static void auth_pairing_complete(struct bt_conn *conn, bool bonded) {
     struct bt_conn_info info;
     char addr[BT_ADDR_LE_STR_LEN];
-    const bt_addr_le_t *dst = bt_conn_get_dst(conn);
+    const bt_addr_le_t *identity_addr = zmk_ble_conn_get_identity_addr(conn);
 
-    bt_addr_le_to_str(dst, addr, sizeof(addr));
+    bt_addr_le_to_str(identity_addr, addr, sizeof(addr));
     bt_conn_get_info(conn, &info);
 
     if (info.role != BT_CONN_ROLE_PERIPHERAL) {
@@ -657,11 +734,12 @@ static void auth_pairing_complete(struct bt_conn *conn, bool bonded) {
 
     if (!pairing_allowed_for_current_profile(conn)) {
         LOG_ERR("Pairing completed but current profile is not open: %s", addr);
-        bt_unpair(BT_ID_DEFAULT, dst);
+        bt_unpair(BT_ID_DEFAULT, identity_addr);
         return;
     }
 
-    set_profile_address(active_profile, dst);
+    LOG_DBG("Pairing complete for profile %d: %s", active_profile, addr);
+    set_profile_address(active_profile, identity_addr);
     update_advertising();
 };
 

--- a/app/src/hog.c
+++ b/app/src/hog.c
@@ -119,27 +119,42 @@ static ssize_t read_hids_input_report(struct bt_conn *conn, const struct bt_gatt
                              sizeof(struct zmk_hid_keyboard_report_body));
 }
 
+#if IS_ENABLED(CONFIG_ZMK_HID_INDICATORS) || IS_ENABLED(CONFIG_ZMK_POINTING_SMOOTH_SCROLLING)
+static int hog_get_ble_endpoint(const struct bt_conn *conn,
+                                struct zmk_endpoint_instance *endpoint) {
+    int profile = zmk_ble_profile_index_from_conn(conn);
+    if (profile < 0) {
+        return -ENODEV;
+    }
+    *endpoint = (struct zmk_endpoint_instance){
+        .transport = ZMK_TRANSPORT_BLE,
+        .ble =
+            {
+                .profile_index = profile,
+            },
+    };
+    return 0;
+}
+#endif // IS_ENABLED(CONFIG_ZMK_HID_INDICATORS) || IS_ENABLED(CONFIG_ZMK_POINTING_SMOOTH_SCROLLING)
+
 #if IS_ENABLED(CONFIG_ZMK_HID_INDICATORS)
+
 static ssize_t write_hids_leds_report(struct bt_conn *conn, const struct bt_gatt_attr *attr,
                                       const void *buf, uint16_t len, uint16_t offset,
                                       uint8_t flags) {
     if (offset != 0) {
         return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
     }
+
     if (len != sizeof(struct zmk_hid_led_report_body)) {
         return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
     }
 
     struct zmk_hid_led_report_body *report = (struct zmk_hid_led_report_body *)buf;
-    int profile = zmk_ble_profile_index(bt_conn_get_dst(conn));
-    if (profile < 0) {
+    struct zmk_endpoint_instance endpoint;
+    if (hog_get_ble_endpoint(conn, &endpoint) != 0) {
         return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
     }
-
-    struct zmk_endpoint_instance endpoint = {.transport = ZMK_TRANSPORT_BLE,
-                                             .ble = {
-                                                 .profile_index = profile,
-                                             }};
     zmk_hid_indicators_process_report(report, endpoint);
 
     return len;
@@ -169,16 +184,10 @@ static ssize_t read_hids_mouse_input_report(struct bt_conn *conn, const struct b
 static ssize_t read_hids_mouse_feature_report(struct bt_conn *conn, const struct bt_gatt_attr *attr,
                                               void *buf, uint16_t len, uint16_t offset) {
 
-    int profile = zmk_ble_profile_index(bt_conn_get_dst(conn));
-    if (profile < 0) {
-        LOG_DBG("   BT_ATT_ERR_UNLIKELY");
+    struct zmk_endpoint_instance endpoint;
+    if (hog_get_ble_endpoint(conn, &endpoint) != 0) {
         return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
     }
-
-    struct zmk_endpoint_instance endpoint = {
-        .transport = ZMK_TRANSPORT_BLE,
-        .ble = {.profile_index = profile},
-    };
 
     struct zmk_pointing_resolution_multipliers mult =
         zmk_pointing_resolution_multipliers_get_profile(endpoint);
@@ -204,15 +213,10 @@ static ssize_t write_hids_mouse_feature_report(struct bt_conn *conn,
 
     struct zmk_hid_mouse_resolution_feature_report_body *report =
         (struct zmk_hid_mouse_resolution_feature_report_body *)buf;
-    int profile = zmk_ble_profile_index(bt_conn_get_dst(conn));
-    if (profile < 0) {
+    struct zmk_endpoint_instance endpoint;
+    if (hog_get_ble_endpoint(conn, &endpoint) != 0) {
         return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
     }
-
-    struct zmk_endpoint_instance endpoint = {.transport = ZMK_TRANSPORT_BLE,
-                                             .ble = {
-                                                 .profile_index = profile,
-                                             }};
     zmk_pointing_resolution_multipliers_process_report(report, endpoint);
 
     return len;


### PR DESCRIPTION
## Summary

Fix BLE profile lookups when a host reconnects using a Resolvable Private Address (RPA).

Fixes #3309.

## Reproduction

The failure is reliably reproducible with my own config [`zmk-config-charybdis@5947354`](https://github.com/Durian-Ice/zmk-config-charybdis/commit/5947354d918f154dfac22db6db85d188340c4407).

That config builds the QWERTY Bluetooth/USB firmware for a split Charybdis using the `nice_nano` board target and tracks upstream `zmkfirmware/zmk:main` in `config/west.yml`.

Environment:

- Keyboard: split Charybdis, `nice_nano` board targets
- Host OS: NixOS 26.11 (Zokor), Linux 6.18.44, x86_64
- Configuration: `CONFIG_ZMK_BLE=y`, `CONFIG_ZMK_BLE_EXPERIMENTAL_CONN=y`, `CONFIG_ZMK_POINTING=y`

Steps:

1. Build and flash the QWERTY Bluetooth/USB firmware to both keyboard halves.
2. Pair the keyboard to the host on BLE profile 0.
3. Leave the keyboard BLE-active and suspend the host to S3.
4. Resume the host.

The keyboard then enters a connect/disconnect loop. Host HID-over-GATT operations fail with ATT error `0x0E` (`BT_ATT_ERR_UNLIKELY`), and the keyboard eventually remains disconnected until it is re-paired.

## Validation

I repeated the same hardware reproduction using ZMK commit [`bfa0f5c6`](https://github.com/Durian-Ice/zmk/commit/bfa0f5c6), referenced by the updated config manifest in [`zmk-config-charybdis@3d586e5`](https://github.com/Durian-Ice/zmk-config-charybdis/commit/3d586e5).

The reconnect now completes successfully: the HOG GATT reads do not return ATT error `0x0E`, and the keyboard remains connected without re-pairing.

## Implementation

- Resolve the peer identity address from the active BLE connection before matching it to a stored profile.
- Fall back to the active profile while identity resolution is still pending during the reconnect race.
- Use the identity-aware lookup for profile connection state, active-profile notifications, pairing, disconnect, and HOG endpoint selection.

## Testing

- Reproduced the failure reliably with `zmk-config-charybdis@5947354`.
- Verified the fix on the same hardware and configuration with ZMK `bfa0f5c6`.
- Built the affected firmware successfully.


## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [x] Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [x] Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).
