### PR TITLE
feat(pointing): declare scroll resolution in the report descriptor

### DIFF
--- a/app/include/zmk/hid.h
+++ b/app/include/zmk/hid.h
@@ -97,9 +97,98 @@
 #define HID_PHYSICAL_MAX8(a) HID_ITEM(HID_ITEM_TAG_PHYSICAL_MAX, HID_ITEM_TYPE_GLOBAL, 1), a
 #endif
 
+#ifndef HID_PHYSICAL_MIN16
+#define HID_PHYSICAL_MIN16(a, b) HID_ITEM(HID_ITEM_TAG_PHYSICAL_MIN, HID_ITEM_TYPE_GLOBAL, 2), a, b
+#endif
+
+#ifndef HID_PHYSICAL_MAX16
+#define HID_PHYSICAL_MAX16(a, b) HID_ITEM(HID_ITEM_TAG_PHYSICAL_MAX, HID_ITEM_TYPE_GLOBAL, 2), a, b
+#endif
+
+#ifndef HID_ITEM_TAG_UNIT_EXPONENT
+#define HID_ITEM_TAG_UNIT_EXPONENT 0x5
+#endif
+
+#ifndef HID_ITEM_TAG_UNIT
+#define HID_ITEM_TAG_UNIT 0x6
+#endif
+
+#ifndef HID_UNIT_EXPONENT
+#define HID_UNIT_EXPONENT(a) HID_ITEM(HID_ITEM_TAG_UNIT_EXPONENT, HID_ITEM_TYPE_GLOBAL, 1), a
+#endif
+
+#ifndef HID_UNIT8
+#define HID_UNIT8(a) HID_ITEM(HID_ITEM_TAG_UNIT, HID_ITEM_TYPE_GLOBAL, 1), a
+#endif
+
 #define HID_USAGE16(a, b) HID_ITEM(HID_ITEM_TAG_USAGE, HID_ITEM_TYPE_LOCAL, 2), a, b
 
 #define HID_USAGE16_SINGLE(a) HID_USAGE16((a & 0xFF), ((a >> 8) & 0xFF))
+
+#if defined(CONFIG_ZMK_POINTING_SCROLL_RESOLUTION) && CONFIG_ZMK_POINTING_SCROLL_RESOLUTION > 0
+
+/*
+ * Declare the physical resolution of the scroll axes, in counts per inch.
+ *
+ * A host needs this to tell a fine grained scroll stream from a notched wheel,
+ * and the report descriptor has no field that states it outright. It is
+ * derived from the ranges instead:
+ *
+ *     resolution = (logical range * 10^-unit_exponent) / physical range
+ *
+ * Leaving the physical range at zero, as this descriptor did before, claims
+ * nothing, and hosts then fall back to a default that assumes a notched wheel.
+ * On macOS that default is 9 counts per inch (kDefaultScrollFixedResolution in
+ * IOHIDEventService.cpp), with two consequences: the high resolution scroll
+ * path stays off, because it is gated on the declared resolution exceeding
+ * twice that default, and the scroll acceleration curve is fed a velocity
+ * divided by resolution/report_rate, so a device that really emits hundreds of
+ * counts per inch is reported as moving far faster than it is and accelerates
+ * away. Scrolling comes out coarse and jumpy no matter how fine the stream is.
+ *
+ * The scroll axes use the whole int16 logical range, so with a unit exponent
+ * of -1, meaning physical units of 0.1 inch, the physical range that expresses
+ * R counts per inch is 65535 * 10 / R. It is split about zero because these
+ * are relative axes and travel either way.
+ */
+#define ZMK_HID_SCROLL_PHYS_RANGE (655350 / CONFIG_ZMK_POINTING_SCROLL_RESOLUTION)
+#define ZMK_HID_SCROLL_PHYS_MAX (ZMK_HID_SCROLL_PHYS_RANGE / 2)
+#define ZMK_HID_SCROLL_PHYS_MIN (ZMK_HID_SCROLL_PHYS_MAX - ZMK_HID_SCROLL_PHYS_RANGE)
+
+/*
+ * A host can only derive the resolution when the physical range differs from
+ * the logical one at both ends, so the range has to stay strictly inside the
+ * int16 logical range. Reaching either end is not a rounding error that shows
+ * up as slightly wrong scrolling: the resolution silently reverts to the
+ * host's notched wheel default, which is the whole problem this is here to
+ * avoid. Hence an assert rather than a clamp.
+ */
+BUILD_ASSERT(ZMK_HID_SCROLL_PHYS_RANGE <= 65533,
+             "CONFIG_ZMK_POINTING_SCROLL_RESOLUTION is too low to express: the physical range "
+             "would reach the ends of the logical range and the host would ignore it. Use 11 or "
+             "more.");
+BUILD_ASSERT(ZMK_HID_SCROLL_PHYS_RANGE >= 1,
+             "CONFIG_ZMK_POINTING_SCROLL_RESOLUTION is too high to express: the physical range "
+             "would round down to nothing. Use 655350 or less.");
+
+/* Masked before shifting: these values are signed and go negative. */
+#define ZMK_HID_ITEM_LO(v) ((v) & 0xFF)
+#define ZMK_HID_ITEM_HI(v) ((((v) & 0xFFFF) >> 8) & 0xFF)
+
+/* 0x13 is English Linear with length to the first power, that is, inches. */
+#define ZMK_HID_SCROLL_RESOLUTION_ITEMS                                                            \
+    HID_PHYSICAL_MIN16(ZMK_HID_ITEM_LO(ZMK_HID_SCROLL_PHYS_MIN),                                   \
+                       ZMK_HID_ITEM_HI(ZMK_HID_SCROLL_PHYS_MIN)),                                  \
+        HID_PHYSICAL_MAX16(ZMK_HID_ITEM_LO(ZMK_HID_SCROLL_PHYS_MAX),                               \
+                           ZMK_HID_ITEM_HI(ZMK_HID_SCROLL_PHYS_MAX)),                              \
+        HID_UNIT8(0x13), HID_UNIT_EXPONENT(0x0F)
+
+#else
+
+/* A physical range of zero claims no particular resolution. */
+#define ZMK_HID_SCROLL_RESOLUTION_ITEMS HID_PHYSICAL_MIN8(0x00), HID_PHYSICAL_MAX8(0x00)
+
+#endif // CONFIG_ZMK_POINTING_SCROLL_RESOLUTION > 0
 
 static const uint8_t zmk_hid_report_desc[] = {
     HID_USAGE_PAGE(HID_USAGE_GEN_DESKTOP),
@@ -228,8 +317,7 @@ static const uint8_t zmk_hid_report_desc[] = {
     HID_USAGE(HID_USAGE_GD_WHEEL),
     HID_LOGICAL_MIN16(0x00, 0x80),
     HID_LOGICAL_MAX16(0xFF, 0x7F),
-    HID_PHYSICAL_MIN8(0x00),
-    HID_PHYSICAL_MAX8(0x00),
+    ZMK_HID_SCROLL_RESOLUTION_ITEMS,
     HID_REPORT_SIZE(0x10),
     HID_REPORT_COUNT(0x01),
     HID_INPUT(ZMK_HID_MAIN_VAL_DATA | ZMK_HID_MAIN_VAL_VAR | ZMK_HID_MAIN_VAL_REL),
@@ -244,8 +332,7 @@ static const uint8_t zmk_hid_report_desc[] = {
     HID_USAGE16_SINGLE(HID_USAGE_CONSUMER_AC_PAN),
     HID_LOGICAL_MIN16(0x00, 0x80),
     HID_LOGICAL_MAX16(0xFF, 0x7F),
-    HID_PHYSICAL_MIN8(0x00),
-    HID_PHYSICAL_MAX8(0x00),
+    ZMK_HID_SCROLL_RESOLUTION_ITEMS,
     HID_REPORT_SIZE(0x10),
     HID_REPORT_COUNT(0x01),
     HID_INPUT(ZMK_HID_MAIN_VAL_DATA | ZMK_HID_MAIN_VAL_VAR | ZMK_HID_MAIN_VAL_REL),

--- a/app/src/pointing/Kconfig
+++ b/app/src/pointing/Kconfig
@@ -27,7 +27,45 @@ if !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
 config ZMK_POINTING_SMOOTH_SCROLLING
     bool "Smooth Scrolling"
     help
-      Enable smooth scrolling, with hosts that support HID Resolution Multipliers
+      Enable smooth scrolling, with hosts that support HID Resolution Multipliers.
+
+      Note that macOS is not such a host: IOHIDFamily never writes the
+      Resolution Multiplier feature report, so the multipliers stay at their
+      default and this option has no effect there. Use
+      ZMK_POINTING_SCROLL_RESOLUTION for macOS.
+
+config ZMK_POINTING_SCROLL_RESOLUTION
+    int "Scroll resolution, in counts per inch"
+    default 0
+    help
+      The physical resolution of the scroll axes, declared to the host in the
+      HID report descriptor. 0 declares nothing, which is the historical
+      behaviour.
+
+      Hosts use this to tell a fine grained scroll stream from a notched
+      wheel. When nothing is declared they assume a notched wheel: macOS
+      assumes 9 counts per inch, keeps its high resolution scroll path off,
+      and feeds its acceleration curve a velocity scaled by
+      resolution/report_rate, so a device emitting hundreds of counts per inch
+      is treated as moving far faster than it is. Scrolling then comes out
+      coarse and accelerates away, however fine the stream is.
+
+      Set this to the number of counts the device really emits per inch of
+      travel, measured after the input processors. A 1600 CPI sensor feeding
+      &zip_xy_to_scroll_mapper directly emits 1600; with "&zip_xy_scaler 1 10"
+      ahead of it, 160. Larger values scroll more slowly, so this doubles as a
+      speed control that needs no reflashing of the scaler.
+
+      This describes the stream as emitted with the finest resolution
+      multiplier, which is what ZMK defaults to. A host that asks for a coarser
+      one through ZMK_POINTING_SMOOTH_SCROLLING is expected to account for the
+      multiplier it chose.
+
+      Must be either 0 or between 11 and 655350; the descriptor cannot express
+      a resolution below 11. macOS ignores anything up to 18, which is twice
+      its own default, so use 19 or more for it to take effect there. Values
+      are rounded to what the descriptor can express, which is exact up to
+      about 800 and within a fraction of a percent above it.
 
 config ZMK_INPUT_LISTENER
     bool "Input listener for processing input events in the system"

--- a/docs/docs/config/pointing.md
+++ b/docs/docs/config/pointing.md
@@ -13,10 +13,43 @@ Definition file: [zmk/app/pointing/Kconfig](https://github.com/zmkfirmware/zmk/b
 
 ### General
 
-| Config                                 | Type | Description                                                                | Default |
-| -------------------------------------- | ---- | -------------------------------------------------------------------------- | ------- |
-| `CONFIG_ZMK_POINTING`                  | bool | Enable the general pointing/mouse functionality                            | n       |
-| `CONFIG_ZMK_POINTING_SMOOTH_SCROLLING` | bool | Enable smooth scrolling HID functionality (via HID Resolution Multipliers) | n       |
+| Config                                  | Type | Description                                                                  | Default |
+| --------------------------------------- | ---- | ---------------------------------------------------------------------------- | ------- |
+| `CONFIG_ZMK_POINTING`                   | bool | Enable the general pointing/mouse functionality                              | n       |
+| `CONFIG_ZMK_POINTING_SMOOTH_SCROLLING`  | bool | Enable smooth scrolling HID functionality (via HID Resolution Multipliers)   | n       |
+| `CONFIG_ZMK_POINTING_SCROLL_RESOLUTION` | int  | Scroll resolution in counts per inch, declared to the host (0 declares none) | 0       |
+
+:::note
+
+`CONFIG_ZMK_POINTING_SMOOTH_SCROLLING` relies on the host writing a HID Resolution
+Multiplier feature report. macOS never does: the multiplier usage does not appear
+anywhere in IOHIDFamily except its usage tables, so the option has no effect there.
+
+:::
+
+### Scroll resolution
+
+`CONFIG_ZMK_POINTING_SCROLL_RESOLUTION` tells the host how many counts the device
+emits per inch of scroll travel. It is declared in the report descriptor as a
+physical range, and it is worth setting on any device that scrolls from a sensor
+rather than from a notched wheel.
+
+Hosts use the declared resolution to tell a fine grained scroll stream from a
+notched wheel, and when nothing is declared they assume the latter. macOS assumes
+9 counts per inch, and that assumption has two effects: its high resolution
+scroll path stays off, since that is gated on the declared resolution exceeding
+twice the default, and its scroll acceleration curve is fed a velocity scaled by
+`resolution / report_rate`, so a trackball emitting hundreds of counts per inch is
+treated as moving far faster than it is. Scrolling comes out in coarse steps and
+accelerates away, however fine the stream from the device is.
+
+Set it to what the device really emits per inch, measured after the input
+processors. A 1600 CPI sensor feeding
+[`&zip_xy_to_scroll_mapper`](../keymaps/input-processors/code-mapper.md#pre-defined-instances)
+directly emits 1600 counts per inch; with
+[`&zip_xy_scaler 1 10`](../keymaps/input-processors/scaler.md#pre-defined-instances)
+ahead of it, 160. Larger values scroll more slowly, which makes this a speed control
+that does not cost any granularity, unlike dividing the stream down with a scaler.
 
 ### Advanced Settings
 


### PR DESCRIPTION
## PR check-list

- [x] Branch has a clean commit history. One commit, conventional message.
- [ ] Additional tests are included, if changing behaviors/core code that is testable. Nothing under `app/tests` covers the HID report descriptor, so there was no harness to extend. The arithmetic was checked against Apple's own algorithm instead, see the collapsed section. Happy to add a test if you can say what shape you want.
- [x] Proper Copyright + License headers added to applicable files. Only existing files touched, headers unchanged.
- [ ] Pre-commit used to check formatting of files, commit messages, etc. `clang-format` was run with the repo's config and reports the touched files clean. The markdown table was aligned by hand the way prettier would. The full suite was not available locally, so please say if CI disagrees.
- [x] Includes any necessary documentation changes. `docs/docs/config/pointing.md`.

## What this fixes

A trackball mapped to scroll is close to unusable on macOS today.

Move the ball slowly and nothing happens for a while, then the page jumps by a big
chunk. There is no small scroll step to be had. Move it at a normal speed and the page
flies much further than the movement should give.

The only knob for this right now is the divider on `zip_xy_scaler`. A bigger divider
slows scrolling down, but it also makes the smallest possible step bigger, because it
rounds the stream to whole counts and drops the rest. So you can have slow scrolling
or fine scrolling, but not both.

With the resolution declared, slow movement scrolls a small amount, normal movement
scrolls in proportion, and the speed can be set without losing the small steps.

This only matters for devices that scroll from a sensor, so trackballs and trackpads.
A rotary encoder is a notched wheel, and the host's guess is fine for one. The default
of `0` leaves those unchanged.

## What the patch does

Adds `CONFIG_ZMK_POINTING_SCROLL_RESOLUTION`, the number of counts the device sends
per inch of travel, and puts it in the report descriptor as a physical range on the
`Wheel` and `AC Pan` axes.

Those axes currently declare a physical range of zero, which tells the host nothing.
The host then falls back to guessing, and macOS guesses 9 counts per inch, the figure
for a notched wheel. That guess is what produces the behaviour above. Details of how
the guess turns into coarse jumps are in the collapsed section.

The default of `0` declares nothing and leaves the descriptor byte for byte as it is
today, so nothing changes unless you set it.

`CONFIG_ZMK_POINTING_SMOOTH_SCROLLING` does not help here, because macOS does not
implement HID Resolution Multipliers at all. The new option is independent of it and
works with it turned off.

## Usage

Set it to what the device sends per inch, after the input processors have run. A 1600
CPI sensor feeding `&zip_xy_to_scroll_mapper` directly sends 1600. With
`&zip_xy_scaler 1 10` in front of it, 160. Bigger numbers scroll slower.

## Testing

Tested on hardware, a Charybdis with a PMW3360 trackball on a dongle, with
`CONFIG_ZMK_POINTING_SCROLL_RESOLUTION=1600` and no scaler on the scroll listener.
Slow scrolling works, and normal speed no longer runs away.

macOS only. Windows and Linux drive high resolution scrolling from the Resolution
Multiplier instead of the physical range, so a declaration they do not read should not
affect them. I cannot test either, so a check would be welcome.

<details>
<summary>Why the host's guess produces coarse jumps, and how the numbers were checked</summary>

### Where the guess comes from

No descriptor field states resolution directly. The host works it out from the ranges,
in `IOHIDEventService::determineResolution`:

    resolution = (logical range * 10^-unit_exponent) / physical range

A physical range of zero gives nothing, so `IOHIDEventService.cpp` falls back to
`kDefaultScrollFixedResolution = (9 << 16)`. The pointer equivalent is
`kDefaultFixedResolution = (400 << 16)`, which is why cursor movement has always felt
right while scrolling did not.

This patch declares the physical range with a unit exponent of -1, split evenly either
side of zero, since these are relative axes.

### What 9 counts per inch does

In `IOHIPointing.cpp`:

```c
isHighResScroll = res > (IOFixed)(SCROLL_DEFAULT_RESOLUTION * 2);   // 9 * 2
consumeClearThreshold = (IOFixedDivide(res, SCROLL_CONSUME_RESOLUTION) >> 16) * 2;
consumeCountThreshold = consumeClearThreshold * SCROLL_CONSUME_COUNT_MULTIPLIER;
```

At `res = 9` the first line is false, so the high resolution path stays off. The
second works out to 0, which switches off the throttle as well. Apple's comment on
that throttle describes the symptom:

> RY: throttle the tranlation of scroll based on the resolution threshold. This allows
> us to not generated traditional scroll wheel (line) events for high res devices at
> really low (fine granularity) speeds. This prevents a succession of single scroll
> events that can make scrolling slowly actually seem faster.

The newer userland path has a second problem. `IOHIDAccelerationAlgorithm`:

```c
double deviceScale = resolution_/rate_;
value /= deviceScale;
```

At `resolution = 9` and `rate = 60` the scale is 0.15, so the speed handed to the
acceleration curve is about 6.7 times too high. That is the runaway at normal speed.

From `ioreg` on the dongle before the change: `HIDScrollResolution = 589824`, which is
9 in 16.16 fixed point. The MacBook trackpad next to it reports `26214400`, or 400.

### Resolution Multipliers on macOS

`ResolutionMultiplier` appears once in the whole IOHIDFamily tree, as
`kHIDUsage_GD_ResolutionMultiplier = 0x48` in `IOHIDUsageTables.h`. Nothing reads it
and nothing writes the feature report, so the multipliers keep their defaults and
`CONFIG_ZMK_POINTING_SMOOTH_SCROLLING` has no effect there. The Kconfig help says so
now.

### Checking the numbers

`determineResolution` was transcribed and run over the descriptor bytes the macros
produce. The bytes decode back correctly, and the computed resolution is exact up to
about 800 counts per inch and within a fraction of a percent above that.

The build assert rejects values the descriptor cannot express. One of those is worth
calling out: if the physical range reaches the end of the logical range, the host
throws the declaration away and goes back to guessing. It does not round, it reverts,
and silently. The bound was checked over the whole input range.

On the hardware result, two things changed at once, the declaration and dropping the
scaler. Dropping the scaler on its own would have made scrolling ten times faster
against the 9 counts per inch guess, so clearly worse. The declaration is what did the
work.

</details>

## Unrelated, spotted while reading this code

`apply_resolution_scaling()` in `input_listener.c` divides by `16 - multiplier`. The
descriptor maps logical `0..15` onto physical `1..16`, so logical value L means a
multiplier of L+1, and the divisor should be `16 / (L + 1)`. The two agree at the ends
only: L=15 gives 1 both ways, L=0 gives 16 both ways. In between they differ, so L=7
should divide by 2 and divides by 9 instead. Left alone here, since it only affects
hosts that write the feature report and I cannot test those. Happy to open a separate
issue.
