### PR TITLE
fix(behaviors): correct HID usage validation range check

### DIFF
--- a/app/src/behavior.c
+++ b/app/src/behavior.c
@@ -130,8 +130,10 @@ static int validate_hid_usage(uint16_t usage_page, uint16_t usage_id) {
     LOG_DBG("Validate usage %d in page %d", usage_id, usage_page);
     switch (usage_page) {
     case HID_USAGE_KEY:
-        if (usage_id == 0 || (usage_id > ZMK_HID_KEYBOARD_NKRO_MAX_USAGE &&
-                              usage_id < LEFT_CONTROL && usage_id > RIGHT_GUI)) {
+        if (usage_id == 0 ||
+            (usage_id > ZMK_HID_KEYBOARD_NKRO_MAX_USAGE &&
+             usage_id < HID_USAGE_KEY_KEYBOARD_LEFTCONTROL) ||
+            usage_id > HID_USAGE_KEY_KEYBOARD_RIGHT_GUI) {
             return -EINVAL;
         }
         break;


### PR DESCRIPTION
Found this while working on #3498.

```c
LEFT_CONTROL  == ZMK_HID_USAGE(HID_USAGE_KEY, 0xE0) == 0x000700E0
RIGHT_GUI     == ZMK_HID_USAGE(HID_USAGE_KEY, 0xE7) == 0x000700E7
```

The middle check is equivalent to `usage_id < 0x000700E0 && usage_id > 0x000700E7`, which is always false, so every keyboard-page usage except `0x00` was accepted.

| `usage_id` | Before | After |
| --- | --- | --- |
| `0x00` | reject | reject |
| `0x01` … `NKRO_MAX` | accept | accept |
| `NKRO_MAX+1` … `0xDF` | accept | reject |
| `0xE0` … `0xE7` | accept | accept |
| `0xE8` … `0xFF` | accept | reject |

<!-- Note: ZMK is generally not accepting PRs for new keyboards. New generic controller PRs *may* still be accepted, please discuss on the Discord server first. -->

## PR check-list

- [x] Branch has a [clean commit history](https://zmk.dev/docs/development/contributing/pull-requests#clean-commit-history)
- [ ] **N/A** Additional tests are included, if changing behaviors/core code that is testable.
- [x] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [x] [Pre-commit](https://zmk.dev/docs/development/local-toolchain/pre-commit) used to check formatting of files, commit messages, etc.
- [ ] **N/A** Includes any necessary [documentation changes](https://zmk.dev/docs/development/contributing/documentation).