### PR TITLE
fix(mod-morph): Only mask/clear mods when mod-morph is configured to do so

### DIFF
--- a/app/src/behaviors/behavior_mod_morph.c
+++ b/app/src/behaviors/behavior_mod_morph.c
@@ -46,7 +46,9 @@ static int on_mod_morph_binding_pressed(struct zmk_behavior_binding *binding,
     }
 
     if (zmk_hid_get_explicit_mods() & cfg->mods) {
-        zmk_hid_masked_modifiers_set(cfg->masked_mods);
+        if (cfg->masked_mods) {
+            zmk_hid_masked_modifiers_set(cfg->masked_mods);
+        }
         data->pressed_binding = (struct zmk_behavior_binding *)&cfg->morph_binding;
     } else {
         data->pressed_binding = (struct zmk_behavior_binding *)&cfg->normal_binding;
@@ -57,6 +59,7 @@ static int on_mod_morph_binding_pressed(struct zmk_behavior_binding *binding,
 static int on_mod_morph_binding_released(struct zmk_behavior_binding *binding,
                                          struct zmk_behavior_binding_event event) {
     const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    const struct behavior_mod_morph_config *cfg = dev->config;
     struct behavior_mod_morph_data *data = dev->data;
 
     if (data->pressed_binding == NULL) {
@@ -68,7 +71,9 @@ static int on_mod_morph_binding_released(struct zmk_behavior_binding *binding,
     data->pressed_binding = NULL;
     int err;
     err = zmk_behavior_invoke_binding(pressed_binding, event, false);
-    zmk_hid_masked_modifiers_clear();
+    if (cfg->masked_mods) {
+        zmk_hid_masked_modifiers_clear();
+    }
     return err;
 }
 

--- a/app/tests/mod-morph/3-unmasked-morph/keycode_events.snapshot
+++ b/app/tests/mod-morph/3-unmasked-morph/keycode_events.snapshot
@@ -1,12 +1,10 @@
 pressed: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
 reg explicit: Modifiers set to 0x02
 reg implicit: Modifiers set to 0x02
-mask mods: Modifiers set to 0x02
 pressed: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
 reg implicit: Modifiers set to 0x02
 released: keycode 0x05 implicit_mods 0x00 explicit_mods 0x00
 unreg implicit: Modifiers set to 0x02
-unmask mods: Modifiers set to 0x02
 released: keycode 0xE1 implicit_mods 0x00 explicit_mods 0x00
 unreg explicit: Modifiers set to 0x00
 unreg implicit: Modifiers set to 0x00


### PR DESCRIPTION
This fixes a small inconsistency in mod-morph which currently always applies and clears the mod mask, even when configured not to mask anything. This matters in interaction with other mod-morph instances or other behaviors that modify the mod mask (example: https://github.com/zmkfirmware/zmk/issues/3161#issuecomment-3765992881). The fix adds a small conditional so that the mod mask is only set when `cfg->masked_mods` is.

