### PR TITLE
fix(split): only process wired RX data when bytes actually arrived

### DIFF
--- a/app/src/split/wired/wired.c
+++ b/app/src/split/wired/wired.c
@@ -51,7 +51,7 @@ int zmk_split_wired_poll_in(struct ring_buf *rx_buf, const struct device *uart,
 
     ring_buf_put_finish(rx_buf, read);
 
-    if (ring_buf_size_get(rx_buf) > 0) {
+    if (read > 0) {
         if (process_data_work) {
             k_work_submit(process_data_work);
         } else if (process_data_cb) {


### PR DESCRIPTION
On a polled wired split, a fragment that never completes can wedge the transport
for good. I ran into this on an RP2040 board with a single-wire half-duplex UART
between the halves: after a while the peripheral half stops responding, and only
a power cycle brings it back.

`zmk_split_wired_poll_in()` submits the process-data work whenever the RX ring
buffer is non-empty, rather than when the call actually read something:

```c
    ring_buf_put_finish(rx_buf, read);

    if (ring_buf_size_get(rx_buf) > 0) {
        if (process_data_work) {
            k_work_submit(process_data_work);
```

On a half-duplex central that work is `publish_events_work`, and the first thing
it does is push `rx_done_work` out by `RX_COMPLETE_TIMEOUT`:

```c
static void publish_events_work(struct k_work *work) {
#if IS_HALF_DUPLEX_MODE
    k_work_reschedule(&rx_done_work,
                      K_MSEC(CONFIG_ZMK_SPLIT_WIRED_HALF_DUPLEX_RX_COMPLETE_TIMEOUT));
#endif
```

`rx_done_cb` is the only thing that sends `POLL_EVENTS`. My poll period is 200us
and the deferral is 20ms, so as soon as a partial fragment is sitting in the
buffer the poller gets pushed 20ms into the future a hundred times a second and
never fires again. No poll, no reply from the peripheral, no new bytes, so the
fragment can't complete — and the prefix resync in `zmk_split_wired_get_item()`
never sees the bytes it would need to throw the bad data away. It sustains
itself.

From the outside it looks like this, with the driver still healthy and polling:

```
half-duplex split: tx=5518 (+0) rx=9 (+0) in_calls=190031 sessions=486 turnarounds=486 txing=0
half-duplex split: tx=5518 (+0) rx=9 (+0) in_calls=200033 sessions=486 turnarounds=486 txing=0
```

Nine bytes stranded, both counters frozen mid-conversation, sessions and
turnarounds still paired. What the user notices is that half the keyboard has
gone quiet — and, less obviously, that cross-hand home-row mods stop resolving,
because the positional trigger for a left-hand hold-tap can only be satisfied by
a key on the right half.

Submitting the work only when `read > 0` breaks the cycle. That's what the TODO
just below it is already pointing at. Nothing is lost by it: a complete envelope
is still drained on the tick its final byte arrives, and an incomplete one is
left for the tick that completes it. With the change, a stuck fragment stops
deferring `rx_done_work`, the poller fires, `POLL_EVENTS` goes out, the
peripheral answers, and the existing resync discards the junk on the next pass.

The interrupt path doesn't need the same treatment: `zmk_split_wired_fifo_read()`
is only called from the ISR when `uart_irq_rx_ready()`, so it already implies
new data.

Worth saying plainly about testing: I've compile-tested both halves of my board
with this applied, and the capture above is from the unpatched build, so I have
the failure well characterised. What I don't have yet is a long soak on the
patched firmware — the wedge takes a while to show up and I've only had it
reproduce reliably right after a reflash of one half while the other keeps
running, which desyncs the link mid-fragment. Happy to sit on this until I can
report a proper soak if you'd rather.
